### PR TITLE
Correct docstrings for check_X and related functions

### DIFF
--- a/sktime/utils/validation/forecasting.py
+++ b/sktime/utils/validation/forecasting.py
@@ -74,20 +74,20 @@ def check_X(
     ----------
     X : pd.Series, pd.DataFrame, np.ndarray
     allow_empty : bool, optional (default=False)
-        If True, empty `y` raises an error.
+        If False, empty `X` raises an error.
     enforce_index_type : type, optional (default=None)
         type of time index
     enforce_univariate : bool, optional (default=False)
-        If True, multivariate Z will raise an error.
+        If True, multivariate X will raise an error.
     Returns
     -------
-    y : pd.Series, pd.DataFrame
+    X : pd.Series, pd.DataFrame
         Validated input data.
 
     Raises
     ------
     ValueError, TypeError
-        If y is an invalid input
+        If X is an invalid input
     UserWarning
         Warning that X is given and model can't use it
     """
@@ -108,7 +108,7 @@ def check_y(y, allow_empty=False, allow_constant=True, enforce_index_type=None):
     ----------
     y : pd.Series
     allow_empty : bool, optional (default=False)
-        If True, empty `y` raises an error.
+        If False, empty `y` raises an error.
     allow_constant : bool, optional (default=True)
         If True, constant `y` does not raise an error.
     enforce_index_type : type, optional (default=None)

--- a/sktime/utils/validation/series.py
+++ b/sktime/utils/validation/series.py
@@ -39,12 +39,13 @@ def check_series(
     enforce_univariate : bool, optional (default=False)
         If True, multivariate Z will raise an error.
     allow_empty : bool
+        If False, empty Z will raise an error
     enforce_index_type : type, optional (default=None)
         type of time index
 
     Returns
     -------
-    y : pd.Series, pd.DataFrame
+    Z : pd.Series, pd.DataFrame
         Validated time series
 
     Raises
@@ -83,7 +84,7 @@ def check_time_index(index, allow_empty=False, enforce_index_type=None):
     index : pd.Index or np.array
         Time index
     allow_empty : bool, optional (default=False)
-        If True, empty `index` raises an error.
+        If False, empty `index` raises an error.
     enforce_index_type : type, optional (default=None)
         type of time index
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
See #700 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
There were inconsistencies in the docstrings, e.g. referring to `y` instead of `X`. See changes in the commit below.





<!--
Thanks for contributing!
-->
