### PR TITLE
Error handling for `get_tag`

### DIFF
--- a/extension_templates/annotation.py
+++ b/extension_templates/annotation.py
@@ -114,7 +114,7 @@ class MySeriesAnnotator(BaseSeriesAnnotator):
         # if est.foo == 42:
         #   self.set_tags(handles-missing-data=True)
         # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce-index-type", "handles-missing-data"])
+        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
 
     # todo: implement this, mandatory
     def _fit(self, X, Y=None):

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -69,7 +69,7 @@ class MyTSC(BaseClassifier):
     _tags = {
         "handles-missing-data": False,  # can estimator handle missing data?
         "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
-        "enforce-index-type": None,  # index type that needs to be enforced in X/y
+        "enforce_index_type": None,  # index type that needs to be enforced in X/y
     }
     # in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)
@@ -103,7 +103,7 @@ class MyTSC(BaseClassifier):
         # if est.foo == 42:
         #   self.set_tags(handles-missing-data=True)
         # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce-index-type", "handles-missing-data"])
+        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
 
     # todo: implement this, mandatory
     def _fit(self, X, y):

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -92,7 +92,7 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
         # if est.foo == 42:
         #   self.set_tags(handles-missing-data=True)
         # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce-index-type", "handles-missing-data"])
+        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
 
     # todo: implement this, mandatory
     def _transform(self, X, X2=None):

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -92,7 +92,7 @@ class MyTrafoPw(BasePairwiseTransformer):
         # if est.foo == 42:
         #   self.set_tags(handles-missing-data=True)
         # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce-index-type", "handles-missing-data"])
+        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
 
     # todo: implement this, mandatory
     def _transform(self, X, X2=None):

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -79,7 +79,7 @@ class MyForecaster(BaseForecaster):
         "X_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for X?
         "requires-fh-in-fit": True,  # is forecasting horizon already required in fit?
         "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
-        "enforce-index-type": None,  # index type that needs to be enforced in X/y
+        "enforce_index_type": None,  # index type that needs to be enforced in X/y
     }
     # in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)
@@ -113,7 +113,7 @@ class MyForecaster(BaseForecaster):
         # if est.foo == 42:
         #   self.set_tags(handles-missing-data=True)
         # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce-index-type", "handles-missing-data"])
+        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
 
     # todo: implement this, mandatory
     def _fit(self, y, X=None, fh=None):

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -152,16 +152,14 @@ class BaseObject(_BaseEstimator):
 
         Raises
         ------
-        ValueError if retrieved tag value is None and raise_error is True
-            e.g., if tag is not found and function defaults are used
-            note: if tag_value_default is not None
-                this will not be raised even if raise_error is True
+        ValueError if raise_error is True and tag_name does not exist
+            i.e., if tag_name is not in self.get_tags().keys()
         """
         collected_tags = self.get_tags()
 
         tag_value = collected_tags.get(tag_name, tag_value_default)
 
-        if raise_error and tag_value is None:
+        if raise_error and tag_name not in collected_tags.keys():
             raise ValueError(f"Tag with name {tag_name} could not be found.")
 
         return tag_value

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -129,25 +129,39 @@ class BaseObject(_BaseEstimator):
 
         return deepcopy(collected_tags)
 
-    def get_tag(self, tag_name, tag_value_default=None):
+    def get_tag(self, tag_name, tag_value_default=None, raise_error=True):
         """Get tag value from estimator class and dynamic tag overrides.
 
         Parameters
         ----------
         tag_name : str
-            Name of tag value.
-        tag_value_default : any type
-            Default/fallback value if tag is not found.
+            Name of tag to be retrieved
+        tag_value_default : any type, optional; default=None
+            Default/fallback value if tag is not found
+        raise_error : bools
+            whether a ValueError is raised when the tag is not found
 
         Returns
         -------
         tag_value :
             Value of the `tag_name` tag in self. If not found, returns
             `tag_value_default`.
