### PR TITLE
fix fh bug in predict_in_sample of ARIMA models

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1069,7 +1069,16 @@
       "contributions": [
         "code"
       ]
-    }
+    },
+    {
+      "login": "AngelPone",
+      "name": "Bohan Zhang",
+      "avatar_url": "https://avatars.githubusercontent.com/u/32930283?v=4",
+      "profile": "https://github.com/AngelPone",
+      "contributions": [
+        "code"
+      ]
+    },
   ],
   "projectName": "sktime",
   "projectOwner": "alan-turing-institute",

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -143,7 +143,6 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/vedazeren"><img src="https://avatars3.githubusercontent.com/u/63582874?v=4?s=100" width="100px;" alt=""/><br /><sub><b>vedazeren</b></sub></a><br /><a href="https://github.com/alan-turing-institute/sktime/commits?author=vedazeren" title="Code">💻</a> <a href="https://github.com/alan-turing-institute/sktime/commits?author=vedazeren" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/vincent-nich12"><img src="https://avatars3.githubusercontent.com/u/36476633?v=4?s=100" width="100px;" alt=""/><br /><sub><b>vincent-nich12</b></sub></a><br /><a href="https://github.com/alan-turing-institute/sktime/commits?author=vincent-nich12" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/vollmersj"><img src="https://avatars2.githubusercontent.com/u/12613127?v=4?s=100" width="100px;" alt=""/><br /><sub><b>vollmersj</b></sub></a><br /><a href="https://github.com/alan-turing-institute/sktime/commits?author=vollmersj" title="Documentation">📖</a></td>
-    <td align="center"><a href="https://github.com/AngelPone"><img src="https://avatars.githubusercontent.com/u/32930283?v=4&s=100" width="100px;" alt=""><br /><sub><b>Bohan Zhang</b></sub></a><br /><a href="https://github.com/alan-turing-institute/sktime/commits?author=AngelPone" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -143,6 +143,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/vedazeren"><img src="https://avatars3.githubusercontent.com/u/63582874?v=4?s=100" width="100px;" alt=""/><br /><sub><b>vedazeren</b></sub></a><br /><a href="https://github.com/alan-turing-institute/sktime/commits?author=vedazeren" title="Code">💻</a> <a href="https://github.com/alan-turing-institute/sktime/commits?author=vedazeren" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/vincent-nich12"><img src="https://avatars3.githubusercontent.com/u/36476633?v=4?s=100" width="100px;" alt=""/><br /><sub><b>vincent-nich12</b></sub></a><br /><a href="https://github.com/alan-turing-institute/sktime/commits?author=vincent-nich12" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/vollmersj"><img src="https://avatars2.githubusercontent.com/u/12613127?v=4?s=100" width="100px;" alt=""/><br /><sub><b>vollmersj</b></sub></a><br /><a href="https://github.com/alan-turing-institute/sktime/commits?author=vollmersj" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/AngelPone"><img src="https://avatars.githubusercontent.com/u/32930283?v=4&s=100" width="100px;" alt=""><br /><sub><b>Bohan Zhang</b></sub></a><br /><a href="https://github.com/alan-turing-institute/sktime/commits?author=AngelPone" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -78,7 +78,7 @@ class _PmdArimaAdapter(BaseForecaster):
         # integer indicies
         start, end = fh.to_absolute_int(self._y.index[0], self.cutoff)[[0, -1]]
         d = self._forecaster.model_.order[1]
-        if start == 0:
+        if start < d:
             start = d
         result = self._forecaster.predict_in_sample(
             start=start,
@@ -93,16 +93,16 @@ class _PmdArimaAdapter(BaseForecaster):
         if return_pred_int:
             # unpack and format results
             y_pred, pred_int = result
-            y_pred = np.concatenate([np.zeros((d,)), y_pred], axis=0)
+            y_pred = np.concatenate([self._y.values[:d], y_pred], axis=0)
             y_pred = pd.Series(y_pred[fh_idx], index=fh_abs)
-            pred_int = np.concatenate([np.zeros((d, 2)), pred_int], axis=0)
+            pred_int = np.concatenate([np.stack([self._y.values[:d], self._y.values[:d]], axis=1), pred_int], axis=0)
             pred_int = pd.DataFrame(
                 pred_int[fh_idx, :], index=fh_abs, columns=["lower", "upper"]
             )
             return y_pred, pred_int
 
         else:
-            result = np.concatenate([np.zeros((d,)), result], axis=0)
+            result = np.concatenate([self._y.values[:d], result], axis=0)
             return pd.Series(result[fh_idx], index=fh_abs)
 
     def _predict_fixed_cutoff(

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -95,7 +95,10 @@ class _PmdArimaAdapter(BaseForecaster):
             y_pred, pred_int = result
             y_pred = np.concatenate([self._y.values[:d], y_pred], axis=0)
             y_pred = pd.Series(y_pred[fh_idx], index=fh_abs)
-            pred_int = np.concatenate([np.stack([self._y.values[:d], self._y.values[:d]], axis=1), pred_int], axis=0)
+            pred_int = np.concatenate(
+                [np.stack([self._y.values[:d], self._y.values[:d]], axis=1), pred_int],
+                axis=0,
+            )
             pred_int = pd.DataFrame(
                 pred_int[fh_idx, :], index=fh_abs, columns=["lower", "upper"]
             )

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -77,7 +77,12 @@ class _PmdArimaAdapter(BaseForecaster):
         # for in-sample predictions, pmdarima requires zero-based
         # integer indicies
         start, end = fh.to_absolute_int(self._y.index[0], self.cutoff)[[0, -1]]
-        d = self._forecaster.model_.order[1]
+        from pmdarima.arima import AutoARIMA
+
+        if isinstance(self._forecaster, AutoARIMA):
+            d = self._forecaster.model_.order[1]
+        else:
+            d = self._forecaster.order[1]
         if start < d:
             start = d
         result = self._forecaster.predict_in_sample(


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1106 


#### What does this implement/fix? Explain your changes.

check order `d` of `_PmdArimaAdapter._forecaster_model_` (i.e. fitted ARIMA model) and get in-sample forecasts of start from `d` instead of `0` when `start=0`, and append zeros to the `pred` and `pred_interval`

#### Does your contribution introduce a new dependency? If yes, which one?

no


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.


