### PR TITLE
ThetaForecaster now works with initial_level

### DIFF
--- a/sktime/forecasting/tests/test_theta.py
+++ b/sktime/forecasting/tests/test_theta.py
@@ -43,3 +43,15 @@ def test_pred_errors_against_y_test(fh):
     for ints in intervals:
         assert np.all(y_test > ints["lower"])
         assert np.all(y_test < ints["upper"])
+
+
+def test_forecaster_with_initial_level():
+    y = np.log1p(load_airline())
+    y_train, y_test = temporal_train_test_split(y)
+    fh = np.arange(len(y_test)) + 1
+
+    f = ThetaForecaster(initial_level=0.1, sp=12)
+    f.fit(y_train)
+    y_pred = f.predict(fh=fh)
+
+    np.testing.assert_allclose(y_pred, y_test, rtol=0.05)

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -94,13 +94,17 @@ class ThetaForecaster(ExponentialSmoothing):
 
         self.sp = sp
         self.deseasonalize = deseasonalize
-
+        self.initialization_method_ = "known" if initial_level else "estimated"
         self.deseasonalizer_ = None
         self.trend_ = None
         self.initial_level_ = None
         self.drift_ = None
         self.se_ = None
-        super(ThetaForecaster, self).__init__(initial_level=initial_level, sp=sp)
+        super(ThetaForecaster, self).__init__(
+            initial_level=initial_level,
+            initialization_method=self.initialization_method_,
+            sp=sp,
+        )
 
     def fit(self, y, X=None, fh=None):
         """Fit to training data.

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -94,17 +94,12 @@ class ThetaForecaster(ExponentialSmoothing):
 
         self.sp = sp
         self.deseasonalize = deseasonalize
-        self.initialization_method_ = "known" if initial_level else "estimated"
         self.deseasonalizer_ = None
         self.trend_ = None
         self.initial_level_ = None
         self.drift_ = None
         self.se_ = None
-        super(ThetaForecaster, self).__init__(
-            initial_level=initial_level,
-            initialization_method=self.initialization_method_,
-            sp=sp,
-        )
+        super(ThetaForecaster, self).__init__(initial_level=initial_level, sp=sp)
 
     def fit(self, y, X=None, fh=None):
         """Fit to training data.
@@ -130,6 +125,7 @@ class ThetaForecaster(ExponentialSmoothing):
             self.deseasonalizer_ = Deseasonalizer(sp=self.sp, model="multiplicative")
             y = self.deseasonalizer_.fit_transform(y)
 
+        self.initialization_method = "known" if self.initial_level else "estimated"
         # fit exponential smoothing forecaster
         # find theta lines: Theta lines are just SES + drift
         super(ThetaForecaster, self).fit(y, fh=fh)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #692

#### What does this implement/fix? Explain your changes.
ThetaForecaster works when passed an initial_level, passed initialization_method parameter to ExponentialSmoothing

#### Does your contribution introduce a new dependency? If yes, which one?
NA

#### What should a reviewer concentrate their feedback on?
Is this a better fix or should I receive it from the user? 
Refer: https://github.com/alan-turing-institute/sktime/issues/692#issuecomment-811197573

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [x] I've added unit tests and made sure they pass locally.