+
+        Raises
+        ------
+        ValueError if retrieved tag value is None and raise_error is True
+            e.g., if tag is not found and function defaults are used
+            note: if tag_value_default is not None
+                this will not be raised even if raise_error is True
         """
         collected_tags = self.get_tags()
 
-        return collected_tags.get(tag_name, tag_value_default)
+        tag_value = collected_tags.get(tag_name, tag_value_default)
+
+        if raise_error and tag_value is None:
+            ValueError(f"Tag with name {tag_name} could not be found.")
+
+        return tag_value
 
     def set_tags(self, **tag_dict):
         """Set dynamic tags to given values.

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -138,7 +138,7 @@ class BaseObject(_BaseEstimator):
             Name of tag to be retrieved
         tag_value_default : any type, optional; default=None
             Default/fallback value if tag is not found
-        raise_error : bools
+        raise_error : bool
             whether a ValueError is raised when the tag is not found
 
         Returns

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -158,7 +158,7 @@ class BaseObject(_BaseEstimator):
         tag_value = collected_tags.get(tag_name, tag_value_default)
 
         if raise_error and tag_value is None:
-            ValueError(f"Tag with name {tag_name} could not be found.")
+            raise ValueError(f"Tag with name {tag_name} could not be found.")
 
         return tag_value
 

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -118,10 +118,10 @@ def test_get_tag():
     object_tags_keys = FIXTURE_OBJECT_TAGS.keys()
 
     for key in object_tags_keys:
-        object_tags[key] = FIXTURE_OBJECT.get_tag(key)
+        object_tags[key] = FIXTURE_OBJECT.get_tag(key, raise_error=False)
 
-    object_tag_default = FIXTURE_OBJECT.get_tag("foo", "bar")
-    object_tag_defaultNone = FIXTURE_OBJECT.get_tag("bar")
+    object_tag_default = FIXTURE_OBJECT.get_tag("foo", "bar", raise_error=False)
+    object_tag_defaultNone = FIXTURE_OBJECT.get_tag("bar", raise_error=False)
 
     msg = "Inheritance logic in BaseObject.get_tag is incorrect"
 

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -22,6 +22,8 @@ __all__ = [
     "test_set_tags",
 ]
 
+import pytest
+
 from copy import deepcopy
 
 from sktime.base import BaseObject
@@ -132,6 +134,17 @@ def test_get_tag():
 
     assert object_tag_default == "bar", msg
     assert object_tag_defaultNone is None, msg
+
+
+def test_get_tag_raises():
+    """Tests that get_tag method raises error for unknown tag.
+
+    Raises
+    ------
+    AssertError if get_tag does not raise error for unknown tag.
+    """
+    with pytest.raises(ValueError, match=r"Tag with name"):
+        FIXTURE_OBJECT.get_tag("bar")
 
 
 FIXTURE_TAG_SET = {"A": 42424243, "E": 3}

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -74,6 +74,7 @@ class BaseClassifier(BaseEstimator):
 
     _tags = {
         "coerce-X-to-numpy": True,
+        "coerce-X-to-pandas": False,
     }
 
     def __init__(self):

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -71,7 +71,7 @@ class BaseForecaster(BaseEstimator):
         "X_inner_mtype": "pd.DataFrame",  # which types do _fit/_predict, support for X?
         "requires-fh-in-fit": True,  # is forecasting horizon already required in fit?
         "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
-        "enforce-index-type": None,  # index type that needs to be enforced in X/y
+        "enforce_index_type": None,  # index type that needs to be enforced in X/y
     }
 
     def __init__(self):

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -65,7 +65,7 @@ class BaseGridSearch(BaseForecaster):
             "y_inner_mtype",
             "X_inner_mtype",
             "X-y-must-have-same-index",
