### PR TITLE
Correct the examples in acf transformations

### DIFF
--- a/sktime/transformations/series/acf.py
+++ b/sktime/transformations/series/acf.py
@@ -25,8 +25,7 @@ class AutoCorrelationTransformer(_SeriesToSeriesTransformer):
 
     Example
     -------
-    >>> from sktime.transformations.series.acf import PartialAutoCorrelationTransformer
-    >>> from sklearn.preprocessing import MinMaxScaler
+    >>> from sktime.transformations.series.acf import AutoCorrelationTransformer
     >>> from sktime.datasets import load_airline
     >>> y = load_airline()
     >>> transformer = AutoCorrelationTransformer(n_lags=12)
@@ -101,11 +100,10 @@ class PartialAutoCorrelationTransformer(_SeriesToSeriesTransformer):
 
     Example
     -------
-    >>> from sktime.transformations.series.acf import AutoCorrelationTransformer
-    >>> from sklearn.preprocessing import MinMaxScaler
+    >>> from sktime.transformations.series.acf import PartialAutoCorrelationTransformer
     >>> from sktime.datasets import load_airline
     >>> y = load_airline()
-    >>> transformer = AutoCorrelationTransformer(n_lags=12)
+    >>> transformer = PartialAutoCorrelationTransformer(n_lags=12)
     >>> y_hat = transformer.fit_transform(y)
     """
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The code examples in acf.py have typos. The one for AutoCorrelationTransformer corresponds to PartialAutoCorrelationTransformer and vice versa.

I have also removed the unnecessary import for `MixMaxScaler` from the examples as it is not used.

#### Does your contribution introduce a new dependency? If yes, which one?

No

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

