### PR TITLE
refactors HCrystallBall Forecaster

### DIFF
--- a/sktime/forecasting/hcrystalball.py
+++ b/sktime/forecasting/hcrystalball.py
@@ -3,8 +3,7 @@ import pandas as pd
 from sklearn.base import clone
 
 from sktime.forecasting.base._base import DEFAULT_ALPHA
-from sktime.forecasting.base._sktime import _OptionalForecastingHorizonMixin
-from sktime.forecasting.base._sktime import _SktimeForecaster
+from sktime.forecasting.base import BaseForecaster
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 _check_soft_dependencies("hcrystalball")
@@ -94,27 +93,61 @@ def _adapt_y_pred(y_pred):
     return y_pred.iloc[:, 0]
 
 
-class HCrystalBallForecaster(_OptionalForecastingHorizonMixin, _SktimeForecaster):
+class HCrystalBallForecaster(BaseForecaster):
+
+    _tags = {
+        "univariate-only": True,
+        "requires-fh-in-fit": False,
+        "handles-missing-data": False,
+    }
+
     def __init__(self, model):
         self.model = model
         super(HCrystalBallForecaster, self).__init__()
 
-    def fit(self, y, X=None, fh=None):
-        self._is_fitted = False
-        self._set_y_X(y, X)
-        self._set_fh(fh)
+    def _fit(self, y, X=None, fh=None):
+        """Fit to training data.
 
-        if fh is not None:
-            _check_fh(self.fh, self.cutoff)
+        Parameters
+        ----------
+        y : pd.Series
+            Target time series with which to fit the forecaster.
+        fh : int, list or np.array, optional (default=None)
+            The forecast horizon with the steps ahead to predict.
+        X : pd.DataFrame, optional (default=None)
+            Exogenous variables are ignored
+
+        Returns
+        -------
+        self : returns an instance of self.
+        """
 
         y, X = _adapt_y_X(y, X)
         self.model_ = clone(self.model)
         self.model_.fit(X, y)
 
-        self._is_fitted = True
         return self
 
     def _predict(self, fh=None, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA):
+        """Make forecasts for the given forecast horizon
+
+        Parameters
+        ----------
+        fh : int, list or np.array
+            The forecast horizon with the steps ahead to predict
+        X : pd.DataFrame, optional (default=None)
+            Exogenous variables (ignored)
+        return_pred_int : bool, optional (default=False)
+            Return the prediction intervals for the forecast.
+        alpha : float or list, optional (default=0.95)
+            If alpha is iterable, multiple intervals will be calculated.
+
+        Returns
+        -------
+        y_pred : pd.Series
+            Point predictions for the forecast
+        y_pred_int : pd.DataFrame
+        """
         if return_pred_int:
             raise NotImplementedError()
         _check_fh(fh, self.cutoff)

--- a/sktime/forecasting/hcrystalball.py
+++ b/sktime/forecasting/hcrystalball.py
@@ -150,7 +150,6 @@ class HCrystalBallForecaster(BaseForecaster):
         """
         if return_pred_int:
             raise NotImplementedError()
-        _check_fh(fh, self.cutoff)
 
         X_pred = _get_X_pred(X, index=fh.to_absolute(self.cutoff).to_pandas())
         y_pred = self.model_.predict(X=X_pred)


### PR DESCRIPTION
Reference : https://github.com/alan-turing-institute/sktime/issues/955

We need to slowly re-factor all forecasters to be compliant with the new interface (see PR #912). i.e., no overrides of fit etc and descendant classes only implementing core logic, while the BaseForecaster implements check etc logic.

Currently this is running due to various downwards compatibility workarounds, which should be removed once all forecasters are ready (in "no-override" state)

The forecasters that still need a downstream refactor are:

  

- [x] HCrystalBallForecaster
