### PR TITLE
Fix in tsf classifier

### DIFF
--- a/sktime/classifiers/interval_based/tsf.py
+++ b/sktime/classifiers/interval_based/tsf.py
@@ -111,7 +111,7 @@ class TimeSeriesForest(ForestClassifier):
             self.n_intervals = 1
         if self.series_length <self.min_interval:
             self.min_interval=self.series_length
-        self.intervals=np.zeros((self.n_trees, 3 * self.n_intervals, 2), dtype=int)
+        self.intervals=np.zeros((self.n_trees, self.n_intervals, 2), dtype=int)
         for i in range(0, self.n_trees):
             transformed_x = np.empty(shape=(3 * self.n_intervals, n_samps))
             # Find the random intervals for classifier i and concatentate features


### PR DESCRIPTION
Initialisation of the `self.intervals` is `np.zeros((self.n_trees, 3*self.n_intervals, 2), dtype=int)` But it should be `np.zeros((self.n_trees, self.n_intervals, 2), dtype=int)` as the range of  `j` is `range(0, self.n_intervals)`
