### PR TITLE
Fix counting for Github's automatic language discovery

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -606,17 +606,6 @@
       ]
     },
     {
-      "login": "AaronX121",
-      "name": "Yi-Xuan Xu",
-      "avatar_url": "https://avatars2.githubusercontent.com/u/22359569?v=4",
-      "profile": "https://github.com/AaronX121",
-      "contributions": [
-        "code",
-        "test",
-        "doc"
-      ]
-    },
-    {
       "login": "huayicodes",
       "name": "Huayi Wei",
       "avatar_url": "https://avatars3.githubusercontent.com/u/22870735?v=4",
@@ -837,7 +826,10 @@
       "avatar_url": "https://avatars2.githubusercontent.com/u/22359569?v=4",
       "profile": "https://github.com/xuyxu",
       "contributions": [
-        "code"
+        "code",
+        "test",
+        "maintenance",
+        "doc"
       ]
     },
     {

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+docs/* linguist-documentation
 sktime/datasets/data/* linguist-vendored
+jquery.js -linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
-docs/* linguist-documentation
 sktime/datasets/data/* linguist-vendored
 jquery.js -linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-sktime/datasets/data/* linguist-vendored
+sktime/datasets/data/** linguist-vendored
 jquery.js -linguist-vendored

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -12,6 +12,7 @@ from sklearn.base import RegressorMixin
 from sklearn.dummy import DummyRegressor
 from sklearn.linear_model import LinearRegression
 from sklearn.pipeline import make_pipeline
+from sktime.datasets import load_airline
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.compose import DirectTabularRegressionForecaster
@@ -60,7 +61,6 @@ def _make_y_X(n_timepoints, n_variables):
     # than its lagged values and the lagged and contemporaneous values of the
     # exogenous variables X
     assert n_variables < 10
-
     base = np.arange(n_timepoints)
     y = pd.Series(base + n_variables / 10)
 
@@ -381,3 +381,114 @@ def test_multioutput_direct_equivalence_tabular_linear_regression(fh):
     np.testing.assert_array_almost_equal(
         y_pred_direct.to_numpy(), y_pred_multioutput.to_numpy()
     )
+
+
+# this expected value created by Lovkush Agarwal by running code locally in Mar 2021
+EXPECTED_AIRLINE_LINEAR_RECURSIVE = [
+    397.28122475088117,
+    391.0055770755232,
+    382.85931770491493,
+    376.75382498759643,
+    421.3439733242519,
+    483.7127665080476,
+    506.5011555360703,
+    485.95155173523494,
+    414.41328025499604,
+    371.2843322707713,
+    379.5680077722808,
+    406.146827316167,
+    426.48249271837176,
+    415.5337957767289,
+    405.48715913377714,
+    423.97150765765025,
+    472.10998764155966,
+    517.7763038626333,
+    515.6077989417864,
+    475.8615207069196,
+    432.47049089698646,
+    417.62468250043514,
+    435.3174101071012,
+    453.8693707695759,
+]
+
+# this expected value created by Lovkush Agarwal by running code locally in Mar 2021
+EXPECTED_AIRLINE_LINEAR_DIRECT = [
+    388.7894742436609,
+    385.4311737990922,
+    404.66760376792183,
+    389.3921653574014,
+    413.5415037170552,
+    491.27471550855756,
+    560.5985060880608,
+    564.1354313250545,
+    462.8049467298484,
+    396.8247623180332,
+    352.5416937680942,
+    369.3915756974357,
+    430.12889943026323,
+    417.13419789042484,
+    434.8091175980315,
+    415.33997516059355,
+    446.97711875155846,
+    539.6761098618977,
+    619.7204673400846,
+    624.3153932803112,
+    499.686252475341,
+    422.0658526180952,
+    373.3847171492921,
+    388.8020135264563,
+]
+
+
+@pytest.mark.parametrize(
+    "forecaster, expected",
+    [
+        (
+            DirectTabularRegressionForecaster(LinearRegression()),
+            EXPECTED_AIRLINE_LINEAR_DIRECT,
+        ),
+        # multioutput should behave the same as direct with linear regression estimator
+        # hence the reason for the same expected predictions
+        (
+            MultioutputTabularRegressionForecaster(LinearRegression()),
+            EXPECTED_AIRLINE_LINEAR_DIRECT,
+        ),
+        (
+            RecursiveTabularRegressionForecaster(LinearRegression()),
+            EXPECTED_AIRLINE_LINEAR_RECURSIVE,
+        ),
+        (
+            DirectTimeSeriesRegressionForecaster(
+                make_pipeline(Tabularizer(), LinearRegression())
+            ),
+            EXPECTED_AIRLINE_LINEAR_DIRECT,
+        ),
+        # multioutput should behave the same as direct with linear regression estimator
+        # hence the reason for the same expected predictions
+        (
+            MultioutputTimeSeriesRegressionForecaster(
+                make_pipeline(Tabularizer(), LinearRegression())
+            ),
+            EXPECTED_AIRLINE_LINEAR_DIRECT,
+        ),
+        (
+            RecursiveTimeSeriesRegressionForecaster(
+                make_pipeline(Tabularizer(), LinearRegression())
+            ),
+            EXPECTED_AIRLINE_LINEAR_RECURSIVE,
+        ),
+    ],
+)
+def test_reductions_airline_data(forecaster, expected):
+    """
+    test reduction forecasters by making prediction on airline dataset
+    using linear estimators. predictions compared with values calculated by Lovkush
+    Agarwal on their local machine in Mar 2021
+    """
+    y = load_airline()
+    y_train, y_test = temporal_train_test_split(y, test_size=24)
+    fh = ForecastingHorizon(y_test.index, is_relative=False)
+
+    actual = forecaster.fit(y_train, fh=fh).predict(fh)
+
+    np.testing.assert_almost_equal(actual, expected)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

resolves #809

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Take suggestions from this [discussion](https://github.com/github/linguist/discussions/5323#discussioncomment-610376) to recursively mark all downstream directories as vendored.

As mentioned in this discussion, in order to trigger the language discovery appropriately, we have to push other changes along with this PR. Therefore, I have modified the config for all-contributors, removing my previous account that causes the duplicates in [CONTRIBUTORS.md](https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTORS.md).
