### PR TITLE
Knn transpose fix

### DIFF
--- a/sktime/classification/distance_based/_elastic_ensemble.py
+++ b/sktime/classification/distance_based/_elastic_ensemble.py
@@ -275,7 +275,7 @@ class ElasticEnsemble(BaseClassifier):
 
                 grid = GridSearchCV(
                     estimator=KNeighborsTimeSeriesClassifier(
-                        metric=this_measure, n_neighbors=1, algorithm="brute"
+                        distance=this_measure, n_neighbors=1, algorithm="brute"
                     ),
                     param_grid=ElasticEnsemble._get_100_param_options(
                         self.distance_measures[dm], X
@@ -292,7 +292,7 @@ class ElasticEnsemble(BaseClassifier):
             else:
                 grid = RandomizedSearchCV(
                     estimator=KNeighborsTimeSeriesClassifier(
-                        metric=this_measure, n_neighbors=1, algorithm="brute"
+                        distance=this_measure, n_neighbors=1, algorithm="brute"
                     ),
                     param_distributions=ElasticEnsemble._get_100_param_options(
                         self.distance_measures[dm], X
@@ -315,8 +315,8 @@ class ElasticEnsemble(BaseClassifier):
             best_model = KNeighborsTimeSeriesClassifier(
                 algorithm="brute",
                 n_neighbors=1,
-                metric=this_measure,
-                metric_params=grid.best_params_["metric_params"],
+                distance=this_measure,
+                distance_params=grid.best_params_["metric_params"],
             )
             preds = cross_val_predict(
                 best_model, full_train_to_use, y, cv=LeaveOneOut()
@@ -339,8 +339,8 @@ class ElasticEnsemble(BaseClassifier):
             best_model = KNeighborsTimeSeriesClassifier(
                 algorithm="brute",
                 n_neighbors=1,
-                metric=this_measure,
-                metric_params=grid.best_params_["metric_params"],
+                distance=this_measure,
+                distance_params=grid.best_params_["metric_params"],
             )
             best_model.fit(full_train_to_use, y)
             end_build_time = time.time()

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -284,7 +284,7 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
             Indices of the nearest points in the population matrix.
         """
         self.check_is_fitted()
-        X = check_X(X,  enforce_univariate=not self.capabilities["multivariate"], 
+        X = check_X(X,  enforce_univariate=not self.capabilities["multivariate"],
                     coerce_to_numpy=True)
         # Transpose to work correctly with distance functions
         X = X.transpose((0, 2, 1))

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -6,19 +6,15 @@ are in sktime.distances.elastic, but these are orders of magnitude slower.
 
 """
 
-__author__ = "Jason Lines"
+__author__ = ["Jason Lines", "TonyBagnall"]
 __all__ = ["KNeighborsTimeSeriesClassifier"]
 
 import warnings
-from distutils.version import LooseVersion
 from functools import partial
 
 import numpy as np
-from joblib import Parallel
-from joblib import delayed
 from joblib import effective_n_jobs
 from scipy import stats
-from scipy.sparse import issparse
 from sklearn.exceptions import DataConversionWarning
 from sklearn.metrics import pairwise_distances_chunked
 from sklearn.model_selection import GridSearchCV
@@ -26,8 +22,6 @@ from sklearn.model_selection import LeaveOneOut
 from sklearn.neighbors import KNeighborsClassifier as _KNeighborsClassifier
 from sklearn.neighbors._base import _check_weights
 from sklearn.neighbors._base import _get_weights
-from sklearn.utils import gen_even_slices
-from sklearn.utils._joblib import __version__ as joblib_version
 from sklearn.utils.extmath import weighted_mode
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_array

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -183,7 +183,8 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
             Target values of shape = [n_samples]
 
         """
-        X, y = check_X_y(X, y, enforce_univariate=not self.capabilities["multivariate"], coerce_to_numpy=True)
+        X, y = check_X_y(X, y, enforce_univariate=not self.capabilities["multivariate"],
+                         coerce_to_numpy=True)
         # Transpose to work correctly with distance functions
         X = X.transpose((0, 2, 1))
 
@@ -283,7 +284,8 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
             Indices of the nearest points in the population matrix.
         """
         self.check_is_fitted()
-        X = check_X(X,  enforce_univariate=not self.capabilities["multivariate"], coerce_to_numpy=True)
+        X = check_X(X,  enforce_univariate=not self.capabilities["multivariate"], 
+                    coerce_to_numpy=True)
         # Transpose to work correctly with distance functions
         X = X.transpose((0, 2, 1))
 

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -92,9 +92,9 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
     or a callable function: default ==' uniform'
     algorithm       : search method for neighbours {‘auto’, ‘ball_tree’,
     ‘kd_tree’, ‘brute’}: default = 'brute'
-    metric          : distance measure for time series: {'dtw','ddtw',
+    distance          : distance measure for time series: {'dtw','ddtw',
     'wdtw','lcss','erp','msm','twe'}: default ='dtw'
-    metric_params   : dictionary for metric parameters: default = None
+    distance_params   : dictionary for metric parameters: default = None
 
     """
 
@@ -109,52 +109,55 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
         self,
         n_neighbors=1,
         weights="uniform",
-        metric="dtw",
-        metric_params=None,
+        distance="dtw",
+        distance_params=None,
         **kwargs
     ):
         self._cv_for_params = False
-        if metric == "euclidean":  # Euclidean will default to the base class distance
-            metric = euclidean_distance
-        elif metric == "dtw":
-            metric = dtw_distance
-        elif metric == "dtwcv":  # special case to force loocv grid search
+        self.distance = distance
+        self.distance_params = distance_params
+
+        if distance == "euclidean":  # Euclidean will default to the base class distance
+            distance = euclidean_distance
+        elif distance == "dtw":
+            distance = dtw_distance
+        elif distance == "dtwcv":  # special case to force loocv grid search
             # cv in training
-            if metric_params is not None:
+            if distance_params is not None:
                 warnings.warn(
                     "Warning: measure parameters have been specified for "
                     "dtwcv. "
                     "These will be ignored and parameter values will be "
                     "found using LOOCV."
                 )
-            metric = dtw_distance
+            distance = dtw_distance
             self._cv_for_params = True
             self._param_matrix = {
                 "metric_params": [{"w": x / 100} for x in range(0, 100)]
             }
-        elif metric == "ddtw":
-            metric = ddtw_distance
-        elif metric == "wdtw":
-            metric = wdtw_distance
-        elif metric == "wddtw":
-            metric = wddtw_distance
-        elif metric == "lcss":
-            metric = lcss_distance
-        elif metric == "erp":
-            metric = erp_distance
-        elif metric == "msm":
-            metric = msm_distance
-        elif metric == "twe":
-            metric = twe_distance
-        elif metric == "mpdist":
-            metric = mpdist
+        elif distance == "ddtw":
+            distance = ddtw_distance
+        elif distance == "wdtw":
+            distance = wdtw_distance
+        elif distance == "wddtw":
+            distance = wddtw_distance
+        elif distance == "lcss":
+            distance = lcss_distance
+        elif distance == "erp":
+            distance = erp_distance
+        elif distance == "msm":
+            distance = msm_distance
+        elif distance == "twe":
+            distance = twe_distance
+        elif distance == "mpdist":
+            distance = mpdist
             # When mpdist is used, the subsequence length (parameter m) must be set
             # Example: knn_mpdist = KNeighborsTimeSeriesClassifier(
             # metric='mpdist', metric_params={'m':30})
         else:
-            if type(metric) is str:
+            if type(distance) is str:
                 raise ValueError(
-                    "Unrecognised distance measure: " + metric + ". Allowed values "
+                    "Unrecognised distance measure: " + distance + ". Allowed values "
                     "are names from [euclidean,dtw,ddtw,wdtw,wddtw,lcss,erp,msm] or "
                     "please pass a callable distance measure into the constuctor"
                 )
@@ -162,8 +165,8 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
         super(KNeighborsTimeSeriesClassifier, self).__init__(
             n_neighbors=n_neighbors,
             algorithm="brute",
-            metric=metric,
-            metric_params=metric_params,
+            metric=distance,
+            metric_params=distance_params,
             **kwargs
         )
         self.weights = _check_weights(weights)
@@ -200,7 +203,7 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
         if self._cv_for_params:
             grid = GridSearchCV(
                 estimator=KNeighborsTimeSeriesClassifier(
-                    metric=self.metric, n_neighbors=1, algorithm="brute"
+                    distance=self.metric, n_neighbors=1, algorithm="brute"
                 ),
                 param_grid=self._param_matrix,
                 cv=LeaveOneOut(),

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -183,8 +183,12 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
             Target values of shape = [n_samples]
 
         """
-        X, y = check_X_y(X, y, enforce_univariate=not self.capabilities["multivariate"],
-                         coerce_to_numpy=True)
+        X, y = check_X_y(
+            X,
+            y,
+            enforce_univariate=not self.capabilities["multivariate"],
+            coerce_to_numpy=True,
+        )
         # Transpose to work correctly with distance functions
         X = X.transpose((0, 2, 1))
 
@@ -284,8 +288,11 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
             Indices of the nearest points in the population matrix.
         """
         self.check_is_fitted()
-        X = check_X(X,  enforce_univariate=not self.capabilities["multivariate"],
-                    coerce_to_numpy=True)
+        X = check_X(
+            X,
+            enforce_univariate=not self.capabilities["multivariate"],
+            coerce_to_numpy=True,
+        )
         # Transpose to work correctly with distance functions
         X = X.transpose((0, 2, 1))
 

--- a/sktime/classification/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/classification/distance_based/tests/test_time_series_neighbors.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from sktime.classification.distance_based._time_series_neighbors import(
+from sktime.classification.distance_based._time_series_neighbors import (
     KNeighborsTimeSeriesClassifier,
 )
 from sktime.datasets import load_arrow_head

--- a/sktime/classification/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/classification/distance_based/tests/test_time_series_neighbors.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+from numpy import testing
+
+from sktime.classification.distance_based._time_series_neighbors import KNeighborsTimeSeriesClassifier
+from sktime.datasets import load_arrow_head
+
+distance_functions = [
+    "dtw",
+    "msm",
+]
+
+# expected correct on test set using default parameters. Verified in tsml
+expected_correct = {
+    "dtw": 123,
+    "msm": 139,
+}
+
+
+def test_knn_on_arrowhead():
+    # load gunpoint data
+    X_train, y_train = load_arrow_head(split="train", return_X_y=True)
+    X_test, y_test = load_arrow_head(split="test", return_X_y=True)
+    for i in range(0, len(distance_functions)):
+        knn = KNeighborsTimeSeriesClassifier(
+            metric=distance_functions[i],
+        )
+        knn.fit(metric = distance_functions[i])
+        pred = knn.predict(X_test)
+        correct = 0
+        for j in range(0, len(pred)):
+            if pred[j] == y_test[j]:
+                correct = correct + 1
+        assert(correct == expected_correct[distance_functions[i]])
+
+

--- a/sktime/classification/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/classification/distance_based/tests/test_time_series_neighbors.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from sktime.classification.distance_based._time_series_neighbors import KNeighborsTimeSeriesClassifier
+from sktime.classification.distance_based._time_series_neighbors \
+    import KNeighborsTimeSeriesClassifier
 from sktime.datasets import load_arrow_head
 
 distance_functions = [
@@ -30,5 +31,3 @@ def test_knn_on_arrowhead():
             if pred[j] == y_test[j]:
                 correct = correct + 1
         assert(correct == expected_correct[distance_functions[i]])
-
-

--- a/sktime/classification/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/classification/distance_based/tests/test_time_series_neighbors.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from sktime.classification.distance_based._time_series_neighbors \
-    import KNeighborsTimeSeriesClassifier
+from sktime.classification.distance_based._time_series_neighbors import(
+    KNeighborsTimeSeriesClassifier,
+)
 from sktime.datasets import load_arrow_head
 
 distance_functions = [
@@ -30,4 +31,4 @@ def test_knn_on_arrowhead():
         for j in range(0, len(pred)):
             if pred[j] == y_test[j]:
                 correct = correct + 1
-        assert(correct == expected_correct[distance_functions[i]])
+        assert correct == expected_correct[distance_functions[i]]

--- a/sktime/classification/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/classification/distance_based/tests/test_time_series_neighbors.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import numpy as np
-from numpy import testing
 
 from sktime.classification.distance_based._time_series_neighbors import KNeighborsTimeSeriesClassifier
 from sktime.datasets import load_arrow_head
@@ -25,7 +23,7 @@ def test_knn_on_arrowhead():
         knn = KNeighborsTimeSeriesClassifier(
             metric=distance_functions[i],
         )
-        knn.fit(metric = distance_functions[i])
+        knn.fit(X_train, y_train)
         pred = knn.predict(X_test)
         correct = 0
         for j in range(0, len(pred)):

--- a/sktime/classification/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/classification/distance_based/tests/test_time_series_neighbors.py
@@ -23,7 +23,7 @@ def test_knn_on_arrowhead():
     X_test, y_test = load_arrow_head(split="test", return_X_y=True)
     for i in range(0, len(distance_functions)):
         knn = KNeighborsTimeSeriesClassifier(
-            metric=distance_functions[i],
+            distance=distance_functions[i],
         )
         knn.fit(X_train, y_train)
         pred = knn.predict(X_test)

--- a/sktime/contrib/basic_benchmarking.py
+++ b/sktime/contrib/basic_benchmarking.py
@@ -278,7 +278,7 @@ def elastic_distance_benchmarking():
     for i in range(0, int(len(distance_test))):
         dataset = distance_test[i]
         print(str(i) + " problem = " + dataset + " writing to " + results_dir + "/DTW/")
-        dtw = dist.KNeighborsTimeSeriesClassifier(metric="dtw")
+        dtw = dist.KNeighborsTimeSeriesClassifier(distance="dtw")
         exp.run_experiment(
             overwrite=False,
             problem_path=data_dir,
@@ -288,7 +288,7 @@ def elastic_distance_benchmarking():
             dataset=dataset,
             train_file=False,
         )
-        twe = dist.KNeighborsTimeSeriesClassifier(metric="dtw")
+        twe = dist.KNeighborsTimeSeriesClassifier(distance="dtw")
         exp.run_experiment(
             overwrite=False,
             problem_path=data_dir,

--- a/sktime/contrib/dictionary_based/bop.py
+++ b/sktime/contrib/dictionary_based/bop.py
@@ -21,7 +21,7 @@ class BagOfPatterns(BaseEstimator):
             (
                 "clf",
                 KNeighborsTimeSeriesClassifier(
-                    n_neighbors=1, metric=euclidean_distance
+                    n_neighbors=1, distance=euclidean_distance
                 ),
             ),
         ]

--- a/sktime/contrib/experiments.py
+++ b/sktime/contrib/experiments.py
@@ -560,8 +560,8 @@ def test_loading():
 
 
 benchmark_datasets = [
-#    "ACSF1",
-#    "Adiac",
+    "ACSF1",
+    "Adiac",
     "ArrowHead",
     "Beef",
     "BeetleFly",

--- a/sktime/contrib/experiments.py
+++ b/sktime/contrib/experiments.py
@@ -558,6 +558,107 @@ def test_loading():
         print(testY.shape)
 
 
+
+benchmark_datasets = [
+#    "ACSF1",
+#    "Adiac",
+    "ArrowHead",
+    "Beef",
+    "BeetleFly",
+    "BirdChicken",
+    "BME",
+    "Car",
+    "CBF",
+    "ChlorineConcentration",
+    "CinCECGTorso",
+    "Coffee",
+    "Computers",
+    "CricketX",
+    "CricketY",
+    "CricketZ",
+    "DiatomSizeReduction",
+    "DistalPhalanxOutlineCorrect",
+    "DistalPhalanxOutlineAgeGroup",
+    "DistalPhalanxTW",
+    "Earthquakes",
+    "ECG200",
+    "ECG5000",
+    "ECGFiveDays",
+    "EOGHorizontalSignal",
+    "EOGVerticalSignal",
+    "EthanolLevel",
+    "FaceAll",
+    "FaceFour",
+    "FacesUCR",
+    "FiftyWords",
+    "Fish",
+    "FreezerRegularTrain",
+    "FreezerSmallTrain",
+    "Ham",
+    "Haptics",
+    "Herring",
+    "InlineSkate",
+    "InsectEPGRegularTrain",
+    "InsectEPGSmallTrain",
+    "InsectWingbeatSound",
+    "ItalyPowerDemand",
+    "LargeKitchenAppliances",
+    "Lightning2",
+    "Lightning7",
+    "Mallat",
+    "Meat",
+    "MedicalImages",
+    "MiddlePhalanxOutlineCorrect",
+    "MiddlePhalanxOutlineAgeGroup",
+    "MiddlePhalanxTW",
+    "MixedShapesRegularTrain",
+    "MixedShapesSmallTrain",
+    "MoteStrain",
+    "OliveOil",
+    "OSULeaf",
+    "PhalangesOutlinesCorrect",
+    "Phoneme",
+    "PigAirwayPressure",
+    "PigArtPressure",
+    "PigCVP",
+    "Plane",
+    "PowerCons",
+    "ProximalPhalanxOutlineCorrect",
+    "ProximalPhalanxOutlineAgeGroup",
+    "ProximalPhalanxTW",
+    "RefrigerationDevices",
+    "Rock",
+    "ScreenType",
+    "SemgHandGenderCh2",
+    "SemgHandMovementCh2",
+    "SemgHandSubjectCh2",
+    "ShapeletSim",
+    "SmallKitchenAppliances",
+    "SmoothSubspace",
+    "SonyAIBORobotSurface1",
+    "SonyAIBORobotSurface2",
+    "Strawberry",
+    "SwedishLeaf",
+    "Symbols",
+    "SyntheticControl",
+    "ToeSegmentation1",
+    "ToeSegmentation2",
+    "Trace",
+    "TwoLeadECG",
+    "TwoPatterns",
+    "UMD",
+    "UWaveGestureLibraryX",
+    "UWaveGestureLibraryY",
+    "UWaveGestureLibraryZ",
+    "Wafer",
+    "Wine",
+    "WordSynonyms",
+    "Worms",
+    "WormsTwoClass",
+    "Yoga",
+]
+
+
 if __name__ == "__main__":
     """
     Example simple usage, with arguments input via script or hard coded for testing
@@ -581,7 +682,7 @@ if __name__ == "__main__":
     else:  # Local run
         print(" Local Run")
         data_dir = "Z:/ArchiveData/Univariate_ts/"
-        results_dir = "C:/Temp/"
+        results_dir = "Z:/Results Working Area/DistanceBased/sktime/"
         dataset = "ArrowHead"
         trainX, trainY = load_ts(data_dir + dataset + "/" + dataset + "_TRAIN.ts")
         testX, testY = load_ts(data_dir + dataset + "/" + dataset + "_TEST.ts")
@@ -592,12 +693,14 @@ if __name__ == "__main__":
         # #            print(i)
         # #            print(" problem = "+dataset)
         tf = False
-        run_experiment(
-            overwrite=True,
-            problem_path=data_dir,
-            results_path=results_dir,
-            cls_name=classifier,
-            dataset=dataset,
-            resampleID=resample,
-            train_file=tf,
-        )
+        for i in range(0, len(benchmark_datasets)):
+            dataset = benchmark_datasets[i]
+            run_experiment(
+                overwrite=True,
+                problem_path=data_dir,
+                results_path=results_dir,
+                cls_name=classifier,
+                dataset=dataset,
+                resampleID=resample,
+                train_file=tf,
+            )

--- a/sktime/contrib/experiments.py
+++ b/sktime/contrib/experiments.py
@@ -558,7 +558,6 @@ def test_loading():
         print(testY.shape)
 
 
-
 benchmark_datasets = [
     "ACSF1",
     "Adiac",

--- a/sktime/contrib/experiments.py
+++ b/sktime/contrib/experiments.py
@@ -112,11 +112,11 @@ def set_classifier(cls, resampleId=None):
     elif name == "ps" or name == "proximityStump":
         return ProximityStump(random_state=resampleId)
     elif name == "dtwcv" or name == "kneighborstimeseriesclassifier":
-        return KNeighborsTimeSeriesClassifier(metric="dtwcv")
+        return KNeighborsTimeSeriesClassifier(distance="dtwcv")
     elif name == "dtw" or name == "1nn-dtw":
-        return KNeighborsTimeSeriesClassifier(metric="dtw")
+        return KNeighborsTimeSeriesClassifier(distance="dtw")
     elif name == "msm" or name == "1nn-msm":
-        return KNeighborsTimeSeriesClassifier(metric="msm")
+        return KNeighborsTimeSeriesClassifier(distance="msm")
     elif name == "ee" or name == "elasticensemble":
         return ElasticEnsemble()
     elif name == "shapedtw":

--- a/sktime/contrib/experiments.py
+++ b/sktime/contrib/experiments.py
@@ -112,7 +112,11 @@ def set_classifier(cls, resampleId=None):
     elif name == "ps" or name == "proximityStump":
         return ProximityStump(random_state=resampleId)
     elif name == "dtwcv" or name == "kneighborstimeseriesclassifier":
+        return KNeighborsTimeSeriesClassifier(metric="dtwcv")
+    elif name == "dtw" or name == "1nn-dtw":
         return KNeighborsTimeSeriesClassifier(metric="dtw")
+    elif name == "msm" or name == "1nn-msm":
+        return KNeighborsTimeSeriesClassifier(metric="msm")
     elif name == "ee" or name == "elasticensemble":
         return ElasticEnsemble()
     elif name == "shapedtw":
@@ -575,18 +579,13 @@ if __name__ == "__main__":
             train_file=tf,
         )
     else:  # Local run
-        #        data_dir = "/scratch/univariate_datasets/"
-        #        results_dir = "/scratch/results"
-        #         data_dir = "/bench/datasets/Univariate2018/"
-        #         results_dir = "C:/Users/ajb/Dropbox/Turing Project/Results/"
         print(" Local Run")
-        data_dir = "C:/Code/sktime/sktime/datasets/data/"
+        data_dir = "Z:/ArchiveData/Univariate_ts/"
         results_dir = "C:/Temp/"
-        #        results_dir = "Z:/Results/sktime Bakeoff/"
-        dataset = "UnitTest"
+        dataset = "ArrowHead"
         trainX, trainY = load_ts(data_dir + dataset + "/" + dataset + "_TRAIN.ts")
         testX, testY = load_ts(data_dir + dataset + "/" + dataset + "_TEST.ts")
-        classifier = "KNeighborsTimeSeriesClassifier"
+        classifier = "1NN-MSM"
         resample = 0
         #         for i in range(0, len(univariate_datasets)):
         #             dataset = univariate_datasets[i]

--- a/sktime/contrib/shape_dtw/experiments/experiments_shape_dtw.py
+++ b/sktime/contrib/shape_dtw/experiments/experiments_shape_dtw.py
@@ -129,7 +129,7 @@ def set_classifier(cls, resampleId):
     elif cls.lower() == "st":
         return st.ShapeletTransformClassifier(time_contract_in_mins=1500)
     elif cls.lower() == "dtw":
-        return nn.KNeighborsTimeSeriesClassifier(metric="dtw")
+        return nn.KNeighborsTimeSeriesClassifier(distance="dtw")
     elif cls.lower() == "ee" or cls.lower() == "elasticensemble":
         return dist.ElasticEnsemble()
     elif cls.lower() == "shapedtw_raw":

--- a/sktime/distances/elastic.py
+++ b/sktime/distances/elastic.py
@@ -234,8 +234,7 @@ def msm_distance(first, second, **kwargs):
         try:
             c = kwargs["c"]
         except KeyError:
-            c = 0.1
-
+            c = 1
         m = len(first)
         n = len(second)
 

--- a/sktime/distances/elastic_cython.pyx
+++ b/sktime/distances/elastic_cython.pyx
@@ -154,12 +154,11 @@ def wddtw_distance(np.ndarray[double, ndim=2] x, np.ndarray[double, ndim=2] y , 
     return wdtw_distance(np.diff(x.T).T,np.diff(y.T).T,g)
 
 
-def msm_distance(np.ndarray[double, ndim=2] x, np.ndarray[double, ndim=2] y, double c = 0, int dim_to_use = 0):
+def msm_distance(np.ndarray[double, ndim=2] x, np.ndarray[double, ndim=2] y, double c = 1, int dim_to_use = 0):
 
     cdef np.ndarray[double, ndim=2] first = x
     cdef np.ndarray[double, ndim=2] second = y
     cdef np.ndarray[double, ndim=2] temp
-
     if len(first) > len(second):
         temp = first
         first = second

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -82,7 +82,6 @@ EXCLUDE_ESTIMATORS = [
     "ShapeDTW",
     "HIVECOTEV1",
     "ElasticEnsemble",
-    # "KNeighborsTimeSeriesClassifier",
     "ProximityForest",
     "ProximityStump",
     "ProximityTree",

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -82,7 +82,7 @@ EXCLUDE_ESTIMATORS = [
     "ShapeDTW",
     "HIVECOTEV1",
     "ElasticEnsemble",
-    "KNeighborsTimeSeriesClassifier",
+    # "KNeighborsTimeSeriesClassifier",
     "ProximityForest",
     "ProximityStump",
     "ProximityTree",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Those goes a way to addressing issues raised in #596

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
1. Fix the data representation

a common framework for check_X was introduced that includes a mechanism for coercing a pandas into a numpy array. This superceded the previous conversion used in the KNeighborsTimeSeriesClassifier. However, check_X converts to data[n][d][m] (n=num cases, d = num dimensions, m = series length), whereas this is set up to use data[n][m][d] to optimise vectorisation). The first fix is to correct this with a simple transpose

2. Fix default setting for MSM
MSM distance was defaulting the cost parameter c to 0. The tsml version uses 1, and this is preferable,

3. Remove the option for algorithm, only use "brute"
the two alternatives in sklearn knn are not usable with time series, and are hard coded that way. It is best to just remove the option and reduce code bloat somewhat

4. First basic unit testing
check accuracy on arrow head, data verified in sister package tsml



