### PR TITLE
checks invalid X type for y multivariate and univariate

### DIFF
--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -125,13 +125,13 @@ def test_X_invalid_type_raises_error(Forecaster, X):
     f = _construct_instance(Forecaster)
 
     if f.get_tag("scitype:y") == "univariate" or f.get_tag("scitype:y") == "both":
-        y = _make_series(n_columns=1)
+        y_train = _make_series(n_columns=1)
 
     elif f.get_tag("scitype:y") == "multivariate" or f.get_tag("scitype:y") == "both":
-        y = _make_series(n_columns=2)
+        y_train = _make_series(n_columns=2)
     try:
         with pytest.raises(TypeError, match=r"type"):
-            f.fit(y, X, fh=FH0)
+            f.fit(y_train, X, fh=FH0)
     except NotImplementedError as e:
         msg = str(e).lower()
         assert "exogenous" in msg

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -123,9 +123,15 @@ def test_y_invalid_type_raises_error(Forecaster, y):
 def test_X_invalid_type_raises_error(Forecaster, X):
     """Test that invalid X input types raise error."""
     f = _construct_instance(Forecaster)
+
+    if f.get_tag("scitype:y") == "univariate" or f.get_tag("scitype:y") == "both":
+        y = _make_series(n_columns=1)
+
+    elif f.get_tag("scitype:y") == "multivariate" or f.get_tag("scitype:y") == "both":
+        y = _make_series(n_columns=2)
     try:
         with pytest.raises(TypeError, match=r"type"):
-            f.fit(y_train, X, fh=FH0)
+            f.fit(y, X, fh=FH0)
     except NotImplementedError as e:
         msg = str(e).lower()
         assert "exogenous" in msg

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -123,11 +123,10 @@ def test_y_invalid_type_raises_error(Forecaster, y):
 def test_X_invalid_type_raises_error(Forecaster, X):
     """Test that invalid X input types raise error."""
     f = _construct_instance(Forecaster)
-
     if f.get_tag("scitype:y") == "univariate" or f.get_tag("scitype:y") == "both":
         y_train = _make_series(n_columns=1)
 
-    elif f.get_tag("scitype:y") == "multivariate" or f.get_tag("scitype:y") == "both":
+    elif f.get_tag("scitype:y") == "multivariate":
         y_train = _make_series(n_columns=2)
     try:
         with pytest.raises(TypeError, match=r"type"):


### PR DESCRIPTION
if the estimator has the tag scitype:y = multivariate, the test example should have 2 columns and should have 1 column if univariate.