### PR TITLE
Refactors ensembler, online-ensembler-forecaster and descendants

### DIFF
--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -9,12 +9,9 @@ import pandas as pd
 
 from sktime.forecasting.base._base import DEFAULT_ALPHA
 from sktime.forecasting.base._meta import _HeterogenousEnsembleForecaster
-from sktime.forecasting.base._sktime import _OptionalForecastingHorizonMixin
 
 
-class EnsembleForecaster(
-    _OptionalForecastingHorizonMixin, _HeterogenousEnsembleForecaster
-):
+class EnsembleForecaster(_HeterogenousEnsembleForecaster):
     """Ensemble of forecasters
 
     Parameters
@@ -29,12 +26,17 @@ class EnsembleForecaster(
     """
 
     _required_parameters = ["forecasters"]
+    _tags = {
+        "univariate-only": True,
+        "requires-fh-in-fit": False,
+        "handles-missing-data": False,
+    }
 
     def __init__(self, forecasters, n_jobs=None, aggfunc="mean"):
         super(EnsembleForecaster, self).__init__(forecasters=forecasters, n_jobs=n_jobs)
         self.aggfunc = aggfunc
 
-    def fit(self, y, X=None, fh=None):
+    def _fit(self, y, X=None, fh=None):
         """Fit to training data.
 
         Parameters
@@ -49,16 +51,12 @@ class EnsembleForecaster(
         -------
         self : returns an instance of self.
         """
-        self._is_fitted = False
 
-        self._set_y_X(y, X)
-        self._set_fh(fh)
         names, forecasters = self._check_forecasters()
         self._fit_forecasters(forecasters, y, X, fh)
-        self._is_fitted = True
         return self
 
-    def update(self, y, X=None, update_params=True):
+    def _update(self, y, X=None, update_params=True):
         """Update fitted parameters
 
         Parameters

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -69,8 +69,7 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         -------
         self : an instance of self
         """
-        self.check_is_fitted()
-        self._update_y_X(y, X)
+
         for forecaster in self.forecasters_:
             forecaster.update(y, X, update_params=update_params)
         return self

--- a/sktime/forecasting/online_learning/_online_ensemble.py
+++ b/sktime/forecasting/online_learning/_online_ensemble.py
@@ -23,6 +23,11 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
     """
 
     _required_parameters = ["forecasters"]
+    _tags = {
+        "univariate-only": True,
+        "requires-fh-in-fit": False,
+        "handles-missing-data": False,
+    }
 
     def __init__(self, forecasters, ensemble_algorithm=None, n_jobs=None):
 
@@ -31,7 +36,7 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
 
         super(EnsembleForecaster, self).__init__(forecasters=forecasters, n_jobs=n_jobs)
 
-    def fit(self, y, X=None, fh=None):
+    def _fit(self, y, X=None, fh=None):
         """Fit to training data.
 
         Parameters
@@ -47,15 +52,12 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
         self : returns an instance of self.
         """
 
-        self._set_y_X(y, X)
-        self._set_fh(fh)
         names, forecasters = self._check_forecasters()
         self.weights = np.ones(len(forecasters)) / len(forecasters)
         self._fit_forecasters(forecasters, y, X, fh)
-        self._is_fitted = True
         return self
 
-    def _fit_ensemble(self, y, X=None):
+    def fit_ensemble(self, y, X=None):
         """Fits the ensemble by allowing forecasters to predict and
            compares to the actual parameters.
 
@@ -72,7 +74,7 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
 
         self.ensemble_algorithm.update(estimator_predictions.T, y)
 
-    def update(self, y, X=None, update_params=False):
+    def _update(self, y, X=None, update_params=False):
         """Update fitted paramters and performs a new ensemble fit.
 
         Parameters
@@ -89,7 +91,7 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
         self._update_y_X(y, X)
 
         if len(y) >= 1 and self.ensemble_algorithm is not None:
-            self._fit_ensemble(y, X)
+            self.fit_ensemble(y, X)
 
         for forecaster in self.forecasters_:
             forecaster.update(y, X, update_params=update_params)

--- a/sktime/forecasting/online_learning/_online_ensemble.py
+++ b/sktime/forecasting/online_learning/_online_ensemble.py
@@ -57,7 +57,7 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
         self._fit_forecasters(forecasters, y, X, fh)
         return self
 
-    def fit_ensemble(self, y, X=None):
+    def _fit_ensemble(self, y, X=None):
         """Fits the ensemble by allowing forecasters to predict and
            compares to the actual parameters.
 
