### PR TITLE
Make OptionalPassthrough to support multivariate input

### DIFF
--- a/sktime/transformations/series/compose.py
+++ b/sktime/transformations/series/compose.py
@@ -64,7 +64,7 @@ class OptionalPassthrough(_SeriesToSeriesTransformer):
 
     _required_parameters = ["transformer"]
     _tags = {
-        "univariate-only": True,
+        "univariate-only": False,
         "fit-in-transform": True,
     }
 
@@ -84,7 +84,7 @@ class OptionalPassthrough(_SeriesToSeriesTransformer):
 
     def transform(self, Z, X=None):
         self.check_is_fitted()
-        z = check_series(Z, enforce_univariate=True)
+        z = check_series(Z, enforce_univariate=False)
         if not self.passthrough:
             z = self.transformer_.transform(z, X)
         return z
@@ -92,7 +92,7 @@ class OptionalPassthrough(_SeriesToSeriesTransformer):
     @if_delegate_has_method(delegate="transformer")
     def inverse_transform(self, Z, X=None):
         self.check_is_fitted()
-        z = check_series(Z, enforce_univariate=True)
+        z = check_series(Z, enforce_univariate=False)
         if not self.passthrough:
             z = self.transformer_.inverse_transform(z, X=None)
         return z


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
`OptionalPassthrough` transformer was only accepting `pd.Series`. This was fixed to also accept `pd.DataFrame`
___
Martin Walter <martin_friedrich.walter@daimler.com>, Mercedes-Benz AG on behalf of Daimler TSS GmbH.
https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md