### PR TITLE
Avoid seaborn warning

### DIFF
--- a/sktime/utils/plotting/__init__.py
+++ b/sktime/utils/plotting/__init__.py
@@ -73,7 +73,7 @@ def plot_series(*series, labels=None):
         else:
             plot_func = sns.lineplot
 
-        plot_func(x, y, ax=ax, marker="o", label=label, color=color)
+        plot_func(x=x, y=y, ax=ax, marker="o", label=label, color=color)
 
     # set combined index as xticklabels, suppress matplotlib warning
     with warnings.catch_warnings():


### PR DESCRIPTION
The function as written produces the following warning (which will become an error)
```
/usr/local/lib/python3.7/site-packages/seaborn/_decorators.py:43: FutureWarning: Pass the following variables as keyword args: x, y. From version 0.12, the only valid positional argument will be `data`, and passing other arguments without an explicit keyword will result in an error or misinterpretation.
  FutureWarning
```
Tested with 
sktime: '0.4.3'
seaborn: ''0.11.0'

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
This removes a warning
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
No
-->


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/master/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/master/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.

Thanks for contributing!
-->
