### PR TITLE
Accept numpy arrays in check_y and coerce to pd.Series 

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -363,6 +363,7 @@ class BaseForecaster(BaseEstimator):
         X : pd.DataFrame, optional (default=None)
             Exogenous time series
         """
+        y = pd.Series(y)
         # set initial training data
         self._y, self._X = check_y_X(
             y, X, allow_empty=False, enforce_index_type=enforce_index_type

--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -56,8 +56,12 @@ def plot_series(
     from matplotlib.cbook import flatten
     import seaborn as sns
 
+    # creates a new series of type pd.Series
+    new_series = []
     for y in series:
-        check_y(y)
+        y = check_y(y)
+        new_series.append(y)
+    series = new_series
 
     n_series = len(series)
     _ax_kwarg_is_none = True if ax is None else False

--- a/sktime/utils/validation/forecasting.py
+++ b/sktime/utils/validation/forecasting.py
@@ -111,7 +111,7 @@ def check_y(y, allow_empty=False, allow_constant=True, enforce_index_type=None):
 
     Parameters
     ----------
-    y : pd.Series
+    y : pd.Series, np.ndarray(1)
     allow_empty : bool, optional (default=False)
         If False, empty `y` raises an error.
     allow_constant : bool, optional (default=True)
@@ -132,7 +132,7 @@ def check_y(y, allow_empty=False, allow_constant=True, enforce_index_type=None):
         y,
         enforce_univariate=True,
         allow_empty=allow_empty,
-        allow_numpy=False,
+        allow_numpy=True,
         enforce_index_type=enforce_index_type,
     )
 

--- a/sktime/utils/validation/forecasting.py
+++ b/sktime/utils/validation/forecasting.py
@@ -140,7 +140,7 @@ def check_y(y, allow_empty=False, allow_constant=True, enforce_index_type=None):
         if np.all(y == y.iloc[0]):
             raise ValueError("All values of `y` are the same.")
 
-    return y
+    return pd.Series(y)
 
 
 def check_cv(cv, enforce_start_with_window=False):

--- a/sktime/utils/validation/tests/test_forecasting.py
+++ b/sktime/utils/validation/tests/test_forecasting.py
@@ -24,4 +24,4 @@ def test_check_fh_empty_input(arg):
 
 # @pytest.mark.parametrize("arg", bad_input)
 def test_check_y():
-    check_y(valid_numpy_input)
+    isinstance(check_y(valid_numpy_input), pd.Series)

--- a/sktime/utils/validation/tests/test_forecasting.py
+++ b/sktime/utils/validation/tests/test_forecasting.py
@@ -10,11 +10,18 @@ import pytest
 from pytest import raises
 
 from sktime.utils.validation.forecasting import check_fh
+from sktime.utils.validation.forecasting import check_y
 
 empty_input = (np.array([]), [], pd.Int64Index([]))
+valid_numpy_input = np.array([3, 4, 5, 6])
 
 
 @pytest.mark.parametrize("arg", empty_input)
 def test_check_fh_empty_input(arg):
     with raises(ValueError):
         check_fh(arg)
+
+
+# @pytest.mark.parametrize("arg", bad_input)
+def test_check_y():
+    check_y(valid_numpy_input)


### PR DESCRIPTION
#880 

There is a little bug in the test. I entered the argument 

```python 

good_numpy_input = (np.array([3, 4]))

@pytest.mark.parametrize("arg", good_numpy_input)
def test_check_y_numpy_input(arg):
    with raises(TypeError):
        check_series(arg)
```

to test if `good_numpy_input` is a valid input , which it is, but it the test passes. However, it should fail. I am a bit unsure of why it is an invalid input