### PR TITLE
[DOC] add conda-forge max dependency recipe to installation and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,23 @@ Using pip, sktime releases are available as source packages and binary wheels. Y
 pip install sktime
 ```
 
+or, with maximum dependencies,
+
+```bash
+pip install sktime[all_extras]
+```
+
 ### conda
 You can also install sktime from `conda` via the `conda-forge` channel. For the feedstock including the build recipe and configuration, check out [this repository](https://github.com/conda-forge/sktime-feedstock).
 
 ```bash
 conda install -c conda-forge sktime
+```
+
+or, with maximum dependencies,
+
+```bash
+conda install -c conda-forge sktime-all-extras
 ```
 
 ## :zap: Quickstart

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -47,9 +47,15 @@ They can be installed via ``conda`` using:
 
 This will install ``sktime`` with core dependencies, excluding soft dependencies.
 
-Currently, there is no easy route to install ``sktime`` with maximum dependencies via ``conda``.
+To install ``sktime`` with maximum dependencies, including soft dependencies, install with the ``all-extras`` recipe:
 
-Community contributions towards this, e.g., via conda metapackages, would be appreciated.
+.. code-block:: bash
+
+    conda install -c conda-forge sktime-all-extras
+
+Note: currently this does not include dependencies ``catch-22``, ``pmdarima``, and ``tbats``.
+As these packages are not available on ``conda-forge``, they must be installed via ``pip`` if desired.
+Contributions to remedy this situation are appreciated.
 
 
 Release versions - troubleshooting


### PR DESCRIPTION
This PR addes the new `conda-forge` recipe for maximum dependencies to installation guidelines and README, in follow-up of #1142.

It also adds the `pip` option with maximum dependences to the README.