### PR TITLE
datetime: Construct Timedelta from parsed pandas frequency

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1001,7 +1001,17 @@
       "contributions": [
         "code"
       ]
-    }
+    },
+    {
+      "login": "ckastner",
+      "name": "Christian Kastner",
+      "avatar_url": "https://avatars.githubusercontent.com/u/15859947?v=4",
+      "profile": "https://github.com/ckastner",
+      "contributions": [
+        "code",
+        "bug",
+      ]
+    },
   ],
   "projectName": "sktime",
   "projectOwner": "alan-turing-institute",

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -164,6 +164,7 @@ def test_shift(timepoint, by):
 
 DURATIONS = [
     pd.TimedeltaIndex(range(3), unit="D", freq="D"),
+    pd.TimedeltaIndex(range(0, 9, 3), unit="D", freq="3D"),
     pd.tseries.offsets.MonthEnd(3),
     pd.Index(pd.tseries.offsets.Day(day) for day in range(3)),
     # we also support pd.Timedelta, but it does not have freqstr so we


### PR DESCRIPTION
Add support for non-unit frequencies (eg: 30 minutes) by parsing the pandas frequency and extracting the relevant values to pass on to pd.Timedelta().

This works for frequencies like `D` and `3D`, as demonstrated by the test.

This does not work with [anchored offsets](https://pandas.pydata.org/docs/user_guide/timeseries.html#anchored-offsets), like the `W-SUN` mentioned in #866, as it's not immediately obvious to me how one would construct a correct Timedelta from this. I suspect that the anchor can simply be dropped (7 days are 7 days, no matter whether they start on Sunday or Monday), but I'm not entirely sure, and I had a hard time constructing a test example.

Fixes: #868
