### PR TITLE
Cleanup metric docstrings and fix bug in _RelativeLossMixin

### DIFF
--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -134,7 +134,7 @@ class _PercentageErrorMixin:
         Returns
         -------
         loss : float
-            Calculated loss metric
+            Calculated loss metric.
         """
         return self._func(
             y_true,
@@ -174,7 +174,7 @@ class _SquaredErrorMixin:
         Returns
         -------
         loss : float
-            Calculated loss metric
+            Calculated loss metric.
         """
         return self._func(
             y_true,
@@ -217,8 +217,6 @@ class _SquaredPercentageErrorMixin:
         -------
         loss : float
             Calculated loss metric.
-            If square_root = True, tells .
-            I
         """
         return self._func(
             y_true,
@@ -251,7 +249,7 @@ class _AsymmetricErrorMixin:
         Returns
         -------
         loss : float
-            Calculated loss metric
+            Calculated loss metric.
         """
         return self._func(
             y_true,
@@ -285,13 +283,13 @@ class _RelativeLossMixin:
         Returns
         -------
         loss : float
-            Calculated loss metric
+            Calculated loss metric.
         """
         return self._func(
             y_true,
             y_pred,
             multioutput=self.multioutput,
-            loss_function=self.relative_loss_function,
+            relative_loss_function=self.relative_loss_function,
             **kwargs,
         )
 
@@ -482,6 +480,28 @@ class MeanAbsoluteScaledError(_ScaledForecastingErrorMetric):
     MeanSquaredScaledError
     MedianSquaredScaledError
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import MeanAbsoluteScaledError
+    >>> y_train = np.array([5, 0.5, 4, 6, 3, 5, 2])
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> mase = MeanAbsoluteScaledError()
+    >>> mase(y_true, y_pred, y_train=y_train)
+    0.18333333333333335
+    >>> y_train = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> mase(y_true, y_pred, y_train=y_train)
+    0.18181818181818182
+    >>> mase = MeanAbsoluteScaledError(multioutput='raw_values')
+    >>> mase(y_true, y_pred, y_train=y_train)
+    array([0.10526316, 0.28571429])
+    >>> mase = MeanAbsoluteScaledError(multioutput=[0.3, 0.7])
+    >>> mase(y_true, y_pred, y_train=y_train)
+    0.21935483870967742
+
     References
     ----------
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
@@ -554,6 +574,28 @@ class MedianAbsoluteScaledError(_ScaledForecastingErrorMetric):
     MeanAbsoluteScaledError
     MeanSquaredScaledError
     MedianSquaredScaledError
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import MedianAbsoluteScaledError
+    >>> y_train = np.array([5, 0.5, 4, 6, 3, 5, 2])
+    >>> y_true = [3, -0.5, 2, 7]
+    >>> y_pred = [2.5, 0.0, 2, 8]
+    >>> mdase = MedianAbsoluteScaledError()
+    >>> mdase(y_true, y_pred, y_train=y_train)
+    0.16666666666666666
+    >>> y_train = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> mdase(y_true, y_pred, y_train=y_train)
+    0.18181818181818182
+    >>> mdase = MedianAbsoluteScaledError(multioutput='raw_values')
+    >>> mdase(y_true, y_pred, y_train=y_train)
+    array([0.10526316, 0.28571429])
+    >>> mdase = MedianAbsoluteScaledError(multioutput=[0.3, 0.7])
+    >>> mdase( y_true, y_pred, y_train=y_train)
+    0.21935483870967742
 
     References
     ----------
@@ -632,6 +674,28 @@ class MeanSquaredScaledError(_ScaledSquaredForecastingErrorMetric):
     MeanAbsoluteScaledError
     MedianAbsoluteScaledError
     MedianSquaredScaledError
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import MeanSquaredScaledError
+    >>> y_train = np.array([5, 0.5, 4, 6, 3, 5, 2])
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> rmsse = MeanSquaredScaledError(square_root=True)
+    >>> rmsse(y_true, y_pred, y_train=y_train)
+    0.20568833780186058
+    >>> y_train = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> rmsse(y_true, y_pred, y_train=y_train)
+    0.15679361328058636
+    >>> rmsse = MeanSquaredScaledError(multioutput='raw_values', square_root=True)
+    >>> rmsse(y_true, y_pred, y_train=y_train)
+    array([0.11215443, 0.20203051])
+    >>> rmsse = MeanSquaredScaledError(multioutput=[0.3, 0.7], square_root=True)
+    >>> rmsse(y_true, y_pred, y_train=y_train)
+    0.17451891814894502
 
     References
     ----------
@@ -713,6 +777,28 @@ class MedianSquaredScaledError(_ScaledSquaredForecastingErrorMetric):
     MedianAbsoluteScaledError
     MedianSquaredScaledError
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import MedianSquaredScaledError
+    >>> y_train = np.array([5, 0.5, 4, 6, 3, 5, 2])
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> rmdsse = MedianSquaredScaledError(square_root=True)
+    >>> rmdsse(y_true, y_pred, y_train=y_train)
+    0.16666666666666666
+    >>> y_train = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> rmdsse(y_true, y_pred, y_train=y_train)
+    0.1472819539849714
+    >>> rmdsse = MedianSquaredScaledError(multioutput='raw_values', square_root=True)
+    >>> rmdsse(y_true, y_pred, y_train=y_train)
+    array([0.08687445, 0.20203051])
+    >>> rmdsse = MedianSquaredScaledError(multioutput=[0.3, 0.7], square_root=True)
+    >>> rmdsse(y_true, y_pred, y_train=y_train)
+    0.16914781383660782
+
     References
     ----------
     M5 Competition Guidelines.
@@ -771,6 +857,26 @@ class MeanAbsoluteError(_BaseForecastingErrorMetric):
     MeanSquaredError
     MedianSquaredError
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import MeanAbsoluteError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> mae = MeanAbsoluteError()
+    >>> mae(y_true, y_pred)
+    0.55
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> mae(y_true, y_pred)
+    0.75
+    >>> mae = MeanAbsoluteError(multioutput='raw_values')
+    >>> mae(y_true, y_pred)
+    array([0.5, 1. ])
+    >>> mae = MeanAbsoluteError(multioutput=[0.3, 0.7])
+    >>> mae(y_true, y_pred)
+    0.85
+
     References
     ----------
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
@@ -823,6 +929,26 @@ class MedianAbsoluteError(_BaseForecastingErrorMetric):
     MeanAbsoluteError
     MeanSquaredError
     MedianSquaredError
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import MedianAbsoluteError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> mdae = MedianAbsoluteError()
+    >>> mdae(y_true, y_pred)
+    0.5
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> mdae(y_true, y_pred)
+    0.75
+    >>> mdae = MedianAbsoluteError(multioutput='raw_values')
+    >>> mdae(y_true, y_pred)
+    array([0.5, 1. ])
+    >>> mdae = MedianAbsoluteError(multioutput=[0.3, 0.7])
+    >>> mdae(y_true, y_pred)
+    0.85
 
     References
     ----------
@@ -881,6 +1007,35 @@ class MeanSquaredError(_SquaredForecastingErrorMetric):
     MeanAbsoluteError
     MedianAbsoluteError
     MedianSquaredError
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import MeanSquaredError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> mse = MeanSquaredError()
+    >>> mse(y_true, y_pred)
+    0.4125
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> mse(y_true, y_pred)
+    0.7083333333333334
+    >>> rmse = MeanSquaredError(square_root=True)
+    >>> rmse(y_true, y_pred)
+    0.8227486121839513
+    >>> rmse = MeanSquaredError(multioutput='raw_values')
+    >>> rmse(y_true, y_pred)
+    array([0.41666667, 1.        ])
+    >>> rmse = MeanSquaredError(multioutput='raw_values', square_root=True)
+    >>> rmse(y_true, y_pred)
+    array([0.64549722, 1.        ])
+    >>> rmse = MeanSquaredError(multioutput=[0.3, 0.7])
+    >>> rmse(y_true, y_pred)
+    0.825
+    >>> rmse = MeanSquaredError(multioutput=[0.3, 0.7], square_root=True)
+    >>> rmse(y_true, y_pred)
+    0.8936491673103708
 
     References
     ----------
@@ -950,6 +1105,37 @@ class MedianSquaredError(_SquaredForecastingErrorMetric):
     MedianAbsoluteError
     MeanSquaredError
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import MedianSquaredError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> mdse = MedianSquaredError()
+    >>> mdse(y_true, y_pred)
+    0.25
+    >>> rmdse = MedianSquaredError(square_root=True)
+    >>> rmdse(y_true, y_pred)
+    0.5
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> mdse(y_true, y_pred)
+    0.625
+    >>> rmdse(y_true, y_pred)
+    0.75
+    >>> mdse = MedianSquaredError(multioutput='raw_values')
+    >>> mdse(y_true, y_pred)
+    array([0.25, 1.  ])
+    >>> rmdse = MedianSquaredError(multioutput='raw_values', square_root=True)
+    >>> rmdse(y_true, y_pred)
+    array([0.5, 1. ])
+    >>> mdse = MedianSquaredError(multioutput=[0.3, 0.7])
+    >>> mdse(y_true, y_pred)
+    0.7749999999999999
+    >>> rmdse = MedianSquaredError(multioutput=[0.3, 0.7], square_root=True)
+    >>> rmdse(y_true, y_pred)
+    0.85
+
     References
     ----------
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
@@ -1015,6 +1201,38 @@ class MeanAbsolutePercentageError(_PercentageForecastingErrorMetric):
     MedianAbsolutePercentageError
     MeanSquaredPercentageError
     MedianSquaredPercentageError
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import \
+    MeanAbsolutePercentageError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> mape = MeanAbsolutePercentageError(symmetric=False)
+    >>> mape(y_true, y_pred)
+    0.33690476190476193
+    >>> smape = MeanAbsolutePercentageError()
+    >>> smape(y_true, y_pred)
+    0.5553379953379953
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> mape(y_true, y_pred)
+    0.5515873015873016
+    >>> smape(y_true, y_pred)
+    0.6080808080808081
+    >>> mape = MeanAbsolutePercentageError(multioutput='raw_values', symmetric=False)
+    >>> mape(y_true, y_pred)
+    array([0.38095238, 0.72222222])
+    >>> smape = MeanAbsolutePercentageError(multioutput='raw_values')
+    >>> smape(y_true, y_pred)
+    array([0.71111111, 0.50505051])
+    >>> mape = MeanAbsolutePercentageError(multioutput=[0.3, 0.7], symmetric=False)
+    >>> mape(y_true, y_pred)
+    0.6198412698412699
+    >>> smape = MeanAbsolutePercentageError(multioutput=[0.3, 0.7])
+    >>> smape(y_true, y_pred)
+    0.5668686868686869
 
     References
     ----------
@@ -1085,6 +1303,38 @@ class MedianAbsolutePercentageError(_PercentageForecastingErrorMetric):
     MeanAbsolutePercentageError
     MeanSquaredPercentageError
     MedianSquaredPercentageError
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import \
+    MedianAbsolutePercentageError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> mdape = MedianAbsolutePercentageError(symmetric=False)
+    >>> mdape(y_true, y_pred)
+    0.16666666666666666
+    >>> smdape = MedianAbsolutePercentageError()
+    >>> smdape(y_true, y_pred)
+    0.18181818181818182
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> mdape(y_true, y_pred)
+    0.5714285714285714
+    >>> smdape(y_true, y_pred)
+    0.39999999999999997
+    >>> mdape = MedianAbsolutePercentageError(multioutput='raw_values', symmetric=False)
+    >>> mdape(y_true, y_pred)
+    array([0.14285714, 1.        ])
+    >>> smdape = MedianAbsolutePercentageError(multioutput='raw_values')
+    >>> smdape(y_true, y_pred)
+    array([0.13333333, 0.66666667])
+    >>> mdape = MedianAbsolutePercentageError(multioutput=[0.3, 0.7], symmetric=False)
+    >>> mdape(y_true, y_pred)
+    0.7428571428571428
+    >>> smdape = MedianAbsolutePercentageError(multioutput=[0.3, 0.7])
+    >>> smdape(y_true, y_pred)
+    0.5066666666666666
 
     References
     ----------
@@ -1160,6 +1410,40 @@ class MeanSquaredPercentageError(_SquaredPercentageForecastingErrorMetric):
     MeanAbsolutePercentageError
     MedianAbsolutePercentageError
     MedianSquaredPercentageError
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import \
+    MeanSquaredPercentageError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> mspe = MeanSquaredPercentageError(symmetric=False)
+    >>> mspe(y_true, y_pred)
+    0.23776218820861678
+    >>> smspe = MeanSquaredPercentageError(square_root=True, symmetric=False)
+    >>> smspe(y_true, y_pred)
+    0.48760864246710883
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> mspe(y_true, y_pred)
+    0.5080309901738473
+    >>> smspe(y_true, y_pred)
+    0.7026794936195895
+    >>> mspe = MeanSquaredPercentageError(multioutput='raw_values', symmetric=False)
+    >>> mspe(y_true, y_pred)
+    array([0.34013605, 0.67592593])
+    >>> smspe = MeanSquaredPercentageError(multioutput='raw_values', \
+    symmetric=False, square_root=True)
+    >>> smspe(y_true, y_pred)
+    array([0.58321184, 0.82214714])
+    >>> mspe = MeanSquaredPercentageError(multioutput=[0.3, 0.7], symmetric=False)
+    >>> mspe(y_true, y_pred)
+    0.5751889644746787
+    >>> smspe = MeanSquaredPercentageError(multioutput=[0.3, 0.7], \
+    symmetric=False, square_root=True)
+    >>> smspe(y_true, y_pred)
+    0.7504665536595034
 
     References
     ----------
@@ -1243,6 +1527,40 @@ class MedianSquaredPercentageError(_SquaredPercentageForecastingErrorMetric):
     MedianAbsolutePercentageError
     MeanSquaredPercentageError
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import \
+    MedianSquaredPercentageError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> mdspe = MedianSquaredPercentageError(symmetric=False)
+    >>> mdspe(y_true, y_pred)
+    0.027777777777777776
+    >>> smdspe = MedianSquaredPercentageError(square_root=True, symmetric=False)
+    >>> smdspe(y_true, y_pred)
+    0.16666666666666666
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> mdspe(y_true, y_pred)
+    0.5102040816326531
+    >>> smdspe(y_true, y_pred)
+    0.5714285714285714
+    >>> mdspe = MedianSquaredPercentageError(multioutput='raw_values', symmetric=False)
+    >>> mdspe(y_true, y_pred)
+    array([0.02040816, 1.        ])
+    >>> smdspe = MedianSquaredPercentageError(multioutput='raw_values', \
+    symmetric=False, square_root=True)
+    >>> smdspe(y_true, y_pred)
+    array([0.14285714, 1.        ])
+    >>> mdspe = MedianSquaredPercentageError(multioutput=[0.3, 0.7], symmetric=False)
+    >>> mdspe(y_true, y_pred)
+    0.7061224489795918
+    >>> smdspe = MedianSquaredPercentageError(multioutput=[0.3, 0.7], \
+    symmetric=False, square_root=True)
+    >>> smdspe(y_true, y_pred)
+    0.7428571428571428
+
     References
     ----------
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
@@ -1301,6 +1619,28 @@ class MeanRelativeAbsoluteError(_BaseForecastingErrorMetric):
     GeometricMeanRelativeAbsoluteError
     GeometricMeanRelativeSquaredError
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import MeanRelativeAbsoluteError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> y_pred_benchmark = y_pred*1.1
+    >>> mrae = MeanRelativeAbsoluteError()
+    >>> mrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.9511111111111111
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> y_pred_benchmark = y_pred*1.1
+    >>> mrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.8703703703703702
+    >>> mrae = MeanRelativeAbsoluteError(multioutput='raw_values')
+    >>> mrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    array([0.51851852, 1.22222222])
+    >>> mrae = MeanRelativeAbsoluteError(multioutput=[0.3, 0.7])
+    >>> mrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    1.0111111111111108
+
     References
     ----------
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
@@ -1356,6 +1696,28 @@ class MedianRelativeAbsoluteError(_BaseForecastingErrorMetric):
     MeanRelativeAbsoluteError
     GeometricMeanRelativeAbsoluteError
     GeometricMeanRelativeSquaredError
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import MedianRelativeAbsoluteError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> y_pred_benchmark = y_pred*1.1
+    >>> mdrae = MedianRelativeAbsoluteError()
+    >>> mdrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    1.0
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> y_pred_benchmark = y_pred*1.1
+    >>> mdrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.6944444444444443
+    >>> mdrae = MedianRelativeAbsoluteError(multioutput='raw_values')
+    >>> mdrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    array([0.55555556, 0.83333333])
+    >>> mdrae = MedianRelativeAbsoluteError(multioutput=[0.3, 0.7])
+    >>> mdrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.7499999999999999
 
     References
     ----------
@@ -1413,6 +1775,29 @@ class GeometricMeanRelativeAbsoluteError(_BaseForecastingErrorMetric):
     MeanRelativeAbsoluteError
     MedianRelativeAbsoluteError
     GeometricMeanRelativeSquaredError
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import \
+    GeometricMeanRelativeAbsoluteError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> y_pred_benchmark = y_pred*1.1
+    >>> gmrae = GeometricMeanRelativeAbsoluteError()
+    >>> gmrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.0007839273064064755
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> y_pred_benchmark = y_pred*1.1
+    >>> gmrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.5578632807409556
+    >>> gmrae = GeometricMeanRelativeAbsoluteError(multioutput='raw_values')
+    >>> gmrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    array([4.97801163e-06, 1.11572158e+00])
+    >>> gmrae = GeometricMeanRelativeAbsoluteError(multioutput=[0.3, 0.7])
+    >>> gmrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.7810066018326863
 
     References
     ----------
@@ -1480,6 +1865,29 @@ class GeometricMeanRelativeSquaredError(_SquaredForecastingErrorMetric):
     MeanRelativeAbsoluteError
     MedianRelativeAbsoluteError
     GeometricMeanRelativeAbsoluteError
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import \
+    GeometricMeanRelativeSquaredError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> y_pred_benchmark = y_pred*1.1
+    >>> gmrse = GeometricMeanRelativeSquaredError()
+    >>> gmrse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.0008303544925949156
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> y_pred_benchmark = y_pred*1.1
+    >>> gmrse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.622419372049448
+    >>> gmrse = GeometricMeanRelativeSquaredError(multioutput='raw_values')
+    >>> gmrse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    array([4.09227746e-06, 1.24483465e+00])
+    >>> gmrse = GeometricMeanRelativeSquaredError(multioutput=[0.3, 0.7])
+    >>> gmrse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.8713854839582426
 
     References
     ----------
@@ -1568,6 +1976,35 @@ class MeanAsymmetricError(_AsymmetricForecastingErrorMetric):
     multioutput : str
         Stores how the metric should aggregate multioutput data.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import MeanAsymmetricError
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> masymmetric = MeanAsymmetricError()
+    >>> masymmetric(y_true, y_pred)
+    0.5
+    >>> masymmetric = MeanAsymmetricError(left_error_function='absolute', \
+    right_error_function='squared')
+    >>> masymmetric(y_true, y_pred)
+    0.4625
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> masymmetric = MeanAsymmetricError()
+    >>> masymmetric(y_true, y_pred)
+    0.75
+    >>> masymmetric = MeanAsymmetricError(left_error_function='absolute', \
+    right_error_function='squared')
+    >>> masymmetric(y_true, y_pred)
+    0.7083333333333334
+    >>> masymmetric = MeanAsymmetricError(multioutput='raw_values')
+    >>> masymmetric(y_true, y_pred)
+    array([0.5, 1. ])
+    >>> masymmetric = MeanAsymmetricError(multioutput=[0.3, 0.7])
+    >>> masymmetric(y_true, y_pred)
+    0.85
+
     References
     ----------
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
@@ -1649,11 +2086,32 @@ class RelativeLoss(_RelativeLossForecastingErrorMetric):
     multioutput : str
         Stores how the metric should aggregate multioutput data.
 
-    Returns
-    -------
-    relative_loss : float
-        Loss for a method relative to loss for a benchmark method for a given
-        loss metric.
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import RelativeLoss
+    >>> from sktime.performance_metrics.forecasting import mean_squared_error
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> y_pred_benchmark = y_pred*1.1
+    >>> relative_mae = RelativeLoss()
+    >>> relative_mae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.8148148148148147
+    >>> relative_mse = RelativeLoss(relative_loss_function=mean_squared_error)
+    >>> relative_mse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.5178095088655261
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> y_pred_benchmark = y_pred*1.1
+    >>> relative_mae = RelativeLoss()
+    >>> relative_mae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.8490566037735847
+    >>> relative_mae = RelativeLoss(multioutput='raw_values')
+    >>> relative_mae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    array([0.625     , 1.03448276])
+    >>> relative_mae = RelativeLoss(multioutput=[0.3, 0.7])
+    >>> relative_mae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.927272727272727
 
     References
     ----------

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -70,19 +70,21 @@ class _BaseForecastingErrorMetric(BaseMetric):
 
         Parameters
         ----------
-        y_true : pandas Series of shape (fh,) or (fh, n_outputs)
-                where fh is the forecasting horizon
+        y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+                (fh, n_outputs) where fh is the forecasting horizon
             Ground truth (correct) target values.
 
-        y_pred : pandas Series of shape (fh,) or (fh, n_outputs)
-                where fh is the forecasting horizon
-            Estimated target values.
+        y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or  \
+                (fh, n_outputs)  where fh is the forecasting horizon
+            Forecasted values.
 
-        y_train : pandas Series
+        y_train : pd.Series, pd.DataFrame or np.array of shape (n_timepoints,) or \
+                (n_timepoints, n_outputs), default = None
             Optional keyword argument to pass training data.
 
-        y_pred_benchmark : pandas Series
-            Optional keyword argument to pass benchmark predictions
+        y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) \
+             or (fh, n_outputs) where fh is the forecasting horizon
+            Optional keyword argument to pass benchmark predictions.
 
         Returns
         -------
@@ -113,19 +115,21 @@ class _PercentageErrorMixin:
 
         Parameters
         ----------
-        y_true : pandas Series of shape (fh,) or (fh, n_outputs)
-                where fh is the forecasting horizon
+        y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+                (fh, n_outputs) where fh is the forecasting horizon
             Ground truth (correct) target values.
 
-        y_pred : pandas Series of shape (fh,) or (fh, n_outputs)
-                where fh is the forecasting horizon
-            Estimated target values.
+        y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or  \
+                (fh, n_outputs)  where fh is the forecasting horizon
+            Forecasted values.
 
-        y_train : pandas Series, default=None
+        y_train : pd.Series, pd.DataFrame or np.array of shape (n_timepoints,) or \
+                (n_timepoints, n_outputs), default = None
             Optional keyword argument to pass training data.
 
-        y_pred_benchmark : pandas Series
-            Optional keyword argument to pass benchmark predictions
+        y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) \
+             or (fh, n_outputs) where fh is the forecasting horizon
+            Optional keyword argument to pass benchmark predictions.
 
         Returns
         -------
@@ -151,19 +155,21 @@ class _SquaredErrorMixin:
 
         Parameters
         ----------
-        y_true : pandas Series of shape (fh,) or (fh, n_outputs)
-                where fh is the forecasting horizon
+        y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+                (fh, n_outputs) where fh is the forecasting horizon
             Ground truth (correct) target values.
 
-        y_pred : pandas Series of shape (fh,) or (fh, n_outputs)
-                where fh is the forecasting horizon
-            Estimated target values.
+        y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or  \
+                (fh, n_outputs)  where fh is the forecasting horizon
+            Forecasted values.
 
-        y_train : pandas Series, default=None
+        y_train : pd.Series, pd.DataFrame or np.array of shape (n_timepoints,) or \
+                (n_timepoints, n_outputs), default = None
             Optional keyword argument to pass training data.
 
-        y_pred_benchmark : pandas Series
-            Optional keyword argument to pass benchmark predictions
+        y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) \
+             or (fh, n_outputs) where fh is the forecasting horizon
+            Optional keyword argument to pass benchmark predictions.
 
         Returns
         -------
@@ -191,19 +197,21 @@ class _SquaredPercentageErrorMixin:
 
         Parameters
         ----------
-        y_true : pandas Series of shape (fh,) or (fh, n_outputs)
-                where fh is the forecasting horizon
+        y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+                (fh, n_outputs) where fh is the forecasting horizon
             Ground truth (correct) target values.
 
-        y_pred : pandas Series of shape (fh,) or (fh, n_outputs)
-                where fh is the forecasting horizon
-            Estimated target values.
+        y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or  \
+                (fh, n_outputs)  where fh is the forecasting horizon
+            Forecasted values.
 
-        y_train : pandas Series
+        y_train : pd.Series, pd.DataFrame or np.array of shape (n_timepoints,) or \
+                (n_timepoints, n_outputs), default = None
             Optional keyword argument to pass training data.
 
-        y_pred_benchmark : pandas Series
-            Optional keyword argument to pass benchmark predictions
+        y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) \
+             or (fh, n_outputs) where fh is the forecasting horizon
+            Optional keyword argument to pass benchmark predictions.
 
         Returns
         -------
@@ -228,17 +236,17 @@ class _AsymmetricErrorMixin:
 
         Parameters
         ----------
-        y_true : pandas Series of shape (fh,) or (fh, n_outputs)
-                where fh is the forecasting horizon
+        y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+                (fh, n_outputs) where fh is the forecasting horizon
             Ground truth (correct) target values.
 
-        y_pred : pandas Series of shape (fh,) or (fh, n_outputs)
-                where fh is the forecasting horizon
-            Estimated target values.
+        y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or  \
+                (fh, n_outputs)  where fh is the forecasting horizon
+            Forecasted values.
 
-        y_train : pandas Series
+        y_train : pd.Series, pd.DataFrame or np.array of shape (n_timepoints,) or \
+                (n_timepoints, n_outputs), default = None
             Optional keyword argument to pass training data.
-
 
         Returns
         -------
@@ -262,16 +270,17 @@ class _RelativeLossMixin:
 
         Parameters
         ----------
-        y_true : pandas Series of shape (fh,) or (fh, n_outputs)
-                where fh is the forecasting horizon
+        y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+                (fh, n_outputs) where fh is the forecasting horizon
             Ground truth (correct) target values.
 
-        y_pred : pandas Series of shape (fh,) or (fh, n_outputs)
-                where fh is the forecasting horizon
-            Estimated target values.
+        y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or  \
+                (fh, n_outputs)  where fh is the forecasting horizon
+            Forecasted values.
 
-        y_pred_benchmark : pandas Series
-            Optional keyword argument to pass benchmark predictions
+        y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) \
+             or (fh, n_outputs) where fh is the forecasting horizon
+            Optional keyword argument to pass benchmark predictions.
 
         Returns
         -------
@@ -406,8 +415,8 @@ def make_forecasting_scorer(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -426,8 +435,10 @@ class MeanAbsoluteScaledError(_ScaledForecastingErrorMetric):
     """Mean absolute scaled error (MASE).
 
     MASE output is non-negative floating point. The best value is 0.0.
-    This scale-free error metric can be used to compare forecast methods on
-    a single series and also to compare forecast accuracy between series.
+
+    Like other scaled performance metrics, this scale-free error metric can be
+    used to compare forecast methods on a single series and also to compare
+    forecast accuracy between series.
 
     This metric is well suited to intermittent-demand series because it
     will not give infinite or undefined values unless the training data
@@ -444,8 +455,8 @@ class MeanAbsoluteScaledError(_ScaledForecastingErrorMetric):
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -473,14 +484,15 @@ class MeanAbsoluteScaledError(_ScaledForecastingErrorMetric):
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
-    ..[2] Hyndman, R. J. (2006). "Another look at forecast accuracy metrics
-          for intermittent demand", Foresight, Issue 4.
-    ..[3] Makridakis, S., Spiliotis, E. and Assimakopoulos, V. (2020)
-          "The M4 Competition: 100,000 time series and 61 forecasting methods",
-          International Journal of Forecasting, Volume 3
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
+
+    Hyndman, R. J. (2006). "Another look at forecast accuracy metrics
+    for intermittent demand", Foresight, Issue 4.
+
+    Makridakis, S., Spiliotis, E. and Assimakopoulos, V. (2020)
+    "The M4 Competition: 100,000 time series and 61 forecasting methods",
+    International Journal of Forecasting, Volume 3.
     """
 
     def __init__(self, multioutput="uniform_average", sp=1):
@@ -498,9 +510,8 @@ class MedianAbsoluteScaledError(_ScaledForecastingErrorMetric):
     makes this metric more robust to error outliers since the median tends
     to be a more robust measure of central tendency in the presence of outliers.
 
-    Like MASE, this scale-free error metric can be used to compare forecast
-    methods on a single series and also to compare forecast accuracy between
-    series.
+    Like MASE and other scaled performance metrics this scale-free metric can be
+    used to compare forecast methods on a single series or between series.
 
     Also like MASE, this metric is well suited to intermittent-demand series
     because it will not give infinite or undefined values unless the training
@@ -517,8 +528,8 @@ class MedianAbsoluteScaledError(_ScaledForecastingErrorMetric):
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -546,14 +557,15 @@ class MedianAbsoluteScaledError(_ScaledForecastingErrorMetric):
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
-    ..[2] Hyndman, R. J. (2006). "Another look at forecast accuracy metrics
-          for intermittent demand", Foresight, Issue 4.
-    ..[3] Makridakis, S., Spiliotis, E. and Assimakopoulos, V. (2020)
-          "The M4 Competition: 100,000 time series and 61 forecasting methods",
-          International Journal of Forecasting, Volume 3
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
+
+    Hyndman, R. J. (2006). "Another look at forecast accuracy metrics
+    for intermittent demand", Foresight, Issue 4.
+
+    Makridakis, S., Spiliotis, E. and Assimakopoulos, V. (2020)
+    "The M4 Competition: 100,000 time series and 61 forecasting methods",
+    International Journal of Forecasting, Volume 3.
     """
 
     def __init__(self, multioutput="uniform_average", sp=1):
@@ -565,13 +577,13 @@ class MedianAbsoluteScaledError(_ScaledForecastingErrorMetric):
 class MeanSquaredScaledError(_ScaledSquaredForecastingErrorMetric):
     """Mean squared scaled error (MSSE) or root mean squared scaled error (RMSSE).
 
-    If `square_root` is False then calculates MSSE and RMSSE if
+    If `square_root` is False then calculates MSSE, otherwise calculates RMSSE if
     `square_root` is True. Both MSSE and RMSSE output is non-negative floating
     point. The best value is 0.0.
 
-    This is a squared varient of the MASE loss metric. Like MASE this
-    scale-free metric can be used to copmare forecast methods on a single
-    series or between series.
+    This is a squared varient of the MASE loss metric.  Like MASE and other
+    scaled performance metrics this scale-free metric can be used to compare
+    forecast methods on a single series or between series.
 
     This metric is also suited for intermittent-demand series because it
     will not give infinite or undefined values unless the training data
@@ -591,8 +603,8 @@ class MeanSquaredScaledError(_ScaledSquaredForecastingErrorMetric):
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -623,11 +635,11 @@ class MeanSquaredScaledError(_ScaledSquaredForecastingErrorMetric):
 
     References
     ----------
-    ..[1] M5 Competition Guidelines.
-          https://mofc.unic.ac.cy/wp-content/uploads/2020/03/M5-Competitors-Guide-Final-10-March-2020.docx
-    ..[2] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    M5 Competition Guidelines.
+    https://mofc.unic.ac.cy/wp-content/uploads/2020/03/M5-Competitors-Guide-Final-10-March-2020.docx
+
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     def __init__(self, multioutput="uniform_average", sp=1, square_root=False):
@@ -645,13 +657,13 @@ class MeanSquaredScaledError(_ScaledSquaredForecastingErrorMetric):
 class MedianSquaredScaledError(_ScaledSquaredForecastingErrorMetric):
     """Median squared scaled error (MdSSE) or root median squared scaled error (RMdSSE).
 
-    If `square_root` is False then calculates MdSSE and if `square_root` is True
-    then RMdSSE. Both MdSSE and RMdSSE output is non-negative floating point.
-    The best value is 0.0.
+    If `square_root` is False then calculates MdSSE, otherwise calculates RMdSSE if
+    `square_root` is True. Both MdSSE and RMdSSE output is non-negative floating
+    point. The best value is 0.0.
 
-    This is a squared varient of the MdASE loss metric. Like MASE, MdASE, MSSE
-    and RMSSE this scale-free metric can be used to compare forecast methods on a
-    single series or between series.
+    This is a squared varient of the MdASE loss metric. Like MASE and other
+    scaled performance metrics this scale-free metric can be used to compare
+    forecast methods on a single series or between series.
 
     This metric is also suited for intermittent-demand series because it
     will not give infinite or undefined values unless the training data
@@ -671,8 +683,8 @@ class MedianSquaredScaledError(_ScaledSquaredForecastingErrorMetric):
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -703,11 +715,11 @@ class MedianSquaredScaledError(_ScaledSquaredForecastingErrorMetric):
 
     References
     ----------
-    ..[1] M5 Competition Guidelines.
-          https://mofc.unic.ac.cy/wp-content/uploads/2020/03/M5-Competitors-Guide-Final-10-March-2020.docx
-    ..[2] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    M5 Competition Guidelines.
+    https://mofc.unic.ac.cy/wp-content/uploads/2020/03/M5-Competitors-Guide-Final-10-March-2020.docx
+
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     def __init__(self, multioutput="uniform_average", sp=1, square_root=False):
@@ -727,16 +739,16 @@ class MeanAbsoluteError(_BaseForecastingErrorMetric):
 
     MAE output is non-negative floating point. The best value is 0.0.
 
-    MAE is on the same scale as the data. Because it takes the absolute value
-    of the forecast error rather than the square, it is less sensitive to
-    outliers than MSE or RMSE.
+    MAE is on the same scale as the data. Because MAE takes the absolute value
+    of the forecast error rather than squaring it, MAE penalizes large errors
+    to a lesser degree than MSE or RMSE.
 
     Parameters
     ----------
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -761,9 +773,8 @@ class MeanAbsoluteError(_BaseForecastingErrorMetric):
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     def __init__(self, multioutput="uniform_average"):
@@ -777,9 +788,9 @@ class MedianAbsoluteError(_BaseForecastingErrorMetric):
 
     MdAE output is non-negative floating point. The best value is 0.0.
 
-    Like MAE, MdAE is on the same scale as the data. Because it takes the
-    absolute value of the forecast error rather than the square, it is less
-    sensitive to outliers than MSE, MdSE, RMSE or RMdSE.
+    Like MAE, MdAE is on the same scale as the data. Because MAE takes the
+    absolute value of the forecast error rather than squaring it, MAE penalizes
+    large errors to a lesser degree than MdSE or RdMSE.
 
     Taking the median instead of the mean of the absolute errors also makes
     this metric more robust to error outliers since the median tends
@@ -789,8 +800,8 @@ class MedianAbsoluteError(_BaseForecastingErrorMetric):
     ----------
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -815,9 +826,8 @@ class MedianAbsoluteError(_BaseForecastingErrorMetric):
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     def __init__(self, multioutput="uniform_average"):
@@ -830,13 +840,13 @@ class MeanSquaredError(_SquaredForecastingErrorMetric):
     """Mean squared error (MSE) or root mean squared error (RMSE).
 
     If `square_root` is False then calculates MSE and if `square_root` is True
-    then calculates RMSE.  Both MSE and RMSE are both non-negative floating point.
-    The best value is 0.0.
+    then RMSE is calculated.  Both MSE and RMSE are both non-negative floating
+    point. The best value is 0.0.
 
     MSE is measured in squared units of the input data, and RMSE is on the
-    same scale as the data. Because both metrics squares the
-    forecast error rather than taking the absolute value, they are more sensitive
-    to outliers than MAE or MdAE.
+    same scale as the data. Because MSE and RMSE square the forecast error
+    rather than taking the absolute value, they penalize large errors more than
+    MAE.
 
     Parameters
     ----------
@@ -845,8 +855,8 @@ class MeanSquaredError(_SquaredForecastingErrorMetric):
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -874,9 +884,8 @@ class MeanSquaredError(_SquaredForecastingErrorMetric):
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     def __init__(self, multioutput="uniform_average", square_root=False):
@@ -894,13 +903,13 @@ class MedianSquaredError(_SquaredForecastingErrorMetric):
     """Median squared error (MdSE) or root median squared error (RMdSE).
 
     If `square_root` is False then calculates MdSE and if `square_root` is True
-    then RMdSE. Both MdSE and RMdSE return non-negative floating point.
-    The best value is 0.0.
+    then RMdSE is calculated. Both MdSE and RMdSE return non-negative floating
+    point. The best value is 0.0.
 
-    Like MSE, MdSE is measured in squared units of the input data. RMdSe is
+    Like MSE, MdSE is measured in squared units of the input data. RMdSE is
     on the same scale as the input data like RMSE. Because MdSE and RMdSE
-    square the forecast error rather than taking the absolute value, they are
-    more sensitive to outliers than MAE or MdAE.
+    square the forecast error rather than taking the absolute value, they
+    penalize large errors more than MAE or MdAE.
 
     Taking the median instead of the mean of the squared errors makes
     this metric more robust to error outliers relative to a meean based metric
@@ -914,8 +923,8 @@ class MedianSquaredError(_SquaredForecastingErrorMetric):
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -943,9 +952,8 @@ class MedianSquaredError(_SquaredForecastingErrorMetric):
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     def __init__(self, multioutput="uniform_average", square_root=False):
@@ -968,7 +976,7 @@ class MeanAbsolutePercentageError(_PercentageForecastingErrorMetric):
 
     sMAPE is measured in percentage error relative to the test data. Because it
     takes the absolute value rather than square the percentage forecast
-    error, it is less sensitive to outliers than MSPE, RMSPE, MdSPE or RMdSPE.
+    error, it penalizes large errors less than MSPE, RMSPE, MdSPE or RMdSPE.
 
     There is no limit on how large the error can be, particulalrly when `y_true`
     values are close to zero. In such cases the function returns a large value
@@ -981,8 +989,8 @@ class MeanAbsolutePercentageError(_PercentageForecastingErrorMetric):
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1004,15 +1012,14 @@ class MeanAbsolutePercentageError(_PercentageForecastingErrorMetric):
 
     See Also
     --------
-    MedianAbsoulutePercentageError
+    MedianAbsolutePercentageError
     MeanSquaredPercentageError
     MedianSquaredPercentageError
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     def __init__(self, multioutput="uniform_average", symmetric=True):
@@ -1035,7 +1042,7 @@ class MedianAbsolutePercentageError(_PercentageForecastingErrorMetric):
 
     MdAPE and sMdAPE are measured in percentage error relative to the test data.
     Because it takes the absolute value rather than square the percentage forecast
-    error, it is less sensitive to outliers than MSPE, RMSPE, MdSPE or RMdSPE.
+    error, it penalizes large errors less than MSPE, RMSPE, MdSPE or RMdSPE.
 
     Taking the median instead of the mean of the absolute percentage errors also
     makes this metric more robust to error outliers since the median tends
@@ -1052,8 +1059,8 @@ class MedianAbsolutePercentageError(_PercentageForecastingErrorMetric):
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1075,15 +1082,14 @@ class MedianAbsolutePercentageError(_PercentageForecastingErrorMetric):
 
     See Also
     --------
-    MeanAbsoulutePercentageError
+    MeanAbsolutePercentageError
     MeanSquaredPercentageError
     MedianSquaredPercentageError
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     def __init__(self, multioutput="uniform_average", symmetric=True):
@@ -1101,13 +1107,14 @@ class MeanSquaredPercentageError(_SquaredPercentageForecastingErrorMetric):
     """Mean squared percentage error (MSPE)  or square root version.
 
     If `square_root` is False then calculates MSPE and if `square_root` is True
-    then calculates root mean squared percentage error (RMSPE). Both
-    MSPE and RMSPE output is non-negative floating point. The best value is 0.0.
+    then calculates root mean squared percentage error (RMSPE). If `symmetric`
+    is True then calculates sMSPE or sRMSPE. Output is non-negative floating
+    point. The best value is 0.0.
 
     MSPE is measured in squared percentage error relative to the test data and
     RMSPE is measured in percentage error relative to the test data.
-    Because either calculation takes the square rather than absolute value of
-    the percentage forecast error, they are more sensitive to outliers than
+    Because the calculation takes the square rather than absolute value of
+    the percentage forecast error, large errors are penalized more than
     MAPE, sMAPE, MdAPE or sMdAPE.
 
     There is no limit on how large the error can be, particulalrly when `y_true`
@@ -1124,8 +1131,8 @@ class MeanSquaredPercentageError(_SquaredPercentageForecastingErrorMetric):
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1150,15 +1157,14 @@ class MeanSquaredPercentageError(_SquaredPercentageForecastingErrorMetric):
 
     See Also
     --------
-    MeanAbsoulutePercentageError
+    MeanAbsolutePercentageError
     MedianAbsolutePercentageError
     MedianSquaredPercentageError
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     def __init__(
@@ -1179,13 +1185,14 @@ class MedianSquaredPercentageError(_SquaredPercentageForecastingErrorMetric):
     """Median squared percentage error (MdSPE)  or square root version.
 
     If `square_root` is False then calculates MdSPE and if `square_root` is True
-    then calculates root median squared percentage error (RMSPE). Both
-    MdSPE and RMdSPE output is non-negative floating point. The best value is 0.0.
+    then calculates root median squared percentage error (RMdSPE). If `symmetric`
+    is True then calculates sMdSPE or sRMdSPE. Output is non-negative floating
+    point. The best value is 0.0.
 
     MdSPE is measured in squared percentage error relative to the test data.
     RMdSPE is measured in percentage error relative to the test data.
-    Because it takes the square rather than absolute value of the percentage
-    forecast error, both calculations are more sensitive to outliers than
+    Because the calculation takes the square rather than absolute value of
+    the percentage forecast error, large errors are penalized more than
     MAPE, sMAPE, MdAPE or sMdAPE.
 
     Taking the median instead of the mean of the absolute percentage errors also
@@ -1206,8 +1213,8 @@ class MedianSquaredPercentageError(_SquaredPercentageForecastingErrorMetric):
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1232,15 +1239,14 @@ class MedianSquaredPercentageError(_SquaredPercentageForecastingErrorMetric):
 
     See Also
     --------
-    MeanAbsoulutePercentageError
+    MeanAbsolutePercentageError
+    MedianAbsolutePercentageError
     MeanSquaredPercentageError
-    MedianSquaredPercentageError
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     def __init__(
@@ -1260,12 +1266,19 @@ class MedianSquaredPercentageError(_SquaredPercentageForecastingErrorMetric):
 class MeanRelativeAbsoluteError(_BaseForecastingErrorMetric):
     """Mean relative absolute error (MRAE).
 
+    In relative error metrics, relative errors are first calculated by
+    scaling (dividing) the individual forecast errors by the error calculated
+    using a benchmark method at the same index position. If the error of the
+    benchmark method is zero then a large value is returned.
+
+    MRAE applies mean absolute error (MAE) to the resulting relative errors.
+
     Parameters
     ----------
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1290,9 +1303,8 @@ class MeanRelativeAbsoluteError(_BaseForecastingErrorMetric):
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     _tags = {
@@ -1310,12 +1322,19 @@ class MeanRelativeAbsoluteError(_BaseForecastingErrorMetric):
 class MedianRelativeAbsoluteError(_BaseForecastingErrorMetric):
     """Median relative absolute error (MdRAE).
 
+    In relative error metrics, relative errors are first calculated by
+    scaling (dividing) the individual forecast errors by the error calculated
+    using a benchmark method at the same index position. If the error of the
+    benchmark method is zero then a large value is returned.
+
+    MdRAE applies medan absolute error (MdAE) to the resulting relative errors.
+
     Parameters
     ----------
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1340,9 +1359,8 @@ class MedianRelativeAbsoluteError(_BaseForecastingErrorMetric):
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     _tags = {
@@ -1360,12 +1378,20 @@ class MedianRelativeAbsoluteError(_BaseForecastingErrorMetric):
 class GeometricMeanRelativeAbsoluteError(_BaseForecastingErrorMetric):
     """Geometric mean relative absolute error (GMRAE).
 
+    In relative error metrics, relative errors are first calculated by
+    scaling (dividing) the individual forecast errors by the error calculated
+    using a benchmark method at the same index position. If the error of the
+    benchmark method is zero then a large value is returned.
+
+    GMRAE applies geometric mean absolute error (GMAE) to the resulting relative
+    errors.
+
     Parameters
     ----------
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1390,9 +1416,8 @@ class GeometricMeanRelativeAbsoluteError(_BaseForecastingErrorMetric):
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     _tags = {
@@ -1413,6 +1438,15 @@ class GeometricMeanRelativeSquaredError(_SquaredForecastingErrorMetric):
     If `square_root` is False then calculates GMRSE and if `square_root` is True
     then calculates root geometric mean relative squared error (RGMRSE).
 
+    In relative error metrics, relative errors are first calculated by
+    scaling (dividing) the individual forecast errors by the error calculated
+    using a benchmark method at the same index position. If the error of the
+    benchmark method is zero then a large value is returned.
+
+    GMRSE applies geometric mean squared error (GMSE) to the resulting relative
+    errors. RGMRSE applies root geometric mean squared error (RGMSE) to the
+    resulting relative errors.
+
     Parameters
     ----------
     square_root : bool, default = False
@@ -1420,8 +1454,8 @@ class GeometricMeanRelativeSquaredError(_SquaredForecastingErrorMetric):
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1449,9 +1483,8 @@ class GeometricMeanRelativeSquaredError(_SquaredForecastingErrorMetric):
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     _tags = {
@@ -1507,8 +1540,8 @@ class MeanAsymmetricError(_AsymmetricForecastingErrorMetric):
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1537,11 +1570,11 @@ class MeanAsymmetricError(_AsymmetricForecastingErrorMetric):
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
-    ..[2] Diebold, Francis X. (2007). "Elements of Forecasting (4th ed.)" ,
-          Thomson, South-Western: Ohio, US.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
+
+    Diebold, Francis X. (2007). "Elements of Forecasting (4th ed.)",
+    Thomson, South-Western: Ohio, US.
     """
 
     def __init__(
@@ -1577,36 +1610,26 @@ class RelativeLoss(_RelativeLossForecastingErrorMetric):
     This function allows the calculation of scale-free relative loss metrics.
     Unlike mean absolute scaled error (MASE) the function calculates the
     scale-free metric relative to a defined loss function on a benchmark
-    method. Like MASE, metrics created using this function can be used to compare
-    forecast methods on a single series and also to compare forecast accuracy
-    between series.
+    method instead of the in-sample training data. Like MASE, metrics created
+    using this function can be used to compare forecast methods on a single
+    series and also to compare forecast accuracy between series.
 
     This is useful when a scale-free comparison is beneficial but the training
-    used to generate some (or all) predictions is unknown such as when
+    data used to generate some (or all) predictions is unknown such as when
     comparing the loss of 3rd party forecasts or surveys of professional
-    forecastsers.
+    forecasters.
+
+    Only metrics that do not require y_train are curretnly supported.
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
-        Ground truth (correct) target values.
-
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
-        Forecasted values.
-
-    y_pred_benchmark : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
-        Forecasted values from benchmark method.
-
     relative_loss_function : function
         Function to use in calculation relative loss.
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1634,9 +1657,8 @@ class RelativeLoss(_RelativeLossForecastingErrorMetric):
 
     References
     ----------
-    ..[1] Hyndman, R. J and Koehler, A. B. (2006).
-          "Another look at measures of forecast accuracy", International
-          Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
 
     def __init__(

--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -256,7 +256,7 @@ def mean_absolute_scaled_error(
 
     Makridakis, S., Spiliotis, E. and Assimakopoulos, V. (2020)
     "The M4 Competition: 100,000 time series and 61 forecasting methods",
-    International Journal of Forecasting, Volume 3
+    International Journal of Forecasting, Volume 3.
 
     Examples
     --------
@@ -403,7 +403,7 @@ def median_absolute_scaled_error(
 
     Makridakis, S., Spiliotis, E. and Assimakopoulos, V. (2020)
     "The M4 Competition: 100,000 time series and 61 forecasting methods",
-    International Journal of Forecasting, Volume 3
+    International Journal of Forecasting, Volume 3.
     """
     y_train = _get_kwarg(
         "y_train", metric_name="median_absolute_scaled_error", **kwargs
@@ -588,7 +588,7 @@ def median_squared_scaled_error(
 ):
     """Median squared scaled error (MdSSE) or root median squared scaled error (RMdSSE).
 
-If `square_root` is False then calculates MdSSE, otherwise calculates RMdSSE if
+    If `square_root` is False then calculates MdSSE, otherwise calculates RMdSSE if
     `square_root` is True. Both MdSSE and RMdSSE output is non-negative floating
     point. The best value is 0.0.
 

--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -92,7 +92,7 @@ def mean_asymmetric_error(
     multioutput="uniform_average",
     **kwargs,
 ):
-    """Calculate asymmetric loss function.
+    """Calculate mean of asymmetric loss function.
 
     Error values that are less than the asymmetric threshold have
     `left_error_function` applied. Error values greater than or equal to
@@ -198,16 +198,17 @@ def mean_absolute_scaled_error(
 
     Parameters
     ----------
-    y_true : pandas Series of shape (fh,) or (fh, n_outputs)
-            where fh is the forecasting horizon
+    y_true : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series of shape (fh,) or (fh, n_outputs)
-            where fh is the forecasting horizon
-        Estimated target values.
+    y_pred : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+        Forecasted values.
 
-    y_train : pandas Series of shape (fh,) or (fh, n_outputs), default = None
-            where fh is the forecasting horizon
+    y_train : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
+            default = None
         Observed training values.
 
     sp : int
@@ -325,16 +326,17 @@ def median_absolute_scaled_error(
 
     Parameters
     ----------
-    y_true : pandas Series of shape (fh,) or (fh, n_outputs)
-            where fh is the forecasting horizon
+    y_true : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series of shape (fh,) or (fh, n_outputs)
-            where fh is the forecasting horizon
-        Estimated target values.
+    y_pred : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+        Forecasted values.
 
-    y_train : pandas Series of shape (fh,) or (fh, n_outputs), default = None
-            where fh is the forecasting horizon
+    y_train : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
+            default = None
         Observed training values.
 
     sp : int
@@ -459,16 +461,17 @@ def mean_squared_scaled_error(
 
     Parameters
     ----------
-    y_true : pandas Series of shape (fh,) or (fh, n_outputs)
-            where fh is the forecasting horizon
+    y_true : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series of shape (fh,) or (fh, n_outputs)
-            where fh is the forecasting horizon
-        Estimated target values.
+    y_pred : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+        Forecasted values.
 
-    y_train : pandas Series of shape (fh,) or (fh, n_outputs), default = None
-            where fh is the forecasting horizon
+    y_train : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
+            default = None
         Observed training values.
 
     sp : int
@@ -597,16 +600,17 @@ def median_squared_scaled_error(
 
     Parameters
     ----------
-    y_true : pandas Series of shape (fh,) or (fh, n_outputs)
-            where fh is the forecasting horizon
+    y_true : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series of shape (fh,) or (fh, n_outputs)
-            where fh is the forecasting horizon
-        Estimated target values.
+    y_pred : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+        Forecasted values.
 
-    y_train : pandas Series of shape (fh,) or (fh, n_outputs), default = None
-            where fh is the forecasting horizon
+    y_train : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
+            default = None
         Observed training values.
 
     sp : int

--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -159,6 +159,29 @@ def mean_asymmetric_error(
 
     Diebold, Francis X. (2007). "Elements of Forecasting (4th ed.)",
     Thomson, South-Western: Ohio, US.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import mean_asymmetric_error
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> mean_asymmetric_error(y_true, y_pred)
+    0.5
+    >>> mean_asymmetric_error(y_true, y_pred, left_error_function='absolute', \
+    right_error_function='squared')
+    0.4625
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> mean_asymmetric_error(y_true, y_pred)
+    0.75
+    >>> mean_asymmetric_error(y_true, y_pred, left_error_function='absolute', \
+    right_error_function='squared')
+    0.7083333333333334
+    >>> mean_asymmetric_error(y_true, y_pred, multioutput='raw_values')
+    array([0.5, 1. ])
+    >>> mean_asymmetric_error(y_true, y_pred, multioutput=[0.3, 0.7])
+    0.85
     """
     _, y_true, y_pred, multioutput = _check_reg_targets(y_true, y_pred, multioutput)
 

--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -2101,8 +2101,10 @@ def relative_loss(
              (fh, n_outputs) where fh is the forecasting horizon, default=None
         Forecasted values from benchmark method.
 
-    relative_loss_function : function
-        Function to use in calculation relative loss
+    relative_loss_function : function, default=mean_absolute_error
+        Function to use in calculation relative loss. The function must comply
+        with API interface of sktime forecasting performance metrics. Metrics
+        requiring y_train or y_pred_benchmark are not supported.
 
     horizon_weight : array-like of shape (fh,), default=None
         Forecast horizon weights.
@@ -2128,6 +2130,31 @@ def relative_loss(
     ----------
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
     forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.performance_metrics.forecasting import relative_loss
+    >>> from sktime.performance_metrics.forecasting import mean_squared_error
+    >>> y_true = np.array([3, -0.5, 2, 7, 2])
+    >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    >>> y_pred_benchmark = y_pred*1.1
+    >>> relative_loss(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.8148148148148147
+    >>> relative_loss(y_true, y_pred, y_pred_benchmark=y_pred_benchmark, \
+    relative_loss_function=mean_squared_error)
+    0.5178095088655261
+    >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    >>> y_pred_benchmark = y_pred*1.1
+    >>> relative_loss(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    0.8490566037735847
+    >>> relative_loss(y_true, y_pred, y_pred_benchmark=y_pred_benchmark, \
+    multioutput='raw_values')
+    array([0.625     , 1.03448276])
+    >>> relative_loss(y_true, y_pred, y_pred_benchmark=y_pred_benchmark, \
+    multioutput=[0.3, 0.7])
+    0.927272727272727
     """
     y_pred_benchmark = _get_kwarg(
         "y_pred_benchmark", metric_name="relative_loss", **kwargs

--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -112,12 +112,12 @@ def mean_asymmetric_error(
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
     asymmetric_threshold : float, default = 0.0
@@ -138,8 +138,8 @@ def mean_asymmetric_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -147,18 +147,23 @@ def mean_asymmetric_error(
     -------
     asymmetric_loss : float
         Loss using asymmetric penalty of on errors.
+        If multioutput is 'raw_values', then asymmetric loss is returned for
+        each output separately.
+        If multioutput is 'uniform_average' or an ndarray of weights, then the
+        weighted average asymmetric loss of all output errors is returned.
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
-    ..[2]   Diebold, Francis X. (2007). "Elements of Forecasting (4th ed.)" ,
-            Thomson, South-Western: Ohio, US.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
+
+    Diebold, Francis X. (2007). "Elements of Forecasting (4th ed.)",
+    Thomson, South-Western: Ohio, US.
     """
     _, y_true, y_pred, multioutput = _check_reg_targets(y_true, y_pred, multioutput)
 
     if horizon_weight is not None:
+
         check_consistent_length(y_true, horizon_weight)
 
     asymmetric_errors = _asymmetric_error(
@@ -185,8 +190,10 @@ def mean_absolute_scaled_error(
     """Mean absolute scaled error (MASE).
 
     MASE output is non-negative floating point. The best value is 0.0.
-    This scale-free error metric can be used to compare forecast methods on
-    a single series and also to compare forecast accuracy between series.
+
+    Like other scaled performance metrics, this scale-free error metric can be
+    used to compare forecast methods on a single series and also to compare
+    forecast accuracy between series.
 
     This metric is well suited to intermittent-demand series because it
     will not give infinite or undefined values unless the training data
@@ -198,17 +205,16 @@ def mean_absolute_scaled_error(
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
-    y_train : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
-            default = None
+    y_train : pd.Series, pd.DataFrame or np.array of shape (n_timepoints,) or \
+             (n_timepoints, n_outputs), default = None
         Observed training values.
 
     sp : int
@@ -219,10 +225,11 @@ def mean_absolute_scaled_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
+
 
     Returns
     -------
@@ -238,6 +245,18 @@ def mean_absolute_scaled_error(
     median_absolute_scaled_error
     mean_squared_scaled_error
     median_squared_scaled_error
+
+    References
+    ----------
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
+
+    Hyndman, R. J. (2006). "Another look at forecast accuracy metrics
+    for intermittent demand", Foresight, Issue 4.
+
+    Makridakis, S., Spiliotis, E. and Assimakopoulos, V. (2020)
+    "The M4 Competition: 100,000 time series and 61 forecasting methods",
+    International Journal of Forecasting, Volume 3
 
     Examples
     --------
@@ -258,17 +277,6 @@ def mean_absolute_scaled_error(
     >>> mean_absolute_scaled_error(y_true, y_pred, y_train=y_train, \
     multioutput=[0.3, 0.7])
     0.21935483870967742
-
-    References
-    ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
-    ..[2]   Hyndman, R. J. (2006). "Another look at forecast accuracy metrics
-            for intermittent demand", Foresight, Issue 4.
-    ..[3]   Makridakis, S., Spiliotis, E. and Assimakopoulos, V. (2020)
-            "The M4 Competition: 100,000 time series and 61 forecasting methods",
-            International Journal of Forecasting, Volume 3
     """
     y_train = _get_kwarg("y_train", metric_name="mean_absolute_scaled_error", **kwargs)
 
@@ -312,9 +320,8 @@ def median_absolute_scaled_error(
     makes this metric more robust to error outliers since the median tends
     to be a more robust measure of central tendency in the presence of outliers.
 
-    Like MASE, this scale-free error metric can be used to compare forecast
-    methods on a single series and also to compare forecast accuracy between
-    series.
+    Like MASE and other scaled performance metrics this scale-free metric can be
+    used to compare forecast methods on a single series or between series.
 
     Also like MASE, this metric is well suited to intermittent-demand series
     because it will not give infinite or undefined values unless the training
@@ -326,17 +333,16 @@ def median_absolute_scaled_error(
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
-    y_train : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
-            default = None
+    y_train : pd.Series, pd.DataFrame or np.array of shape (n_timepoints,) or \
+             (n_timepoints, n_outputs), default = None
         Observed training values.
 
     sp : int
@@ -347,8 +353,8 @@ def median_absolute_scaled_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -389,14 +395,15 @@ def median_absolute_scaled_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
-    ..[2]   Hyndman, R. J. (2006). "Another look at forecast accuracy metrics
-            for intermittent demand", Foresight, Issue 4.
-    ..[3]   Makridakis, S., Spiliotis, E. and Assimakopoulos, V. (2020)
-            "The M4 Competition: 100,000 time series and 61 forecasting methods",
-            International Journal of Forecasting, Volume 3
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
+
+    Hyndman, R. J. (2006). "Another look at forecast accuracy metrics
+    for intermittent demand", Foresight, Issue 4.
+
+    Makridakis, S., Spiliotis, E. and Assimakopoulos, V. (2020)
+    "The M4 Competition: 100,000 time series and 61 forecasting methods",
+    International Journal of Forecasting, Volume 3
     """
     y_train = _get_kwarg(
         "y_train", metric_name="median_absolute_scaled_error", **kwargs
@@ -443,13 +450,13 @@ def mean_squared_scaled_error(
 ):
     """Mean squared scaled error (MSSE) or root mean squared scaled error (RMSSE).
 
-    If `square_root` is False then calculates MSSE and RMSSE if
+    If `square_root` is False then calculates MSSE, otherwise calculates RMSSE if
     `square_root` is True. Both MSSE and RMSSE output is non-negative floating
     point. The best value is 0.0.
 
-    This is a squared varient of the MASE loss metric. Like MASE this
-    scale-free metric can be used to copmare forecast methods on a single
-    series or between series.
+    This is a squared varient of the MASE loss metric.  Like MASE and other
+    scaled performance metrics this scale-free metric can be used to compare
+    forecast methods on a single series or between series.
 
     This metric is also suited for intermittent-demand series because it
     will not give infinite or undefined values unless the training data
@@ -461,17 +468,16 @@ def mean_squared_scaled_error(
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
-    y_train : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
-            default = None
+    y_train : pd.Series, pd.DataFrame or np.array of shape (n_timepoints,) or \
+             (n_timepoints, n_outputs), default = None
         Observed training values.
 
     sp : int
@@ -482,8 +488,8 @@ def mean_squared_scaled_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -529,11 +535,11 @@ def mean_squared_scaled_error(
 
     References
     ----------
-    ..[1]   M5 Competition Guidelines.
-            https://mofc.unic.ac.cy/wp-content/uploads/2020/03/M5-Competitors-Guide-Final-10-March-2020.docx
-    ..[2]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    M5 Competition Guidelines.
+    https://mofc.unic.ac.cy/wp-content/uploads/2020/03/M5-Competitors-Guide-Final-10-March-2020.docx
+
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     y_train = _get_kwarg("y_train", metric_name="mean_squared_scaled_error", **kwargs)
 
@@ -582,13 +588,13 @@ def median_squared_scaled_error(
 ):
     """Median squared scaled error (MdSSE) or root median squared scaled error (RMdSSE).
 
-    If `square_root` is False then calculates MdSSE and if `square_root` is True
-    then RMdSSE. Both MdSSE and RMdSSE output is non-negative floating point.
-    The best value is 0.0.
+If `square_root` is False then calculates MdSSE, otherwise calculates RMdSSE if
+    `square_root` is True. Both MdSSE and RMdSSE output is non-negative floating
+    point. The best value is 0.0.
 
-    This is a squared varient of the MdASE loss metric. Like MASE, MdASE, MSSE
-    and RMSSE this scale-free metric can be used to compare forecast methods on a
-    single series or between series.
+    This is a squared varient of the MdASE loss metric. Like MASE and other
+    scaled performance metrics this scale-free metric can be used to compare
+    forecast methods on a single series or between series.
 
     This metric is also suited for intermittent-demand series because it
     will not give infinite or undefined values unless the training data
@@ -600,17 +606,16 @@ def median_squared_scaled_error(
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
-    y_train : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
-            default = None
+    y_train : pd.Series, pd.DataFrame or np.array of shape (n_timepoints,) or \
+             (n_timepoints, n_outputs), default = None
         Observed training values.
 
     sp : int
@@ -621,8 +626,8 @@ def median_squared_scaled_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -663,11 +668,11 @@ def median_squared_scaled_error(
 
     References
     ----------
-    ..[1]   M5 Competition Guidelines.
-            https://mofc.unic.ac.cy/wp-content/uploads/2020/03/M5-Competitors-Guide-Final-10-March-2020.docx
-    ..[2]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    M5 Competition Guidelines.
+    https://mofc.unic.ac.cy/wp-content/uploads/2020/03/M5-Competitors-Guide-Final-10-March-2020.docx
+
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     y_train = _get_kwarg("y_train", metric_name="median_squared_scaled_error", **kwargs)
 
@@ -713,18 +718,18 @@ def mean_absolute_error(
 
     MAE output is non-negative floating point. The best value is 0.0.
 
-    MAE is on the same scale as the data. Because it takes the absolute value
-    of the forecast error rather than the square, it is less sensitive to
-    outliers than MSE or RMSE.
+    MAE is on the same scale as the data. Because MAE takes the absolute value
+    of the forecast error rather than squaring it, MAE penalizes large errors
+    to a lesser degree than MSE or RMSE.
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
     horizon_weight : array-like of shape (fh,), default=None
@@ -732,8 +737,8 @@ def mean_absolute_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -770,9 +775,8 @@ def mean_absolute_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     return _mean_absolute_error(
         y_true, y_pred, sample_weight=horizon_weight, multioutput=multioutput
@@ -790,22 +794,22 @@ def mean_squared_error(
     """Mean squared error (MSE) or root mean squared error (RMSE).
 
     If `square_root` is False then calculates MSE and if `square_root` is True
-    then calculates RMSE.  Both MSE and RMSE are both non-negative floating point.
-    The best value is 0.0.
+    then RMSE is calculated.  Both MSE and RMSE are both non-negative floating
+    point. The best value is 0.0.
 
     MSE is measured in squared units of the input data, and RMSE is on the
-    same scale as the data. Because both metrics squares the
-    forecast error rather than taking the absolute value, they are more sensitive
-    to outliers than MAE or MdAE.
+    same scale as the data. Because MSE and RMSE square the forecast error
+    rather than taking the absolute value, they penalize large errors more than
+    MAE.
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
     horizon_weight : array-like of shape (fh,), default=None
@@ -813,10 +817,10 @@ def mean_squared_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
-        If 'uniform_average' errors of all outputs are averaged with uniform weight.
+        If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
     square_root : bool, default=False
         Whether to take the square root of the mean squared error.
@@ -862,9 +866,8 @@ def mean_squared_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     # Scikit-learn argument `squared` returns MSE when True and RMSE when False
     # Scikit-time argument `square_root` returns RMSE when True and MSE when False
@@ -887,9 +890,9 @@ def median_absolute_error(
 
     MdAE output is non-negative floating point. The best value is 0.0.
 
-    Like MAE, MdAE is on the same scale as the data. Because it takes the
-    absolute value of the forecast error rather than the square, it is less
-    sensitive to outliers than MSE, MdSE, RMSE or RMdSE.
+    Like MAE, MdAE is on the same scale as the data. Because MAE takes the
+    absolute value of the forecast error rather than squaring it, MAE penalizes
+    large errors to a lesser degree than MdSE or RdMSE.
 
     Taking the median instead of the mean of the absolute errors also makes
     this metric more robust to error outliers since the median tends
@@ -897,12 +900,12 @@ def median_absolute_error(
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
     horizon_weight : array-like of shape (fh,), default=None
@@ -910,8 +913,8 @@ def median_absolute_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -948,9 +951,8 @@ def median_absolute_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     return _median_absolute_error(
         y_true, y_pred, sample_weight=horizon_weight, multioutput=multioutput
@@ -968,13 +970,13 @@ def median_squared_error(
     """Median squared error (MdSE) or root median squared error (RMdSE).
 
     If `square_root` is False then calculates MdSE and if `square_root` is True
-    then RMdSE. Both MdSE and RMdSE return non-negative floating point.
-    The best value is 0.0.
+    then RMdSE is calculated. Both MdSE and RMdSE return non-negative floating
+    point. The best value is 0.0.
 
-    Like MSE, MdSE is measured in squared units of the input data. RMdSe is
+    Like MSE, MdSE is measured in squared units of the input data. RMdSE is
     on the same scale as the input data like RMSE. Because MdSE and RMdSE
-    square the forecast error rather than taking the absolute value, they are
-    more sensitive to outliers than MAE or MdAE.
+    square the forecast error rather than taking the absolute value, they
+    penalize large errors more than MAE or MdAE.
 
     Taking the median instead of the mean of the squared errors makes
     this metric more robust to error outliers relative to a meean based metric
@@ -983,12 +985,12 @@ def median_squared_error(
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
     horizon_weight : array-like of shape (fh,), default=None
@@ -996,8 +998,8 @@ def median_squared_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1048,9 +1050,8 @@ def median_squared_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     _, y_true, y_pred, multioutput = _check_reg_targets(y_true, y_pred, multioutput)
     if horizon_weight is None:
@@ -1091,7 +1092,7 @@ def mean_absolute_percentage_error(
 
     sMAPE is measured in percentage error relative to the test data. Because it
     takes the absolute value rather than square the percentage forecast
-    error, it is less sensitive to outliers than MSPE, RMSPE, MdSPE or RMdSPE.
+    error, it penalizes large errors less than MSPE, RMSPE, MdSPE or RMdSPE.
 
     There is no limit on how large the error can be, particulalrly when `y_true`
     values are close to zero. In such cases the function returns a large value
@@ -1099,12 +1100,12 @@ def mean_absolute_percentage_error(
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
     horizon_weight : array-like of shape (fh,), default=None
@@ -1112,8 +1113,8 @@ def mean_absolute_percentage_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1124,10 +1125,10 @@ def mean_absolute_percentage_error(
     -------
     loss : float
         MAPE or sMAPE loss.
-        If multioutput is 'raw_values', then sMAPE is returned for each
+        If multioutput is 'raw_values', then MAPE or sMAPE is returned for each
         output separately.
         If multioutput is 'uniform_average' or an ndarray of weights, then the
-        weighted average sMAPE of all output errors is returned.
+        weighted average MAPE or sMAPE of all output errors is returned.
 
     See Also
     --------
@@ -1164,9 +1165,8 @@ def mean_absolute_percentage_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     _, y_true, y_pred, multioutput = _check_reg_targets(y_true, y_pred, multioutput)
     if horizon_weight is not None:
@@ -1204,7 +1204,7 @@ def median_absolute_percentage_error(
 
     MdAPE and sMdAPE are measured in percentage error relative to the test data.
     Because it takes the absolute value rather than square the percentage forecast
-    error, it is less sensitive to outliers than MSPE, RMSPE, MdSPE or RMdSPE.
+    error, it penalizes large errors less than MSPE, RMSPE, MdSPE or RMdSPE.
 
     Taking the median instead of the mean of the absolute percentage errors also
     makes this metric more robust to error outliers since the median tends
@@ -1216,12 +1216,12 @@ def median_absolute_percentage_error(
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
     horizon_weight : array-like of shape (fh,), default=None
@@ -1229,8 +1229,8 @@ def median_absolute_percentage_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1281,9 +1281,8 @@ def median_absolute_percentage_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     _, y_true, y_pred, multioutput = _check_reg_targets(y_true, y_pred, multioutput)
     if horizon_weight is None:
@@ -1316,16 +1315,17 @@ def mean_squared_percentage_error(
     symmetric=True,
     **kwargs,
 ):
-    """Mean squared percentage error (MSPE)  or square root version.
+    """Mean squared percentage error (MSPE) or square root version.
 
     If `square_root` is False then calculates MSPE and if `square_root` is True
-    then calculates root mean squared percentage error (RMSPE). Both
-    MSPE and RMSPE output is non-negative floating point. The best value is 0.0.
+    then calculates root mean squared percentage error (RMSPE). If `symmetric`
+    is True then calculates sMSPE or sRMSPE. Output is non-negative floating
+    point. The best value is 0.0.
 
     MSPE is measured in squared percentage error relative to the test data and
     RMSPE is measured in percentage error relative to the test data.
-    Because either calculation takes the square rather than absolute value of
-    the percentage forecast error, they are more sensitive to outliers than
+    Because the calculation takes the square rather than absolute value of
+    the percentage forecast error, large errors are penalized more than
     MAPE, sMAPE, MdAPE or sMdAPE.
 
     There is no limit on how large the error can be, particulalrly when `y_true`
@@ -1334,12 +1334,12 @@ def mean_squared_percentage_error(
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
     horizon_weight : array-like of shape (fh,), default=None
@@ -1347,8 +1347,8 @@ def mean_squared_percentage_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1407,9 +1407,8 @@ def mean_squared_percentage_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.s
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     _, y_true, y_pred, multioutput = _check_reg_targets(y_true, y_pred, multioutput)
     if horizon_weight is not None:
@@ -1446,13 +1445,14 @@ def median_squared_percentage_error(
     """Median squared percentage error (MdSPE)  or square root version.
 
     If `square_root` is False then calculates MdSPE and if `square_root` is True
-    then calculates root median squared percentage error (RMSPE). Both
-    MdSPE and RMdSPE output is non-negative floating point. The best value is 0.0.
+    then calculates root median squared percentage error (RMdSPE). If `symmetric`
+    is True then calculates sMdSPE or sRMdSPE. Output is non-negative floating
+    point. The best value is 0.0.
 
     MdSPE is measured in squared percentage error relative to the test data.
     RMdSPE is measured in percentage error relative to the test data.
-    Because it takes the square rather than absolute value of the percentage
-    forecast error, both calculations are more sensitive to outliers than
+    Because the calculation takes the square rather than absolute value of
+    the percentage forecast error, large errors are penalized more than
     MAPE, sMAPE, MdAPE or sMdAPE.
 
     Taking the median instead of the mean of the absolute percentage errors also
@@ -1465,12 +1465,12 @@ def median_squared_percentage_error(
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
     horizon_weight : array-like of shape (fh,), default=None
@@ -1478,8 +1478,8 @@ def median_squared_percentage_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1539,9 +1539,8 @@ def median_squared_percentage_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.s
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     _, y_true, y_pred, multioutput = _check_reg_targets(y_true, y_pred, multioutput)
     perc_err = _percentage_error(y_true, y_pred, symmetric=symmetric)
@@ -1576,19 +1575,25 @@ def mean_relative_absolute_error(
 ):
     """Mean relative absolute error (MRAE).
 
+    In relative error metrics, relative errors are first calculated by
+    scaling (dividing) the individual forecast errors by the error calculated
+    using a benchmark method at the same index position. If the error of the
+    benchmark method is zero then a large value is returned.
+
+    MRAE applies mean absolute error (MAE) to the resulting relative errors.
+
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
-    y_pred_benchmark : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
-            default = None
+    y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+             (fh, n_outputs) where fh is the forecasting horizon, default=None
         Forecasted values from benchmark method.
 
     horizon_weight : array-like of shape (fh,), default=None
@@ -1596,8 +1601,8 @@ def mean_relative_absolute_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1640,9 +1645,8 @@ def mean_relative_absolute_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     y_pred_benchmark = _get_kwarg(
         "y_pred_benchmark", metric_name="mean_relative_absolute_error", **kwargs
@@ -1677,21 +1681,27 @@ def mean_relative_absolute_error(
 def median_relative_absolute_error(
     y_true, y_pred, horizon_weight=None, multioutput="uniform_average", **kwargs
 ):
-    """Median relative absolute error (MdRAEs).
+    """Median relative absolute error (MdRAE).
+
+    In relative error metrics, relative errors are first calculated by
+    scaling (dividing) the individual forecast errors by the error calculated
+    using a benchmark method at the same index position. If the error of the
+    benchmark method is zero then a large value is returned.
+
+    MdRAE applies medan absolute error (MdAE) to the resulting relative errors.
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
-    y_pred_benchmark : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
-            default = None
+    y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+             (fh, n_outputs) where fh is the forecasting horizon, default=None
         Forecasted values from benchmark method.
 
     horizon_weight : array-like of shape (fh,), default=None
@@ -1699,8 +1709,8 @@ def median_relative_absolute_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1744,9 +1754,8 @@ def median_relative_absolute_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     y_pred_benchmark = _get_kwarg(
         "y_pred_benchmark", metric_name="median_relative_absolute_error", **kwargs
@@ -1786,19 +1795,26 @@ def geometric_mean_relative_absolute_error(
 ):
     """Geometric mean relative absolute error (GMRAE).
 
+    In relative error metrics, relative errors are first calculated by
+    scaling (dividing) the individual forecast errors by the error calculated
+    using a benchmark method at the same index position. If the error of the
+    benchmark method is zero then a large value is returned.
+
+    GMRAE applies geometric mean absolute error (GMAE) to the resulting relative
+    errors.
+
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
-    y_pred_benchmark : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
-            default = None
+    y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+             (fh, n_outputs) where fh is the forecasting horizon, default=None
         Forecasted values from benchmark method.
 
     horizon_weight : array-like of shape (fh,), default=None
@@ -1806,8 +1822,8 @@ def geometric_mean_relative_absolute_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1851,9 +1867,8 @@ def geometric_mean_relative_absolute_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     y_pred_benchmark = _get_kwarg(
         "y_pred_benchmark",
@@ -1901,19 +1916,27 @@ def geometric_mean_relative_squared_error(
     If `square_root` is False then calculates GMRSE and if `square_root` is True
     then calculates root geometric mean relative squared error (RGMRSE).
 
+    In relative error metrics, relative errors are first calculated by
+    scaling (dividing) the individual forecast errors by the error calculated
+    using a benchmark method at the same index position. If the error of the
+    benchmark method is zero then a large value is returned.
+
+    GMRSE applies geometric mean squared error (GMSE) to the resulting relative
+    errors. RGMRSE applies root geometric mean squared error (RGMSE) to the
+    resulting relative errors.
+
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
-    y_pred_benchmark : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
-            default = None
+    y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+             (fh, n_outputs) where fh is the forecasting horizon, default=None
         Forecasted values from benchmark method.
 
     horizon_weight : array-like of shape (fh,), default=None
@@ -1921,8 +1944,8 @@ def geometric_mean_relative_squared_error(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -1971,9 +1994,8 @@ def geometric_mean_relative_squared_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     y_pred_benchmark = _get_kwarg(
         "y_pred_benchmark",
@@ -2018,7 +2040,7 @@ def relative_loss(
     multioutput="uniform_average",
     **kwargs,
 ):
-    """Calculate relative loss of forecast versus benchmark forecast.
+    """Relative loss of forecast versus benchmark forecast for a given metric.
 
     Applies a forecasting performance metric to a set of forecasts and
     benchmark forecasts and reports ratio of the metric from the forecasts to
@@ -2031,28 +2053,29 @@ def relative_loss(
     This function allows the calculation of scale-free relative loss metrics.
     Unlike mean absolute scaled error (MASE) the function calculates the
     scale-free metric relative to a defined loss function on a benchmark
-    method. Like MASE, metrics created using this function can be used to compare
-    forecast methods on a single series and also to compare forecast accuracy
-    between series.
+    method instead of the in-sample training data. Like MASE, metrics created
+    using this function can be used to compare forecast methods on a single
+    series and also to compare forecast accuracy between series.
 
     This is useful when a scale-free comparison is beneficial but the training
-    used to generate some (or all) predictions is unknown such as when
+    data used to generate some (or all) predictions is unknown such as when
     comparing the loss of 3rd party forecasts or surveys of professional
-    forecastsers.
+    forecasters.
+
+    Only metrics that do not require y_train are curretnly supported.
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
-    y_pred_benchmark : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon,
-            default = None
+    y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+             (fh, n_outputs) where fh is the forecasting horizon, default=None
         Forecasted values from benchmark method.
 
     relative_loss_function : function
@@ -2063,8 +2086,8 @@ def relative_loss(
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
             (n_outputs,), default='uniform_average'
-        Defines aggregating of multiple output values.
-        Array-like value defines weights used to average errors.
+        Defines how to aggregate metric for multivariate (multioutput) data.
+        If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
 
@@ -2073,12 +2096,15 @@ def relative_loss(
     relative_loss : float
         Loss for a method relative to loss for a benchmark method for a given
         loss metric.
+        If multioutput is 'raw_values', then relative loss is returned for each
+        output separately.
+        If multioutput is 'uniform_average' or an ndarray of weights, then the
+        weighted average relative loss of all output errors is returned.
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     y_pred_benchmark = _get_kwarg(
         "y_pred_benchmark", metric_name="relative_loss", **kwargs
@@ -2111,12 +2137,12 @@ def _asymmetric_error(
 
     Parameters
     ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Forecasted values.
 
     asymmetric_threshold : float, default = 0.0
@@ -2125,10 +2151,10 @@ def _asymmetric_error(
         applied. Error values greater than or equal to asymmetric threshold
         have `right_error_function` applied.
 
-    left_error_function : str, {'squared', 'absolute'}
+    left_error_function : {'squared', 'absolute'}, default='squared'
         Loss penalty to apply to error values less than the asymmetric threshold.
 
-    right_error_function : str, {'squared', 'absolute'}
+    right_error_function : {'squared', 'absolute'}, default='absolute'
         Loss penalty to apply to error values greater than or equal to the
         asymmetric threshold.
 
@@ -2139,9 +2165,8 @@ def _asymmetric_error(
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     functions = {"squared": np.square, "absolute": np.abs}
     left_func, right_func = (
@@ -2170,8 +2195,8 @@ def _relative_error(y_true, y_pred, y_pred_benchmark):
             shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
         Forecasted values.
 
-    y_pred_benchmark : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+    y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+             (fh, n_outputs) where fh is the forecasting horizon, default=None
         Forecasted values from benchmark method.
 
     Returns
@@ -2181,9 +2206,8 @@ def _relative_error(y_true, y_pred, y_pred_benchmark):
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of \
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     denominator = np.where(
         y_true - y_pred_benchmark >= 0,
@@ -2198,13 +2222,13 @@ def _percentage_error(y_true, y_pred, symmetric=True):
 
     Parameters
     ----------
-    y_true : pandas Series of shape (fh,) or (fh, n_outputs)
-            where fh is the forecasting horizon
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
         Ground truth (correct) target values.
 
-    y_pred : pandas Series of shape (fh,) or (fh, n_outputs)
-            where fh is the forecasting horizon
-        Estimated target values.
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
+        Forecasted values.
 
     symmetric : bool, default = False
         Whether to calculate symmetric percentage error.
@@ -2215,9 +2239,8 @@ def _percentage_error(y_true, y_pred, symmetric=True):
 
     References
     ----------
-    ..[1]   Hyndman, R. J and Koehler, A. B. (2006).
-            "Another look at measures of forecast accuracy", International
-            Journal of Forecasting, Volume 22, Issue 4.
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of \
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
     if symmetric:
         # Alternatively could use np.abs(y_true + y_pred) in denom

--- a/sktime/performance_metrics/tests/test_performance_metrics_forecasting.py
+++ b/sktime/performance_metrics/tests/test_performance_metrics_forecasting.py
@@ -6,6 +6,7 @@ __author__ = ["Tomasz Chodakowski", "Ryan Kuhns"]
 
 import pytest
 import numpy as np
+import pandas as pd
 from pandas.api.types import is_numeric_dtype
 from sktime.utils._testing.series import _make_series
 from sktime.performance_metrics.forecasting import (
@@ -95,7 +96,7 @@ Y1 = np.array(
     ]
 )
 
-Y2 = np.array(
+Y2 = pd.Series(
     [
         0.982136629140069,
         1.45950325745833,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #959, as well as a bug in _RelativeLossMixin that was discovered when adding docstring examples. 

Bug meant that RelativeLoss class's relative_loss_function parameter was not being passed to underlying function; therefore, default (mean_absolute_error) was always being used.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Addresses the docstring issues (with `y_true`, `y_pred`, and `y_train`) in #959. Also improves docstring formatting (see References section) and tweaks docstring explanations to improve clarity in some cases. Adds examples to docstrings that were missing examples (relative_loss, RelativeLoss, mean_asymmetric_error, MeanAsymmetricError).

In addition to docstring cleanup, a bug in _RelativeLossMixin that was identified when creating docstring examples was corrected. 

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

No new dependencies. 

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
