### PR TITLE
Upload source tarball to PyPI during releases

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -925,6 +925,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "dsherry",
+      "name": "Dylan Sherry",
+      "avatar_url": "https://avatars.githubusercontent.com/dsherry",
+      "profile": "https://github.com/dsherry",
+      "contributions": [
+        "infra"
+      ]
     }
   ],
   "projectName": "sktime",

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -54,6 +54,7 @@ jobs:
           python -m pip install --upgrade twine
           python -m twine upload -r pypi --non-interactive --skip-existing --verbose dist/*.whl
       - name: Upload source tarball to PyPI
+        env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         # for simplicity only do the upload once

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           ls -l dist/*
           python -m pip install --upgrade twine
-          python -m twine upload -r pypi --non-interactive --skip-existing --verbose dist/*.whl
+          python -m twine upload -r pypi --non-interactive --skip-existing --verbose dist/*
       - name: Upload source tarball to PyPI
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -45,7 +45,7 @@ jobs:
           cp setup.cfg testdir/
           cd testdir/
           pytest --showlocals --durations=10 --pyargs --cov-report=xml --cov=sktime sktime
-      - name: Upload wheel to PyPI
+      - name: Upload wheel and source tarball to PyPI
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
@@ -53,11 +53,3 @@ jobs:
           ls -l dist/*
           python -m pip install --upgrade twine
           python -m twine upload -r pypi --non-interactive --skip-existing --verbose dist/*
-      - name: Upload source tarball to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        # for simplicity only do the upload once
-        if: ${{ matrix.python_version == "3.8"}}
-        run: |
-          python -m twine upload -r pypi --non-interactive --skip-existing --verbose dist/*.tar.gz

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -45,7 +45,7 @@ jobs:
           cp setup.cfg testdir/
           cd testdir/
           pytest --showlocals --durations=10 --pyargs --cov-report=xml --cov=sktime sktime
-      - name: Upload to PyPI
+      - name: Upload wheel to PyPI
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
@@ -53,3 +53,10 @@ jobs:
           ls -l dist/*
           python -m pip install --upgrade twine
           python -m twine upload -r pypi --non-interactive --skip-existing --verbose dist/*.whl
+      - name: Upload source tarball to PyPI
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        # for simplicity only do the upload once
+        if: ${{ matrix.python_version == "3.8"}}
+        run: |
+          python -m twine upload -r pypi --non-interactive --skip-existing --verbose dist/*.tar.gz


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #607 

Relates to #723 #748 (@freddyaboulton FYI)


#### What does this implement/fix? Explain your changes.
I see sktime [was uploading a source tarball in v0.4.3](https://pypi.org/project/sktime/0.4.3/#files) and prior, but [has not done so since that version](https://pypi.org/project/sktime/0.5.3/#files).

As a result, running `pip install sktime` on platforms for which sktime has not built a wheel (like mac OS 10.14) will install that older version of sktime, v0.4.3.

Uploading a source tarball to PyPI will enable `pip`-installation of future sktime releases on platforms for which sktime didn't upload a wheel.

#### Does your contribution introduce a new dependency? If yes, which one?
Nope!

#### What should a reviewer concentrate their feedback on?
Check out [the console output from the last run of the PyPI upload action](https://github.com/alan-turing-institute/sktime/runs/1844683304?check_suite_focus=true) (for the v0.5.3 release). You can see it ran `python setup.py sdist` meaning it created a source tarball, but that tarball was simply never uploaded to PyPI.

#### Any other comments?
I also suggest the project owners (@mloning ) manually upload a source tarball for the last version (v0.5.3), to allow users of more platforms to install the latest package version without having to wait for the next release. I believe this would do it, from looking at [the twine docs](https://twine.readthedocs.io/en/latest/):
```bash
git checkout v0.5.3
python3 setup.py sdist
twine upload dist/sktime-0.5.3.tar.gz
```

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
