### PR TITLE
Implement the `feature_importances_` property for RISE

### DIFF
--- a/sktime/classification/frequency_based/_rise.py
+++ b/sktime/classification/frequency_based/_rise.py
@@ -161,6 +161,13 @@ class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):
         # We need to add is-fitted state when inheriting from scikit-learn
         self._is_fitted = False
 
+    @property
+    def feature_importances_(self):
+        raise NotImplementedError(
+            "The impurity-based feature importances of "
+            "RandomIntervalSpectralForest is currently not supported."
+        )
+
     def fit(self, X, y):
         """
         Build a forest of trees from the training set (X, y) using random
@@ -340,10 +347,10 @@ def acf(x, max_lag):
         y[lag - 1] = y[lag - 1] / (length - lag)
         v1 = ss1 / (length - lag) - s1 * s1
         v2 = ss2 / (length - lag) - s2 * s2
-        if v1 <= 0.000000001 and v2 <= 0.000000001:  # Both zero variance,
+        if v1 <= 1e-9 and v2 <= 1e-9:  # Both zero variance,
             # so must be 100% correlated
             y[lag - 1] = 1
-        elif v1 <= 0.000000001 or v2 <= 0.000000001:  # One zero variance
+        elif v1 <= 1e-9 or v2 <= 1e-9:  # One zero variance
             # the other not
             y[lag - 1] = 0
         else:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #493.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

This PR overrides the `feature_importances_` property for RISE to avoid calling `feature_importances_` from its parent class in scikit-learn and raising un-recognized errors.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

