### PR TITLE
Undo pmdarima hotfix and avoid pmdarima 1.8.1

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -944,6 +944,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "aaronreidsmith",
+      "name": "Aaron Smith",
+      "avatar_url": "https://avatars.githubusercontent.com/u/21350310?v=4",
+      "profile": "https://github.com/aaronreidsmith",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "projectName": "sktime",

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -7,7 +7,7 @@ notebook
 numba>=0.50,<0.53
 numpy==1.19
 pandas==1.1.5
-pmdarima==1.8.0
+pmdarima>=1.8.0,!=1.8.1
 scikit-learn==0.24.*
 scikit-posthocs
 seaborn

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -5,7 +5,7 @@ hcrystalball>=0.1.9
 numba>=0.50,<0.53
 numpy==1.19
 pandas==1.1.5
-pmdarima==1.8.0
+pmdarima>=1.8.0,!=1.8.1
 pystan>=2.14,<3.0
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ EXTRAS_REQUIRE = {
     "all_extras": [
         "cython>=0.29.0",
         "matplotlib>=3.3.2",
-        "pmdarima==1.8.0",
+        "pmdarima>=1.8.0,!=1.8.1",
         "scikit_posthocs>= 0.6.5",
         "seaborn>=0.11.0",
         "tsfresh>=0.17.0",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Reverts hotfix from #828 (also see alkaline-ml/pmdarima#423) and pins so `pmdarima 1.8.1` is avoided.

#### What does this implement/fix? Explain your changes.

Removes the need for the hotfix and keeps `numpy` compatibility.

#### Does your contribution introduce a new dependency? If yes, which one?

No, just fixes an existing one 🙂 

#### What should a reviewer concentrate their feedback on?

N/A

#### Any other comments?

Sorry I pushed a bad `pmdarima` version yesterday 😅 

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
