### PR TITLE
Fix adding of estimators when re-fitting `EnsembleForecaster`

### DIFF
--- a/sktime/forecasters/compose.py
+++ b/sktime/forecasters/compose.py
@@ -60,6 +60,9 @@ class EnsembleForecaster(BaseForecaster):
         # validate forecasting horizon
         fh = validate_fh(fh)
 
+        # Clear previously fitted estimators
+        self.fitted_estimators_ = []
+
         for _, estimator in self.estimators:
             # TODO implement set/get params interface
             # estimator.set_params(**{"check_input": False})


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #173 

#### What does this implement/fix? Explain your changes.
Whenever the fit function of EnsembleForecaster is called, any previously fitted estimators stored in self.fitted_estimators_ are discarded and reinitialised with an empty list. 

#### Any other comments?
No additional test cases were written to confirm that this remains.

The issue also refers a potential re-write of the `EnsembleForecaster` class based on sklearn Ensemble. This provides a preliminary fix until the re-write is done. 
