### PR TITLE
[ENH] Add functionality to evaluate forecasting performance metric on samples

### DIFF
--- a/sktime/performance_metrics/base/_base.py
+++ b/sktime/performance_metrics/base/_base.py
@@ -20,7 +20,7 @@ class BaseMetric(BaseObject):
         function's name is used.
     """
 
-    def __init__(self, func, sample_func=None, name=None):
+    def __init__(self, func, name=None):
         self._func = func
         self.name = name if name is not None else func.__name__
 

--- a/sktime/performance_metrics/base/_base.py
+++ b/sktime/performance_metrics/base/_base.py
@@ -11,13 +11,19 @@ from sktime.base import BaseObject
 class BaseMetric(BaseObject):
     """Base class for defining metrics in sktime.
 
-    Extends sktime BaseObject.
+    Parameters
+    ----------
+    func : function
+        Function that implements the aggregate metric.
+    name : str, default=None
+        Optional name to pass to metric's name attribute. If None, then the
+        function's name is used.
     """
 
-    def __init__(self, func, name=None):
+    def __init__(self, func, sample_func=None, name=None):
         self._func = func
         self.name = name if name is not None else func.__name__
 
     def __call__(self, y_true, y_pred, **kwargs):
         """Calculate metric value using underlying metric function."""
-        NotImplementedError("abstract method")
+        raise NotImplementedError("abstract method")

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -232,7 +232,9 @@ class _PercentageErrorMixin:
 
     def _score_samples(self, y_true, y_pred, multioutput, **kwargs):
         """Apply metric's underlying loss function to each sample."""
-        scored_samples = _absolute_percentage_error(y_true, y_pred, self.symmetric)
+        scored_samples = _absolute_percentage_error(
+            y_true, y_pred, symmetric=self.symmetric
+        )
         scored_samples = np.average(scored_samples, weights=multioutput)
         return scored_samples
 

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -127,7 +127,6 @@ class _BaseForecastingErrorMetric(BaseMetric):
 
     def _score_samples(self, y_true, y_pred, multioutput, **kwargs):
         """Apply metric's underlying loss function to each sample."""
-
         sample_metric_func = _make_sample_metric_func(
             self.func, y_true, y_pred, multioutput=multioutput
         )
@@ -233,7 +232,6 @@ class _PercentageErrorMixin:
 
     def _score_samples(self, y_true, y_pred, multioutput, **kwargs):
         """Apply metric's underlying loss function to each sample."""
-
         scored_samples = _absolute_percentage_error(y_true, y_pred, self.symmetric)
         scored_samples = np.average(scored_samples, weights=multioutput)
         return scored_samples
@@ -280,7 +278,6 @@ class _SquaredErrorMixin:
 
     def _score_samples(self, y_true, y_pred, multioutput, **kwargs):
         """Apply metric's underlying loss function to each sample."""
-
         scored_samples = _squared_error(y_true, y_pred)
         scored_samples = np.average(scored_samples, weights=multioutput)
         return scored_samples
@@ -330,7 +327,6 @@ class _SquaredPercentageErrorMixin:
 
     def _score_samples(self, y_true, y_pred, multioutput, **kwargs):
         """Apply metric's underlying loss function to each sample."""
-
         scored_samples = _squared_percentage_error(
             y_true, y_pred, symmetric=self.symmetric
         )
@@ -373,7 +369,6 @@ class _AsymmetricErrorMixin:
 
     def _score_samples(self, y_true, y_pred, multioutput, **kwargs):
         """Apply metric's underlying loss function to each sample."""
-
         scored_samples = _asymmetric_error(
             y_true,
             y_pred,
@@ -459,7 +454,6 @@ class _SquaredScaledErrorMixIn(_SquaredErrorMixin):
 class _AbsoluteErrorMixIn:
     def _score_samples(self, y_true, y_pred, multioutput, **kwargs):
         """Apply metric's underlying loss function to each sample."""
-
         scored_samples = _absolute_error(y_true, y_pred)
         scored_samples = np.average(scored_samples, weights=multioutput)
         return scored_samples

--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -2151,7 +2151,7 @@ def relative_loss(
 
 
 def _squared_error(y_true, y_pred):
-    """Calculates squared error.
+    """Calculate squared error.
 
     Parameters
     ----------
@@ -2175,7 +2175,7 @@ def _squared_error(y_true, y_pred):
 
 
 def _absolute_error(y_true, y_pred):
-    """Calculates squared error.
+    """Calculate squared error.
 
     Parameters
     ----------
@@ -2241,7 +2241,6 @@ def _asymmetric_error(
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
     forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
     """
-
     functions = {"squared": _squared_error, "absolute": _absolute_error}
     if left_error_function not in functions or right_error_function not in functions:
         msg = " ".join(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This is a draft of the functionality discussed in #958. 


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
This adds the ability for forecasting performance_metric classes to be able to evaluate the underlying function (without aggregation) on error samples (e.g. each `y_true - y_pred`). 

Signature of the method is `score_samples(y_true, y_pred, **kwargs)`. This implements an interface that builds on the `__call__` signature of the metrics (`y_train` or `y_pred_benchmark` are passed as kwargs) and the discussion in #958. Note that I'm open to having a different name than `score_samples`. I also built on the forecasting module refactor and have the primary logic in `_score_samples`. 

When implementing I considered the the ability to leverage the same code as much as possible when calculating the metrics on a sample or the aggregate metrics. To do this I did a mild refactor of `_functions.py` to make the functionality that is needed when evaluating samples and the aggregate metrics portable (e.g. the sample based code is mostly in non-public functions used by the aggregate functions and `_score_samples`). 

Note that I've set it up so that the BaseForecastingMetric will evaluate the metric functions on each sample using np.vectorize. This will only be used when creating a metric via `make_forecasting_metric`. This is not efficient, but it allows the user to only pass the aggregate metric function instead of having to write and pass two functions to `make_forecasting_metric` (i.e.: aggregate metric function and a sample function). I sided with making it easier on users relative to performance in that case. 

For all the built-in metrics we offer out of the box, they are using individualized implementations that are more efficient. 

 
#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No new dependencies.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->



#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
