### PR TITLE
Fixes _fit(X)

### DIFF
--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -247,11 +247,11 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
         return fx
 
     def _more_tags(self):
-        """ Removes the need to pass y with _fit
+        """Removes the need to pass y with _fit
         Overrides the scikit learn (>0.23) base class setting where 'requires_y' is true
         so we can call fx = self._fit(X) and maintain backward compatibility. 
         """
-        return {'requires_y': False}
+        return {"requires_y": False}
 
     def kneighbors(self, X, n_neighbors=None, return_distance=True):
         """Finds the K-neighbors of a point.

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -188,8 +188,6 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
         X, y = check_X_y(X, y, enforce_univariate=False, coerce_to_numpy=True)
         y = np.asarray(y)
         check_classification_targets(y)
-        print(f" dimensions of X are {X.shape}")
-        print(X)
         # if internal cv is desired, the relevant flag forces a grid search
         # to evaluate the possible values,
         # find the best, and then set this classifier's params to match

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -188,8 +188,8 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
         X, y = check_X_y(X, y, enforce_univariate=False, coerce_to_numpy=True)
         y = np.asarray(y)
         check_classification_targets(y)
-
-        # print(X)
+        print(f" dimensions of X are {X.shape}")
+        print(X)
         # if internal cv is desired, the relevant flag forces a grid search
         # to evaluate the possible values,
         # find the best, and then set this classifier's params to match
@@ -236,8 +236,9 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
         else:
             temp = check_array.__code__
             check_array.__code__ = _check_array_ts.__code__
-
-        fx = self._fit(X, self._y)
+        #  this not fx = self._fit(X, self_y) in order to maintain backward
+        # compatibility with scikit learn 0.23, where _fit does not take an arg y
+        fx = self._fit(X)
 
         if hasattr(check_array, "__wrapped__"):
             check_array.__wrapped__.__code__ = temp
@@ -246,6 +247,13 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
 
         self._is_fitted = True
         return fx
+
+    def _more_tags(self):
+        """ Removes the need to pass y with _fit
+        Overrides the scikit learn (>0.23) base class setting where 'requires_y' is true
+        so we can call fx = self._fit(X) and maintain backward compatibility. 
+        """
+        return {'requires_y': False}
 
     def kneighbors(self, X, n_neighbors=None, return_distance=True):
         """Finds the K-neighbors of a point.

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -249,7 +249,7 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
     def _more_tags(self):
         """Removes the need to pass y with _fit
         Overrides the scikit learn (>0.23) base class setting where 'requires_y' is true
-        so we can call fx = self._fit(X) and maintain backward compatibility. 
+        so we can call fx = self._fit(X) and maintain backward compatibility.
         """
         return {"requires_y": False}
 


### PR DESCRIPTION
#### Reference Issues/PRs

 Fixes #608 . See also #596.

#### What does this implement/fix? Explain your changes.

scikit learn changed how KNN works in v0.24. _fit(X) was replaced by _fit(X, y=None), with a test for a _tag whether 'requires_y' is true. this is called in sklearn/neighbors/_base.py function_fit. 

y is not actually required. Fixed by implementing
   def _more_tags(self):
        return {'requires_y': False}
 this will overwrite the base class requires_y: True, since this function _get_tags is calls all _more_tags in the inheritance hierarchy in reverse order, from base class to self, using inspect.getmro, which seems to be pythons version of reflection. 
