### PR TITLE
Fix boxcox docstring 884

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -953,6 +953,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "GuzalBulatova",
+      "name": "Guzal Bulatova",
+      "avatar_url": "https://avatars.githubusercontent.com/GuzalBulatova",
+      "profile": "https://github.com/GuzalBulatova",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "projectName": "sktime",

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -26,7 +26,7 @@ from sktime.utils.validation.series import check_series
 class BoxCoxTransformer(_SeriesToSeriesTransformer):
     """
     Example
-    ----------
+    -------
     >>> from sktime.transformations.series.boxcox import BoxCoxTransformer
     >>> from sktime.datasets import load_airline
     >>> y = load_airline()
@@ -144,13 +144,13 @@ def _boxcox_normmax(x, bounds=None, brack=(-2.0, 2.0), method="pearsonr"):
 
 def _guerrero(x, sp, bounds=None):
     r"""
-    Returns lambda estimated by the Guerrero method [Guerrero].
+    Return lambda estimated by the Guerrero method [Guerrero].
     Parameters
     ----------
     x : ndarray
         Input array. Must be 1-dimensional.
     sp : integer
-        Seasonal periodicity value. Must be an integer >= 2
+        Seasonal periodicity value. Must be an integer >= 2.
     bounds : {None, (float, float)}, optional
         Bounds on lambda to be used in minimization.
     Returns

--- a/sktime/transformations/series/tests/test_boxcox.py
+++ b/sktime/transformations/series/tests/test_boxcox.py
@@ -10,7 +10,6 @@ import pytest
 from scipy.stats import boxcox
 from sktime.datasets import load_airline
 from sktime.transformations.series.boxcox import BoxCoxTransformer
-from pytest import approx
 
 
 def test_boxcox_against_scipy():
@@ -60,4 +59,4 @@ def test_guerrero_against_r_implementation(bounds, r_lambda):
     y = load_airline()
     t = BoxCoxTransformer(bounds=bounds, method="guerrero", sp=20)
     t.fit(y)
-    assert t.lambda_ == approx(r_lambda, abs=1e-4)
+    np.testing.assert_almost_equal(t.lambda_, r_lambda, decimal=4)

--- a/sktime/transformations/series/tests/test_boxcox.py
+++ b/sktime/transformations/series/tests/test_boxcox.py
@@ -10,6 +10,7 @@ import pytest
 from scipy.stats import boxcox
 from sktime.datasets import load_airline
 from sktime.transformations.series.boxcox import BoxCoxTransformer
+from pytest import approx
 
 
 def test_boxcox_against_scipy():
@@ -26,10 +27,37 @@ def test_boxcox_against_scipy():
 
 @pytest.mark.parametrize("bounds", [(0, 1), (-1, 0), (-1, 2)])
 @pytest.mark.parametrize(
-    "method_sp", [("mle", None), ("pearsonr", None), ("guerrero", 5)]
+    "method, sp", [("mle", None), ("pearsonr", None), ("guerrero", 5)]
 )
-def test_lambda_bounds(bounds, method_sp):
+def test_lambda_bounds(bounds, method, sp):
     y = load_airline()
-    t = BoxCoxTransformer(bounds=bounds, method=method_sp[0], sp=method_sp[1])
+    t = BoxCoxTransformer(bounds=bounds, method=method, sp=sp)
     t.fit(y)
     assert bounds[0] < t.lambda_ < bounds[1]
+
+
+@pytest.mark.parametrize(
+    "bounds, r_lambda",
+    [
+        ((0, 1), 6.61069613518961e-05),
+        ((-1, 0), -0.156975034727656),
+        ((-1, 2), -0.156981228426408),
+    ],
+)
+def test_guerrero_against_r_implementation(bounds, r_lambda):
+    """
+    Testing lambda values estimated by the R implementation of the Guerrero method
+    https://github.com/robjhyndman/forecast/blob/master/R/guerrero.R
+    against the guerrero method in BoxCoxTransformer.
+    R code to generate the hardcoded value for bounds=(-1, 2) used in the test
+    ('Airline.csv' contains the data from 'load_airline()'):
+        airline_file <- read.csv(file = 'Airline.csv')[,c('Passengers')]
+        airline.ts <- ts(airline_file)
+        guerrero(airline.ts, lower=-1, upper=2, nonseasonal.length = 20)
+    Output:
+        -0.156981228426408
+    """
+    y = load_airline()
+    t = BoxCoxTransformer(bounds=bounds, method="guerrero", sp=20)
+    t.fit(y)
+    assert t.lambda_ == approx(r_lambda, abs=1e-4)

--- a/sktime/transformations/series/tests/test_boxcox.py
+++ b/sktime/transformations/series/tests/test_boxcox.py
@@ -25,7 +25,7 @@ def test_boxcox_against_scipy():
 
 
 @pytest.mark.parametrize("bounds", [(0, 1), (-1, 0), (-1, 2)])
-@pytest.mark.parametrize("method", ["mle", "pearsonr"])
+@pytest.mark.parametrize("method", ["mle", "pearsonr", "guerrero"])
 def test_lambda_bounds(bounds, method):
     y = load_airline()
     t = BoxCoxTransformer(bounds=bounds, method=method)

--- a/sktime/transformations/series/tests/test_boxcox.py
+++ b/sktime/transformations/series/tests/test_boxcox.py
@@ -25,9 +25,11 @@ def test_boxcox_against_scipy():
 
 
 @pytest.mark.parametrize("bounds", [(0, 1), (-1, 0), (-1, 2)])
-@pytest.mark.parametrize("method", ["mle", "pearsonr", "guerrero"])
-def test_lambda_bounds(bounds, method):
+@pytest.mark.parametrize(
+    "method_sp", [("mle", None), ("pearsonr", None), ("guerrero", 5)]
+)
+def test_lambda_bounds(bounds, method_sp):
     y = load_airline()
-    t = BoxCoxTransformer(bounds=bounds, method=method)
+    t = BoxCoxTransformer(bounds=bounds, method=method_sp[0], sp=method_sp[1])
     t.fit(y)
     assert bounds[0] < t.lambda_ < bounds[1]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

Fixes #884 (partially)
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fixes minor typos in `transformations/series/boxcox.py`

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Are the docstrings now according to convention?

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
