### PR TITLE
[DOC] data container conventions, conversions, and data sets documentation

### DIFF
--- a/examples/00_datatypes.ipynb
+++ b/examples/00_datatypes.ipynb
@@ -256,7 +256,7 @@
    "source": [
     "### Section 1.2.1: Time series panels - the `\"pd-multiindex\"` mtype\r\n",
     "\r\n",
-    "In the `\"pd-multiindex\"` mtype, time series are represented by an in-memory container `obj: pandas.DataFrame` as follows.\r\n",
+    "In the `\"pd-multiindex\"` mtype, time series panels are represented by an in-memory container `obj: pandas.DataFrame` as follows.\r\n",
     "\r\n",
     "* structure convention: `obj.index` must be a pair multi-index of type `(RangeIndex, t)`, where `t` is one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex` and monotonous. `obj.index` must have name `(\"instances\", \"timepoints\")`.\r\n",
     "* instances: rows with the same `\"instances\"` index correspond to the same instance; rows with a different `\"instances\"` index correspond to a different instances.\r\n",
@@ -283,6 +283,76 @@
    "outputs": [],
    "source": [
     "get_examples(mtype=\"pd-multiindex\", as_scitype=\"Panel\")[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Section 1.2.2: Time series panels - the `\"numpy3D\"` mtype\r\n",
+    "\r\n",
+    "In the `\"numpy3D\"` mtype, time series panels are represented by an in-memory container `obj: np.ndarray` as follows.\r\n",
+    "\r\n",
+    "* structure convention: `obj` must be 3D, i.e., `obj.shape` must have length 2.\r\n",
+    "* instances: instances correspond to axis 0 elements of `obj`.\r\n",
+    "* instance index: the instance index is implicit and by-convention. The `i`-th element of axis 0 (for an integer `i`) is interpreted as indicative of observing instance `i`. \r\n",
+    "* variables: variables correspond to axis 1 elements of `obj`.\r\n",
+    "* variable names: the `\"numpy3D\"` mtype cannot represent variable names.\r\n",
+    "* time points: time points correspond to axis 2 elements of `obj`.\r\n",
+    "* time index: the time index is implicit and by-convention. The `i`-th elemtn of axis 2 (for an integer `i`) is interpreted as an observation at the time point `i`.\r\n",
+    "* capabilities: can represent panels of multivariate series; cannot represent unequally spaced series; cannot represent panels of unequally supported series; cannot represent panels of series with different sets of variables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example of a panel of multivariate series in `\"numpy3D\"` mtype representation.\r\n",
+    "The panel contains three multivariate series, with instance indices 0, 1, 2. All series have two variables (unnamed). All series are observed at three time points 0, 1, 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_examples(mtype=\"numpy3D\", as_scitype=\"Panel\")[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Section 1.2.3: Time series panels - the `\"df-list\"` mtype\r\n",
+    "\r\n",
+    "In the `\"df-list\"` mtype, time series panels are represented by an in-memory container `obj: List[pandas.DataFrame]` as follows.\r\n",
+    "\r\n",
+    "* structure convention: `obj` must be a list of `pandas.DataFrames`. Individual list elements of `obj` must follow the `\"pd.DataFrame\"` mtype convention for the `\"Series\"` scitype.\r\n",
+    "* instances: instances correspond to different list elements of `obj`.\r\n",
+    "* instance index: the instance index of an instance is the list index at which it is located in `obj`. That is, the data at `obj[i]` correspond to observations of the instance with index `i`.\r\n",
+    "* variables: columns of `obj[i]` correspond to different variables available for instance `i`.\r\n",
+    "* variable names: column names `obj[i].columns` are the names of variables available for instance `i`.\r\n",
+    "* time points: rows of `obj[i]` correspond to different, distinct time points, at which instance `i` is observed.\r\n",
+    "* time index: `obj[i].index` is interpreted as the time index for instance `i`.\r\n",
+    "* capabilities: can represent panels of multivariate series; can represent unequally spaced series; can represent panels of unequally supported series; can represent panels of series with different sets of variables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example of a panel of multivariate series in `\"df-list\"` mtype representation.\r\n",
+    "The panel contains three multivariate series, with instance indices 0, 1, 2. All series have two variables with names `\"var_0\"`, `\"var_1\"`. All series are observed at three time points 0, 1, 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_examples(mtype=\"df-list\", as_scitype=\"Panel\")[0]"
    ]
   },
   {

--- a/examples/00_datatypes.ipynb
+++ b/examples/00_datatypes.ipynb
@@ -1,0 +1,193 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Set-up instructions:** this notebook give a tutorial on the forecasting learning task supported by `sktime`.\n",
+    "On binder, this should run out-of-the-box.\n",
+    "\n",
+    "To run this notebook as intended, ensure that `sktime` with basic dependency requirements is installed in your python environment.\n",
+    "\n",
+    "To run this notebook with a local development version of sktime, either uncomment and run the below, or `pip install -e` a local clone of the `sktime` `main` branch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# from os import sys\n",
+    "# sys.path.append(\"..\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# In-memory data representations and data loading\r\n",
+    "\r\n",
+    "`sktime` provides modules for a number of time series related learning tasks.\r\n",
+    "\r\n",
+    "These modules use `sktime` specific in-memory (i.e., python workspace) representations for time series and related objects, most importantly individual time series and time series panels. `sktime`'s in-memory representations rely on `pandas` and `numpy`, with additional conventions on the `pandas` and `numpy` object.\r\n",
+    "\r\n",
+    "Users of `sktime` should be aware of these representations, since presenting the data in an `sktime` compatible representation is usually the first step in using any of the `sktime` modules.\r\n",
+    "\r\n",
+    "This notebook introduces the data types used in `sktime`, related functionality such as converters and validity checkers, and common workflows for loading and conversion:\r\n",
+    "\r\n",
+    "**Section 1** introduces in-memory data containers used in `sktime`, with examples.\r\n",
+    "\r\n",
+    "**Section 2** introduces validity checkers and conversion functionality for in-memory data containers.\r\n",
+    "\r\n",
+    "**Section 3** introduces common workflows to load data from file formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 1: in-memory data containers\r\n",
+    "\r\n",
+    "This section provides a reference to data containers used for time series and related objets in `sktime`.\r\n",
+    "\r\n",
+    "Conceptually, `sktime` distinguishes:\r\n",
+    "\r\n",
+    "* the *scientific type* (or short: scitype) of a data container, defined by relational and statistical properties of the data being represented - for instance, a (scientific) \"time series\" or a (scientific) \"time series panel\", in the mathematical-abstract sense, without specifying a machine representation\r\n",
+    "* the *machine type* (or short: mtype) of a data container, which, for a defined *scientific type*, specifies the python type and conventions on structure and value of the python in-memory object. For instance, a specific (scientific) time series is represented by a concrete `pandas.DataFrame` in `sktime`, subject to certain conventions on the `pandas.DataFrame`. Formally, these conventions form a specific mtype, i.e., a way to represent the (abstract) \"time series\" scitype.\r\n",
+    "\r\n",
+    "In `sktime`, the same scitype can be represented by multiple mtypes. For instance, `sktime` allows the user to specify time series as `pandas.DataFrame`, as `pandas.Series`, or as a `numpy.ndarray`. These are different mtypes which are admissible representations of the same scitype, \"time series\". Also, not all mtypes are equally rich in metadata - for instance, `pandas.DataFrame` can store column names, while this is not possible in `numpy.ndarray`.\r\n",
+    "\r\n",
+    "Both scitypes and mtypes are encoded by strings in `sktime`, for easy reference.\r\n",
+    "\r\n",
+    "This section introduces the mtypes for the following scitypes:\r\n",
+    "* `\"Series\"`, the `sktime` scitype for time series of any kind\r\n",
+    "* `\"Panel\"`, the `sktime` scitype for time series panels of any kind"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Section 1.1: Time series - the `\"Series\"` scitype\r\n",
+    "\r\n",
+    "The major representations of time series in `sktime` are:\r\n",
+    "\r\n",
+    "* `pd.DataFrame` - uni- or multivariate series, with rows corresponding to different time points\r\n",
+    "* `pd.Series` - univariate series, with entries corresponding to different time points\r\n",
+    "* `np.ndarray` - \r\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### step 2 - specifying the forecasting horizon"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we need to specify the forecasting horizon and pass that to our forecasting algorithm.\n",
+    "\n",
+    "There are two main ways:\n",
+    "\n",
+    "* using a `numpy.array` of integers. This assumes either integer index or periodic index (`PeriodIndex`) in the time series; the integer indicates the number of time points or periods ahead we want to make a forecast for. E.g., `1` means forecast the next period, `2` the second next period, and so on.\n",
+    "* using a `ForecastingHorizon` object. This can be used to define forecast horizons, using any supported index type as an argument. No periodic index is assumed.\n",
+    "\n",
+    "Forecasting horizons can be absolute, i.e., referencing specific time points in the future, or relative, i.e., referencing time differences to the present. As a default, the present is that latest time point seen in any `y` passed to the forecaster.\n",
+    "\n",
+    "`numpy.array` based forecasting horizons are always relative; `ForecastingHorizon` objects can be both relative and absolute. In particular, absolute forecasting horizons can only be specified using `ForecastingHorizon`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "hide_input": false,
+  "interpreter": {
+   "hash": "bc250fec99d1b72e5bb23d9fb06e1f1ac90e860438a1535c061277d2caf5ebfc"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.7.10 64-bit ('sktime': conda)",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": ""
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/00_datatypes.ipynb
+++ b/examples/00_datatypes.ipynb
@@ -18,7 +18,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# from os import sys\n",
+    "# from os import sys\r\n",
     "# sys.path.append(\"..\")"
    ]
   },
