### PR TITLE
PCATransformer

### DIFF
--- a/sktime/transformers/pca.py
+++ b/sktime/transformers/pca.py
@@ -1,0 +1,95 @@
+import pandas as pd
+
+from sklearn.utils.validation import check_is_fitted
+from sklearn.decomposition import PCA
+
+from sktime.transformers.base import BaseTransformer
+from sktime.utils.validation.supervised import validate_X, check_X_is_univariate
+from sktime.utils.data_container import tabularise, detabularise, check_equal_index
+
+
+class PCATransformer(BaseTransformer):
+    """ Transformer that applies Principle Components Analysis to a univariate time series.
+
+    Provides a simple wrapper around ``sklearn.decomposition.PCA``.
+
+    Parameters
+    ----------
+    n_components : int, float, str or None (default None)
+        Number of principle components to retain. By default, all components are retained. See
+        ``sklearn.decomposition.PCA`` documentation for a detailed description of all options.
+    **kwargs
+        Additional parameters passed on to ``sklearn.decomposition.PCA``. See ``sklearn.decomposition.PCA``
+        documentation for a detailed description of all options.
+    """
+
+    def __init__(self, n_components=None, **kwargs):
+        self.pca = PCA(n_components, **kwargs)
+        self.input_dim_ = None
+
+    def fit(self, X, y=None):
+        """
+        Fit transformer, finding all principal components.
+
+        Parameters
+        ----------
+        X : nested pandas DataFrame of shape [n_samples, 1]
+            Nested dataframe with univariate time-series in cells.
+
+        Returns
+        -------
+        self : an instance of self.
+        """
+
+        validate_X(X)
+        check_X_is_univariate(X)
+        check_equal_index(X)
+
+        # Transform the time series column into tabular format and
+        # apply PCA to the tabular format
+        Xtab = tabularise(X)
+        self.input_dim_ = Xtab.shape[1]
+        self.pca.fit(Xtab)
+
+        return self
+
+    def transform(self, X, y=None):
+        """
+        Transform X, transforms univariate time-series using sklearn's PCA class
+
+        Parameters
+        ----------
+        X : nested pandas DataFrame of shape [n_samples, 1]
+            Nested dataframe with time-series in cells.
+
+        Returns
+        -------
+        Xt : pandas DataFrame
+          Transformed pandas DataFrame with the same number of rows and the (potentially reduced) PCA transformed
+          column. Time indices of the original column are replaced with 0:(n_components - 1).
+        """
+
+        # Check inputs.
+        check_is_fitted(self.pca, 'n_components_')
+        validate_X(X)
+        check_X_is_univariate(X)
+        check_equal_index(X)
+
+        # Check that the input is of the same shape as the one passed
+        # during fit.
+        Xtab = tabularise(X)
+
+        if Xtab.shape[1] != self.input_dim_:
+            raise ValueError('Number of time points of input is different from what was seen'
+                             'in `fit`')
+
+        # Transform X using the fitted PCA
+        Xpca = pd.DataFrame(data=self.pca.transform(Xtab),
+                            index=Xtab.index,
+                            columns=Xtab.columns[:self.pca.n_components_])
+
+        # Back-transform into time series data format
+        Xt = detabularise(Xpca, index=X.index)
+        Xt.columns = X.columns
+
+        return Xt

--- a/sktime/transformers/pca.py
+++ b/sktime/transformers/pca.py
@@ -60,7 +60,7 @@ class PCATransformer(BaseTransformer):
         Parameters
         ----------
         X : nested pandas DataFrame of shape [n_samples, 1]
-            Nested dataframe with time-series in cells.
+            Nested dataframe with univariate time-series in cells.
 
         Returns
         -------

--- a/sktime/transformers/pca.py
+++ b/sktime/transformers/pca.py
@@ -25,7 +25,6 @@ class PCATransformer(BaseTransformer):
 
     def __init__(self, n_components=None, **kwargs):
         self.pca = PCA(n_components, **kwargs)
