### PR TITLE
Make update_params=true by default

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -87,14 +87,14 @@ class BaseForecaster(BaseEstimator):
         """
         raise NotImplementedError("abstract method")
 
-    def update(self, y, X=None, update_params=False):
+    def update(self, y, X=None, update_params=True):
         """Update fitted parameters
 
         Parameters
         ----------
         y : pd.Series
         X : pd.DataFrame
-        update_params : bool, optional (default=False)
+        update_params : bool, optional (default=True)
 
         Returns
         -------
@@ -107,7 +107,7 @@ class BaseForecaster(BaseEstimator):
         y,
         cv=None,
         X=None,
-        update_params=False,
+        update_params=True,
         return_pred_int=False,
         alpha=DEFAULT_ALPHA,
     ):
@@ -118,7 +118,7 @@ class BaseForecaster(BaseEstimator):
         y : pd.Series
         cv : cross-validation generator, optional (default=None)
         X : pd.DataFrame, optional (default=None)
-        update_params : bool, optional (default=False)
+        update_params : bool, optional (default=True)
         return_pred_int : bool, optional (default=False)
         alpha : int or list of ints, optional (default=None)
 
@@ -136,7 +136,7 @@ class BaseForecaster(BaseEstimator):
         y_new,
         fh=None,
         X=None,
-        update_params=False,
+        update_params=True,
         return_pred_int=False,
         alpha=DEFAULT_ALPHA,
     ):

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -349,7 +349,15 @@ class _SktimeForecaster(BaseForecaster):
         return self.predict(fh, X, return_pred_int=return_pred_int, alpha=alpha)
 
     def update(self, y, X=None, update_params=True):
-        """Update fitted parameters
+        """Update cutoff value and, optionally, fitted parameters.
+
+        This is useful in an online learning setting where new data is observed as
+        time moves on. Updating the cutoff value allows to generate new predictions
+        from the most recent time point that was observed. Updating the fitted
+        parameters allows to incrementally update the parameters without having to
+        completely refit. However, note that if no estimator-specific update method
+        has been implemented for updating parameters refitting is the default fall-back
+        option.
 
         Parameters
         ----------

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -371,6 +371,7 @@ class _SktimeForecaster(BaseForecaster):
                 f"{self.__class__.__name__} will be refit each time "
                 f"`update` is called."
             )
+            # refit with updated data, not only passed data
             self.fit(self._y, self._X, self.fh)
         return self
 

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -6,6 +6,7 @@ __author__ = ["Markus Löning", "@big-o"]
 __all__ = ["_SktimeForecaster", "_BaseWindowForecaster"]
 
 from contextlib import contextmanager
+from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -60,7 +61,7 @@ class _SktimeForecaster(BaseForecaster):
             if X is len(X) > 0:
                 self._X = X.combine_first(self._X)
 
-    def _update_y_X(self, y, X=None, enfore_index_type=None):
+    def _update_y_X(self, y, X=None, enforce_index_type=None):
         """Update training data.
 
         Parameters
@@ -71,7 +72,7 @@ class _SktimeForecaster(BaseForecaster):
             Exogenous time series
         """
         # update only for non-empty data
-        y, X = check_y_X(y, X, allow_empty=True, enforce_index_type=enfore_index_type)
+        y, X = check_y_X(y, X, allow_empty=True, enforce_index_type=enforce_index_type)
 
         if len(y) > 0:
             self._y = y.combine_first(self._y)
@@ -290,7 +291,7 @@ class _SktimeForecaster(BaseForecaster):
         y_new,
         fh=None,
         X=None,
-        update_params=False,
+        update_params=True,
         return_pred_int=False,
         alpha=DEFAULT_ALPHA,
     ):
@@ -334,7 +335,7 @@ class _SktimeForecaster(BaseForecaster):
         y,
         fh,
         X=None,
-        update_params=False,
+        update_params=True,
         return_pred_int=False,
         alpha=DEFAULT_ALPHA,
     ):
@@ -347,27 +348,30 @@ class _SktimeForecaster(BaseForecaster):
         self.update(y, X, update_params=update_params)
         return self.predict(fh, X, return_pred_int=return_pred_int, alpha=alpha)
 
