### PR TITLE
Depcrecate manylinux2010

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,10 +67,6 @@ stages:
           - template: build_tools/azure/publish.yml
         strategy:
           matrix:
-            64x2010: # 64 bit 2010
-              PLATFORM: manylinux2010_x86_64
-              IMAGE: quay.io/pypa/manylinux2010_x86_64
-              PYTHON_ARCHITECTURE: x64
             64x2014: # 64 bit
               PLATFORM: manylinux2014_x86_64
               IMAGE: quay.io/pypa/manylinux2014_x86_64


### PR DESCRIPTION
#### Reference Issues/PRs
Resolves https://github.com/alan-turing-institute/sktime/issues/1377

#### What does this implement/fix? Explain your changes.
Removes support for [manylinux2010](https://www.python.org/dev/peps/pep-0571/) based on CentOS 6 which has [reached its end of life at the end of 2020](https://endoflife.software/operating-systems/linux/centos).
