### PR TITLE
Add parallelization for training the `RandomIntervalSpectralForest`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -606,6 +606,7 @@
       "avatar_url": "https://avatars2.githubusercontent.com/u/22359569?v=4",
       "profile": "https://github.com/AaronX121",
       "contributions": [
+        "code",
         "doc"
       ]
     },

--- a/sktime/classification/frequency_based/_rise.py
+++ b/sktime/classification/frequency_based/_rise.py
@@ -81,17 +81,21 @@ class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):
     ----------
     n_estimators : int, optional (default=200)
         The number of trees in the forest.
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
     min_interval : int, optional (default=16)
         The minimum width of an interval.
     acf_lag : int, optional (default=100)
         The maximum number of autocorrelation terms to use.
     acf_min_values : int, optional (default=4)
         Never use fewer than this number of terms to find a correlation.
+    n_jobs : int or None, optional (default=None)
+        The number of jobs to run in parallel for both `fit` and `predict`.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors.
+    random_state : int, RandomState instance or None, optional (default=None)
+        If int, random_state is the seed used by the random number generator;
+        If RandomState instance, random_state is the random number generator;
+        If None, the random number generator is the RandomState instance used
+        by `np.random`.
 
     Attributes
     ----------


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

The training stage of `RandomIntervalSpectralForest` is quite slow because decision trees are fitted sequentially within a loop.

This PR uses `joblib.Parallel` and `joblib.delayed` to parallelize the training stage of `RandomIntervalSpectralForest`. Following the routine in `_forest.py` from `scikit-learn`, a private function named `_parallel_build_trees` is added to support parallelization. [Reference](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/ensemble/_forest.py#L140).

This PR also includes improvements on the docstrings for better readability and style consistency.

Changes:
In my personal experiment, by setting `n_jobs` to `-1` (i.e., using all processors), fitting a `RandomIntervalSpectralForest` with `100` decision trees on `Adiac` dataset is able to speed up the training time by over 6 times on a CPU with 10 physical cores, and the results with the random state fixed are exactly the same.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

Since `joblib` is required by `scikit-learn`, and `scikit-learn` is required by `sktime`, the answer is No ;-)

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/master/.all-contributorsrc).