-            "enforce-index-type",
+            "enforce_index_type",
         ]
 
         self.clone_tags(forecaster, tags_to_clone)

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -94,7 +94,7 @@ ESTIMATOR_TAG_REGISTER = [
         "do X/y in fit/update and X/fh in predict have to be same indices?",
     ),
     (
-        "enforce-index-type",
+        "enforce_index_type",
         ["forecaster", "classifier", "regressor"],
         "type",
         "passed to input checks, input conversion index type to enforce",

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -36,6 +36,18 @@ Panel = Union[pd.DataFrame, np.ndarray]  # 3d or nested array
 class BaseTransformer(BaseEstimator):
     """Transformer base class"""
 
+    # default tag values - these typically make the "safest" assumption
+    _tags = {
+        "univariate-only": False,  # can the transformer handle multivariate X?
+        "handles-missing-data": False,  # can estimator handle missing data?
+        "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
+        "enforce_index_type": None,  # index type that needs to be enforced in X/y
+        "fit-in-transform": True,  # is fit empty and can be skipped? Yes = True
+        "transform-returns-same-time-index": False,
+        # does transform return have the same time index as input X
+        "skip-inverse-transform": False,  # is inverse-transform skipped when called?
+    }
+
     def __init__(self):
         super(BaseTransformer, self).__init__()
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3 -u
+# -*- coding: utf-8 -*-
 """Base class template for transformers."""
 
 __author__ = ["mloning"]

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3 -u
-# -*- coding: utf-8 -*-
+"""Base class template for transformers."""
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = [
     "BaseTransformer",
     "_SeriesToPrimitivesTransformer",
@@ -34,7 +34,7 @@ Panel = Union[pd.DataFrame, np.ndarray]  # 3d or nested array
 
 
 class BaseTransformer(BaseEstimator):
-    """Transformer base class"""
+    """Transformer base class."""
 
     # default tag values - these typically make the "safest" assumption
     _tags = {
@@ -52,8 +52,7 @@ class BaseTransformer(BaseEstimator):
         super(BaseTransformer, self).__init__()
 
     def fit(self, Z, X=None):
-        """
-        Fit transformer to X and y.
+        """Fit transformer to X and y.
 
         By default, fit is empty. Fittable transformations overwrite fit method.
 
@@ -72,7 +71,7 @@ class BaseTransformer(BaseEstimator):
         return self
 
     def transform(self, Z, X=None):
-        """Transform data. Returns a transformed version of X."""
+        """Transform data. Returns a transformed version of Z."""
         raise NotImplementedError("abstract method")
 
     def fit_transform(self, Z, X=None):
@@ -110,28 +109,32 @@ class BaseTransformer(BaseEstimator):
 
 
 class _SeriesToPrimitivesTransformer(BaseTransformer):
-    """Transformer base class for series to primitive(s) transforms"""
+    """Transformer base class for series to primitive(s) transforms."""
 
     def transform(self, Z: Series, X=None) -> Primitives:
+        """Transform data. Returns a transformed version of Z."""
         raise NotImplementedError("abstract method")
 
 
 class _SeriesToSeriesTransformer(BaseTransformer):
-    """Transformer base class for series to series transforms"""
+    """Transformer base class for series to series transforms."""
 
     def transform(self, Z: Series, X=None) -> Series:
+        """Transform data. Returns a transformed version of Z."""
         raise NotImplementedError("abstract method")
 
 
 class _PanelToTabularTransformer(BaseTransformer):
-    """Transformer base class for panel to tabular transforms"""
+    """Transformer base class for panel to tabular transforms."""
 
     def transform(self, X: Panel, y=None) -> Tabular:
+        """Transform data. Returns a transformed version of X."""
         raise NotImplementedError("abstract method")
 
 
 class _PanelToPanelTransformer(BaseTransformer):
-    """Transformer base class for panel to panel transforms"""
+    """Transformer base class for panel to panel transforms."""
 
     def transform(self, X: Panel, y=None) -> Panel:
+        """Transform data. Returns a transformed version of X."""
         raise NotImplementedError("abstract method")


### PR DESCRIPTION
This adds the possibility to raise an error when `get_tag` is used.

An error will always be raised if the function is used with parameter defaults and the tag with the specified `tag_name` does not exist, but this can be overridden by setting the new `raise_error` parameter to `False`.

This should hopefully prevent the human error that caused the bug in #1449 for the future.

FYI @aiwalter, @thayeylolu, @mloning 

This PR also contains a second test for `get_tag` to cover the behaviour if `raise_error=True`, the old test covers the behaviour if `raise_errpr=False` with minor changes.

The change has caught the following bugs which are also fixed:

* `"enforce_index_type"` tag was sometimes written `"enforce-index-type"`, this was changed to `"enforce_index_type"` consistently
* transformer base class did not have any default tag values set, which caused framework to look for non-existent tags - added a set of defaults
* `"coerce-X-to-pandas"` was called in some classifiers but not set in the tine series classification base class