### PR TITLE
bugfix - pd.DataFrame->pd.Series conversion missing

### DIFF
--- a/sktime/forecasting/base/convertIO/_convertIO.py
+++ b/sktime/forecasting/base/convertIO/_convertIO.py
@@ -135,7 +135,7 @@ def convert_MvS_to_UvS_as_Series(obj: pd.DataFrame, store=None) -> pd.Series:
     return obj[obj.columns[0]]
 
 
-convert_dict[("pd.Series", "pd.DataFrame", "Series")] = convert_MvS_to_UvS_as_Series
+convert_dict[("pd.DataFrame", "pd.Series", "Series")] = convert_MvS_to_UvS_as_Series
 
 
 def convert_MvS_to_np_as_Series(obj: pd.DataFrame, store=None) -> np.array:


### PR DESCRIPTION
The pd.DataFrame->pd.Series conversion was incorrectly missing from `_convertIO` (from #980), this is fixed now.