### PR TITLE
post-fix merge error in #967

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -393,6 +393,6 @@ class TransformedTargetForecaster(_Pipeline, _SeriesToSeriesTransformer):
         self.check_is_fitted()
         zt = check_series(Z, enforce_univariate=True)
         for _, _, transformer in self._iter_transformers(reverse=True):
-            if not _has_tag(transformer, "skip-inverse-transform"):
+            if not transformer._all_tags()["skip-inverse-transform"]:
                 zt = transformer.inverse_transform(zt, X)
         return zt

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -11,7 +11,6 @@ from sktime.base import _HeterogenousMetaEstimator
 from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.base._base import DEFAULT_ALPHA
 from sktime.transformations.base import _SeriesToSeriesTransformer
-from sktime.utils import _has_tag
 from sktime.utils.validation.series import check_series
 
 


### PR DESCRIPTION
This is a post-fix to #1118 to make this consistent with changes introduced in #1068.

I.e., removes the new instance of `_has_tag` from #967 in favour of `_all_tags`, as done in #1068 with the other instance in the same class.