-    def update(self, y, X=None, update_params=False):
+    def update(self, y, X=None, update_params=True):
         """Update fitted parameters
 
         Parameters
         ----------
         y : pd.Series
         X : pd.DataFrame
-        update_params : bool, optional (default=False)
+        update_params : bool, optional (default=True)
 
         Returns
         -------
         self : an instance of self
         """
-        if update_params:
-            raise NotImplementedError(
-                f"{self.__class__.__name__} does not "
-                f"yet support updating fitted "
-                f"parameters."
-            )
         self.check_is_fitted()
         self._update_y_X(y, X)
+        if update_params:
+            # default to re-fitting if update is not implemented
+            warn(
+                f"NotImplementedWarning: {self.__class__.__name__} "
+                f"does not have a custom `update` method implemented. "
+                f"{self.__class__.__name__} will be refit each time "
+                f"`update` is called."
+            )
+            self.fit(self._y, self._X, self.fh)
         return self
 
     def update_predict(
@@ -375,7 +379,7 @@ class _SktimeForecaster(BaseForecaster):
         y,
         cv=None,
         X=None,
-        update_params=False,
+        update_params=True,
         return_pred_int=False,
         alpha=DEFAULT_ALPHA,
     ):
@@ -386,7 +390,7 @@ class _SktimeForecaster(BaseForecaster):
         y : pd.Series
         cv : temporal cross-validation generator, optional (default=None)
         X : pd.DataFrame, optional (default=None)
-        update_params : bool, optional (default=False)
+        update_params : bool, optional (default=True)
         return_pred_int : bool, optional (default=False)
         alpha : int or list of ints, optional (default=None)
 
@@ -416,7 +420,7 @@ class _SktimeForecaster(BaseForecaster):
         y,
         cv,
         X=None,
-        update_params=False,
+        update_params=True,
         return_pred_int=False,
         alpha=DEFAULT_ALPHA,
     ):
@@ -582,7 +586,7 @@ class _BaseWindowForecaster(_SktimeForecaster):
         y,
         cv=None,
         X=None,
-        update_params=False,
+        update_params=True,
         return_pred_int=False,
         alpha=DEFAULT_ALPHA,
     ):
@@ -593,7 +597,7 @@ class _BaseWindowForecaster(_SktimeForecaster):
         y : pd.Series
         cv : temporal cross-validation generator, optional (default=None)
         X : pd.DataFrame, optional (default=None)
-        update_params : bool, optional (default=False)
+        update_params : bool, optional (default=True)
         return_pred_int : bool, optional (default=False)
         alpha : int or list of ints, optional (default=None)
 
@@ -743,7 +747,7 @@ class _BaseWindowForecaster(_SktimeForecaster):
         y,
         fh,
         X=None,
