### PR TITLE
Exemplary concrete estimator refactor post interface refactor, of NaiveForecaster

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -105,6 +105,8 @@ class BaseForecaster(BaseEstimator):
         self._X = X
         self._y = y
 
+        self._set_cutoff(y.index[-1])
+
         self._fit(y=y, X=X, fh=fh)
 
         # this should happen last

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -11,12 +11,11 @@ import numpy as np
 
 from sktime.forecasting.base._base import DEFAULT_ALPHA
 from sktime.forecasting.base._sktime import _BaseWindowForecaster
-from sktime.forecasting.base._sktime import _OptionalForecastingHorizonMixin
 from sktime.utils.validation.forecasting import check_sp
 from sktime.utils.validation import check_window_length
 
 
-class NaiveForecaster(_OptionalForecastingHorizonMixin, _BaseWindowForecaster):
+class NaiveForecaster(_BaseWindowForecaster):
     """
     NaiveForecaster is a forecaster that makes forecasts using simple
     strategies.
@@ -59,13 +58,15 @@ class NaiveForecaster(_OptionalForecastingHorizonMixin, _BaseWindowForecaster):
     >>> y_pred = forecaster.predict(fh=[1,2,3])
     """
 
+    _tags = {"requires-fh-in-fit": False}
+
     def __init__(self, strategy="last", window_length=None, sp=1):
         super(NaiveForecaster, self).__init__()
         self.strategy = strategy
         self.sp = sp
         self.window_length = window_length
 
-    def fit(self, y, X=None, fh=None):
+    def _fit(self, y, X=None, fh=None):
         """Fit to training data.
 
         Parameters
@@ -81,10 +82,7 @@ class NaiveForecaster(_OptionalForecastingHorizonMixin, _BaseWindowForecaster):
         self : returns an instance of self.
         """
         # X_train is ignored
-        self._is_fitted = False
 
-        self._set_y_X(y, X)
-        self._set_fh(fh)
         n_timepoints = y.shape[0]
 
         if self.strategy == "last":
@@ -152,7 +150,6 @@ class NaiveForecaster(_OptionalForecastingHorizonMixin, _BaseWindowForecaster):
                 f"the training series."
             )
 
-        self._is_fitted = True
         return self
 
     def _predict_last_window(


### PR DESCRIPTION
This is an exemplary refactor of a concrete estimator class, `NaiveForecaster`, to explore how general concrete forecaster refactors would work, along the lines discussed in #912.

This PR changes:

* `_BaseWindowForecaster` still inherits from `BaseForecaster` directly, and already looked extension spec compliant (no overrides, no tags)
* `NaiveForecaster` inherits from `_BaseWindowForecaster`, and has been made extension spec compliant by adding the `requires-fh-in-fit` tag, and moving core logic from `fit` to `_fit`, while avoiding to override `fit`
* it adds one line in `BaseForecaster.fit`, as a general change: the `cutoff` is set to the latest `y` index using `_set_cutoff`. This is done pre-`_fit`, which could override the set cut-off.