### PR TITLE
Forecasting return type update: series in, series out

### DIFF
--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -134,7 +134,7 @@ def check_is(
             f"Error in check_is, more than one mtype identified: {found_mtype}"
         )
     # b. one mtype is found - then return that mtype
-    elif len(found_mtype == 1):
+    elif len(found_mtype) == 1:
         if return_metadata:
             # add the mtype return to the metadata
             final_result[2]["mtype"] = found_mtype[0]

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -38,6 +38,14 @@ check_dict.update(check_dict_Series)
 check_dict.update(check_dict_Panel)
 
 
+def _check_scitype_valid(scitype: str = None):
+    """Check validity of scitype."""
+    valid_scitypes = list(set([x[1] for x in check_dict.keys()]))
+
+    if scitype is not None and scitype not in valid_scitypes:
+        raise TypeError(scitype + " is not a supported scitype")
+
+
 def check_is(
     obj,
     mtype: Union[str, List[str]],
@@ -69,12 +77,14 @@ def check_is(
         fields:
             "is_univariate": bool, True iff series has one variable
             "is_equally_spaced": bool, True iff series index is equally spaced
+            "mtype": str, mtype of obj if inferred
 
     Raises
     ------
     TypeError if no checks defined for mtype/scitype combination
     ValueError if mtype input argument is not of expected type
     """
+    _check_scitype_valid(scitype)
 
     def ret(valid, msg, metadata, return_metadata):
         if return_metadata:
@@ -92,7 +102,10 @@ def check_is(
 
     valid_keys = check_dict.keys()
 
+    # we loop through individual mtypes in mtype and see whether they pass the check
+    #  for each check we remember whether it passed and what it returned
     msg = []
+    found_mtype = []
 
     for m in mtype:
         if scitype is None:
@@ -109,14 +122,32 @@ def check_is(
             check_passed = res
 
         if check_passed:
-            return res
+            found_mtype.append(m)
+            final_result = res
         elif return_metadata:
             msg.append(res[1])
 
-    if len(msg) == 1:
-        msg = msg[0]
+    # there are three options on the result of check_is:
+    # a. two or more mtypes are found - this is unexpected and an error with checks
+    if len(found_mtype) > 1:
+        raise TypeError(
+            f"Error in check_is, more than one mtype identified: {found_mtype}"
+        )
+    # b. one mtype is found - then return that mtype
+    elif len(found_mtype == 1):
+        if return_metadata:
+            # add the mtype return to the metadata
+            final_result[2]["mtype"] = found_mtype[0]
+            # final_result already has right shape and dependency on return_metadata
+            return final_result
+        else:
+            return True
+    # c. no mtype is found - then return False and all error messages if requested
+    else:
+        if len(msg) == 1:
+            msg = msg[0]
 
-    return ret(False, msg, None, return_metadata)
+        return ret(False, msg, None, return_metadata)
 
 
 def check_raise(obj, mtype: str, scitype: str = None, var_name: str = "input"):
@@ -181,10 +212,7 @@ def mtype(obj, as_scitype: str = None):
     if obj is None:
         return None
 
-    valid_as_scitypes = list(set([x[1] for x in check_dict.keys()]))
-
-    if as_scitype is not None and as_scitype not in valid_as_scitypes:
-        raise TypeError(as_scitype + " is not a supported scitype")
+    _check_scitype_valid(as_scitype)
 
     if as_scitype is None:
         mtypes = np.array([x[0] for x in check_dict.keys()])

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -83,7 +83,10 @@ def convert_MvS_to_UvS_as_Series(obj: pd.DataFrame, store=None) -> pd.Series:
     if isinstance(store, dict):
         store["columns"] = obj.columns[[0]]
 
-    return obj[obj.columns[0]]
+    y = obj[obj.columns[0]]
+    y.name = None
+
+    return y
 
 
 convert_dict[("pd.DataFrame", "pd.Series", "Series")] = convert_MvS_to_UvS_as_Series

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -138,7 +138,7 @@ class BaseForecaster(BaseEstimator):
 
         y = check_series(y, **check_y_args, var_name="y")
 
-        self.y_mtype = mtype(y)
+        self._y_mtype_last_seen = mtype(y)
         # end checking y
 
         # checking X
@@ -250,7 +250,7 @@ class BaseForecaster(BaseEstimator):
         # convert to output mtype, identical with last y mtype seen
         y_out = convert_to(
             y_pred,
-            self.y_mtype,
+            self._y_mtype_last_seen,
             as_scitype="Series",
             store=self.converter_store_y,
         )
@@ -379,7 +379,7 @@ class BaseForecaster(BaseEstimator):
         # update only for non-empty data
         y = check_series(y, allow_empty=True, **check_y_args, var_name="y")
 
-        self.y_mtype = mtype(y)
+        self._y_mtype_last_seen = mtype(y)
         # end checking y
 
         # checking X

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -137,6 +137,8 @@ class BaseForecaster(BaseEstimator):
         }
 
         y = check_series(y, **check_y_args, var_name="y")
+
+        self.y_mtype = mtype(y)
         # end checking y
 
         # checking X
@@ -245,16 +247,10 @@ class BaseForecaster(BaseEstimator):
             pred_int = y_pred[1]
             y_pred = y_pred[0]
 
-        # convert to default output type, dependent on scitype
-        scitype_y = self.get_tag("scitype:y")
-        to_dict = {
-            "univariate": "pd.Series",
-            "multivariate": "pd.DataFrame",
-            "both": "pd.DataFrame",
-        }
+        # convert to output mtype, identical with last y mtype seen
         y_out = convert_to(
             y_pred,
-            to_dict[scitype_y],
+            self.y_mtype,
             as_scitype="Series",
             store=self.converter_store_y,
         )
@@ -382,6 +378,8 @@ class BaseForecaster(BaseEstimator):
 
         # update only for non-empty data
         y = check_series(y, allow_empty=True, **check_y_args, var_name="y")
+
+        self.y_mtype = mtype(y)
         # end checking y
 
         # checking X
@@ -712,9 +710,11 @@ class BaseForecaster(BaseEstimator):
         -----
         Set self._cutoff to last index seen in `y`.
         """
-        if mtype(y, as_scitype="Series") in ["pd.Series", "pd.DataFrame"]:
+        y_mtype = mtype(y, as_scitype="Series")
+
+        if y_mtype in ["pd.Series", "pd.DataFrame"]:
             self._cutoff = y.index[-1]
-        elif mtype(y, as_scitype="Series") == "np.ndarray":
+        elif y_mtype == "np.ndarray":
             self._cutoff = len(y)
         else:
             raise TypeError("y does not have a supported type")


### PR DESCRIPTION
This PR implements the change request from the last core developer meeting:

forecasters' `predict` will now return the forecast series in the `mtype` that is idential to the last `mtype` seen for `y`, in `fit` or `update`.

The PR also includes some clean-up of `check_is` in the `datatypes` module which is not necessary for the new feature but improves code quality. The utility `check_is` is called in the check that is changed.