### PR TITLE
Add summary transformer

### DIFF
--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -293,3 +293,15 @@ Theta
     :template: class.rst
 
     ThetaLinesTransformer
+
+Summary
+~~~~~~~
+
+.. currentmodule:: sktime.transformations.series.summarize
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    SummaryTransformer
+    MeanTransformer

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -27,7 +27,7 @@ ALLOWED_SUM_FUNCS = (
 )
 
 
-def _series_summary(series_or_df, summary_function="mean"):
+def _series_summary(series_or_df, summary_function="mean", axis=0):
     """Calculate summary value of a time series.
 
     For multivariate data the summary is applied to each column.
@@ -40,6 +40,8 @@ def _series_summary(series_or_df, summary_function="mean"):
         One of pandas summary functions ("mean", "min", "max", "sum",
         "skew", "kurtosis", "var", "std", "sem", "nunique", "count") that is used
         to summarize each column of the dataset.
+    axis : int, default=0
+        Axis to apply the summary function along. Only used for multivariate data.
 
     Raises
     ------
@@ -63,35 +65,35 @@ def _series_summary(series_or_df, summary_function="mean"):
         raise ValueError("`series_or_df` must be pd.Series or pd>DataFrame.")
 
     if summary_function == "mean":
-        summary_value = series_or_df.mean(axis=0)
+        summary_value = series_or_df.mean(axis=axis)
     elif summary_function == "min":
-        summary_value = series_or_df.min(axis=0)
+        summary_value = series_or_df.min(axis=axis)
     elif summary_function == "max":
-        summary_value = series_or_df.max(axis=0)
+        summary_value = series_or_df.max(axis=axis)
     elif summary_function == "sum":
-        summary_value = series_or_df.sum(axis=0)
+        summary_value = series_or_df.sum(axis=axis)
     elif summary_function == "skew":
-        summary_value = series_or_df.skew(axis=0)
+        summary_value = series_or_df.skew(axis=axis)
     elif summary_function == "kurtosis":
-        summary_value = series_or_df.kurtosis(axis=0)
+        summary_value = series_or_df.kurtosis(axis=axis)
     elif summary_function == "std":
-        summary_value = series_or_df.std(axis=0)
+        summary_value = series_or_df.std(axis=axis)
     elif summary_function == "var":
-        summary_value = series_or_df.var(axis=0)
+        summary_value = series_or_df.var(axis=axis)
     elif summary_function == "mad":
-        summary_value = series_or_df.mad(axis=0)
+        summary_value = series_or_df.mad(axis=axis)
     elif summary_function == "sem":
-        summary_value = series_or_df.sem(axis=0)
+        summary_value = series_or_df.sem(axis=axis)
     elif summary_function == "nunique":
         if is_series:
             summary_value = series_or_df.nunique()
         else:
-            summary_value = series_or_df.nunique(axis=0)
+            summary_value = series_or_df.nunique(axis=axis)
     elif summary_function == "count":
         if is_series:
             summary_value = series_or_df.count()
         else:
-            summary_value = series_or_df.count(axis=0)
+            summary_value = series_or_df.count(axis=axis)
     else:
         raise ValueError(f"`summary_function must be one of {ALLOWED_SUM_FUNCS}.")
 
@@ -105,9 +107,13 @@ def _series_summary(series_or_df, summary_function="mean"):
 class SummaryTransformer(_SeriesToPrimitivesTransformer):
     """Calculate summary value of a time series.
 
+    Calculates scalar value when applied to a :term:`univariate time series`.
+    If input is :term:`multivariate time series` then Scalar values for each
+    column and returned as elements of a pd.Series.
+
     Parameters
     ----------
