### PR TITLE
Add limits.h to ensure pip install on certain OS's

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1012,6 +1012,15 @@
         "bug",
       ]
     },
+    {
+      "login": "tombh",
+      "name": "Thomas Buckley-Houston",
+      "avatar_url": "https://avatars.githubusercontent.com/u/160835?s=80&v=4",
+      "profile": "https://github.com/tombh",
+      "contributions": [
+        "bug",
+      ]
+    },
   ],
   "projectName": "sktime",
   "projectOwner": "alan-turing-institute",

--- a/sktime/classification/shapelet_based/mrseql/SNode.h
+++ b/sktime/classification/shapelet_based/mrseql/SNode.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <algorithm>
 #include <iostream>
+#include <limits>
 
 class SNode
 {


### PR DESCRIPTION
Fixes #913

On certain OS's, installing with `pip install sktime` gives:
```
sktime/classification/shapelet_based/mrseql/SNode.cpp:89:39:
  error: ‘numeric_limits’ is not a member of ‘std’
   89 | totalWildcardLimit = std::numeric_limits<int>::max();
      |                           ^~~~~~~~~~~~~~
sktime/classification/shapelet_based/mrseql/SNode.cpp:89:54:
  error: expected primary-expression before ‘int’
   89 | totalWildcardLimit = std::numeric_limits<int>::max();
      |                                          ^~~

```

By "certain OS's", this happened on an up to date Arch Linux system:
  python: 3.9.5
  gcc: 11.1.0