@@ -73,37 +73,216 @@
     "\r\n",
     "The major representations of time series in `sktime` are:\r\n",
     "\r\n",
-    "* `pd.DataFrame` - uni- or multivariate series, with rows corresponding to different time points\r\n",
-    "* `pd.Series` - univariate series, with entries corresponding to different time points\r\n",
-    "* `np.ndarray` - \r\n"
+    "* `\"pd.DataFrame\"` - a uni- or multivariate `pandas.DataFrame`, with rows = time points, cols = variables\r\n",
+    "* `\"pd.Series\"` - a (univariate) `pandas.Series`, with entries corresponding to different time points\r\n",
+    "* `\"np.ndarray\"` - a 2D `numpy.ndarray`, with rows = time points, cols = variables\r\n",
+    "\r\n",
+    "`pandas` objects must have one of the following `pandas` index types:\r\n",
+    "`Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex`; if `DatetimeIndex`, the `freq` attribute must be set.\r\n",
+    "\r\n",
+    "`numpy.ndarray` 2D arrays are interpreted as having an `RangeIndex` on the rows, and generally equivalent to the `pandas.DataFrame` obtained after default coercion using the `pandas.DataFrame` constructor.\r\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import to retrieve examples\r\n",
+    "from sktime.datatypes import get_examples"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "#### step 2 - specifying the forecasting horizon"
+    "### Section 1.1.1: Time series - the `\"pd.DataFrame\"` mtype\r\n",
+    "\r\n",
+    "In the `\"pd.DataFrame\"` mtype, time series are represented by an in-memory container `obj: pandas.DataFrame` as follows.\r\n",
+    "\r\n",
+    "* structure convention: `obj.index` must be monotonous, and one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex`.\r\n",
+    "* variables: columns of `obj` correspond to different variables\r\n",
+    "* variable names: column names `obj.columns`\r\n",
+    "* time points: rows of `obj` correspond to different, distinct time points\r\n",
+    "* time index: `obj.index` is interpreted as a time index.\r\n",
+    "* capabilities: can represent multivariate series; can represent unequally spaced series"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we need to specify the forecasting horizon and pass that to our forecasting algorithm.\n",
-    "\n",
-    "There are two main ways:\n",
-    "\n",
-    "* using a `numpy.array` of integers. This assumes either integer index or periodic index (`PeriodIndex`) in the time series; the integer indicates the number of time points or periods ahead we want to make a forecast for. E.g., `1` means forecast the next period, `2` the second next period, and so on.\n",
-    "* using a `ForecastingHorizon` object. This can be used to define forecast horizons, using any supported index type as an argument. No periodic index is assumed.\n",
-    "\n",
-    "Forecasting horizons can be absolute, i.e., referencing specific time points in the future, or relative, i.e., referencing time differences to the present. As a default, the present is that latest time point seen in any `y` passed to the forecaster.\n",
-    "\n",
-    "`numpy.array` based forecasting horizons are always relative; `ForecastingHorizon` objects can be both relative and absolute. In particular, absolute forecasting horizons can only be specified using `ForecastingHorizon`."
+    "Example of a univariate series in `\"pd.DataFrame\"` representation.\r\n",
+    "The single variable has name `\"a\"`, and is observed at four time points 0, 1, 2, 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_examples(mtype=\"pd.DataFrame\", as_scitype=\"Series\")[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example of a bivariate series in `\"pd.DataFrame\"` representation.\r\n",
+    "This series has two variables, named `\"a\"` and `\"b\"`. Both are observed at the same four time points 0, 1, 2, 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_examples(mtype=\"pd.DataFrame\", as_scitype=\"Series\")[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Section 1.1.2: Time series - the `\"pd.Series\"` mtype\r\n",
+    "\r\n",
+    "In the `\"pd.Series\"` mtype, time series are represented by an in-memory container `obj: pandas.Series` as follows.\r\n",
+    "\r\n",
+    "* structure convention: `obj.index` must be monotonous, and one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex`.\r\n",
+    "* variables: there is a single variable, corresponding to the values of `obj`. Only univariate series can be represented.\r\n",
+    "* variable names: by default, there is no column name. If needed, a variable name can be provided as `obj.name`.\r\n",
+    "* time points: entries of `obj` correspond to different, distinct time points\r\n",
+    "* time index: `obj.index` is interpreted as a time index.\r\n",
+    "* capabilities: cannot represent multivariate series; can represent unequally spaced series"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example of a univariate series in `\"pd.Series\"` mtype representation.\r\n",
+    "The single variable has name `\"a\"`, and is observed at four time points 0, 1, 2, 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_examples(mtype=\"pd.Series\", as_scitype=\"Series\")[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Section 1.1.3: Time series - the `\"np.ndarray\"` mtype\r\n",
+    "\r\n",
+    "In the `\"np.ndarray\"` mtype, time series are represented by an in-memory container `obj: np.ndarray` as follows.\r\n",
+    "\r\n",
+    "* structure convention: `obj` must be 2D, i.e., `obj.shape` must have length 2. This is also true for univariate time series.\r\n",
+    "* variables: variables correspond to columns of `obj`.\r\n",
+    "* variable names: the `\"np.ndarray\"` mtype cannot represent variable names.\r\n",
+    "* time points: the rows of `obj` correspond to different, distinct time points. \r\n",
+    "* time index: The time index is implicit and by-convention. The `i`-th row (for an integer `i`) is interpreted as an observation at the time point `i`.\r\n",
+    "* capabilities: cannot represent multivariate series; cannot represent unequally spaced series"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example of a univariate series in `\"np.ndarray\"` mtype representation.\r\n",
+    "There is a single (unnamed) variable, it is observed at four time points 0, 1, 2, 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_examples(mtype=\"np.ndarray\", as_scitype=\"Series\")[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example of a bivariate series in `\"np.ndarray\"` mtype representation.\r\n",
+    "There are two (unnamed) variables, they are both observed at four time points 0, 1, 2, 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_examples(mtype=\"np.ndarray\", as_scitype=\"Series\")[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Section 1.2: Time series panels - the `\"Panel\"` scitype\r\n",
+    "\r\n",
+    "The major representations of time series panels in `sktime` are:\r\n",
+    "\r\n",
+    "* `\"pd-multiindex\"` - a `pandas.DataFrame`, with row multi-index (`instances`, `timepoints`), cols = variables\r\n",
+    "* `\"numpy3D\"` - a 3D `np.ndarray`, with axis 0 = instances, axis 1 = variables, axis 2 = time points\r\n",
+    "* `\"df-list\"` - a `list` of `pandas.DataFrame`, with list index = instances, data frame rows = time points, data frame cols = variables\r\n",
+    "\r\n",
+    "These representations are considered primary representations in `sktime` and are core to internal computations.\r\n",
+    "\r\n",
+    "There are further, minor representations of time series panels in `sktime`:\r\n",
+    "\r\n",
+    "* `\"nested_univ\"` - a `pandas.DataFrame`, with `pandas.Series` in cells. data frame rows = instances, data frame cols = variables, and series axis = time points\r\n",
+    "* `\"numpyflat\"` - a 2D `np.ndarray` with rows = instances, and columns indexed by a pair index of (variables, time points). This format is only being converted to and cannot be converted from (since number of variables and time points may be ambiguous).\r\n",
+    "* `\"pd-wide\"` - a `pandas.DataFrame` in wide format: has column multi-index (variables, time points), rows = instances\r\n",
+    "* `\"pd-long\"` - a `pandas.DataFrame` in long format: has cols `instances`, `timepoints`, `variable`, `value`; `value` is indexed by the tuple of values in (`instances`, `timepoints`, `variable`).\r\n",
+    "\r\n",
+    "The minor representations are currently not fully consolidated in-code and are not discussed further below. Contributions are appreciated."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Section 1.2.1: Time series panels - the `\"pd-multiindex\"` mtype\r\n",
+    "\r\n",
+    "In the `\"pd-multiindex\"` mtype, time series are represented by an in-memory container `obj: pandas.DataFrame` as follows.\r\n",
+    "\r\n",
+    "* structure convention: `obj.index` must be a pair multi-index of type `(RangeIndex, t)`, where `t` is one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex` and monotonous. `obj.index` must have name `(\"instances\", \"timepoints\")`.\r\n",
+    "* instances: rows with the same `\"instances\"` index correspond to the same instance; rows with a different `\"instances\"` index correspond to a different instances.\r\n",
+    "* instance index: the first element of pairs in `obj.index` is interpreted as an instance index. \r\n",
+    "* variables: columns of `obj` correspond to different variables\r\n",
+    "* variable names: column names `obj.columns`\r\n",
+    "* time points: rows of `obj` with the same `\"timepoints\"` index correspond correspond to the same time point; rows of `obj` with different `\"timepoints\"` index correspond correspond to the different time points.\r\n",
+    "* time index: the second element of pairs in `obj.index` is interpreted as a time index. \r\n",
+    "* capabilities: can represent panels of multivariate series; can represent unequally spaced series; can represent panels of unequally supported series; cannot represent panels of series with different sets of variables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example of a panel of multivariate series in `\"pd-multiindex\"` mtype representation.\r\n",
+    "The panel contains three multivariate series, with instance indices 0, 1, 2. All series have two variables with names `\"var_0\"`, `\"var_1\"`. All series are observed at three time points 0, 1, 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_examples(mtype=\"pd-multiindex\", as_scitype=\"Panel\")[0]"
    ]
   },
   {

--- a/sktime/datatypes/__init__.py
+++ b/sktime/datatypes/__init__.py
@@ -1,5 +1,21 @@
 # -*- coding: utf-8 -*-
 """Module exports: series type converters."""
-__all__ = ["convert", "convert_to", "mtype"]
+
+__author__ = ["fkiraly"]
 
 from sktime.datatypes._convert import convert, convert_to, mtype
+from sktime.datatypes._registry import (
+    MTYPE_REGISTER,
+    MTYPE_LIST_PANEL,
+    MTYPE_LIST_SERIES,
+)
+
+
+__all__ = [
+    "convert",
+    "convert_to",
+    "mtype",
+    "MTYPE_REGISTER",
+    "MTYPE_LIST_PANEL",
+    "MTYPE_LIST_SERIES"
+]

--- a/sktime/datatypes/__init__.py
+++ b/sktime/datatypes/__init__.py
@@ -8,6 +8,7 @@ from sktime.datatypes._registry import (
     MTYPE_REGISTER,
     MTYPE_LIST_PANEL,
     MTYPE_LIST_SERIES,
+    SCITYPE_REGISTER,
 )
 
 from sktime.datatypes._examples import get_examples
@@ -17,8 +18,9 @@ __all__ = [
     "convert",
     "convert_to",
     "mtype",
+    "get_examples",
     "MTYPE_REGISTER",
     "MTYPE_LIST_PANEL",
     "MTYPE_LIST_SERIES",
-    "get_examples",
+    "SCITYPE_REGISTER",
 ]

--- a/sktime/datatypes/__init__.py
+++ b/sktime/datatypes/__init__.py
@@ -10,6 +10,8 @@ from sktime.datatypes._registry import (
     MTYPE_LIST_SERIES,
 )
 
+from sktime.datatypes._examples import get_examples
+
 
 __all__ = [
     "convert",
@@ -17,5 +19,6 @@ __all__ = [
     "mtype",
     "MTYPE_REGISTER",
     "MTYPE_LIST_PANEL",
-    "MTYPE_LIST_SERIES"
+    "MTYPE_LIST_SERIES",
+    "get_examples",
 ]

--- a/sktime/datatypes/_convert.py
+++ b/sktime/datatypes/_convert.py
@@ -57,7 +57,6 @@ str - the type to convert "obj" to, a valid mtype string
     or None, if obj is None
 """
 
-
 __author__ = ["fkiraly"]
 
 __all__ = [
@@ -66,6 +65,8 @@ __all__ = [
     "mtype",
 ]
 
+import numpy as np
+import pandas as pd
 
 from sktime.datatypes._series import convert_dict_Series
 from sktime.datatypes._series import infer_mtype_dict_Series
@@ -191,3 +192,33 @@ def convert_to(obj, to_type: str, as_scitype: str, store=None):
     )
 
     return converted_obj
+
+
+def _conversions_defined(scitype: str):
+    """Return an indicator matrix which conversions are defined for scitype.
+
+    Parameters
+    ----------
+    scitype: str - name of scitype for which conversions are queried
+
+    Returns
+    -------
+    conv_df: pd.DataFrame, columns and index is list of mtypes for scitype
+            entry of row i, col j is 1 if conversion from i to j is defined,
+                                     0 if conversion from i to j is not defined
+    """
+    pairs = [(x[0], x[1]) for x in list(convert_dict.keys()) if x[2] == scitype]
+    cols0 = set([x[0] for x in list(convert_dict.keys()) if x[2] == scitype])
+    cols1 = set([x[1] for x in list(convert_dict.keys()) if x[2] == scitype])
+    cols = sorted(list(cols0.union(cols1)))
+
+    mat = np.zeros((len(cols), len(cols)), dtype=int)
+    nkeys = len(cols)
+    for i in range(nkeys):
+        for j in range(nkeys):
+            if (cols[i], cols[j]) in pairs:
+                mat[i, j] = 1
+
+    conv_df = pd.DataFrame(mat, index=cols, columns=cols)
+
+    return conv_df

--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -23,13 +23,17 @@ __all__ = [
 
 from sktime.datatypes._series import example_dict_Series
 from sktime.datatypes._series import example_dict_lossy_Series
+from sktime.datatypes._panel import example_dict_Panel
+from sktime.datatypes._panel import example_dict_lossy_Panel
 
 # pool example_dict-s
 example_dict = dict()
 example_dict.update(example_dict_Series)
+example_dict.update(example_dict_Panel)
 
 example_dict_lossy = dict()
 example_dict_lossy.update(example_dict_lossy_Series)
+example_dict_lossy.update(example_dict_lossy_Panel)
 
 
 def get_example(mtype: str, as_scitype: str, ind: int = 0, return_lossy: bool = False):

--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -48,7 +48,7 @@ def get_examples(mtype: str, as_scitype: str, return_lossy: bool = False):
 
     Returns
     -------
-    fixtures: list with elements being
+    fixtures: dict with integer keys, elements being
         fixture - example for mtype mtype, scitype as_scitype
         if return_lossy=True, elements are pairs with fixture and
         lossy: bool - whether the example is a lossy representation
@@ -58,11 +58,12 @@ def get_examples(mtype: str, as_scitype: str, return_lossy: bool = False):
     keys = [k for k in exkeys if k[0] == mtype and k[1] == as_scitype]
 
     # retrieve all fixtures that match the key
-    fixtures = [example_dict[k] for k in keys]
+    fixtures = dict()
 
-    if return_lossy:
-        fixtures = [(example_dict[k], example_dict_lossy[k]) for k in keys]
-    else:
-        fixtures = [example_dict[k] for k in keys]
+    for k in keys:
+        if return_lossy:
+            fixtures[k[2]] = (example_dict[k], example_dict_lossy[k])
+        else:
+            fixtures[k[2]] = example_dict[k]
 
     return fixtures

--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -3,10 +3,10 @@
 
 Exports
 -------
-get_example(mtype: str, as_scitype: str, ind=0, return_lossy=False)
-    retrieves the ind-th example for mtype/scitype, and/or whether it is lossy
+get_examples(mtype: str, as_scitype: str, return_lossy=False)
+    retrieves examples for mtype/scitype, and/or whether it is lossy
 
-examples are assumed "content-wise the same" for the same as_scitype, ind
+examples[i] are assumed "content-wise the same" for the same as_scitype, i
     only in different machine representations
 
 the representation is considered "lossy" if the representation is incomplete
@@ -17,7 +17,7 @@ the representation is considered "lossy" if the representation is incomplete
 __author__ = ["fkiraly"]
 
 __all__ = [
-    "get_example",
+    "get_examples",
 ]
 
 
@@ -36,29 +36,33 @@ example_dict_lossy.update(example_dict_lossy_Series)
 example_dict_lossy.update(example_dict_lossy_Panel)
 
 
-def get_example(mtype: str, as_scitype: str, ind: int = 0, return_lossy: bool = False):
+def get_examples(mtype: str, as_scitype: str, return_lossy: bool = False):
     """Retrieve the ind-th example for mtype mtype, scitype as_scitype.
 
     Parameters
     ----------
     mtype: str - name of the mtype for the example
     as_scitype: str - name of scitype for the example
-    ind: int - index number of the example
     return_lossy: bool, optional, default=False
         whether to return second argument
 
     Returns
     -------
-    fixture - ind-th example for mtype mtype, scitype as_scitype
-    if return_lossy=True, also returns:
-    lossy: bool - whether the example is a lossy representation
+    fixtures: list with elements being
+        fixture - example for mtype mtype, scitype as_scitype
+        if return_lossy=True, elements are pairs with fixture and
+        lossy: bool - whether the example is a lossy representation
     """
-    key = (mtype, as_scitype, ind)
+    # retrieve all keys that match the query
+    exkeys = example_dict.keys()
+    keys = [k for k in exkeys if k[0] == mtype and k[1] == as_scitype]
 
-    if key not in example_dict.keys():
-        raise KeyError("no example for the requested combination")
+    # retrieve all fixtures that match the key
+    fixtures = [example_dict[k] for k in keys]
 
     if return_lossy:
-        return example_dict[key], example_dict_lossy[key]
+        fixtures = [(example_dict[k], example_dict_lossy[k]) for k in keys]
     else:
-        return example_dict[key]
+        fixtures = [example_dict[k] for k in keys]
+
+    return fixtures

--- a/sktime/datatypes/_panel/__init__.py
+++ b/sktime/datatypes/_panel/__init__.py
@@ -3,6 +3,10 @@
 
 from sktime.datatypes._panel._convert import convert_dict as convert_dict_Panel
 from sktime.datatypes._panel._registry import MTYPE_LIST_PANEL, MTYPE_REGISTER_PANEL
+from sktime.datatypes._panel._examples import example_dict as example_dict_Panel
+from sktime.datatypes._panel._examples import (
+    example_dict_lossy as example_dict_lossy_Panel
+)
 
 # from sktime.datatypes._panel._mtypes import infer_mtype_dict as infer_mtype_dict_Panel
 

--- a/sktime/datatypes/_panel/__init__.py
+++ b/sktime/datatypes/_panel/__init__.py
@@ -5,7 +5,7 @@ from sktime.datatypes._panel._convert import convert_dict as convert_dict_Panel
 from sktime.datatypes._panel._registry import MTYPE_LIST_PANEL, MTYPE_REGISTER_PANEL
 from sktime.datatypes._panel._examples import example_dict as example_dict_Panel
 from sktime.datatypes._panel._examples import (
-    example_dict_lossy as example_dict_lossy_Panel
+    example_dict_lossy as example_dict_lossy_Panel,
 )
 
 # from sktime.datatypes._panel._mtypes import infer_mtype_dict as infer_mtype_dict_Panel

--- a/sktime/datatypes/_panel/__init__.py
+++ b/sktime/datatypes/_panel/__init__.py
@@ -11,4 +11,6 @@ __all__ = [
     "infer_mtype_dict_Panel",
     "MTYPE_LIST_PANEL",
     "MTYPE_REGISTER_PANEL",
+    "example_dict_Panel",
+    "example_dict_lossy_Panel",
 ]

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -1009,7 +1009,7 @@ convert_dict[("df-list", "pd-multiindex", "Panel")] = from_multiindex_to_dflist
 
 def from_dflist_to_numpy3D(obj, store=None):
 
-    if not isinstance(obj, "list"):
+    if not isinstance(obj, list):
         raise TypeError("obj must be a list of pd.DataFrame")
 
     n = len(obj[0])
@@ -1029,7 +1029,7 @@ convert_dict[("numpy3D", "df-list", "Panel")] = from_dflist_to_numpy3D
 
 def from_numpy3D_to_dflist(obj, store=None):
 
-    if not isinstance(obj, "np.ndarray") or len(obj.shape) != 3:
+    if not isinstance(obj, np.ndarray) or len(obj.shape) != 3:
         raise TypeError("obj must be a 3D numpy.ndarray")
 
     cols = _make_column_names(obj.shape[1])

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -994,17 +994,20 @@ def from_dflist_to_multiindex(obj, store=None):
     return mi
 
 
-convert_dict[("pd-multiindex", "df-list", "Panel")] = from_dflist_to_multiindex
+convert_dict[("df-list", "pd-multiindex", "Panel")] = from_dflist_to_multiindex
 
 
 def from_multiindex_to_dflist(obj, store=None):
 
-    Xlist = [obj.loc[i].rename_axis(None) for i in len(obj)]
+    instance_index = obj.index.levels[0]
+    n = len(instance_index)
+
+    Xlist = [obj.loc[i].rename_axis(None) for i in range(n)]
 
     return Xlist
 
 
-convert_dict[("df-list", "pd-multiindex", "Panel")] = from_multiindex_to_dflist
+convert_dict[("pd-multiindex", "df-list", "Panel")] = from_multiindex_to_dflist
 
 
 def from_dflist_to_numpy3D(obj, store=None):
@@ -1015,8 +1018,8 @@ def from_dflist_to_numpy3D(obj, store=None):
     n = len(obj[0])
     cols = set(obj[0].columns)
 
-    for i in len(obj):
-        if not n == len(obj[i]) or not set(obj[i].cols) == cols:
+    for i in range(len(obj)):
+        if not n == len(obj[i]) or not set(obj[i].columns) == cols:
             raise ValueError("elements of obj must have same length and columns")
 
     nparr = np.array([X.to_numpy().transpose() for X in obj])
@@ -1033,7 +1036,7 @@ def from_numpy3D_to_dflist(obj, store=None):
         raise TypeError("obj must be a 3D numpy.ndarray")
 
     cols = _make_column_names(obj.shape[1])
-    Xlist = [pd.DataFrame(obj[i].T, colulmns=cols) for i in len(obj)]
+    Xlist = [pd.DataFrame(obj[i].T, columns=cols) for i in range(len(obj))]
 
     return Xlist
 

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -19,9 +19,9 @@ from sktime.datatypes._panel._registry import MTYPE_LIST_PANEL
 convert_dict = dict()
 
 
-def convert_identity(what, store=None):
+def convert_identity(obj, store=None):
 
-    return what
+    return obj
 
 
 # assign identity function to type conversion to self
@@ -140,9 +140,9 @@ def from_3d_numpy_to_2d_array(X):
     return array_2d
 
 
-def from_3d_numpy_to_2d_array_adp(what, store=None):
+def from_3d_numpy_to_2d_array_adp(obj, store=None):
 
-    return from_3d_numpy_to_2d_array(what)
+    return from_3d_numpy_to_2d_array(obj)
 
 
 convert_dict[("numpy3D", "numpyflat", "Panel")] = from_3d_numpy_to_2d_array_adp
@@ -233,14 +233,14 @@ def from_nested_to_2d_array(X, return_numpy=False):
     return Xt
 
 
-def from_nested_to_pdwide(what, store=None):
+def from_nested_to_pdwide(obj, store=None):
 
-    return from_nested_to_2d_array(X=what, return_numpy=False)
+    return from_nested_to_2d_array(X=obj, return_numpy=False)
 
 
-def from_nested_to_2d_np_array(what, store=None):
+def from_nested_to_2d_np_array(obj, store=None):
 
-    return from_nested_to_2d_array(X=what, return_numpy=True)
+    return from_nested_to_2d_array(X=obj, return_numpy=True)
 
 
 convert_dict[("nested_univ", "pd-wide", "Panel")] = from_nested_to_pdwide
@@ -303,9 +303,9 @@ def from_2d_array_to_nested(
     return Xt
 
 
-def from_pd_wide_to_nested(what, store=None):
+def from_pd_wide_to_nested(obj, store=None):
 
-    return from_2d_array_to_nested(X=what)
+    return from_2d_array_to_nested(X=obj)
 
 
 convert_dict[("pd-wide", "nested_univ", "Panel")] = from_pd_wide_to_nested
@@ -457,10 +457,10 @@ def from_nested_to_long(
     return long_df
 
 
-def from_nested_to_long_adp(what, store=None):
+def from_nested_to_long_adp(obj, store=None):
 
     return from_nested_to_long(
-        X=what,
+        X=obj,
         instance_column_name="case_id",
         time_column_name="reading_id",
         dimension_column_name="dim_id",
@@ -569,9 +569,9 @@ def from_long_to_nested(
     return X_nested
 
 
-def from_long_to_nested_adp(what, store=None):
+def from_long_to_nested_adp(obj, store=None):
 
-    return from_long_to_nested(X_long=what)
+    return from_long_to_nested(X_long=obj)
 
 
 convert_dict[("pd-long", "nested_univ", "Panel")] = from_nested_to_long_adp
@@ -626,10 +626,10 @@ def from_multi_index_to_3d_numpy(X, instance_index=None, time_index=None):
     return X_3d
 
 
-def from_multi_index_to_3d_numpy_adp(what, store=None):
+def from_multi_index_to_3d_numpy_adp(obj, store=None):
 
     return from_multi_index_to_3d_numpy(
-        X=what, instance_index="instances", time_index="timepoints"
+        X=obj, instance_index="instances", time_index="timepoints"
     )
 
 
@@ -699,9 +699,9 @@ def from_3d_numpy_to_multi_index(
     return X_mi
 
 
-def from_3d_numpy_to_multi_index_adp(what, store=None):
+def from_3d_numpy_to_multi_index_adp(obj, store=None):
 
-    return from_3d_numpy_to_multi_index(X=what)
+    return from_3d_numpy_to_multi_index(X=obj)
 
 
 convert_dict[("numpy3D", "pd-multiindex", "Panel")] = from_3d_numpy_to_multi_index_adp
@@ -766,9 +766,9 @@ def from_multi_index_to_nested(
     return x_nested
 
 
-def from_multi_index_to_nested_adp(what, store=None):
+def from_multi_index_to_nested_adp(obj, store=None):
 
-    return from_multi_index_to_nested(X=what, instance_index_name="instances")
+    return from_multi_index_to_nested(X=obj, instance_index_name="instances")
 
 
 convert_dict[("pd-multiindex", "nested_univ", "Panel")] = from_multi_index_to_nested_adp
@@ -856,10 +856,10 @@ def from_nested_to_multi_index(X, instance_index=None, time_index=None):
     return X_mi
 
 
-def from_nested_to_multi_index_adp(what, store=None):
+def from_nested_to_multi_index_adp(obj, store=None):
 
     return from_nested_to_multi_index(
-        X=what, instance_index_name="instances", time_index="timepoints"
+        X=obj, instance_index_name="instances", time_index="timepoints"
     )
 
 
@@ -923,9 +923,9 @@ def from_nested_to_3d_numpy(X):
     return X_3d
 
 
-def from_nested_to_3d_numpy_adp(what, store=None):
+def from_nested_to_3d_numpy_adp(obj, store=None):
 
-    return from_nested_to_3d_numpy(X=what)
+    return from_nested_to_3d_numpy(X=obj)
 
 
 convert_dict[("nested_univ", "numpy3D", "Panel")] = from_nested_to_3d_numpy_adp
@@ -978,9 +978,9 @@ def from_3d_numpy_to_nested(X, column_names=None, cells_as_numpy=False):
     return df
 
 
-def from_3d_numpy_to_nested_adp(what, store=None):
+def from_3d_numpy_to_nested_adp(obj, store=None):
 
-    return from_3d_numpy_to_nested(X=what)
+    return from_3d_numpy_to_nested(X=obj)
 
 
 convert_dict[("numpy3D", "nested_univ", "Panel")] = from_3d_numpy_to_nested_adp

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -724,7 +724,6 @@ def from_multi_index_to_nested(
         If True, then nested cells contain NumPy array
         If False, then nested cells contain pandas Series
 
-
     Returns
     -------
     x_nested : pd.DataFrame
@@ -984,6 +983,28 @@ def from_3d_numpy_to_nested_adp(obj, store=None):
 
 
 convert_dict[("numpy3D", "nested_univ", "Panel")] = from_3d_numpy_to_nested_adp
+
+
+def from_dflist_to_multiindex(obj, store=None):
+
+    n = len(obj)
+
+    mi = pd.concat(obj, axis=0, keys=range(n), names=["instances", "timepoints"])
+
+    return mi
+
+
+convert_dict[("pd-multiindex", "df-list", "Panel")] = from_dflist_to_multiindex
+
+
+def from_multiindex_to_dflist(obj, store=None):
+
+    Xlist = [obj.loc[i].rename_axis(None) for i in len(obj)]
+
+    return Xlist
+
+
+convert_dict[("df-list", "pd-multiindex", "Panel")] = from_multiindex_to_dflist
 
 
 def is_nested_dataframe(X):

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -1024,7 +1024,7 @@ def from_dflist_to_numpy3D(obj, store=None):
     return nparr
 
 
-convert_dict[("numpy3D", "df-list", "Panel")] = from_dflist_to_numpy3D
+convert_dict[("df-list", "numpy3D", "Panel")] = from_dflist_to_numpy3D
 
 
 def from_numpy3D_to_dflist(obj, store=None):
@@ -1038,7 +1038,7 @@ def from_numpy3D_to_dflist(obj, store=None):
     return Xlist
 
 
-convert_dict[("df-list", "numpy3D", "Panel")] = from_numpy3D_to_dflist
+convert_dict[("numpy3D", "df-list", "Panel")] = from_numpy3D_to_dflist
 
 
 def is_nested_dataframe(X):

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -1007,6 +1007,40 @@ def from_multiindex_to_dflist(obj, store=None):
 convert_dict[("df-list", "pd-multiindex", "Panel")] = from_multiindex_to_dflist
 
 
+def from_dflist_to_numpy3D(obj, store=None):
+
+    if not isinstance(obj, "list"):
+        raise TypeError("obj must be a list of pd.DataFrame")
+
+    n = len(obj[0])
+    cols = set(obj[0].columns)
+
+    for i in len(obj):
+        if not n == len(obj[i]) or not set(obj[i].cols) == cols:
+            raise ValueError("elements of obj must have same length and columns")
+
+    nparr = np.array([X.to_numpy().transpose() for X in obj])
+
+    return nparr
+
+
+convert_dict[("numpy3D", "df-list", "Panel")] = from_dflist_to_numpy3D
+
+
+def from_numpy3D_to_dflist(obj, store=None):
+
+    if not isinstance(obj, "np.ndarray") or len(obj.shape) != 3:
+        raise TypeError("obj must be a 3D numpy.ndarray")
+
+    cols = _make_column_names(obj.shape[1])
+    Xlist = [pd.DataFrame(obj[i].T, colulmns=cols) for i in len(obj)]
+
+    return Xlist
+
+
+convert_dict[("df-list", "numpy3D", "Panel")] = from_numpy3D_to_dflist
+
+
 def is_nested_dataframe(X):
     """Check whether the input is a nested DataFrame.
 

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""Example generation for testing.
+
+Exports dict of examples, useful for testing as fixtures.
+
+example_dict: dict indexed by triple
+  1st element = mtype - str
+  2nd element = considered as this scitype - str
+  3rd element = int - index of example
+elements are data objects, considered examples for the mtype
+    all examples with same index are considered "same" on scitype content
+    if None, indicates that representation is not possible
+
+example_lossy: dict of bool indexed by pairs of str
+  1st element = mtype - str
+  2nd element = considered as this scitype - str
+  3rd element = int - index of example
+elements are bool, indicate whether representation has information removed
+    all examples with same index are considered "same" on scitype content
+
+overall, conversions from non-lossy representations to any other ones
+    should yield the element exactly, identidally (given same index)
+"""
+
+import pandas as pd
+import numpy as np
+
+example_dict = dict()
+example_dict_lossy = dict()
+
+###
+
+
+X = np.array([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 55, 6]], [[1, 2, 3], [42, 5, 6]]])
+
+example_dict[("numpy3D", "Panel", 0)] = X
+example_dict_lossy[("numpy3D", "Panel",  0)] = False
+
+cols = [f"var_{i}" for i in range(2)]
+Xlist = [
+  pd.DataFrame([[1, 4], [2, 5], [3, 6]], columns=cols),
+  pd.DataFrame([[1, 4], [2, 55], [3, 6]], columns=cols),
+  pd.DataFrame([[1, 42], [2, 5], [3, 6]], columns=cols),
+  ]
+
+example_dict[("df-list", "Panel", 0)] = Xlist
+example_dict_lossy[("df-list", "Panel",  0)] = False
+

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -32,29 +32,29 @@ example_dict_lossy = dict()
 
 
 X = np.array(
-  [[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 55, 6]], [[1, 2, 3], [42, 5, 6]]],
-  dtype=np.int64
+    [[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 55, 6]], [[1, 2, 3], [42, 5, 6]]],
+    dtype=np.int64
 )
 
 example_dict[("numpy3D", "Panel", 0)] = X
-example_dict_lossy[("numpy3D", "Panel",  0)] = False
+example_dict_lossy[("numpy3D", "Panel", 0)] = False
 
 cols = [f"var_{i}" for i in range(2)]
 Xlist = [
-  pd.DataFrame([[1, 4], [2, 5], [3, 6]], columns=cols),
-  pd.DataFrame([[1, 4], [2, 55], [3, 6]], columns=cols),
-  pd.DataFrame([[1, 42], [2, 5], [3, 6]], columns=cols),
+    pd.DataFrame([[1, 4], [2, 5], [3, 6]], columns=cols),
+    pd.DataFrame([[1, 4], [2, 55], [3, 6]], columns=cols),
+    pd.DataFrame([[1, 42], [2, 5], [3, 6]], columns=cols),
 ]
 
 example_dict[("df-list", "Panel", 0)] = Xlist
-example_dict_lossy[("df-list", "Panel",  0)] = False
+example_dict_lossy[("df-list", "Panel", 0)] = False
 
 cols = ["instances", "timepoints"] + [f"var_{i}" for i in range(2)]
 
 Xlist = [
-  pd.DataFrame([[0, 0, 1, 4], [0, 1, 2, 5], [0, 2, 3, 6]], columns=cols),
-  pd.DataFrame([[1, 0, 1, 4], [1, 1, 2, 55], [1, 2, 3, 6]], columns=cols),
-  pd.DataFrame([[2, 0, 1, 42], [2, 1, 2, 5], [2, 2, 3, 6]], columns=cols),
+    pd.DataFrame([[0, 0, 1, 4], [0, 1, 2, 5], [0, 2, 3, 6]], columns=cols),
+    pd.DataFrame([[1, 0, 1, 4], [1, 1, 2, 55], [1, 2, 3, 6]], columns=cols),
+    pd.DataFrame([[2, 0, 1, 42], [2, 1, 2, 5], [2, 2, 3, 6]], columns=cols),
 ]
 X = pd.concat(Xlist)
 X = X.set_index(["instances", "timepoints"])

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -33,7 +33,7 @@ example_dict_lossy = dict()
 
 X = np.array(
     [[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 55, 6]], [[1, 2, 3], [42, 5, 6]]],
-    dtype=np.int64
+    dtype=np.int64,
 )
 
 example_dict[("numpy3D", "Panel", 0)] = X
@@ -60,4 +60,4 @@ X = pd.concat(Xlist)
 X = X.set_index(["instances", "timepoints"])
 
 example_dict[("pd-multiindex", "Panel", 0)] = X
-example_dict_lossy[("pd-multiindex", "Panel",  0)] = False
+example_dict_lossy[("pd-multiindex", "Panel", 0)] = False

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -31,7 +31,10 @@ example_dict_lossy = dict()
 ###
 
 
-X = np.array([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 55, 6]], [[1, 2, 3], [42, 5, 6]]])
+X = np.array(
+  [[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 55, 6]], [[1, 2, 3], [42, 5, 6]]],
+  dtype=np.int64
+)
 
 example_dict[("numpy3D", "Panel", 0)] = X
 example_dict_lossy[("numpy3D", "Panel",  0)] = False

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -41,8 +41,20 @@ Xlist = [
   pd.DataFrame([[1, 4], [2, 5], [3, 6]], columns=cols),
   pd.DataFrame([[1, 4], [2, 55], [3, 6]], columns=cols),
   pd.DataFrame([[1, 42], [2, 5], [3, 6]], columns=cols),
-  ]
+]
 
 example_dict[("df-list", "Panel", 0)] = Xlist
 example_dict_lossy[("df-list", "Panel",  0)] = False
 
+cols = ["instances", "timepoints"] + [f"var_{i}" for i in range(2)]
+
+Xlist = [
+  pd.DataFrame([[0, 0, 1, 4], [0, 1, 2, 5], [0, 2, 3, 6]], columns=cols),
+  pd.DataFrame([[1, 0, 1, 4], [1, 1, 2, 55], [1, 2, 3, 6]], columns=cols),
+  pd.DataFrame([[2, 0, 1, 42], [2, 1, 2, 5], [2, 2, 3, 6]], columns=cols),
+]
+X = pd.concat(Xlist)
+X = X.set_index(["instances", "timepoints"])
+
+example_dict[("pd-multiindex", "Panel", 0)] = X
+example_dict_lossy[("pd-multiindex", "Panel",  0)] = False

--- a/sktime/datatypes/_panel/_registry.py
+++ b/sktime/datatypes/_panel/_registry.py
@@ -24,8 +24,8 @@ MTYPE_REGISTER_PANEL = [
         "Panel",
         "2D np.array of format (n_instances, n_columns*n_timepoints)",
     ),
-    ("pd-multiindex", "Panel", "pd.DataFrame with multi-index (instance, time point)"),
-    ("pd-wide", "Panel", "pd.DataFrame in wide format, cols = (instance*time point)"),
+    ("pd-multiindex", "Panel", "pd.DataFrame with multi-index (instances, timepoints)"),
+    ("pd-wide", "Panel", "pd.DataFrame in wide format, cols = (instance*timepoints)"),
     (
         "pd-long",
         "Panel",

--- a/sktime/datatypes/_registry.py
+++ b/sktime/datatypes/_registry.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from sktime.datatypes._series._registry import (
+    MTYPE_REGISTER_SERIES,
+    MTYPE_LIST_SERIES,
+)
+
+from sktime.datatypes._panel._registry import (
+    MTYPE_REGISTER_PANEL,
+    MTYPE_LIST_PANEL,
+)
+
+MTYPE_REGISTER = MTYPE_REGISTER_SERIES + MTYPE_REGISTER_PANEL
+
+__all__ = [
+    "MTYPE_REGISTER",
+    "MTYPE_LIST_PANEL",
+    "MTYPE_LIST_SERIES",
+]

--- a/sktime/datatypes/_registry.py
+++ b/sktime/datatypes/_registry.py
@@ -17,4 +17,11 @@ __all__ = [
     "MTYPE_REGISTER",
     "MTYPE_LIST_PANEL",
     "MTYPE_LIST_SERIES",
+    "SCITYPE_REGISTER"
+]
+
+
+SCITYPE_REGISTER = [
+    ("Series", "uni- or multivariate time series"),
+    ("Panel", "panel of uni- or multivariate time series"),
 ]

--- a/sktime/datatypes/_registry.py
+++ b/sktime/datatypes/_registry.py
@@ -12,6 +12,7 @@ from sktime.datatypes._panel._registry import (
 
 MTYPE_REGISTER = MTYPE_REGISTER_SERIES + MTYPE_REGISTER_PANEL
 
+
 __all__ = [
     "MTYPE_REGISTER",
     "MTYPE_LIST_PANEL",

--- a/sktime/datatypes/_registry.py
+++ b/sktime/datatypes/_registry.py
@@ -17,7 +17,7 @@ __all__ = [
     "MTYPE_REGISTER",
     "MTYPE_LIST_PANEL",
     "MTYPE_LIST_SERIES",
-    "SCITYPE_REGISTER"
+    "SCITYPE_REGISTER",
 ]
 
 

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -25,9 +25,6 @@ Raises
 ------
 ValueError and TypeError, if requested conversion is not possible
                             (depending on conversion logic)
-
----
-
 """
 
 __author__ = ["fkiraly"]

--- a/sktime/datatypes/_series/_examples.py
+++ b/sktime/datatypes/_series/_examples.py
@@ -52,10 +52,10 @@ example_dict_lossy[("pd.Series", "Series", 1)] = None
 
 df = pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
 
-example_dict[("pd.DataFrame", "Series", 0)] = df
-example_dict_lossy[("pd.DataFrame", "Series", 0)] = False
+example_dict[("pd.DataFrame", "Series", 1)] = df
+example_dict_lossy[("pd.DataFrame", "Series", 1)] = False
 
 arr = np.array([[1, 3], [4, 7], [0.5, 2], [-3, -3 / 7]])
 
-example_dict[("np.ndarray", "Series", 0)] = arr
-example_dict_lossy[("np.ndarray", "Series", 0)] = True
+example_dict[("np.ndarray", "Series", 1)] = arr
+example_dict_lossy[("np.ndarray", "Series", 1)] = True

--- a/sktime/datatypes/tests/test_convert.py
+++ b/sktime/datatypes/tests/test_convert.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Testing machine type converters for scitypes."""
+
+__author__ = ["fkiraly"]
+
+import pytest
+
+from sktime.datatypes._convert import convert, _conversions_defined
+from sktime.datatypes._examples import get_examples
+from sktime.datatypes import SCITYPE_REGISTER
+
+from sktime.utils._testing.deep_equals import deep_equals
+
+SCITYPES = [sci[0] for sci in SCITYPE_REGISTER]
+
+
+@pytest.mark.parametrize("scitype", SCITYPES)
+def test_convert(scitype):
+    """Tests that conversions for scitype agree with from/to example fixtures.
+
+    Parameters
+    ----------
+    scitype : str - name of scitype for which mtype conversions are tested
+
+    Raises
+    ------
+    AssertionError if a converted object does not match fixture
+    error if conversion itself raises an error
+    """
+    conv_mat = _conversions_defined(scitype)
+    mtypes = conv_mat.index.values
+
+    if len(mtypes) == 0:
+        raise RuntimeError("no mtypes defined for scitype "+scitype)
+
+    fixtures = dict()
+
+    for mtype in mtypes:
+        fixtures[mtype] = get_examples(
+            mtype=mtype,
+            as_scitype=scitype,
+            return_lossy=True
+        )
+
+    if len(fixtures[mtypes[0]]) == 0:
+        raise RuntimeError("no fixtures defined for scitype "+scitype)
+
+    n_fixtures = len(fixtures[mtypes[0]])
+
+    for i in range(n_fixtures):
+        for from_type in mtypes:
+            for to_type in mtypes:
+
+                # retrieve from/to fixture for conversion
+                to_fixture = fixtures[to_type].get(i)
+                from_fixture = fixtures[from_type].get(i)
+
+                # retrieve indicators whether conversion makes sense
+                # to-fixture is in example dict and is not None
+                cond1 = to_fixture is not None and to_fixture[0] is not None
+                # from-fixture is in example dict andis not None
+                cond2 = from_fixture is not None and from_fixture[0] is not None
+                # from-fixture is not None and not lossy
+                cond3 = cond2 and from_fixture[1] is not None and not from_fixture[1]
+
+                msg = f"conversion {from_type} to {to_type} failed for fixture {i}"
+
+                # test that converted from-fixture equals to-fixture
+                if cond1 and cond2 and cond3:
+
+                    converted_fixture_i = convert(
+                        obj=from_fixture[0],
+                        from_type=from_type,
+                        to_type=to_type,
+                        as_scitype=scitype,
+                    )
+
+                    assert deep_equals(
+                        converted_fixture_i,
+                        to_fixture[0],
+                    ), msg

--- a/sktime/datatypes/tests/test_convert.py
+++ b/sktime/datatypes/tests/test_convert.py
@@ -31,19 +31,21 @@ def test_convert(scitype):
     mtypes = conv_mat.index.values
 
     if len(mtypes) == 0:
-        raise RuntimeError("no mtypes defined for scitype "+scitype)
+        raise RuntimeError("no mtypes defined for scitype " + scitype)
 
     fixtures = dict()
 
     for mtype in mtypes:
+        # if we don't do this we get into a clash between linters
+        mtype_long_variable_name_to_avoid_linter_clash = mtype
         fixtures[mtype] = get_examples(
-            mtype=mtype,
+            mtype=mtype_long_variable_name_to_avoid_linter_clash,
             as_scitype=scitype,
-            return_lossy=True
+            return_lossy=True,
         )
 
     if len(fixtures[mtypes[0]]) == 0:
-        raise RuntimeError("no fixtures defined for scitype "+scitype)
+        raise RuntimeError("no fixtures defined for scitype " + scitype)
 
     n_fixtures = len(fixtures[mtypes[0]])
 


### PR DESCRIPTION
DRAFT pull request on data container conventions and related functionality.

This is based on, and branching off the state of #1225 - and requests of @mloning and @TonyBagnall to document this.

The increment in this PR is the notebook `examples/00_datatypes` which is supposed to explain:
* the different core in-memory data container datatypes for series and panels used in `sktime`, with examples to play around with
* validity checking, conversion, register, and type functionality
* possibly: data sets loading functionality

Still work in progress, but would already appreciate a look at section 1.