-    summary_function : str
+    summary_function : str, default="mean"
         One of pandas summary functions ("mean", "min", "max", "sum",
         "skew", "kurtosis", "var", "std", "sem", "nunique", "count") that is used
         to summarize each column of the dataset.

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -3,17 +3,195 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements transformers for summarizing a time series."""
 
-__author__ = ["Markus Löning"]
-__all__ = ["MeanTransformer"]
+__author__ = ["mloning", "RNKuhns"]
+__all__ = ["SummaryTransformer", "MeanTransformer"]
 
-import numpy as np
+import pandas as pd
 
 from sktime.transformations.base import _SeriesToPrimitivesTransformer
 from sktime.utils.validation.series import check_series
 
 
-class MeanTransformer(_SeriesToPrimitivesTransformer):
-    """Get mean value of time series.
+ALLOWED_SUM_FUNCS = (
+    "mean",
+    "min",
+    "max",
+    "sum",
+    "skew",
+    "kurtosis",
+    "var",
+    "std",
+    "sem",
+    "nunique",
+    "count",
+)
+
+
+def _series_summary(series_or_df, summary_function="mean"):
+    """Calculate summary value of a time series.
+
+    For multivariate data the summary is applied to each column.
+
+    Parameters
+    ----------
+    series_or_df : pd.Series or pd.DataFrame
+        The series to summarize.
+    summary_function : str
+        One of pandas summary functions ("mean", "min", "max", "sum",
+        "skew", "kurtosis", "var", "std", "sem", "nunique", "count") that is used
+        to summarize each column of the dataset.
+
+    Raises
+    ------
+    ValueError :
+        `series_or_df` must be pd.Series or pd>DataFrame.
+    ValueError :
+        `summary_function must be one of ("mean", "min", "max", "mode", "sum",
+        "skew", "kurtosis", "var", "std", "sem", "nunique", "count").
+
+    Returns
+    -------
+    summary_value : scalar or pd.Series
+        If `series_or_df` is univariate then a scalar is returned. Otherwise,
+        a pd.Series is returned.
+    """
+    if isinstance(series_or_df, pd.Series):
+        is_series = True
+    elif isinstance(series_or_df, pd.DataFrame):
+        is_series = False
+    else:
+        raise ValueError("`series_or_df` must be pd.Series or pd>DataFrame.")
+
+    if summary_function == "mean":
+        summary_value = series_or_df.mean(axis=0)
+    elif summary_function == "min":
+        summary_value = series_or_df.min(axis=0)
+    elif summary_function == "max":
+        summary_value = series_or_df.max(axis=0)
+    elif summary_function == "sum":
+        summary_value = series_or_df.sum(axis=0)
+    elif summary_function == "skew":
+        summary_value = series_or_df.skew(axis=0)
+    elif summary_function == "kurtosis":
+        summary_value = series_or_df.kurtosis(axis=0)
+    elif summary_function == "std":
+        summary_value = series_or_df.std(axis=0)
+    elif summary_function == "var":
+        summary_value = series_or_df.var(axis=0)
+    elif summary_function == "mad":
+        summary_value = series_or_df.mad(axis=0)
+    elif summary_function == "sem":
+        summary_value = series_or_df.sem(axis=0)
+    elif summary_function == "nunique":
+        if is_series:
+            summary_value = series_or_df.nunique()
+        else:
+            summary_value = series_or_df.nunique(axis=0)
+    elif summary_function == "count":
+        if is_series:
+            summary_value = series_or_df.count()
+        else:
+            summary_value = series_or_df.count(axis=0)
+    else:
+        raise ValueError(f"`summary_function must be one of {ALLOWED_SUM_FUNCS}.")
+
+    # For univariate data in DataFrame return scalar like when input is pd.Series
+    if is_series is False and series_or_df.shape[1] == 1:
+        summary_value = summary_value.iloc[0]
+
+    return summary_value
+
+
+class SummaryTransformer(_SeriesToPrimitivesTransformer):
+    """Calculate summary value of a time series.
+
+    Parameters
+    ----------
+    summary_function : str
+        One of pandas summary functions ("mean", "min", "max", "sum",
+        "skew", "kurtosis", "var", "std", "sem", "nunique", "count") that is used
+        to summarize each column of the dataset.
+
+    See Also
+    --------
+    MeanTransformer :
+        Calculate the mean of a timeseries.
+
+    Notes
+    -----
+    This provides a wrapper around pandas DataFrame and Series summary methods.
+
+    Examples
+    --------
+    >>> from sktime.transformations.series.summarize import SummaryTransformer
+    >>> from sktime.datasets import load_airline
+    >>> y = load_airline()
+    >>> transformer = SummaryTransformer(summary_function="median")
+    >>> y_mean = transformer.fit_transform(y)
+    """
+
+    _tags = {
+        "univariate-only": False,
+        "multivariate-only": False,
+        "fit-in-transform": True,
+    }
+
+    def __init__(self, summary_function="mean"):
+        self.summary_function = summary_function
+        super(SummaryTransformer, self).__init__()
+
+    def _transform(self, Z, X=None):
+        """Logic to transform series.
+
+        Parameters
+        ----------
+        Z : pd.Series or pd.DataFrame
+            The series to transform.
+
+        Returns
+        -------
+        summary_value : scalar or pd.Series
+            If `series_or_df` is univariate then a scalar is returned. Otherwise,
+            a pd.Series is returned.
+        """
+        summary_value = _series_summary(Z, self.summary_function)
+        return summary_value
+
+    def transform(self, Z, X=None):
+        """Transform series.
+
+        Parameters
+        ----------
+        Z : pd.Series or pd.DataFrame
+            The series to transform.
+
+        Returns
+        -------
+        summary_value : scalar or pd.Series
+            If `series_or_df` is univariate then a scalar is returned. Otherwise,
+            a pd.Series is returned.
+        """
+        self.check_is_fitted()
+        Z = check_series(Z)
+        summary_value = self._transform(Z, X=X)
+        return summary_value
+
+
+class MeanTransformer(SummaryTransformer):
+    """Calculate mean value of a time series.
+
+    Calculates scalar value when applied to a :term:`univariate time series`.
+    If input is :term:`multivariate time series` then Scalar values for each
+    column and returned as elements of a pd.Series.
+
+    See Also
+    --------
+    SummaryTransformer :
+        Calculate summary value of a time series.
+
+    Notes
+    -----
+    This provides a wrapper around pandas DataFrame and Series summary methods.
 
     Examples
     --------
@@ -24,17 +202,5 @@ class MeanTransformer(_SeriesToPrimitivesTransformer):
     >>> y_mean = transformer.fit_transform(y)
     """
 
-    def transform(self, Z, X=None):
-        """Transform series.
-
-        Parameters
-        ----------
-        Z : pd.Series
-
-        Returns
-        -------
-        float/int
-        """
-        self.check_is_fitted()
-        Z = check_series(Z)
-        return np.mean(Z, axis=0)
+    def __init__(self):
+        super().__init__(summary_function="mean")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
While cleaning up docstrings I noticed that `sktime.transformations.series.summarize.py` currently includes a MeanTransformer that returns the mean of a time series. 

I've added a `SummaryTransformer` that provides additional summary functionality (wrapping pandas summary methods). 
`MeanTransformer` is then a special case that inherits directly from `SummaryTransformer`. 

I've also added these transformers to the API reference (they had not previously been there). 

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

Does it make sense to continue to have the `MeanTransformer` as shorthand for `SummaryTransformer(summary_function="mean")`?

It does not appear to be used elsewhere in ``sktime``, so I'd propose we deprecate it and remove it in a future release. This will give us fewer transformers to maintain.

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
