### PR TITLE
Add SlidingWindowSplitter visualization on doctrings

### DIFF
--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -177,18 +177,18 @@ class SlidingWindowSplitter(BaseWindowSplitter):
     Examples
     --------
     For example for `window_length = 5`, `step_length = 1` and `fh = 3`
-    here is a representation of the folds:
-    ```
+    here is a representation of the folds::
+    
     |-----------------------|
     | * * * * * x x x - - - |
     | - * * * * * x x x - - |
     | - - * * * * * x x x - |
     | - - - * * * * * x x x |
-    ```
+    
 
-    `*` = training fold.
+    ``*`` = training fold.
 
-    `x` = test fold.
+    ``x`` = test fold.
     """
 
     def __init__(

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -178,13 +178,13 @@ class SlidingWindowSplitter(BaseWindowSplitter):
     --------
     For example for `window_length = 5`, `step_length = 1` and `fh = 3`
     here is a representation of the folds::
-    
+
     |-----------------------|
     | * * * * * x x x - - - |
     | - * * * * * x x x - - |
     | - - * * * * * x x x - |
     | - - - * * * * * x x x |
-    
+
 
     ``*`` = training fold.
 

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -173,6 +173,19 @@ class SlidingWindowSplitter(BaseWindowSplitter):
     step_length : int
     initial_window : int
     start_with_window : bool, optional (default=True)
+
+    Examples
+    --------
+    For example for `window_length = 5`, `step_length = 1` and `fh = 3`
+    here is a representation of the folds:
+    |-----------------------|
+    | * * * * * x x x - - - |
+    | - * * * * * x x x - - |
+    | - - * * * * * x x x - |
+    | - - - * * * * * x x x |
+
+    * = training fold.
+    x = test fold.
     """
 
     def __init__(

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -178,14 +178,17 @@ class SlidingWindowSplitter(BaseWindowSplitter):
     --------
     For example for `window_length = 5`, `step_length = 1` and `fh = 3`
     here is a representation of the folds:
+    ```
     |-----------------------|
     | * * * * * x x x - - - |
     | - * * * * * x x x - - |
     | - - * * * * * x x x - |
     | - - - * * * * * x x x |
+    ```
 
-    * = training fold.
-    x = test fold.
+    `*` = training fold.
+
+    `x` = test fold.
     """
 
     def __init__(


### PR DESCRIPTION
Partially solves [Issue 477](https://github.com/alan-turing-institute/sktime/issues/477). This PR simply adds an example of the `SlidingWindowSplitter` folds to the docstring class.