### PR TITLE
Update feature_request.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,10 +8,10 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. 
+A clear and concise description of what the problem is.
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen, ideally taking into consideration the existing toolbox design, classes and methods. 
+A clear and concise description of what you want to happen, ideally taking into consideration the existing toolbox design, classes and methods.
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: "\u2728 Feature request"
 about: Suggest an idea for this project
-title: ''
+title: '[FEATURE]'
 labels: enhancement
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: "\u2728 Feature request"
 about: Suggest an idea for this project
-title: '[FEATURE]'
+title: '[ENH]'
 labels: enhancement
 assignees: ''
 


### PR DESCRIPTION
Added `[FEATURE]` as start of title for all feature request issues. So all issues following the issue template would have either `[FEATURE], [DOC] or [BUG]` and we can easily see issues that were opened without templates and request user to use the templates. 

Alternatively we could use `[ENH]` as a abbreviation which is e.g. used by `pandas`. 