-        self.input_dim_ = None
 
     def fit(self, X, y=None):
         """
@@ -43,12 +42,10 @@ class PCATransformer(BaseTransformer):
 
         validate_X(X)
         check_X_is_univariate(X)
-        check_equal_index(X)
 
         # Transform the time series column into tabular format and
         # apply PCA to the tabular format
         Xtab = tabularise(X)
-        self.input_dim_ = Xtab.shape[1]
         self.pca.fit(Xtab)
 
         return self
@@ -73,17 +70,9 @@ class PCATransformer(BaseTransformer):
         check_is_fitted(self.pca, 'n_components_')
         validate_X(X)
         check_X_is_univariate(X)
-        check_equal_index(X)
-
-        # Check that the input is of the same shape as the one passed
-        # during fit.
-        Xtab = tabularise(X)
-
-        if Xtab.shape[1] != self.input_dim_:
-            raise ValueError('Number of time points of input is different from what was seen'
-                             'in `fit`')
 
         # Transform X using the fitted PCA
+        Xtab = tabularise(X)
         Xpca = pd.DataFrame(data=self.pca.transform(Xtab),
                             index=Xtab.index,
                             columns=Xtab.columns[:self.pca.n_components_])

--- a/sktime/transformers/pca.py
+++ b/sktime/transformers/pca.py
@@ -69,7 +69,6 @@ class PCATransformer(BaseTransformer):
           column. Time indices of the original column are replaced with 0:(n_components - 1).
         """
 
-        # Check inputs.
         check_is_fitted(self.pca, 'n_components_')
         validate_X(X)
         check_X_is_univariate(X)

--- a/sktime/transformers/tests/test_PCATransformer.py
+++ b/sktime/transformers/tests/test_PCATransformer.py
@@ -29,7 +29,8 @@ def test_bad_input_args(bad_components):
                                     {'iterated_power': 10},
                                     {'random_state': 42}])
 def test_pca_kwargs(kwargs):
-    X = generate_df_from_array(np.ones(10), n_rows=10, n_cols=1)
+    np.random.seed(42)
+    X = detabularize(pd.DataFrame(data=np.random.randn(10, 5)))
     pca = PCATransformer(n_components=1, **kwargs)
     pca.fit_transform(X)
 
