### PR TITLE
refactors PmdArimaAdapter

### DIFF
--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -8,12 +8,17 @@ __all__ = ["_PmdArimaAdapter"]
 import pandas as pd
 
 from sktime.forecasting.base._base import DEFAULT_ALPHA
-from sktime.forecasting.base._sktime import _OptionalForecastingHorizonMixin
-from sktime.forecasting.base._sktime import _SktimeForecaster
+from sktime.forecasting.base import BaseForecaster
 
 
-class _PmdArimaAdapter(_OptionalForecastingHorizonMixin, _SktimeForecaster):
+class _PmdArimaAdapter(BaseForecaster):
     """Base class for interfacing pmdarima"""
+
+    _tags = {
+        "univariate-only": True,
+        "requires-fh-in-fit": False,
+        "handles-missing-data": False,
+    }
 
     def __init__(self):
         self._forecaster = None
@@ -22,7 +27,7 @@ class _PmdArimaAdapter(_OptionalForecastingHorizonMixin, _SktimeForecaster):
     def _instantiate_model(self):
         raise NotImplementedError("abstract method")
 
-    def fit(self, y, X=None, fh=None, **fit_params):
+    def _fit(self, y, X=None, fh=None, **fit_params):
         """Fit to training data.
 
         Parameters
@@ -37,12 +42,8 @@ class _PmdArimaAdapter(_OptionalForecastingHorizonMixin, _SktimeForecaster):
         -------
         self : returns an instance of self.
         """
-        self._is_fitted = False
-        self._set_y_X(y, X)
-        self._set_fh(fh)
         self._forecaster = self._instantiate_model()
         self._forecaster.fit(y, X=X, **fit_params)
-        self._is_fitted = True
         return self
 
     def _predict(self, fh, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA):


### PR DESCRIPTION
Reference : https://github.com/alan-turing-institute/sktime/issues/955

We need to slowly re-factor all forecasters to be compliant with the new interface (see PR #912). i.e., no overrides of fit etc and descendant classes only implementing core logic, while the BaseForecaster implements check etc logic.

Currently this is running due to various downwards compatibility workarounds, which should be removed once all forecasters are ready (in "no-override" state)

The forecasters that still need a downstream refactor are:

  

- [x] PmdArimaAdapter and descendants ARIMA, AutoARIMA
