### PR TITLE
Add missing docstrings to methods

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -51,7 +51,7 @@ GitHub account to your local disk:
 .. code-block:: bash
 
    git fetch upstream
-   git checkout dev --track origin/dev
+   git checkout --track origin/dev
    git merge upstream/dev
 
 

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -343,13 +343,38 @@ class _RecursiveReducer(OptionalForecastingHorizonMixin, BaseReducer):
 
 
 ##############################################################################
-# redution to regression
+# reduction to regression
 class DirectRegressionForecaster(ReducedTabularRegressorMixin, _DirectReducer):
+    """
+    Forecasting based on reduction to tabular regression with a direct
+    reduction strategy.
+    For the direct reduction strategy, a separate forecaster is fitted
+    for each step ahead of the forecasting horizon
+
+    Parameters
+    ----------
+    regressor : sklearn estimator object
+    window_length : int (default=10)
+    step_length : int (default=1)
+    """
     pass
 
 
 class RecursiveRegressionForecaster(ReducedTabularRegressorMixin,
                                     _RecursiveReducer):
+    """
+    Forecasting based on reduction to tabular regression with a recursive
+    reduction strategy.
+    For the recursive reduction strategy, a single estimator is
+    fit for a one-step-ahead forecasting horizon and then called
+    iteratively to predict multiple steps ahead.
+
+    Parameters
+    ----------
+    regressor : sklearn estimator object
+    window_length : int (default=10)
+    step_length : int (default=1)
+    """
     pass
 
 