@@ -91,7 +91,7 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
         self._update_y_X(y, X)
 
         if len(y) >= 1 and self.ensemble_algorithm is not None:
-            self.fit_ensemble(y, X)
+            self._fit_ensemble(y, X)
 
         for forecaster in self.forecasters_:
             forecaster.update(y, X, update_params=update_params)

--- a/sktime/forecasting/online_learning/_online_ensemble.py
+++ b/sktime/forecasting/online_learning/_online_ensemble.py
@@ -87,8 +87,6 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
         -------
         self : an instance of self
         """
-        self.check_is_fitted()
-        self._update_y_X(y, X)
 
         if len(y) >= 1 and self.ensemble_algorithm is not None:
             self._fit_ensemble(y, X)

--- a/sktime/forecasting/online_learning/_prediction_weighted_ensembler.py
+++ b/sktime/forecasting/online_learning/_prediction_weighted_ensembler.py
@@ -17,13 +17,19 @@ class _PredictionWeightedEnsembler:
         loss function which follows sklearn.metrics API, for updating weights
     """
 
+    _tags = {
+        "univariate-only": True,
+        "requires-fh-in-fit": False,
+        "handles-missing-data": False,
+    }
+
     def __init__(self, n_estimators=10, loss_func=None):
         self.n_estimators = n_estimators
         self.weights = np.ones(n_estimators) / n_estimators
         self.loss_func = loss_func
         super(_PredictionWeightedEnsembler, self).__init__()
 
-    def predict(self, y_pred):
+    def _predict(self, y_pred):
         """Performs prediction by taking a weighted average of the estimator
             predictions w.r.t the weights vector
 
@@ -94,6 +100,12 @@ class HedgeExpertEnsemble(_PredictionWeightedEnsembler):
         loss function which follows sklearn.metrics API, for updating weights
     """
 
+    _tags = {
+        "univariate-only": True,
+        "requires-fh-in-fit": False,
+        "handles-missing-data": False,
+    }
+
     def __init__(self, n_estimators=10, T=10, a=1, loss_func=None):
         super().__init__(n_estimators=n_estimators, loss_func=loss_func)
         self.T = T
@@ -118,6 +130,12 @@ class NormalHedgeEnsemble(HedgeExpertEnsemble):
     loss_func : function
         loss function which follows sklearn.metrics API, for updating weights
     """
+
+    _tags = {
+        "univariate-only": True,
+        "requires-fh-in-fit": False,
+        "handles-missing-data": False,
+    }
 
     def __init__(self, n_estimators=10, a=1, loss_func=None):
         super().__init__(n_estimators=n_estimators, T=None, a=a, loss_func=loss_func)
@@ -219,6 +237,12 @@ class NNLSEnsemble(_PredictionWeightedEnsembler):
     loss_func : function
         loss function which follows sklearn.metrics API, for updating weights
     """
+
+    _tags = {
+        "univariate-only": True,
+        "requires-fh-in-fit": False,
+        "handles-missing-data": False,
+    }
 
     def __init__(self, n_estimators=10, loss_func=None):
         super().__init__(n_estimators=n_estimators, loss_func=loss_func)

--- a/sktime/forecasting/online_learning/_prediction_weighted_ensembler.py
+++ b/sktime/forecasting/online_learning/_prediction_weighted_ensembler.py
@@ -59,7 +59,7 @@ class _PredictionWeightedEnsembler:
         self.weights = self.weights * new_array
         self.weights /= np.sum(self.weights)
 
-    def update(self, y_pred, y_true):
+    def _update(self, y_pred, y_true):
         """Resets the weights over the estimators by passing previous observations
             to the weighting algorithm
 


### PR DESCRIPTION
Reference : https://github.com/alan-turing-institute/sktime/issues/955

We need to slowly re-factor all forecasters to be compliant with the new interface (see PR #912). i.e., no overrides of fit etc and descendant classes only implementing core logic, while the BaseForecaster implements check etc logic.

Currently this is running due to various downwards compatibility workarounds, which should be removed once all forecasters are ready (in "no-override" state)

The forecasters that still need a downstream refactor are:

  

- [x] Online Ensembler Forecaster , Descendant and Ensembler
