### PR TITLE
bugfix - broken binder and test_examples check

### DIFF
--- a/.binder/prelim_requirements.txt
+++ b/.binder/prelim_requirements.txt
@@ -5,8 +5,8 @@ hcrystalball>=0.1.9
 LunarCalendar >= 0.0.9
 matplotlib
 notebook
-numba>=0.50,<0.53
-numpy==1.20
+numba==0.53
+numpy>=1.19
 pystan==2.19.1.1
 seaborn
 stumpy>=1.5.1

--- a/.binder/prelim_requirements.txt
+++ b/.binder/prelim_requirements.txt
@@ -5,7 +5,7 @@ hcrystalball>=0.1.9
 LunarCalendar >= 0.0.9
 matplotlib
 notebook
-numba>=0.53
+numba>=0.50,<0.53
 numpy>=1.19
 pystan==2.19.1.1
 seaborn

--- a/.binder/prelim_requirements.txt
+++ b/.binder/prelim_requirements.txt
@@ -6,7 +6,7 @@ LunarCalendar >= 0.0.9
 matplotlib
 notebook
 numba>=0.50,<0.53
-numpy==1.19
+numpy==1.20
 pystan==2.19.1.1
 seaborn
 stumpy>=1.5.1

--- a/.binder/prelim_requirements.txt
+++ b/.binder/prelim_requirements.txt
@@ -6,7 +6,7 @@ LunarCalendar >= 0.0.9
 matplotlib
 notebook
 numba>=0.50,<0.53
-numpy>=1.19
+numpy==1.19
 pystan==2.19.1.1
 seaborn
 stumpy>=1.5.1


### PR DESCRIPTION
An attempt to address #1342 by reverting `numba` and `numpy` version bounds to pre #1266 values