### PR TITLE
Binder build fix

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -239,7 +239,7 @@
         "maintenance",
         "doc"
       ]
-    },    
+    },
     {
       "login": "angus924",
       "name": "angus924",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -231,6 +231,16 @@
       ]
     },
     {
+      "login": "ddorf",
+      "name": "Dan Mittendorf",
+      "avatar_url": "https://avatars.githubusercontent.com/u/28767641?v=4",
+      "profile": "https://github.com/ddorf",
+      "contributions": [
+        "maintenance",
+        "doc"
+      ]
+    },    
+    {
       "login": "angus924",
       "name": "angus924",
       "avatar_url": "https://avatars0.githubusercontent.com/u/55837131?v=4",

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -20,7 +20,7 @@ RUN chown -R ${NB_UID} ${HOME}
 USER ${USERR}
 WORKDIR ${HOME}
 
-RUN LLVM_CONFIG=/opt/llvm/bin/llvm-config pip install llvmlite==0.36.0
+RUN conda update llvmlite
 
 # Install extra requirements and sktime based on master branch
 #RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -21,6 +21,5 @@ USER ${USERR}
 WORKDIR ${HOME}
 
 # Install extra requirements and sktime based on master branch
-RUN conda install llvmlite>=0.36.0
 RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt
 RUN pip install --no-cache-dir .

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -21,5 +21,5 @@ USER ${USERR}
 WORKDIR ${HOME}
 
 # Install extra requirements and sktime based on master branch
-RUN pip install --upgrade pip>=19.0 --no-cache-dir -r .binder/requirements.txt
+RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt
 RUN pip install --no-cache-dir .

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -20,7 +20,7 @@ RUN chown -R ${NB_UID} ${HOME}
 USER ${USERR}
 WORKDIR ${HOME}
 
-RUN LLVM_CONFIG=/home/local/opt/llvm/bin/llvm-config pip install llvm-lite==0.36.0
+RUN LLVM_CONFIG=/home/local/opt/llvm/bin/llvm-config pip install llvmlite==0.36.0
 
 # Install extra requirements and sktime based on master branch
 #RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -20,7 +20,7 @@ RUN chown -R ${NB_UID} ${HOME}
 USER ${USERR}
 WORKDIR ${HOME}
 
-RUN LLVM_CONFIG=/home/local/opt/llvm/bin/llvm-config pip install llvmlite==0.36.0
+RUN LLVM_CONFIG=/opt/llvm/bin/llvm-config pip install llvmlite==0.36.0
 
 # Install extra requirements and sktime based on master branch
 #RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -21,5 +21,5 @@ USER ${USERR}
 WORKDIR ${HOME}
 
 # Install extra requirements and sktime based on master branch
-RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt
+RUN pip install --upgrade pip>=19.0 --no-cache-dir -r .binder/requirements.txt
 RUN pip install --no-cache-dir .

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -21,6 +21,6 @@ USER ${USERR}
 WORKDIR ${HOME}
 
 # Install extra requirements and sktime based on master branch
-RUN conda install llvmlite==0.36.0
+RUN conda install llvmlite>=0.36.0
 RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt
 RUN pip install --no-cache-dir .

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -20,6 +20,8 @@ RUN chown -R ${NB_UID} ${HOME}
 USER ${USERR}
 WORKDIR ${HOME}
 
+RUN LLVM_CONFIG=/home/local/opt/llvm/bin/llvm-config pip install llvm-lite==0.36
+
 # Install extra requirements and sktime based on master branch
-RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt
-RUN pip install --no-cache-dir .
+#RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt
+#RUN pip install --no-cache-dir .

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -20,7 +20,7 @@ RUN chown -R ${NB_UID} ${HOME}
 USER ${USERR}
 WORKDIR ${HOME}
 
-RUN conda update llvmlite
+RUN conda install llvmlite==0.36.0
 
 # Install extra requirements and sktime based on master branch
 #RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -20,7 +20,7 @@ RUN chown -R ${NB_UID} ${HOME}
 USER ${USERR}
 WORKDIR ${HOME}
 
-RUN LLVM_CONFIG=/home/local/opt/llvm/bin/llvm-config pip install llvm-lite==0.36
+RUN LLVM_CONFIG=/home/local/opt/llvm/bin/llvm-config pip install llvm-lite==0.36.0
 
 # Install extra requirements and sktime based on master branch
 #RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -20,8 +20,7 @@ RUN chown -R ${NB_UID} ${HOME}
 USER ${USERR}
 WORKDIR ${HOME}
 
-RUN conda install llvmlite==0.36.0
-
 # Install extra requirements and sktime based on master branch
-#RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt
-#RUN pip install --no-cache-dir .
+RUN conda install llvmlite==0.36.0
+RUN pip install --upgrade pip --no-cache-dir -r .binder/requirements.txt
+RUN pip install --no-cache-dir .

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -2,7 +2,7 @@ catch22
 cython>=0.29.0
 fbprophet>=0.7.1
 hcrystalball>=0.1.9
-llvmlite==0.16.0
+llvmlite>=0.16.0
 matplotlib
 notebook
 numba>=0.50,<0.53

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -2,10 +2,11 @@ catch22
 cython>=0.29.0
 fbprophet>=0.7.1
 hcrystalball>=0.1.9
+llvmlite==0.16.0
 matplotlib
 notebook
-numba>=0.50,<0.53
 numpy==1.19
+numba>=0.50,<0.53
 pandas==1.1.5
 pmdarima>=1.8.0
 scikit-learn==0.23.*
@@ -14,4 +15,4 @@ seaborn
 statsmodels>=0.12.1
 stumpy>=1.5.1
 tbats>=1.1.0
-tsfresh>=0.17.0
+tsfresh==0.17.0

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -5,8 +5,8 @@ hcrystalball>=0.1.9
 llvmlite==0.16.0
 matplotlib
 notebook
-numpy==1.19
 numba>=0.50,<0.53
+numpy==1.19
 pandas==1.1.5
 pmdarima>=1.8.0
 scikit-learn==0.23.*

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -2,6 +2,7 @@ catch22
 cython>=0.29.0
 fbprophet>=0.7.1
 hcrystalball>=0.1.9
+llvmlite==0.16.0
 matplotlib
 notebook
 numba>=0.50,<0.53

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -2,7 +2,7 @@ catch22
 cython>=0.29.0
 fbprophet>=0.7.1
 hcrystalball>=0.1.9
-llvmlite>=0.16.0
+llvmlite==0.16.0
 matplotlib
 notebook
 numba>=0.50,<0.53

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -2,7 +2,6 @@ catch22
 cython>=0.29.0
 fbprophet>=0.7.1
 hcrystalball>=0.1.9
-llvmlite==0.16.0
 matplotlib
 notebook
 numba>=0.50,<0.53


### PR DESCRIPTION
Fixes #662 

#### What does this implement/fix? Explain your changes.

Updated `.binder/requirements.txt` so that binder-build finishes successfully. Have tested this by using `https://mybinder.org/` to build from my fork.

The changed requirement for `tsfresh` avoids an attempt to install `numpy-1.20.1` which is incompatible with `python 3.6` installed on binder and causes failed build. Extra line to address separate issue around `llvm` (see below).

#### Does your contribution introduce a new dependency? If yes, which one?

`llvm-lite-0.16.0` is the default version installed on Binder. Including the extra line avoids a doomed re-installation attempt out of the `/.binder` subfolder, where a certain `llvm-config` can't be found. Later in the build process, `llvm-lite` is successfully updated to `0.35.0`, presumably because the path to `llvm-config` works from the main directory.

#### What should a reviewer concentrate their feedback on?

This is my first pull request, so any feedback is very welcome!

#### PR checklist
##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/master/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/master/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.

