### PR TITLE
Move prediction interval API to base classes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,0 @@
-# Even if empty this file is useful so that when running from the root folder
-# the local codebase is added to sys.path by pytest. See
-# https://docs.pytest.org/en/latest/pythonpath.html for more details.  For
-# example, this allows us to build extensions in place and run pytest using the package
-# from the local folder rather than the one from site-packages.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -85,8 +85,9 @@ class BaseForecaster(BaseEstimator):
         -------
 
         intervals : pd.DataFrame
-            A table of upper and lower bounds for each point prediction in ``y_pred``.
-            If ``alpha`` was iterable, then ``intervals`` will be a list of such tables.
+            A table of upper and lower bounds for each point prediction in
+            ``y_pred``. If ``alpha`` was iterable, then ``intervals`` will be a
+            list of such tables.
         """
         raise NotImplementedError("abstract method")
 

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -184,7 +184,7 @@ class BaseSktimeForecaster(BaseForecaster):
         """
 
         alphas = check_alpha(alpha)
-        errors = self._compute_pred_errors(alphas)
+        errors = self._compute_pred_err(alphas)
 
         # compute prediction intervals
         pred_int = [
@@ -202,7 +202,7 @@ class BaseSktimeForecaster(BaseForecaster):
         # otherwise return list of pd.DataFrames
         return pred_int
 
-    def _compute_pred_errors(self, alphas):
+    def _compute_pred_err(self, alphas):
         """Calculate the prediction errors for each point.
 
         Parameters

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -161,8 +161,8 @@ class BaseSktimeForecaster(BaseForecaster):
 
     def compute_pred_int(self, y_pred, alpha=DEFAULT_ALPHA):
         """
-        Get the prediction intervals for a forecast. Must be run *after* the forecaster
-        has been fitted.
+        Get the prediction intervals for a forecast. Must be run *after* the
+        forecaster has been fitted.
 
         If alpha is iterable, multiple intervals will be calculated.
 
@@ -179,8 +179,9 @@ class BaseSktimeForecaster(BaseForecaster):
         -------
 
         intervals : pd.DataFrame
-            A table of upper and lower bounds for each point prediction in ``y_pred``.
-            If ``alpha`` was iterable, then ``intervals`` will be a list of such tables.
+            A table of upper and lower bounds for each point prediction in
+            ``y_pred``. If ``alpha`` was iterable, then ``intervals`` will be a
+            list of such tables.
         """
 
         alphas = check_alpha(alpha)
@@ -215,8 +216,8 @@ class BaseSktimeForecaster(BaseForecaster):
         -------
 
         errors : list of pd.Series
-            Each series in the list will contain the errors for each point in the
-            forecast for the corresponding alpha.
+            Each series in the list will contain the errors for each point in
+            the forecast for the corresponding alpha.
         """
         raise NotImplementedError("abstract method")
 

--- a/sktime/forecasting/tests/test_theta.py
+++ b/sktime/forecasting/tests/test_theta.py
@@ -1,7 +1,6 @@
 __author__ = ["@big-o"]
 
 import numpy as np
-import pandas as pd
 import pytest
 from sktime.datasets import load_airline
 from sktime.forecasting.model_selection import temporal_train_test_split

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -192,7 +192,7 @@ class ThetaForecaster(ExponentialSmoothing):
 
         return drift
 
-    def _compute_pred_errors(self, alphas):
+    def _compute_pred_err(self, alphas):
         """
         Get the prediction errors for the forecast.
         """

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -222,4 +222,3 @@ class ThetaForecaster(ExponentialSmoothing):
                 "smoothing_level"]
             self.trend_ = self._compute_trend(y_new)
         return self
-


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the extension guidelines: https://github.com/alan-turing-institute/sktime/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented. 
-->
Most of the code in `ThetaForecaster` for computing prediction intervals is applicable to all forecasters. I've moved that code out into the base classes (`_base.py` and `_sktime.py`), leaving only the parts that are specific to the Theta algorithm in `ThetaForecaster`.

An added benefit is that all forecasters will now have a `compute_pred_int` method, allowing for a common API. If the method hasn't been implemented for a forecaster, a `NotImplementedError` will be raised.

I wasn't sure whether my changes belonged in `_base.py` or `_sktime.py`. Let me know if I've got it wrong and I can change it.

#### Does your contribution introduce a new dependency? If yes, which one? 

<!--
If your contribution does add a new dependency, we may suggest to initially develop your contribution in a separate
 companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum. 
-->
No

#### PR checklist for new estimators 
<!--
This is only relevant if you contribute a new estimator
 (classifiers, regressors, forecasters, etc
.). If so, please go through the checklist below. Otherwise please ignore check list.

- [ ] I've added unit tests and made sure they pass locally. 
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.
- [ ] I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/master/CODEOWNERS) and I'm committed to maintain my algorithm.
- [ ] I've added myself to the list of contributors
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.

Thanks for contributing!
-->
The old `compute_pred_int` code had a minor bug in it. It's supposed to return a list of intervals if you provide an iterable of alphas. However if you provide an iterable of length 1, `compute_pred_int` just gives you a single set of intervals, not in a list. This has been fixed now, so the output type is based on the type of input provided for `alpha`, rather than the number of alphas provided.