### PR TITLE
added mloning and aiwalter as forecasting/base code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,7 +24,7 @@ sktime/transformations/series/compose.py @aiwalter
 sktime/transformations/panel/signature_based/ @jambo6
 sktime/transformations/series/theta.py @GuzalBulatova
 
-sktime/forecasting/base/ @fkiraly
+sktime/forecasting/base/ @fkiraly @mloning @aiwalter
 sktime/forecasting/ets.py @HYang1996
 sktime/forecasting/tests/test_ets.py @HYang1996
 sktime/forecasting/fbprophet.py @aiwalter


### PR DESCRIPTION
@mloning, a while ago when I added myself as code owner of `forecasting/base`, I did not realize that this would overwrite your "general" code owner tag. That is, you don't receive auto-review invites for `forecasting/base` anymore.

I fixed this, and also added @aiwalter who has been closely involved with the foreasting module's design.