@@ -357,11 +382,36 @@ class RecursiveRegressionForecaster(ReducedTabularRegressorMixin,
 # reduction to time series regression
 class DirectTimeSeriesRegressionForecaster(ReducedTimeSeriesRegressorMixin,
                                            _DirectReducer):
+    """
+    Forecasting based on reduction to time series regression with a direct
+    reduction strategy.
+    For the direct reduction strategy, a separate forecaster is fitted
+    for each step ahead of the forecasting horizon
+
+    Parameters
+    ----------
+    regressor : sklearn estimator object
+    window_length : int (default=10)
+    step_length : int (default=1)
+    """
     pass
 
 
 class RecursiveTimeSeriesRegressionForecaster(ReducedTimeSeriesRegressorMixin,
                                               _RecursiveReducer):
+    """
+    Forecasting based on reduction to time series regression with a recursive
+    reduction strategy.
+    For the recursive reduction strategy, a single estimator is
+    fit for a one-step-ahead forecasting horizon and then called
+    iteratively to predict multiple steps ahead.
+
+    Parameters
+    ----------
+    regressor : sklearn estimator object
+    window_length : int (default=10)
+    step_length : int (default=1)
+    """
     pass
 
 

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -354,8 +354,13 @@ class DirectRegressionForecaster(ReducedTabularRegressorMixin, _DirectReducer):
     Parameters
     ----------
     regressor : sklearn estimator object
-    window_length : int (default=10)
-    step_length : int (default=1)
+        Define the regression model type.
+    window_length : int, optional (default=10)
+        The length of the sliding window used to transform the series into
+        a tabular matrix
+    step_length : int, optional (default=1)
+        The number of time steps taken at each step of the sliding window
+        used to transform the series into a tabular matrix.
     """
     pass
 
@@ -372,8 +377,13 @@ class RecursiveRegressionForecaster(ReducedTabularRegressorMixin,
     Parameters
     ----------
     regressor : sklearn estimator object
-    window_length : int (default=10)
-    step_length : int (default=1)
+        Define the regression model type.
+    window_length : int, optional (default=10)
+        The length of the sliding window used to transform the series into
+        a tabular matrix
+    step_length : int, optional (default=1)
+        The number of time steps taken at each step of the sliding window
+        used to transform the series into a tabular matrix.
     """
     pass
 
@@ -390,9 +400,14 @@ class DirectTimeSeriesRegressionForecaster(ReducedTimeSeriesRegressorMixin,
 
     Parameters
     ----------
-    regressor : sklearn estimator object
-    window_length : int (default=10)
-    step_length : int (default=1)
+    regressor : sktime estimator object
+        Define the type of time series regression model.
+    window_length : int, optional (default=10)
+        The length of the sliding window used to transform the series into
+        a tabular matrix
+    step_length : int, optional (default=1)
+        The number of time steps taken at each step of the sliding window
+        used to transform the series into a tabular matrix.
     """
     pass
 
@@ -408,9 +423,14 @@ class RecursiveTimeSeriesRegressionForecaster(ReducedTimeSeriesRegressorMixin,
 
     Parameters
     ----------
-    regressor : sklearn estimator object
-    window_length : int (default=10)
-    step_length : int (default=1)
+    regressor : sktime estimator object
+        Define the type of time series regression model.
+    window_length : int, optional (default=10)
+        The length of the sliding window used to transform the series into
+        a tabular matrix
+    step_length : int, optional (default=1)
+        The number of time steps taken at each step of the sliding window
+        used to transform the series into a tabular matrix.
     """
     pass
 

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -446,6 +446,57 @@ class BaseGridSearch(BaseForecaster):
 
 
 class ForecastingGridSearchCV(BaseGridSearch):
+    """
+    Performs grid-search cross-validation to find optimal model parameters.
+    The forecaster is fit on the initial window and then temporal cross-validation is used to find the optimal parameter
+
+    Grid-search cross-validation is performed based on a cross-validation
+    iterator encoding the cross-validation scheme, the parameter grid to
+    search over, and (optionally) the evaluation metric for comparing model
+    performance. As in scikit-learn, tuning works through the common hyper-parameter
+    interface which allows to repeatedly fit and evaluate the same forecaster
+    with different hyper-parameters.
+
+    Parameters
+    ----------
+    forecaster : estimator object
+        The estimator should implement the sktime or scikit-learn estimator interface.
+        The either the estimator must contain a "score" function, or a scoring function must be passed.
+    cv : cross-validation generator or an iterable
+        e.g. SlidingWindowSplitter()
+    param_grid : dict or list of dictionaries
+        Model tuning parameters of the forecaster to evaluate via grid-search cross-validation
+    scoring: function, optional (default=None)
+        Function to score models for evaluation of optimal parameters
+    n_jobs: int, optional (default=None)
+        Number of jobs to run in parallel.
+        None means 1 unless in a joblib.parallel_backend context. -1 means using all processors.
+    refit: bool, optional (default=True)
+        Refit the forecaster with the best parameters on all the data
+    verbose: int, optional (default=0)
+    pre_dispatch: str, optional (default='2*n_jobs')
+    error_score: numeric value or the string 'raise', optional (default=np.nan)
+        The test score returned when a forecaster fails to be fitted.
+    return_train_score: bool, optional (default=False)
+
+    Attributes
+    ----------
+    best_index_ : int
+    best_score_: float
+        Score of the best model
+    best_params_ : dict
+        Best parameter values across the parameter grid
+    best_forecaster_ : estimator
+        Fitted estimator with the best parameters
+    cv_results_ : dict
+        Results from grid search cross validation
+    n_splits_: int
+        Number of splits in the data for cross validation}
+    refit_time_ : float
+        Time (seconds) to refit the best forecaster
+    scorer_ : function
+        Function used to score model
+    """
     _required_parameters = ["forecaster", "cv", "param_grid"]
 
     def __init__(self, forecaster, cv, param_grid, scoring=None,

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -448,34 +448,37 @@ class BaseGridSearch(BaseForecaster):
 class ForecastingGridSearchCV(BaseGridSearch):
     """
     Performs grid-search cross-validation to find optimal model parameters.
-    The forecaster is fit on the initial window and then temporal cross-validation is used to find the optimal parameter
+    The forecaster is fit on the initial window and then temporal
+    cross-validation is used to find the optimal parameter
 
     Grid-search cross-validation is performed based on a cross-validation
     iterator encoding the cross-validation scheme, the parameter grid to
     search over, and (optionally) the evaluation metric for comparing model
-    performance. As in scikit-learn, tuning works through the common hyper-parameter
-    interface which allows to repeatedly fit and evaluate the same forecaster
-    with different hyper-parameters.
+    performance. As in scikit-learn, tuning works through the common
+    hyper-parameter interface which allows to repeatedly fit and evaluate
+    the same forecaster with different hyper-parameters.
 
     Parameters
     ----------
     forecaster : estimator object
-        The estimator should implement the sktime or scikit-learn estimator interface.
-        The either the estimator must contain a "score" function, or a scoring function must be passed.
+        The estimator should implement the sktime or scikit-learn estimator
+        interface. Either the estimator must contain a "score" function,
+        or a scoring function must be passed.
     cv : cross-validation generator or an iterable
         e.g. SlidingWindowSplitter()
     param_grid : dict or list of dictionaries
-        Model tuning parameters of the forecaster to evaluate via grid-search cross-validation
+        Model tuning parameters of the forecaster to evaluate
     scoring: function, optional (default=None)
         Function to score models for evaluation of optimal parameters
     n_jobs: int, optional (default=None)
         Number of jobs to run in parallel.
-        None means 1 unless in a joblib.parallel_backend context. -1 means using all processors.
+        None means 1 unless in a joblib.parallel_backend context.
+        -1 means using all processors.
     refit: bool, optional (default=True)
         Refit the forecaster with the best parameters on all the data
     verbose: int, optional (default=0)
     pre_dispatch: str, optional (default='2*n_jobs')
-    error_score: numeric value or the string 'raise', optional (default=np.nan)
+    error_score: numeric value or the str 'raise', optional (default=np.nan)
         The test score returned when a forecaster fails to be fitted.
     return_train_score: bool, optional (default=False)
 

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -20,17 +20,20 @@ class PolynomialTrendForecaster(OptionalForecastingHorizonMixin,
                                 BaseSktimeForecaster):
     """
     Forecast time series data with a polynomial trend.
-    Default settings train a linear regression model with a 1st degree polynomial transformation of the feature.
+    Default settings train a linear regression model with a 1st degree
+    polynomial transformation of the feature.
 
     Parameters
     ----------
     regressor : estimator object, optional (default = None)
-        Define the regression model type. If not set, will default to sklearn.linear_model.LinearRegression
+        Define the regression model type. If not set, will default to
+         sklearn.linear_model.LinearRegression
     degree : int, optional (default = 1)
         Degree of polynomial function
     with_intercept : bool, optional (default=True)
-        If true, then include a feature in which all polynomial powers are zero.
-        (i.e. a column of ones - acts as an intercept term in a linear model)
+        If true, then include a feature in which all polynomial powers are
+        zero. (i.e. a column of ones, acts as an intercept term in a linear
+        model)
 
     Attributes
     ----------

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -18,6 +18,24 @@ from sktime.forecasting.base._sktime import OptionalForecastingHorizonMixin
 
 class PolynomialTrendForecaster(OptionalForecastingHorizonMixin,
                                 BaseSktimeForecaster):
+    """
+    Forecast time series data with a polynomial trend.
+    Default settings train a linear regression model with a 1st degree polynomial transformation of the feature.
+
+    Parameters
+    ----------
+    regressor : estimator object, optional (default = None)
+        Define the regression model type. If not set, will default to sklearn.linear_model.LinearRegression
+    degree : int, optional (default = 1)
+        Degree of polynomial function
+    with_intercept : bool, optional (default=True)
+        If true, then include a feature in which all polynomial powers are zero.
+        (i.e. a column of ones - acts as an intercept term in a linear model)
+
+    Attributes
+    ----------
+
+    """
 
     def __init__(self, regressor=None, degree=1, with_intercept=True):
         self.regressor = regressor
@@ -32,11 +50,12 @@ class PolynomialTrendForecaster(OptionalForecastingHorizonMixin,
         Parameters
         ----------
         y_train : pd.Series
-            Target time series to which to fit the forecaster.
+            Target time series with which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to to predict.
+            The forecast horizon with the steps ahead to predict.
         X_train : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored
+
         Returns
         -------
         self : returns an instance of self.
@@ -61,21 +80,25 @@ class PolynomialTrendForecaster(OptionalForecastingHorizonMixin,
 
     def predict(self, fh=None, X=None, return_pred_int=False,
                 alpha=DEFAULT_ALPHA):
-        """Make forecasts
+        """Make forecasts for the given forecast horizon
 
         Parameters
         ----------
         fh : int, list or np.array
+            The forecast horizon with the steps ahead to predict
         X : pd.DataFrame, optional (default=None)
+            Exogenous variables (ignored)
         return_pred_int : bool, optional (default=False)
+            Return the prediction intervals for the forecast.
         alpha : float or list, optional (default=0.95)
+            If alpha is iterable, multiple intervals will be calculated.
 
         Returns
         -------
         y_pred : pd.Series
-            Point predictions
+            Point predictions for the forecast
         y_pred_int : pd.DataFrame
-            Prediction intervals
+            Prediction intervals for the forecast
         """
         if return_pred_int or X is not None:
             raise NotImplementedError()

--- a/sktime/transformers/series_as_features/summarize/_extract.py
+++ b/sktime/transformers/series_as_features/summarize/_extract.py
@@ -257,7 +257,7 @@ class RandomIntervalFeatureExtractor(RandomIntervalSegmenter):
 class FittedParamExtractor(MetaEstimatorMixin,
                            _NonFittableSeriesAsFeaturesTransformer):
     """
-    Extract parameters of a fitted forecaster as features a subsequent task.
+    Extract parameters of a fitted forecaster as features for a subsequent tabular learning task.
     This class first fits a forecaster to the given time series and then
     returns the fitted parameters.
     The fitted parameters can be used as features for a tabular estimator

--- a/sktime/transformers/series_as_features/summarize/_extract.py
+++ b/sktime/transformers/series_as_features/summarize/_extract.py
@@ -257,7 +257,8 @@ class RandomIntervalFeatureExtractor(RandomIntervalSegmenter):
 class FittedParamExtractor(MetaEstimatorMixin,
                            _NonFittableSeriesAsFeaturesTransformer):
     """
-    Extract parameters of a fitted forecaster as features for a subsequent tabular learning task.
+    Extract parameters of a fitted forecaster as features for a subsequent
+    tabular learning task.
     This class first fits a forecaster to the given time series and then
     returns the fitted parameters.
     The fitted parameters can be used as features for a tabular estimator

--- a/sktime/transformers/series_as_features/summarize/_extract.py
+++ b/sktime/transformers/series_as_features/summarize/_extract.py
@@ -257,9 +257,11 @@ class RandomIntervalFeatureExtractor(RandomIntervalSegmenter):
 class FittedParamExtractor(MetaEstimatorMixin,
                            _NonFittableSeriesAsFeaturesTransformer):
     """
-    Extract parameters of a fitted forecaster as features for another algorithm.
-    This class first fits a forecaster to the given time series and then returns the fitted parameters.
-    The fitted parameters can be used as features for some tabular estimator (e.g. classification).
+    Extract parameters of a fitted forecaster as features a subsequent task.
+    This class first fits a forecaster to the given time series and then
+    returns the fitted parameters.
+    The fitted parameters can be used as features for a tabular estimator
+    (e.g. classification).
 
     Parameters
     ----------
@@ -269,7 +271,8 @@ class FittedParamExtractor(MetaEstimatorMixin,
         Name of parameters to extract from the forecaster.
     n_jobs : int, optional (default=None)
         Number of jobs to run in parallel.
-        None means 1 unless in a joblib.parallel_backend context. -1 means using all processors.
+        None means 1 unless in a joblib.parallel_backend context.
+        -1 means using all processors.
     """
     _required_parameters = ["forecaster"]
 

--- a/sktime/transformers/series_as_features/summarize/_extract.py
+++ b/sktime/transformers/series_as_features/summarize/_extract.py
@@ -256,6 +256,21 @@ class RandomIntervalFeatureExtractor(RandomIntervalSegmenter):
 
 class FittedParamExtractor(MetaEstimatorMixin,
                            _NonFittableSeriesAsFeaturesTransformer):
+    """
+    Extract parameters of a fitted forecaster as features for another algorithm.
+    This class first fits a forecaster to the given time series and then returns the fitted parameters.
+    The fitted parameters can be used as features for some tabular estimator (e.g. classification).
+
+    Parameters
+    ----------
+    forecaster : estimator object
+        sktime estimator to extract features from
+    param_names : str
+        Name of parameters to extract from the forecaster.
+    n_jobs : int, optional (default=None)
+        Number of jobs to run in parallel.
+        None means 1 unless in a joblib.parallel_backend context. -1 means using all processors.
+    """
     _required_parameters = ["forecaster"]
 
     def __init__(self, forecaster, param_names, n_jobs=None):
@@ -265,6 +280,20 @@ class FittedParamExtractor(MetaEstimatorMixin,
         super(FittedParamExtractor, self).__init__()
 
     def transform(self, X, y=None):
+        """
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Univariate time series to transform.
+        y : pd.DataFrame, optional (default=False)
+            Exogenous variables
+
+        Returns
+        -------
+        y_hat : pd.DataFrame
+            Extracted parameters; columns are parameter values
+        """
         self.check_is_fitted()
         X = check_X(X, enforce_univariate=True)
         param_names = self._check_param_names(self.param_names)

--- a/sktime/transformers/single_series/detrend/_detrend.py
+++ b/sktime/transformers/single_series/detrend/_detrend.py
@@ -15,6 +15,33 @@ from sktime.utils.validation.forecasting import check_y
 
 
 class Detrender(MetaForecasterMixin, BaseSingleSeriesTransformer):
+    """
+    Remove a trend from a series.
+    This transformer uses any forecaster and returns the in-sample residuals of the forecaster's predicted values.
+
+    The Detrender works by first fitting the forecaster to the input data.
+    To transform data, it uses the fitted forecaster to generate
+    forecasts for the time points of the passed data and returns the residuals of the forecasts.
+    Depending on the passed data, this will require it to generate in-sample or out-of-sample forecasts.
+
+    The detrender also works in a pipeline as a form of boosting,
+    by first detrending a time series and then fitting another forecaster on the residuals.
+
+    For example, to remove the linear trend of a time series:
+    forecaster = PolynomialTrendForecaster(degree=1)
+    transformer = Detrender(forecaster=forecaster)
+    yt = transformer.fit_transform(y_train)
+
+    Parameters
+    ----------
+    forecaster : estimator object
+        The forcasting model to remove the trend with (e.g. PolynomialTrendForecaster)
+
+    Attributes
+    ----------
+    forecaster_ : estimator object
+        Model that defines the trend in the series
+    """
 
     def __init__(self, forecaster):
         self.forecaster = forecaster
@@ -22,12 +49,41 @@ class Detrender(MetaForecasterMixin, BaseSingleSeriesTransformer):
         super(Detrender, self).__init__()
 
     def fit(self, y_train, X_train=None):
+        """
+        Compute the trend in the series
+
+        Parameters
+        ----------
+        y_train : pd.Series
+            Time series to fit a trend to
+        X_train : pd.DataFrame, optional (default=None)
+            Exogenous variables
+
+        Returns
+        -------
+        self : an instance of self
+        """
         forecaster = clone(self.forecaster)
         self.forecaster_ = forecaster.fit(y_train, X_train=X_train)
         self._is_fitted = True
         return self
 
     def transform(self, y, X=None):
+        """
+        Remove trend from the data.
+
+        Parameters
+        ----------
+        y : pd.Series, list
+            Time series to be detrended
+        X : pd.DataFrame, optional (default=False)
+            Exogenous variables
+
+        Returns
+        -------
+        y_hat : pd.Series
+            De-trended series
+        """
         self.check_is_fitted()
         y = check_y(y)
         fh = self._get_relative_fh(y)
@@ -35,6 +91,21 @@ class Detrender(MetaForecasterMixin, BaseSingleSeriesTransformer):
         return y - y_pred
 
     def inverse_transform(self, y, X=None):
+        """
+        Add trend back to a time series
+
+        Parameters
+        ----------
+        y : pd.Series, list
+            Detrended time series to revert
+        X : pd.DataFrame, optional (default=False)
+            Exogenous variables
+
+        Returns
+        -------
+        y_hat : pd.Series
+            Series with the trend
+        """
         self.check_is_fitted()
         y = check_y(y)
         fh = self._get_relative_fh(y)
@@ -45,16 +116,19 @@ class Detrender(MetaForecasterMixin, BaseSingleSeriesTransformer):
         return y.index.values - self.forecaster_.cutoff
 
     def update(self, y_new, update_params=False):
-        """Update fitted parameters
+        """
+        Update the parameters of the detrending estimator with new data
 
-         Parameters
-         ----------
-         y_new : pd.Series
-         update_params : bool, optional (default=False)
+        Parameters
+        ----------
+        y_new : pd.Series
+            New time series
+        update_params : bool, optional (default=False)
+            Update the parameters of the detrender model with
 
-         Returns
-         -------
-         self : an instance of self
-         """
+        Returns
+        -------
+        self : an instance of self
+        """
         self.forecaster_.update(y_new, update_params=update_params)
         return self

--- a/sktime/transformers/single_series/detrend/_detrend.py
+++ b/sktime/transformers/single_series/detrend/_detrend.py
@@ -17,15 +17,19 @@ from sktime.utils.validation.forecasting import check_y
 class Detrender(MetaForecasterMixin, BaseSingleSeriesTransformer):
     """
     Remove a trend from a series.
-    This transformer uses any forecaster and returns the in-sample residuals of the forecaster's predicted values.
+    This transformer uses any forecaster and returns the in-sample residuals
+    of the forecaster's predicted values.
 
     The Detrender works by first fitting the forecaster to the input data.
     To transform data, it uses the fitted forecaster to generate
-    forecasts for the time points of the passed data and returns the residuals of the forecasts.
-    Depending on the passed data, this will require it to generate in-sample or out-of-sample forecasts.
+    forecasts for the time points of the passed data and returns the residuals
+     of the forecasts.
+    Depending on the passed data, this will require it to generate in-sample
+    or out-of-sample forecasts.
 
     The detrender also works in a pipeline as a form of boosting,
-    by first detrending a time series and then fitting another forecaster on the residuals.
+    by first detrending a time series and then fitting another forecaster on
+    the residuals.
 
     For example, to remove the linear trend of a time series:
     forecaster = PolynomialTrendForecaster(degree=1)
@@ -35,7 +39,8 @@ class Detrender(MetaForecasterMixin, BaseSingleSeriesTransformer):
     Parameters
     ----------
     forecaster : estimator object
-        The forcasting model to remove the trend with (e.g. PolynomialTrendForecaster)
+        The forcasting model to remove the trend with
+        (e.g. PolynomialTrendForecaster)
 
     Attributes
     ----------


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #349 

#### What does this implement/fix? Explain your changes.
Docstrings have been created for the following classes:
 
-  PolynomialTrendForecaster
-  DirectRegressionForecaster
-  DirectTimeSeriesRegressionForecaster
-  RecursiveRegressionForecaster
-  RecursiveTimeSeriesRegressionForecaster
-  ForecastingGridSearchCV
-  FittedParamExtractor
-  Detrender

#### Does your contribution introduce a new dependency? If yes, which one? 
No new dependences

#### PR checklist for new estimators 
N/A
