### PR TITLE
Fix plot-series

### DIFF
--- a/sktime/utils/plotting/__init__.py
+++ b/sktime/utils/plotting/__init__.py
@@ -5,8 +5,6 @@
 __all__ = ["plot_series"]
 __author__ = ["Markus Löning"]
 
-import warnings
-
 import numpy as np
 
 from sktime.utils.check_imports import _check_soft_dependencies
@@ -30,6 +28,8 @@ def plot_series(*series, labels=None):
     """
     _check_soft_dependencies("matplotlib", "seaborn")
     import matplotlib.pyplot as plt
+    from matplotlib.ticker import FuncFormatter, MaxNLocator
+    from matplotlib.cbook import flatten
     import seaborn as sns
 
     n_series = len(series)
@@ -75,10 +75,19 @@ def plot_series(*series, labels=None):
 
         plot_func(x=x, y=y, ax=ax, marker="o", label=label, color=color)
 
-    # set combined index as xticklabels, suppress matplotlib warning
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore")
-        ax.set(xticklabels=index)
+    # combine data points for all series
+    xs_flat = list(flatten(xs))
+
+    # set x label of data point to the matching index
+    def format_fn(tick_val, tick_pos):
+        if int(tick_val) in xs_flat:
+            return index[int(tick_val)]
+        else:
+            return ""
+
+    # dynamically set x label ticks and spacing from index labels
+    ax.xaxis.set_major_formatter(FuncFormatter(format_fn))
+    ax.xaxis.set_major_locator(MaxNLocator(integer=True))
 
     if legend:
         ax.legend()


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #519 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
As the issue points out, the x-axis labels don't match with the data points plotted. It turns out that mathplotlib recommends  [a different solution](https://matplotlib.org/examples/ticks_and_spines/tick_labels_from_values.html) for dynamically assigning tick labels from a list. I tweaked this code a bit to accommodate multiple series, which gives this result:

```
y = load_airline()
y = y[:48]
fh=np.arange(1, 13)

y_train, y_test = temporal_train_test_split(y, test_size=len(fh))
plot_series(y_train, y_test, labels=["y_train", "y_test"]);
print(y.shape, y_train.shape[0], y_test.shape[0])
print(y.index)
```

> (48,) 36 12
> PeriodIndex(['1949-01', '1949-02', '1949-03', '1949-04', '1949-05', '1949-06',
> '1949-07', '1949-08', '1949-09', '1949-10', '1949-11', '1949-12',
> '1950-01', '1950-02', '1950-03', '1950-04', '1950-05', '1950-06',
> '1950-07', '1950-08', '1950-09', '1950-10', '1950-11', '1950-12',
> '1951-01', '1951-02', '1951-03', '1951-04', '1951-05', '1951-06',
> '1951-07', '1951-08', '1951-09', '1951-10', '1951-11', '1951-12',
> '1952-01', '1952-02', '1952-03', '1952-04', '1952-05', '1952-06',
> '1952-07', '1952-08', '1952-09', '1952-10', '1952-11', '1952-12'],
> dtype='period[M]', name='Period', freq='M')

![image](https://user-images.githubusercontent.com/38268331/101943620-68e8ae00-3bb9-11eb-85f3-1232c0918d34.png)


#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No, I just imported some new functions from mathplotlib.ticker and mathplotlib.cbook.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/master/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/master/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.

Thanks for contributing!
-->
I'm not too sure what parts of the PR checklist are relevant - feel free to let me know if there are any changes / additional actions that I should take!