### PR TITLE
[DOC] updated extension templates - object tags

### DIFF
--- a/extension_templates/annotation.py
+++ b/extension_templates/annotation.py
@@ -102,6 +102,16 @@ class MySeriesAnnotator(BaseSeriesAnnotator):
         # todo: change "MySeriesAnnotator" to the name of the class
         super(MySeriesAnnotator, self).__init__(fmt=fmt, labels=labels)
 
+        # todo: if tags of estimator depend on component tags, set these here
+        #  only needed if estimator is a composite
+        #  tags set in the constructor apply to the object and override the class
+        #
+        # example 1: conditional setting of a tag
+        # if est.foo == 42:
+        #   self.set_tags(handles-missing-data=True)
+        # example 2: cloning tags from component
+        #   self.clone_tags(est2, ["enforce-index-type", "handles-missing-data"])
+
     # todo: implement this, mandatory
     def _fit(self, X, Y=None):
         """Fit to training data.

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -91,6 +91,16 @@ class MyTSC(BaseClassifier):
         # todo: change "MyTSC" to the name of the class
         super(MyTSC, self).__init__()
 
+        # todo: if tags of estimator depend on component tags, set these here
+        #  only needed if estimator is a composite
+        #  tags set in the constructor apply to the object and override the class
+        #
+        # example 1: conditional setting of a tag
+        # if est.foo == 42:
+        #   self.set_tags(handles-missing-data=True)
+        # example 2: cloning tags from component
+        #   self.clone_tags(est2, ["enforce-index-type", "handles-missing-data"])
+
     # todo: implement this, mandatory
     def _fit(self, X, y):
         """Fit time series classifier to training data.
@@ -119,7 +129,7 @@ class MyTSC(BaseClassifier):
 
     # todo: implement this, mandatory
     def _predict(self, X):
-        """predicts labels for sequences in X
+        """Predict labels for sequences in X.
 
         core logic
 

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -84,8 +84,7 @@ class MyClusterer(BaseClusterer):
 
     # todo: implement this, mandatory
     def _fit(self, X):
-        """
-        Fit the clustering algorithm on the dataset X
+        """Fit the clustering algorithm on the dataset X.
 
             core logic
 
@@ -126,13 +125,12 @@ class MyClusterer(BaseClusterer):
     # this is typically important for clustering
     # at least one of _predict and _get_fitted_params should be implemented
     def _get_fitted_params(self):
-        """
-        Retrieves fitted parameters of cluster model
+        """Retrieve fitted parameters of cluster model.
 
             core logic
 
-        returns
-        ----------
+        Returns
+        -------
         param_dict: dictionary of fitted parameters
         """
         # implement here

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -80,6 +80,16 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
         # todo: change "MyTrafoPwPanel" to the name of the class
         super(MyTrafoPwPanel, self).__init__()
 
+        # todo: if tags of estimator depend on component tags, set these here
+        #  only needed if estimator is a composite
+        #  tags set in the constructor apply to the object and override the class
+        #
+        # example 1: conditional setting of a tag
+        # if est.foo == 42:
+        #   self.set_tags(handles-missing-data=True)
+        # example 2: cloning tags from component
+        #   self.clone_tags(est2, ["enforce-index-type", "handles-missing-data"])
+
     # todo: implement this, mandatory
     def _transform(self, X, X2=None):
         """Compute distance/kernel matrix between time series.

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -80,6 +80,16 @@ class MyTrafoPw(BasePairwiseTransformer):
         # todo: change "MyTrafoPw" to the name of the class
         super(MyTrafoPw, self).__init__()
 
+        # todo: if tags of estimator depend on component tags, set these here
+        #  only needed if estimator is a composite
+        #  tags set in the constructor apply to the object and override the class
+        #
+        # example 1: conditional setting of a tag
+        # if est.foo == 42:
+        #   self.set_tags(handles-missing-data=True)
+        # example 2: cloning tags from component
+        #   self.clone_tags(est2, ["enforce-index-type", "handles-missing-data"])
+
     # todo: implement this, mandatory
     def _transform(self, X, X2=None):
         """Compute distance/kernel matrix between samples.

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -66,7 +66,7 @@ class MyForecaster(BaseForecaster):
     """
 
     # todo: fill out estimator tags here
-    #  delete the tags that you *didn't* change - these defaults are inherited
+    #  tags are inherited from parent class if they are not set
     _tags = {
         "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
         "univariate-only": True,  # does estimator use the exogeneous X?
@@ -100,6 +100,16 @@ class MyForecaster(BaseForecaster):
 
         # todo: change "MyForecaster" to the name of the class
         super(MyForecaster, self).__init__()
+
+        # todo: if tags of estimator depend on component tags, set these here
+        #  only needed if estimator is a composite
+        #  tags set in the constructor apply to the object and override the class
+        #
+        # example 1: conditional setting of a tag
+        # if est.foo == 42:
+        #   self.set_tags(handles-missing-data=True)
+        # example 2: cloning tags from component
+        #   self.clone_tags(est2, ["enforce-index-type", "handles-missing-data"])
 
     # todo: implement this, mandatory
     def _fit(self, y, X=None, fh=None):


### PR DESCRIPTION
This updates all extension templates with a section in the constructor that explain how to set/override tags for the object (not the class).

Further changes fix the docstrings in the clustering extension template.