### PR TITLE
minor bugfix - setting _is_fitted to False before input checks in forecasters

### DIFF
--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -32,6 +32,7 @@ class _ProphetAdapter(_OptionalForecastingHorizonMixin, _SktimeForecaster):
         -------
         self : returns an instance of self.
         """
+        self._is_fitted = False
         self._instantiate_model()
         self._check_changepoints()
         self._set_y_X(y, X, enforce_index_type=pd.DatetimeIndex)

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -37,6 +37,7 @@ class _PmdArimaAdapter(_OptionalForecastingHorizonMixin, _SktimeForecaster):
         -------
         self : returns an instance of self.
         """
+        self._is_fitted = False
         self._set_y_X(y, X)
         self._set_fh(fh)
         self._forecaster = self._instantiate_model()

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -41,7 +41,7 @@ class _StatsModelsAdapter(_OptionalForecastingHorizonMixin, _SktimeForecaster):
         # so we coerce them here to pd.RangeIndex
         if isinstance(y, pd.Series) and type(y.index) == pd.Int64Index:
             y, X = _coerce_int_to_range_index(y, X)
-
+        self._is_fitted = False
         self._set_y_X(y, X)
         self._set_fh(fh)
         self._fit_forecaster(y, X)

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -80,6 +80,7 @@ class _TbatsAdapter(_OptionalForecastingHorizonMixin, _SktimeForecaster):
         -------
         self : returns an instance of self.
         """
+        self._is_fitted = False
         y, X = check_y_X(y, X)
         self._set_y_X(y, X)
         self._set_fh(fh)

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -49,6 +49,8 @@ class EnsembleForecaster(
         -------
         self : returns an instance of self.
         """
+        self._is_fitted = False
+
         self._set_y_X(y, X)
         self._set_fh(fh)
         names, forecasters = self._check_forecasters()

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -147,6 +147,8 @@ class MultiplexForecaster(
         self : returns an instance of self.
         """
 
+        self._is_fitted = False
+
         self._set_y_X(y, X)
         self._set_fh(fh)
         self._check_forecasters()

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -129,6 +129,8 @@ class TransformedTargetForecaster(
         -------
         self : returns an instance of self.
         """
+        self._is_fitted = False
+
         self.steps_ = self._check_steps()
         self._set_y_X(y, X)
         self._set_fh(fh)

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -168,6 +168,8 @@ class _Reducer(_BaseWindowForecaster):
         self : Estimator
             An fitted instance of self.
         """
+        self._is_fitted = False
+
         n_timepoints = len(y)
         self._set_y_X(y, X)
         self._set_fh(fh)

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -43,6 +43,8 @@ class StackingForecaster(
         -------
         self : returns an instance of self.
         """
+        self._is_fitted = False
+
         self._set_y_X(y, X)
         if X is not None:
             raise NotImplementedError()

--- a/sktime/forecasting/hcrystalball.py
+++ b/sktime/forecasting/hcrystalball.py
@@ -100,6 +100,7 @@ class HCrystalBallForecaster(_OptionalForecastingHorizonMixin, _SktimeForecaster
         super(HCrystalBallForecaster, self).__init__()
 
     def fit(self, y, X=None, fh=None):
+        self._is_fitted = False
         self._set_y_X(y, X)
         self._set_fh(fh)
 

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -215,6 +215,7 @@ class BaseGridSearch(BaseForecaster):
         -------
         self : returns an instance of self.
         """
+        self._is_fitted = False
         y, X = check_y_X(y, X)
         cv = check_cv(self.cv)
         scoring = check_scoring(self.scoring)

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -81,6 +81,8 @@ class NaiveForecaster(_OptionalForecastingHorizonMixin, _BaseWindowForecaster):
         self : returns an instance of self.
         """
         # X_train is ignored
+        self._is_fitted = False
+
         self._set_y_X(y, X)
         self._set_fh(fh)
         n_timepoints = y.shape[0]

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -69,6 +69,8 @@ class PolynomialTrendForecaster(_OptionalForecastingHorizonMixin, _SktimeForecas
         -------
         self : returns an instance of self.
         """
+        self._is_fitted = False
+
         if X is not None:
             raise NotImplementedError(
                 "Support for exogenous variables is not yet implemented"

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -83,6 +83,7 @@ class Deseasonalizer(_SeriesToSeriesTransformer):
         -------
         self : an instance of self
         """
+        self._is_fitted = False
         z = check_series(Z, enforce_univariate=True)
         self._set_y_index(z)
         sp = check_sp(self.sp)

--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -81,6 +81,7 @@ class Detrender(_SeriesToSeriesTransformer):
         -------
         self : an instance of self
         """
+        self._is_fitted = False
         z = check_series(Z, enforce_univariate=True)
         if self.forecaster is None:
             self.forecaster = PolynomialTrendForecaster(degree=1)


### PR DESCRIPTION
This is a minuscule change which is a preemptive fix.

The change sets `self._is_fitted = False` in the first line of `fit`, of a number of forecasters, before the input checks.

This prevents some unexpected behaviour when `fit`, of the estimator, is called multiple times in sequence, e.g., in grid search (as in the tutorial notebook).

It also prevents exceptions caused by this unexpected behaviour in any future refactor (e.g., #912) where `_set_fh` uses `_is_fitted` to check whether an `fh` is expected.

This should be done in all forecasters.