### PR TITLE
[bugfix] `set_tags` call in `BaseObject.clone_tags` used incorrect signature

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -190,7 +190,7 @@ class BaseObject(_BaseEstimator):
 
         update_dict = {key: tags_est[key] for key in tag_names}
 
-        self.set_tags(update_dict)
+        self.set_tags(**update_dict)
 
         return self
 


### PR DESCRIPTION
This is a bugfix to `BaseObject.clone_tags`.

`set_tags` was called incorrectly from `clone_tags` without the kwargs symbol.