### PR TITLE
Fixed issue outlined in issue 522

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -702,7 +702,7 @@
       "profile": "https://github.com/ngupta23",
       "contributions": [
         "code",
-        "bug"        
+        "bug"
       ]
     }
   ],

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -694,6 +694,16 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "ngupta23",
+      "name": "Nikhil Gupta",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/33585645?v=4",
+      "profile": "https://github.com/ngupta23",
+      "contributions": [
+        "code",
+        "bug"        
+      ]
     }
   ],
   "projectName": "sktime",

--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -301,8 +301,6 @@ class AutoARIMA(_OptionalForecastingHorizonMixin, _SktimeForecaster):
 
         super(AutoARIMA, self).__init__()
 
-        
-
     def fit(self, y, X=None, fh=None, **fit_params):
         """Fit to training data.
 

--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -5,7 +5,7 @@
 __author__ = ["Markus Löning"]
 __all__ = ["AutoARIMA"]
 
-import pandas as pd
+import pandas as pd  # type: ignore
 
 from sktime.forecasting.base._base import DEFAULT_ALPHA
 from sktime.forecasting.base._sktime import _SktimeForecaster
@@ -297,53 +297,11 @@ class AutoARIMA(_OptionalForecastingHorizonMixin, _SktimeForecaster):
         self.scoring = scoring
         self.scoring_args = scoring_args
         self.with_intercept = with_intercept
+        self.model_kwargs = kwargs
 
         super(AutoARIMA, self).__init__()
 
-        # import inside method to avoid hard dependency
-        from pmdarima.arima import AutoARIMA as _AutoARIMA
-
-        self._forecaster = _AutoARIMA(
-            start_p=start_p,
-            d=d,
-            start_q=start_q,
-            max_p=max_p,
-            max_d=max_d,
-            max_q=max_q,
-            start_P=start_P,
-            D=D,
-            start_Q=start_Q,
-            max_P=max_P,
-            max_D=max_D,
-            max_Q=max_Q,
-            max_order=max_order,
-            m=sp,
-            seasonal=seasonal,
-            stationary=stationary,
-            information_criterion=information_criterion,
-            alpha=alpha,
-            test=test,
-            seasonal_test=seasonal_test,
-            stepwise=stepwise,
-            n_jobs=n_jobs,
-            start_params=None,
-            trend=trend,
-            method=method,
-            maxiter=maxiter,
-            offset_test_args=offset_test_args,
-            seasonal_test_args=seasonal_test_args,
-            suppress_warnings=suppress_warnings,
-            error_action=error_action,
-            trace=trace,
-            random=random,
-            random_state=random_state,
-            n_fits=n_fits,
-            out_of_sample_size=out_of_sample_size,
-            scoring=scoring,
-            scoring_args=scoring_args,
-            with_intercept=with_intercept,
-            **kwargs
-        )
+        
 
     def fit(self, y, X=None, fh=None, **fit_params):
         """Fit to training data.
@@ -360,6 +318,51 @@ class AutoARIMA(_OptionalForecastingHorizonMixin, _SktimeForecaster):
         -------
         self : returns an instance of self.
         """
+        # import inside method to avoid hard dependency
+        from pmdarima.arima import AutoARIMA as _AutoARIMA  # type: ignore
+
+        self._forecaster = _AutoARIMA(
+            start_p=self.start_p,
+            d=self.d,
+            start_q=self.start_q,
+            max_p=self.max_p,
+            max_d=self.max_d,
+            max_q=self.max_q,
+            start_P=self.start_P,
+            D=self.D,
+            start_Q=self.start_Q,
+            max_P=self.max_P,
+            max_D=self.max_D,
+            max_Q=self.max_Q,
+            max_order=self.max_order,
+            m=self.sp,
+            seasonal=self.seasonal,
+            stationary=self.stationary,
+            information_criterion=self.information_criterion,
+            alpha=self.alpha,
+            test=self.test,
+            seasonal_test=self.seasonal_test,
+            stepwise=self.stepwise,
+            n_jobs=self.n_jobs,
+            start_params=None,
+            trend=self.trend,
+            method=self.method,
+            maxiter=self.maxiter,
+            offset_test_args=self.offset_test_args,
+            seasonal_test_args=self.seasonal_test_args,
+            suppress_warnings=self.suppress_warnings,
+            error_action=self.error_action,
+            trace=self.trace,
+            random=self.random,
+            random_state=self.random_state,
+            n_fits=self.n_fits,
+            out_of_sample_size=self.out_of_sample_size,
+            scoring=self.scoring,
+            scoring_args=self.scoring_args,
+            with_intercept=self.with_intercept,
+            **self.model_kwargs
+        )
+
         self._set_y_X(y, X)
         self._set_fh(fh)
         self._forecaster.fit(y, X, **fit_params)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes https://github.com/alan-turing-institute/sktime/issues/522


#### What does this implement/fix? Explain your changes.
As outlined in https://github.com/alan-turing-institute/sktime/issues/522, this fix allows using AutoARIMA with the sliding window forecaster along with Grid Search. This can allow for the search of the right hyperparameters such as sp.

#### Does your contribution introduce a new dependency? If yes, which one?

No. `pmdarima` is already a soft dependency and this simply uses that.


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/master/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/master/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally. 
  - I tested locally in a notebook and it works. I am only familiar with `unittest` and had some issues setting up `pytest` on my end so I could not add a unit test specifically for this. If you could add it for me, I would appreciate it. The code is as follows

```python
y = load_airline()
y_train, y_test = temporal_train_test_split(y, test_size=36)

forecaster_param_grid = {'sp': [3, 12]}
forecaster = AutoARIMA(suppress_warnings=True)

cv = SlidingWindowSplitter(
    initial_window=int(len(y_train) * 0.5),
    start_with_window=True,
    window_length=36,
)

gscv = ForecastingGridSearchCV(forecaster, cv=cv, param_grid=forecaster_param_grid, verbose=True)
gscv.fit(y_train)

expected = np.array([0.37408572, 0.29277678])
np.testing.assert_array_equal(gscv.cv_results_['mean_test_sMAPE'], expected)
```