-        update_params=False,
+        update_params=True,
         return_pred_int=False,
         alpha=DEFAULT_ALPHA,
     ):

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -53,14 +53,14 @@ class EnsembleForecaster(
         self._is_fitted = True
         return self
 
-    def update(self, y, X=None, update_params=False):
+    def update(self, y, X=None, update_params=True):
         """Update fitted parameters
 
         Parameters
         ----------
         y : pd.Series
         X : pd.DataFrame
-        update_params : bool, optional (default=False)
+        update_params : bool, optional (default=True)
 
         Returns
         -------

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -132,14 +132,14 @@ class TransformedTargetForecaster(
 
         return y_pred
 
-    def update(self, y, X=None, update_params=False):
+    def update(self, y, X=None, update_params=True):
         """Update fitted parameters
 
         Parameters
         ----------
         y : pd.Series
         X : pd.DataFrame
-        update_params : bool, optional (default=False)
+        update_params : bool, optional (default=True)
 
         Returns
         -------

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -13,6 +13,8 @@ __all__ = [
     "ReducedForecaster",
 ]
 
+from warnings import warn
+
 import numpy as np
 import pandas as pd
 from sklearn.base import clone
@@ -43,23 +45,32 @@ class BaseReducer(_BaseWindowForecaster):
         self.step_length_ = None
         self._cv = None
 
-    def update(self, y, X=None, update_params=False):
+    def update(self, y, X=None, update_params=True):
         """Update fitted parameters
 
         Parameters
         ----------
         y : pd.Series
         X : pd.DataFrame
-        update_params : bool, optional (default=False)
+        update_params : bool, optional (default=True)
 
         Returns
         -------
         self : an instance of self
         """
-        if X is not None or update_params:
+        if X is not None:
             raise NotImplementedError()
         self.check_is_fitted()
         self._update_y_X(y, X)
+        if update_params:
+            # default to re-fitting if update is not implemented
+            warn(
+                f"NotImplementedWarning: {self.__class__.__name__} "
+                f"does not have a custom `update` method implemented. "
+                f"{self.__class__.__name__} will be refit each time "
+                f"`update` is called."
+            )
+            self.fit(self._y, self._X, self.fh)
         return self
 
     def _transform(self, y, X=None):

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -13,8 +13,6 @@ __all__ = [
     "ReducedForecaster",
 ]
 
-from warnings import warn
-
 import numpy as np
 import pandas as pd
 from sklearn.base import clone
@@ -24,8 +22,8 @@ from sktime.forecasting.base._sktime import _BaseWindowForecaster
 from sktime.forecasting.base._sktime import _OptionalForecastingHorizonMixin
 from sktime.forecasting.base._sktime import _RequiredForecastingHorizonMixin
 from sktime.forecasting.model_selection import SlidingWindowSplitter
-from sktime.utils.validation.forecasting import check_step_length
 from sktime.utils.validation import check_window_length
+from sktime.utils.validation.forecasting import check_step_length
 from sktime.utils.validation.forecasting import check_y
 
 
@@ -44,34 +42,6 @@ class BaseReducer(_BaseWindowForecaster):
         self.step_length = step_length
         self.step_length_ = None
         self._cv = None
-
-    def update(self, y, X=None, update_params=True):
-        """Update fitted parameters
-
-        Parameters
-        ----------
-        y : pd.Series
-        X : pd.DataFrame
-        update_params : bool, optional (default=True)
-
-        Returns
-        -------
-        self : an instance of self
-        """
-        if X is not None:
-            raise NotImplementedError()
-        self.check_is_fitted()
-        self._update_y_X(y, X)
-        if update_params:
-            # default to re-fitting if update is not implemented
-            warn(
-                f"NotImplementedWarning: {self.__class__.__name__} "
-                f"does not have a custom `update` method implemented. "
-                f"{self.__class__.__name__} will be refit each time "
-                f"`update` is called."
-            )
-            self.fit(self._y, self._X, self.fh)
-        return self
 
     def _transform(self, y, X=None):
         """Transform data using rolling window approach"""

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -72,14 +72,14 @@ class StackingForecaster(
         self._is_fitted = True
         return self
 
-    def update(self, y, X=None, update_params=False):
+    def update(self, y, X=None, update_params=True):
         """Update fitted parameters
 
         Parameters
         ----------
         y : pd.Series
         X : pd.DataFrame
-        update_params : bool, optional (default=False)
+        update_params : bool, optional (default=True)
 
         Returns
         -------

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -39,7 +39,7 @@ def compute_expected_gscv_scores(forecaster, cv, param_grid, y, scoring):
     for i, params in enumerate(param_grid):
         f = clone(forecaster)
         f.set_params(**params)
-        f.fit(y_train)
+        f.fit(y_train, fh=cv.fh)
         y_pred = f.update_predict(y_test, cv)
         y_test_subset = y_test.loc[
             y_pred.index

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -243,7 +243,7 @@ def test_score(Forecaster, fh):
 
 @pytest.mark.parametrize("Forecaster", FORECASTERS)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
-@pytest.mark.parametrize("update_params", [False])
+@pytest.mark.parametrize("update_params", [True, False])
 def test_update_predict_single(Forecaster, fh, update_params):
     # Check correct time index of update-predict
     f = _construct_instance(Forecaster)
@@ -265,7 +265,7 @@ def _check_update_predict_y_pred(y_pred, y_test, fh, step_length):
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 @pytest.mark.parametrize("step_length", TEST_STEP_LENGTHS)
-@pytest.mark.parametrize("update_params", [False])
+@pytest.mark.parametrize("update_params", [True, False])
 def test_update_predict_predicted_indices(
     Forecaster, fh, window_length, step_length, update_params
 ):

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -265,8 +265,28 @@ def _check_update_predict_y_pred(y_pred, y_test, fh, step_length):
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 @pytest.mark.parametrize("step_length", TEST_STEP_LENGTHS)
-@pytest.mark.parametrize("update_params", [True, False])
+@pytest.mark.parametrize("update_params", [False])
 def test_update_predict_predicted_indices(
+    Forecaster, fh, window_length, step_length, update_params
+):
+    y = make_forecasting_problem(all_positive=True, index_type="datetime")
+    y_train, y_test = temporal_train_test_split(y)
+    cv = SlidingWindowSplitter(fh, window_length=window_length, step_length=step_length)
+    f = _construct_instance(Forecaster)
+    f.fit(y_train, fh=fh)
+    try:
+        y_pred = f.update_predict(y_test, cv=cv, update_params=update_params)
+        _check_update_predict_y_pred(y_pred, y_test, fh, step_length)
+    except NotImplementedError:
+        pass
+
+
+@pytest.mark.parametrize("Forecaster", FORECASTERS)
+@pytest.mark.parametrize("fh", TEST_OOS_FHS)
+@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
+@pytest.mark.parametrize("step_length", [1])
+@pytest.mark.parametrize("update_params", [True])
+def test_update_params_predict_predicted_indices(
     Forecaster, fh, window_length, step_length, update_params
 ):
     y = make_forecasting_problem(all_positive=True, index_type="datetime")

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -243,11 +243,12 @@ def test_score(Forecaster, fh):
 
 @pytest.mark.parametrize("Forecaster", FORECASTERS)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
-def test_update_predict_single(Forecaster, fh):
+@pytest.mark.parametrize("update_params", [False])
+def test_update_predict_single(Forecaster, fh, update_params):
     # Check correct time index of update-predict
     f = _construct_instance(Forecaster)
     f.fit(y_train, fh=fh)
-    y_pred = f.update_predict_single(y_test)
+    y_pred = f.update_predict_single(y_test, update_params=update_params)
     _assert_correct_pred_time_index(y_pred.index, y_test.index[-1], fh)
 
 
@@ -264,14 +265,17 @@ def _check_update_predict_y_pred(y_pred, y_test, fh, step_length):
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 @pytest.mark.parametrize("step_length", TEST_STEP_LENGTHS)
-def test_update_predict_predicted_indices(Forecaster, fh, window_length, step_length):
+@pytest.mark.parametrize("update_params", [False])
+def test_update_predict_predicted_indices(
+    Forecaster, fh, window_length, step_length, update_params
+):
     y = make_forecasting_problem(all_positive=True, index_type="datetime")
     y_train, y_test = temporal_train_test_split(y)
     cv = SlidingWindowSplitter(fh, window_length=window_length, step_length=step_length)
     f = _construct_instance(Forecaster)
     f.fit(y_train, fh=fh)
     try:
-        y_pred = f.update_predict(y_test, cv=cv)
+        y_pred = f.update_predict(y_test, cv=cv, update_params=update_params)
         _check_update_predict_y_pred(y_pred, y_test, fh, step_length)
     except NotImplementedError:
         pass

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -9,15 +9,16 @@ __all__ = [
     "test_raises_not_fitted_error",
     "test_score",
     "test_predict_time_index",
-    "test_update_predict_predicted_indices",
+    "test_update_predict_predicted_index",
+    "test_update_predict_predicted_index_update_params",
     "test_y_multivariate_raises_error",
     "test_get_fitted_params",
     "test_predict_time_index_in_sample_full",
     "test_predict_pred_interval",
     "test_update_predict_single",
-    "test_invalid_y_type_raises_error",
+    "test_y_invalid_type_raises_error",
     "test_predict_time_index_with_X",
-    "test_invalid_X_type_raises_error",
+    "test_X_invalid_type_raises_error",
 ]
 
 import numpy as np
@@ -96,7 +97,7 @@ def test_y_multivariate_raises_error(Forecaster):
 
 @pytest.mark.parametrize("Forecaster", FORECASTERS)
 @pytest.mark.parametrize("y", INVALID_INPUT_TYPES)
-def test_invalid_y_type_raises_error(Forecaster, y):
+def test_y_invalid_type_raises_error(Forecaster, y):
     f = _construct_instance(Forecaster)
     with pytest.raises(TypeError, match=r"type"):
         f.fit(y, fh=FH0)
@@ -104,7 +105,7 @@ def test_invalid_y_type_raises_error(Forecaster, y):
 
 @pytest.mark.parametrize("Forecaster", FORECASTERS)
 @pytest.mark.parametrize("X", INVALID_INPUT_TYPES)
-def test_invalid_X_type_raises_error(Forecaster, X):
+def test_X_invalid_type_raises_error(Forecaster, X):
     f = _construct_instance(Forecaster)
     try:
         with pytest.raises(TypeError, match=r"type"):
@@ -252,7 +253,16 @@ def test_update_predict_single(Forecaster, fh, update_params):
     _assert_correct_pred_time_index(y_pred.index, y_test.index[-1], fh)
 
 
-def _check_update_predict_y_pred(y_pred, y_test, fh, step_length):
+def _check_update_predict_predicted_index(
+    Forecaster, fh, window_length, step_length, update_params
+):
+    y = make_forecasting_problem(all_positive=True, index_type="datetime")
+    y_train, y_test = temporal_train_test_split(y)
+    cv = SlidingWindowSplitter(fh, window_length=window_length, step_length=step_length)
+    f = _construct_instance(Forecaster)
+    f.fit(y_train, fh=fh)
+    y_pred = f.update_predict(y_test, cv=cv, update_params=update_params)
+
     assert isinstance(y_pred, (pd.Series, pd.DataFrame))
     if isinstance(y_pred, pd.DataFrame):
         assert y_pred.shape[1] > 1
@@ -261,41 +271,29 @@ def _check_update_predict_y_pred(y_pred, y_test, fh, step_length):
     np.testing.assert_array_equal(actual, expected)
 
 
+# test with update_params=False and different values for steps_length
 @pytest.mark.parametrize("Forecaster", FORECASTERS)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 @pytest.mark.parametrize("step_length", TEST_STEP_LENGTHS)
 @pytest.mark.parametrize("update_params", [False])
-def test_update_predict_predicted_indices(
+def test_update_predict_predicted_index(
     Forecaster, fh, window_length, step_length, update_params
 ):
-    y = make_forecasting_problem(all_positive=True, index_type="datetime")
-    y_train, y_test = temporal_train_test_split(y)
-    cv = SlidingWindowSplitter(fh, window_length=window_length, step_length=step_length)
-    f = _construct_instance(Forecaster)
-    f.fit(y_train, fh=fh)
-    try:
-        y_pred = f.update_predict(y_test, cv=cv, update_params=update_params)
-        _check_update_predict_y_pred(y_pred, y_test, fh, step_length)
-    except NotImplementedError:
-        pass
+    _check_update_predict_predicted_index(
+        Forecaster, fh, window_length, step_length, update_params
+    )
 
 
+# test with update_params=True and step_length=1
 @pytest.mark.parametrize("Forecaster", FORECASTERS)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 @pytest.mark.parametrize("step_length", [1])
 @pytest.mark.parametrize("update_params", [True])
-def test_update_params_predict_predicted_indices(
+def test_update_predict_predicted_index_update_params(
     Forecaster, fh, window_length, step_length, update_params
 ):
-    y = make_forecasting_problem(all_positive=True, index_type="datetime")
-    y_train, y_test = temporal_train_test_split(y)
-    cv = SlidingWindowSplitter(fh, window_length=window_length, step_length=step_length)
-    f = _construct_instance(Forecaster)
-    f.fit(y_train, fh=fh)
-    try:
-        y_pred = f.update_predict(y_test, cv=cv, update_params=update_params)
-        _check_update_predict_y_pred(y_pred, y_test, fh, step_length)
-    except NotImplementedError:
-        pass
+    _check_update_predict_predicted_index(
+        Forecaster, fh, window_length, step_length, update_params
+    )

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -214,10 +214,12 @@ class ThetaForecaster(ExponentialSmoothing):
         return errors
 
     def update(self, y, X=None, update_params=True):
-        super(ThetaForecaster, self).update(y, X, update_params=update_params)
+        super(ThetaForecaster, self).update(
+            y, X, update_params=False
+        )  # use custom update_params routine
         if update_params:
             if self.deseasonalize:
-                y = self.deseasonalizer_.transform(y)
+                y = self.deseasonalizer_.transform(self._y)  # use updated y
             self.initial_level_ = self._fitted_forecaster.params["smoothing_level"]
             self.trend_ = self._compute_trend(y)
         return self

--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -119,7 +119,7 @@ class Detrender(_SeriesToSeriesTransformer):
         z_pred = self.forecaster_.predict(fh, X)
         return z + z_pred
 
-    def update(self, Z, X=None, update_params=False):
+    def update(self, Z, X=None, update_params=True):
         """
         Update the parameters of the detrending estimator with new data
 
@@ -127,7 +127,7 @@ class Detrender(_SeriesToSeriesTransformer):
         ----------
         y_new : pd.Series
             New time series
-        update_params : bool, optional (default=False)
+        update_params : bool, optional (default=True)
             Update the parameters of the detrender model with
 
         Returns

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -75,7 +75,7 @@ def _shift(x, by=1):
     assert isinstance(x, (pd.Period, pd.Timestamp, int, np.integer)), type(x)
     assert isinstance(by, (int, np.integer, pd.Int64Index)), type(by)
     if isinstance(x, pd.Timestamp):
-        if not hasattr(x, "freq"):
+        if not hasattr(x, "freq") or x.freq is None:
             raise ValueError("No `freq` information available")
         by *= x.freq
     return x + by


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #647. See also sktime/enhancement-proposals#8

#### What does this implement/fix? Explain your changes.
- Makes `update_params=True` by default for all `update`-related forecasting methods.
- Implements a refit in the base Forecaster class when `update_params=True`

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
- [x] I have set the Theta forecaster `update_params=False` for the `super().update` call since the function then does a custom  routine if `update_params=True`, so, presumably, we don't want to refit. I have also set the `Deseasonalizer` transform to use the updated `y` as opposed to just the passed `y`
- [x] Assumption has been made that `update_predict` on a CV with `step_length>1` when `update_params=True` is not a desired use case for testing since the time-series is not continuous

#### Any other comments
The behaviour of the Forecaster w.r.t. update is as follows:
First, the Forecaster calls `fit` on a time period `y_a=y1,y2,...,yN`
Then, when we call `update`, the Forecaster uses the new information, e.g. `y_b=yN+1,...,yN+k` along with the old information to update the model. If a custom `update` routine is not implemented, then we simply fit a new model on `y=concat(y_a,y_b)`.

Original test failures have been isolated to when `step_length > 1`. In this case, when `update_params=True`, the model attempts to refit on a concatenation of the previous data (e.g. daily from "2000-01-01" to "2000-02-01") with the new data point as selected by the CV splitter. If the CV splitter has a `step_length > 1` then the frequency of the time series is no longer valid (e.g. daily up to "2000-02-01" then stepping multiple days into the future, e.g. "2000-02-07", before continuing at the same frequency)

The testing of `update_predict` where `step_length>1` and `update_params=True` has been left out, as a result.

#### PR checklist

- [x] set `update_params=True` for all methods
- [x] ensure all tests still pass when `update_params=False` (maintain original behaviour)
- [x] implement refit method in base Forecaster using original and update data
- [x] ensure all tests pass when `update_params=True` and `step_length=1`
- [ ] check desired behaviour for `update_params=True` and `step_length>1`


##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/master/.all-contributorsrc).
- [x] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/master/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.