### PR TITLE
adding fkiraly as codeowner for forecasting base classes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,6 +21,7 @@ sktime/transformations/series/impute.py @aiwalter
 sktime/transformations/series/outlier_detection.py @aiwalter
 sktime/transformations/series/compose.py @aiwalter
 
+sktime/forecasting/base/ @fkiraly
 sktime/forecasting/ets.py @HYang1996
 sktime/forecasting/tests/test_ets.py @HYang1996
 sktime/forecasting/fbprophet.py @aiwalter


### PR DESCRIPTION
This minuscule PR adds me as a codeowner for anything going on in `forecasting/base`, i.e., I'll get auto-PR reviews on any changes to the forecasting base/template interface.

As discussed with @mloning (who is current codeowner).

Also FYI, @aiwalter, @TonyBagnall.