### PR TITLE
Exclude Python 3.10 from manylinux CI 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@
 .. |twitter| image:: https://img.shields.io/twitter/follow/sktime_toolbox?label=%20Twitter&style=social
 .. _twitter: https://twitter.com/sktime_toolbox
 
-.. |python| image:: https://img.shields.io/badge/python-3.6+-blue?logo=python
+.. |python| image:: https://img.shields.io/pypi/pyversions/sktime
 .. _python: https://www.python.org/
 
 .. |codestyle| image:: https://img.shields.io/badge/code%20style-black-000000.svg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@
 
 variables:
   REQUIREMENTS: build_tools/requirements.txt
-  EXCLUDE_PYTHON_VERSIONS: "2.7, 3.5, 3.9"  # comma-separate string
+  EXCLUDE_PYTHON_VERSIONS: "2.7, 3.5, 3.9, 3.10"  # comma-separate string
 
 trigger:
   branches:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
* Fix broken manylinux builds by skipping Python 3.10 which was recently added to the manylinux image. 
* Fix badge for supported Python version (thanks to discussion in #664)

I initially thought this is related to numba (hence the branch name), but it wasn't.