### PR TITLE
Added function to convert 3d numpy array to nested pandas dataframe

### DIFF
--- a/sktime/utils/data_container.py
+++ b/sktime/utils/data_container.py
@@ -288,6 +288,26 @@ def nested_to_3d_numpy(X, a=None, b=None):
             lambda row: np.stack(row), axis=1).to_numpy())
 
 
+def nd_numpy_to_nested(X):
+    """Convert NumPy ndarray with shape (n_instances, n_columns, n_timepoints)
+    into pandas DataFrame (with time series as pandas Series in cells)
+
+    Parameters
+    ----------
+    X : NumPy ndarray, input
+    
+    Returns
+    -------
+    pandas DataFrame
+    """
+    df = pd.DataFrame()
+    n_instances = X.shape[0]
+    n_variables = X.shape[1]
+    for variable in range(n_variables):
+        df['var_'+str(variable)]=[pd.Series(X[instance][variable]) for instance in range(n_instances)]
+    return df
+
+
 def is_nested_dataframe(X):
     return isinstance(X, pd.DataFrame) and isinstance(X.iloc[0, 0],
                                                       (np.ndarray, pd.Series))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the extension guidelines: https://github.com/alan-turing-institute/sktime/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes: #298 


#### What does this implement/fix? Explain your changes.
Added function to convert 3d numpy array to nested pandas dataframe


#### Does your contribution introduce a new dependency? If yes, which one? 
No

#### PR checklist for new estimators 
<!--
This is only relevant if you contribute new algorithm or estimator (classifiers, regressors, forecasters, etc
.). If so, please go through the checklist below. Otherwise please ignore check list.

- [ ] I have added unit tests and made sure they pass locally. 
- [x] I have updated the existing example notebooks or provided a new one to showcase how my algorithm works.
- [ ] I have updated sktime's [estimator overview](https://github.com/alan-turing-institute/sktime/blob/master/ESTIMATOR_OVERVIEW.md) and I'm committed to maintain my contribution and provide bug fixes if necessary.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.

Thanks for contributing!
-->
