### PR TITLE
Forecasting: base/template docstring fixes, added fit_predict method

### DIFF
--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -29,7 +29,8 @@ Optional implements:
 
 State:
     fitted model/strategy   - by convention, any attributes ending in "_"
-    fitted state flag       - check_is_fitted()
+    fitted state flag       - is_fitted (property)
+    fitted state inspection - check_is_fitted()
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -158,9 +158,9 @@ class BaseForecaster(BaseEstimator):
 
         return self._predict(self.fh, X, return_pred_int=return_pred_int, alpha=alpha)
 
-    def fit_predict(self, y, X=None, fh=None,
-                    return_pred_int=False, alpha=DEFAULT_ALPHA
-                    ):
+    def fit_predict(
+        self, y, X=None, fh=None, return_pred_int=False, alpha=DEFAULT_ALPHA
+    ):
         """Fit and forecast time series at future horizon.
 
         Parameters

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -8,9 +8,11 @@ Scitype defining methods:
     fitting         - fit(self, y, X=None, fh=None)
     forecasting     - predict(self, fh=None, X=None, return_pred_int=False,
                               alpha=DEFAULT_ALPHA)
-    updating        - update(self, y, X=None, update_params=True):
-    update&predict  - update_predict(y, cv=None, X=None, update_params=True,
-                        return_pred_int=False, alpha=DEFAULT_ALPHA):
+    fit&forecast    - fit_predict(self, y, X=None, fh=None,
+                              return_pred_int=False, alpha=DEFAULT_ALPHA)
+    updating        - update(self, y, X=None, update_params=True)
+    update&forecast - update_predict(y, cv=None, X=None, update_params=True,
+                        return_pred_int=False, alpha=DEFAULT_ALPHA)
 
 Inspection methods:
     hyper-parameter inspection  - get_params()
@@ -18,7 +20,8 @@ Inspection methods:
 
 State:
     fitted model/strategy   - by convention, any attributes ending in "_"
-    fitted state flag       - check_is_fitted()
+    fitted state flag       - is_fitted (property)
+    fitted state inspection - check_is_fitted()
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """
@@ -158,6 +161,41 @@ class BaseForecaster(BaseEstimator):
         #  doesn't do the check, and needs it as a float or it breaks
         # todo: needs fixing in ARIMA and AutoARIMA
         # alpha = check_alpha(alpha)
+
+        return self._predict(self.fh, X, return_pred_int=return_pred_int, alpha=alpha)
+
+    def fit_predict(self, y, X=None, fh=None,
+                    return_pred_int=False, alpha=DEFAULT_ALPHA
+                    ):
+        """Fit and forecast time series at future horizon.
+
+            public method including checks & utility
+            dispatches to core logic in _predict
+
+        Parameters
+        ----------
+        y : pd.Series
+            Target time series to which to fit the forecaster.
+        fh : int, list, np.array or ForecastingHorizon
+            Forecasting horizon, default = y.index (in-sample forecast)
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+        return_pred_int : bool, optional (default=False)
+            If True, returns prediction intervals for given alpha values.
+        alpha : float or list, optional (default=0.95)
+
+        Returns
+        -------
+        y_pred : pd.Series
+            Point predictions
+        y_pred_int : pd.DataFrame - only if return_pred_int=True
+            Prediction intervals
+        """
+
+        if fh is None:
+            fh = y.index
+
+        self.fit(y=y, X=X, fh=fh)
 
         return self._predict(self.fh, X, return_pred_int=return_pred_int, alpha=alpha)
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -183,7 +183,6 @@ class BaseForecaster(BaseEstimator):
             Prediction intervals
         """
 
-
         self.fit(y=y, X=X, fh=fh)
 
         return self._predict(fh=fh, X=X, return_pred_int=return_pred_int, alpha=alpha)

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -85,9 +85,6 @@ class BaseForecaster(BaseEstimator):
     def fit(self, y, X=None, fh=None):
         """Fit forecaster to training data.
 
-        public method including checks & utility
-        dispatches to core logic in _fit
-
         Parameters
         ----------
         y : pd.Series
@@ -129,9 +126,6 @@ class BaseForecaster(BaseEstimator):
     def predict(self, fh=None, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA):
         """Forecast time series at future horizon.
 
-            public method including checks & utility
-            dispatches to core logic in _predict
-
         Parameters
         ----------
         fh : int, list, np.array or ForecastingHorizon
@@ -169,9 +163,6 @@ class BaseForecaster(BaseEstimator):
                     ):
         """Fit and forecast time series at future horizon.
 
-            public method including checks & utility
-            dispatches to core logic in _predict
-
         Parameters
         ----------
         y : pd.Series
@@ -197,7 +188,7 @@ class BaseForecaster(BaseEstimator):
 
         self.fit(y=y, X=X, fh=fh)
 
-        return self._predict(self.fh, X, return_pred_int=return_pred_int, alpha=alpha)
+        return self._predict(fh=fh, X=X, return_pred_int=return_pred_int, alpha=alpha)
 
     def compute_pred_int(self, y_pred, alpha=DEFAULT_ALPHA):
         """

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -183,8 +183,6 @@ class BaseForecaster(BaseEstimator):
             Prediction intervals
         """
 
-        if fh is None:
-            fh = y.index
 
         self.fit(y=y, X=X, fh=fh)
 


### PR DESCRIPTION
Some small changes to the forecasting base class and template:

* updates to docstrings, clarifications
* added `fit_predict` method which does what one would "obviously" expect, fitting & forecast in one step.