### PR TITLE
bugfix: wilcoxon expected result changed

### DIFF
--- a/sktime/benchmarking/tests/test_evaluator.py
+++ b/sktime/benchmarking/tests/test_evaluator.py
@@ -187,7 +187,7 @@ def test_plots():
 def test_wilcoxon():
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
     results = evaluator.wilcoxon_test().iloc[:, 2:].values
-    expected = np.array([[0.5, 0], [0.5, 0], [0.5, 0]])
+    expected = np.array([[0, 0.5], [0, 0.5], [0, 0.5]])
     assert np.array_equal(results, expected)
 
 


### PR DESCRIPTION
The test `test_evaluator.test_wilcoxon` was failing, since the expected and found result swiched columns.

No changes have been made to related functionality, so perhaps it is due to a change in `stats.wilcoxon` signature?
Or, do I have a version inconsistency in my local version? (let's see what the remote tests say).

Either way, this PR fixes the expected results to the new results.