@@ -46,8 +47,6 @@ def test_early_trans_fail():
 # Test output format and dimensions.
 @pytest.mark.parametrize(
     "n_instances,len_series,n_components", [
-        (1,  2, 1),
-        (1, 10, 1),
         (5,  2, 1),
         (5, 10, 1),
         (5, 10, 3),
@@ -89,7 +88,8 @@ def test_pca_results(n_components):
 # Check output indices (row indices and columns the same, time indices start from 0)
 @pytest.mark.parametrize("n_components", [1, 5, None])
 def test_indices(n_components):
-    X = generate_df_from_array(np.ones(10), n_rows=10, n_cols=1)
+    np.random.seed(42)
+    X = detabularize(pd.DataFrame(data=np.random.randn(10, 5)))
     X.columns = pd.CategoricalIndex(['col_0'])
     X.index = pd.Int64Index([i+10 for i in range(10)])
 

--- a/sktime/transformers/tests/test_PCATransformer.py
+++ b/sktime/transformers/tests/test_PCATransformer.py
@@ -1,0 +1,101 @@
+from sklearn.decomposition import PCA
+from sklearn.exceptions import NotFittedError
+from sktime.transformers.pca import PCATransformer
+from sktime.utils.testing import generate_df_from_array
+from sktime.utils.data_container import tabularize, detabularize, get_time_index
+import pytest
+import pandas as pd
+import numpy as np
+
+
+# Check that exception is raised for bad input args.
+@pytest.mark.parametrize("bad_components", ['str', 1.2, -1.2, -1, 11])
+def test_bad_input_args(bad_components):
+    X = generate_df_from_array(np.ones(10), n_rows=10, n_cols=1)
+
+    if isinstance(bad_components, str):
+        with pytest.raises(TypeError):
+            PCATransformer(n_components=bad_components).fit(X)
+    else:
+        with pytest.raises(ValueError):
+            PCATransformer(n_components=bad_components).fit(X)
+
+
+# Test that keywords can be passed to PCA
+@pytest.mark.parametrize("kwargs", [{'copy': False},
+                                    {'whiten': True},
+                                    {'svd_solver': 'arpack'},
+                                    {'tol': 10e-6},
+                                    {'iterated_power': 10},
+                                    {'random_state': 42}])
+def test_pca_kwargs(kwargs):
+    X = generate_df_from_array(np.ones(10), n_rows=10, n_cols=1)
+    pca = PCATransformer(n_components=1, **kwargs)
+    pca.fit_transform(X)
+
+
+# Test that PCATransformer fails if attempt to transform before fit
+def test_early_trans_fail():
+    X = generate_df_from_array(np.ones(10), n_rows=1, n_cols=1)
+    pca = PCATransformer(n_components=1)
+
+    with pytest.raises(NotFittedError):
+        pca.transform(X)
+
+
+# Test output format and dimensions.
+@pytest.mark.parametrize(
+    "n_instances,len_series,n_components", [
+        (1,  2, 1),
+        (1, 10, 1),
+        (5,  2, 1),
+        (5, 10, 1),
+        (5, 10, 3),
+        (5, 10, 5),
+    ])
+def test_output_format_dim(len_series, n_instances, n_components):
+    np.random.seed(42)
+    X = detabularize(pd.DataFrame(data=np.random.randn(n_instances, len_series)))
+
+    trans = PCATransformer(n_components=n_components)
+    Xt = trans.fit_transform(X)
+
+    # Check number of rows and output type.
+    assert isinstance(Xt, pd.DataFrame)
+    assert Xt.shape[0] == X.shape[0]
+
+    # Check number of principal components in the output.
+    assert tabularize(Xt).shape[1] == min(n_components, tabularize(X).shape[1])
+
+
+# Check that the returned values agree with those produced by ``sklearn.decomposition.PCA``
+@pytest.mark.parametrize("n_components", [1, 5, 0.9, 'mle'])
+def test_pca_results(n_components):
+    np.random.seed(42)
+
+    # sklearn
+    X = pd.DataFrame(data=np.random.randn(10, 5))
+    pca = PCA(n_components=n_components)
+    Xt1 = pca.fit_transform(X)
+
+    # sktime
+    Xs = detabularize(X)
+    pca_transform = PCATransformer(n_components=n_components)
+    Xt2 = pca_transform.fit_transform(Xs)
+
+    assert np.allclose(np.asarray(Xt1), np.asarray(tabularize(Xt2)))
+
+
+# Check output indices (row indices and columns the same, time indices start from 0)
+@pytest.mark.parametrize("n_components", [1, 5, None])
+def test_indices(n_components):
+    X = generate_df_from_array(np.ones(10), n_rows=10, n_cols=1)
+    X.columns = pd.CategoricalIndex(['col_0'])
+    X.index = pd.Int64Index([i+10 for i in range(10)])
+
+    pca = PCATransformer(n_components=n_components)
+    Xt = pca.fit_transform(X)
+
+    assert X.columns.equals(Xt.columns)
+    assert X.index.equals(Xt.index)
+    assert get_time_index(Xt).equals(pd.Int64Index(range(pca.pca.n_components_)))


### PR DESCRIPTION
#### Reference Issues/PRs
Create PCA transformer

#### What does this implement/fix? Explain your changes.
Implement a wrapper `PCATransformer` around `sklearn.decomposition.PCA` for column-wise PCA on time series formatted data. The transformer requires a univariate, equal length time series (i.e. DataFrame with one column and the same number of elements in each cell). Independent PCA of multiple columns can be performed using ColumnTransformer.

Examples:
```python

from sktime.datasets import load_gunpoint, load_basic_motions
from sktime.transformers.compose import ColumnTransformer
from sktime.transformers.pca import PCATransformer

# Univariate case
X, y = load_gunpoint("TRAIN", True)
pca = PCATransformer()
pca.fit_transform(X)

# Multivariate case (separate per column)
X, y = load_basic_motions('TRAIN', True)
pcas = [("pca" + str(c), PCATransformer(), [c]) for c in range(X.shape[1])]
ctf = ColumnTransformer(transformers=pcas)
ctf.fit_transform(X)
```

#### Any other comments?
* The implementation currently resides in `transformers.pca.PCATransformer` as I was unsure where it belongs. You might want to move it to any of the existing files.
* I have tried to align the documentation, naming and tests with other transformers but please double check and let me know if anything should be done differently.