### PR TITLE
Refactor sktime/.../_panels/_examples.py for tsai compatibility

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1234,7 +1234,16 @@
         "doc",
         "test"
       ]
-    }
+    },
+    {
+      "login": "bobbys-dev",
+      "name": "bobbys",
+      "avatar_url": "https://avatars.githubusercontent.com/bobbys-dev",
+      "profile": "https://github.com/bobbys-dev",
+      "contributions": [
+        "code"
+      ]        
+    }    
   ],
   "projectName": "sktime",
   "projectOwner": "alan-turing-institute",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1251,7 +1251,7 @@
       "profile": "https://github.com/bobbys-dev",
       "contributions": [
         "code"
-      ]        
+      ]
     }
   ],
   "projectName": "sktime",

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -64,12 +64,16 @@ example_dict_lossy[("pd-multiindex", "Panel", 0)] = False
 
 cols = [f"var_{i}" for i in range(2)]
 X = pd.DataFrame(columns=cols, index=[0, 1, 2])
-X.iloc[0][0] = pd.Series([1, 2, 3])
-X.iloc[0][1] = pd.Series([4, 5, 6])
-X.iloc[1][0] = pd.Series([1, 2, 3])
-X.iloc[1][1] = pd.Series([4, 55, 6])
-X.iloc[2][0] = pd.Series([1, 2, 3])
-X.iloc[2][1] = pd.Series([42, 5, 6])
+X['var_0'] = pd.Series([
+    pd.Series([1, 2, 3]),
+    pd.Series([1, 2, 3]),
+    pd.Series([1, 2, 3])
+])
+X['var_1'] = pd.Series([
+    pd.Series([4, 5, 6]),
+    pd.Series([4, 55, 6]),
+    pd.Series([42, 5, 6])
+])
 
 example_dict[("nested_univ", "Panel", 0)] = X
 example_dict_lossy[("nested_univ", "Panel", 0)] = False

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -68,7 +68,7 @@ X["var_0"] = pd.Series(
     [pd.Series([1, 2, 3]), pd.Series([1, 2, 3]), pd.Series([1, 2, 3])]
 )
 
-X['var_1'] = pd.Series(
+X["var_1"] = pd.Series(
     [pd.Series([4, 5, 6]), pd.Series([4, 55, 6]), pd.Series([42, 5, 6])]
 )
 

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -72,6 +72,5 @@ X["var_1"] = pd.Series(
     [pd.Series([4, 5, 6]), pd.Series([4, 55, 6]), pd.Series([42, 5, 6])]
 )
 
-
 example_dict[("nested_univ", "Panel", 0)] = X
 example_dict_lossy[("nested_univ", "Panel", 0)] = False

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -64,16 +64,14 @@ example_dict_lossy[("pd-multiindex", "Panel", 0)] = False
 
 cols = [f"var_{i}" for i in range(2)]
 X = pd.DataFrame(columns=cols, index=[0, 1, 2])
-X['var_0'] = pd.Series([
-    pd.Series([1, 2, 3]),
-    pd.Series([1, 2, 3]),
-    pd.Series([1, 2, 3])
-])
-X['var_1'] = pd.Series([
-    pd.Series([4, 5, 6]),
-    pd.Series([4, 55, 6]),
-    pd.Series([42, 5, 6])
-])
+X["var_0"] = pd.Series(
+    [pd.Series([1, 2, 3]), pd.Series([1, 2, 3]), pd.Series([1, 2, 3])]
+)
+
+X['var_1'] = pd.Series(
+    [pd.Series([4, 5, 6]), pd.Series([4, 55, 6]), pd.Series([42, 5, 6])]
+)
+
 
 example_dict[("nested_univ", "Panel", 0)] = X
 example_dict_lossy[("nested_univ", "Panel", 0)] = False


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1452  [#1452](https://github.com/alan-turing-institute/sktime/issues/1452)

#### What does this implement/fix? Explain your changes.
`X.iloc[0][1] = ...` and similar assignments will raise a
SettingWithCopy error in later versions of Pandas.
Refactor the respective lines for compatibility
up to v1.3.3 while maintaining same value assignments to dataframe

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependency

#### What should a reviewer concentrate their feedback on?
Refactor should produce same result and behaviour as previous code intended


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [X] I've added unit tests and made sure they pass locally.
