### PR TITLE
Updates ColumnEnsembleForecaster with "copy forecaster for all columns" functionality

### DIFF
--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -77,14 +77,22 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
         via _HeterogenousMetaEstimator._get_params which expects
         lists of tuples of len 2.
         """
-        return [(name, forecasters) for name, forecasters, _ in self.forecasters]
+        forecasters = self.forecasters
+        if isinstance(forecasters, BaseForecaster):
+            return forecasters
+        else:
+            return [(name, forecasters) for name, forecasters, _ in self.forecasters]
 
     @_forecasters.setter
     def _forecasters(self, value):
-        self.forecasters = [
-            (name, forecasters, columns)
-            for ((name, forecasters), (_, _, columns)) in zip(value, self.forecasters)
-        ]
+        if isinstance(value, BaseForecaster):
+            self.forecasters = value
+        else:
+            self.forecasters = [
+                (name, forecasters, columns)
+                for ((name, forecasters), (_, _, columns))
+                in zip(value, self.forecasters)
+            ]
 
     def _fit(self, y, X=None, fh=None):
         """Fit to training data.

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -183,10 +183,10 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
 
         # if a single estimator is passed, replicate across columns
         if isinstance(self.forecasters, BaseForecaster):
-            ycols = y.columns
+            ycols = [str(col) for col in y.columns]
             colrange = range(len(ycols))
             forecaster_list = [clone(self.forecasters) for _ in colrange]
-            self.forecasters = zip(ycols, forecaster_list, colrange)
+            self.forecasters = list(zip(ycols, forecaster_list, colrange))
 
         if (
             self.forecasters is None

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -90,8 +90,9 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
         else:
             self.forecasters = [
                 (name, forecaster, columns)
-                for ((name, forecaster), (_, _, columns))
-                in zip(value, self.forecasters)
+                for ((name, forecaster), (_, _, columns)) in zip(
+                    value, self.forecasters
+                )
             ]
 
     def _fit(self, y, X=None, fh=None):

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -81,7 +81,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
         if isinstance(forecasters, BaseForecaster):
             return forecasters
         else:
-            return [(name, forecasters) for name, forecasters, _ in self.forecasters]
+            return [(name, forecaster) for name, forecaster, _ in self.forecasters]
 
     @_forecasters.setter
     def _forecasters(self, value):
@@ -89,8 +89,8 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
             self.forecasters = value
         else:
             self.forecasters = [
-                (name, forecasters, columns)
-                for ((name, forecasters), (_, _, columns))
+                (name, forecaster, columns)
+                for ((name, forecaster), (_, _, columns))
                 in zip(value, self.forecasters)
             ]
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -159,7 +159,6 @@ TIME_SERIES_CLASSIFIERS = [
     ("tsf2", TIME_SERIES_CLASSIFIER),
 ]
 FORECASTER = ExponentialSmoothing()
-COLUMN_ENSEMBLE_FORECASTER = [("naive", NaiveForecaster(), 0)]
 FORECASTERS = [("ses1", FORECASTER), ("ses2", FORECASTER)]
 STEPS_y = [
     ("transformer", Detrender(ThetaForecaster())),
@@ -170,7 +169,7 @@ STEPS_X = [
     ("forecaster", NaiveForecaster()),
 ]
 ESTIMATOR_TEST_PARAMS = {
-    ColumnEnsembleForecaster: {"forecasters": COLUMN_ENSEMBLE_FORECASTER},
+    ColumnEnsembleForecaster: {"forecasters": NaiveForecaster()},
     OnlineEnsembleForecaster: {"forecasters": FORECASTERS},
     FeatureUnion: {"transformer_list": TRANSFORMERS},
     DirectTabularRegressionForecaster: {"estimator": REGRESSOR},


### PR DESCRIPTION
This extends `ColumnEnsembleForecaster` so the same forecaster is cloned across all columns if not a list of forecasters is passed, but just a single forecaster, as the `forecasters` parameter.

This is achieved by a change in the `_check_forecasters` that is called at the start of `_fit`, which, at the very start, replaced a single forecaster with clones per column in the old expected format.

We ought to merge this quickly, since the current signature of `ColumnEnsembleForecaster` prevents upgrading the forecaster tests to the multivariate case, which in turn is blocking VAR.

FYI @thayeylolu.