### PR TITLE
Pin pandas version to fix pandas-related AutoETS error on Linux 

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -5,7 +5,7 @@ hcrystalball>=0.1.9
 matplotlib
 notebook
 numba==0.50.*
-pandas>=1.1.0
+pandas==1.1.5
 pmdarima>=1.8.0
 scikit-learn==0.23.*
 scikit-posthocs

--- a/build_tools/hard_dependencies.txt
+++ b/build_tools/hard_dependencies.txt
@@ -1,6 +1,6 @@
 cython>=0.29.0
 numba==0.50.*
-pandas>=1.1.0
+pandas==1.1.5
 scikit-learn==0.23.*
 statsmodels>=0.12.1
 wheel

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -3,7 +3,7 @@ cython>=0.29.0
 fbprophet>=0.7.1
 hcrystalball>=0.1.9
 numba==0.50.*
-pandas>=1.1.0
+pandas==1.1.5
 pmdarima>=1.8.0
 pytest
 pytest-cov


### PR DESCRIPTION
#### Reference Issues/PRs
On Linux (manylinux) with Python 3.7, `sktime/forecasting/tests/test_ets.py` fails with `pandas==1.2.0` for some reason, see e.g. #559 

#### What does this implement/fix? Explain your changes.
Pin pandas to `pandas==1.1.5`
