### PR TITLE
Fixed ESTIMATOR_TEST_PARAMS reference in `test_all_estimators`

### DIFF
--- a/sktime/utils/_testing/estimator_checks.py
+++ b/sktime/utils/_testing/estimator_checks.py
@@ -32,7 +32,6 @@ from sktime.dists_kernels import BasePairwiseTransformer, BasePairwiseTransforme
 from sktime.exceptions import NotFittedError
 from sktime.forecasting.base import BaseForecaster
 from sktime.regression.base import BaseRegressor
-from sktime.tests._config import ESTIMATOR_TEST_PARAMS
 from sktime.tests._config import NON_STATE_CHANGING_METHODS
 from sktime.tests._config import VALID_ESTIMATOR_BASE_TYPES
 from sktime.tests._config import VALID_ESTIMATOR_TYPES
@@ -263,7 +262,11 @@ def check_constructor(Estimator):
     # Filter out required parameters with no default value and parameters
     # set for running tests
     required_params = getattr(estimator, "_required_parameters", tuple())
-    test_params = ESTIMATOR_TEST_PARAMS.get(Estimator, {}).keys()
+
+    test_params = Estimator.get_test_params()
+    if isinstance(test_params, list):
+        test_params = test_params[0]
+    test_params = test_params.keys()
 
     init_params = [
         param


### PR DESCRIPTION
The testing issue in #1347 highlighted that the tests refactor in #1361 was incomplete by oversight - `check_constructor` `test_all_estimators` suite was still referring to `ESTIMATOR_TEST_PARAMS` in `_config`.

This caused errors to be raised if a new implementation of `create_test_instance` deviated from the default parameter settings.

This should be fixed in this PR.