### PR TITLE
Update 01_forecasting.ipynb

### DIFF
--- a/examples/01_forecasting.ipynb
+++ b/examples/01_forecasting.ipynb
@@ -244,7 +244,7 @@
     "forecaster = NaiveForecaster(strategy=\"last\")\n",
     "forecaster.fit(y_train)\n",
     "y_last = forecaster.predict(fh)\n",
-    "plot_ys(y_train, y_test, y_pred, labels=[\"y_train\", \"y_test\", \"y_pred\"]);\n",
+    "plot_ys(y_train, y_test, y_last, labels=[\"y_train\", \"y_test\", \"y_last\"]);\n",
     "smape_loss(y_last, y_test)"
    ]
   },


### PR DESCRIPTION
While this does not change the plot, it improves clarity since it explicitly uses the output of forecaster.predict(fh), i.e., "y_last" instead of the numpy interpolation from the previous cell (y_pred).
