### PR TITLE
sktime clean clone method

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -274,6 +274,22 @@ class BaseObject(_BaseEstimator):
 
         return cls(**params)
 
+    def clone(self):
+        """Create and return deep clone of self.
+
+        Returns
+        -------
+        self_clone : deep clone of self
+            self_clone is identical to sklearn's clone(self), plus
+            it obtains a clean copy of the _tags_dynamic field
+                (which sklearn.clone does not properly deal with)
+        """
+        self_clone = clone(self)
+
+        self_clone._tags_dynamic = self._tags_dynamic.copy()
+
+        return self_clone
+
 
 class BaseEstimator(BaseObject):
     """Base class for defining estimators in sktime.

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -19,12 +19,15 @@ Hyper-parameter inspection and setter methods:
     setting hyper-parameters     - set_params(**params)
 
 Tag inspection and setter methods
-    inspect tags (all)            - get_tags()
-    inspect tags (one tag)        - get_tag(tag_name: str, tag_value_default=None)
-    inspect tags (class method)   - get_class_tags()
-    inspect tags (one tag, class) - get_class_tag(tag_name:str, tag_value_default=None)
-    setting dynamic tags          - set_tag(**tag_dict: dict)
-    set/clone dynamic tags        - clone_tags(estimator, tag_names=None)
+    inspect tags (all)             - get_tags()
+    inspect tags (one tag)         - get_tag(tag_name: str, tag_value_default=None)
+    inspect tags (class method)    - get_class_tags()
+    inspect tags (one tag, class)  - get_class_tag(tag_name:str, tag_value_default=None)
+    setting dynamic tags           - set_tag(**tag_dict: dict)
+    set/clone dynamic tags to self - clone_tags(estimator, tag_names=None)
+
+Persistence and cloning methods
+    return deep clone of self    - clone()
 
 Testing with default parameters methods
     getting default parameters           - get_test_params()

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -9,7 +9,6 @@ __all__ = ["ForecastingGridSearchCV", "ForecastingRandomizedSearchCV"]
 import pandas as pd
 from joblib import Parallel
 from joblib import delayed
-from sklearn.base import clone
 from sklearn.model_selection import ParameterGrid
 from sklearn.model_selection import ParameterSampler
 from sklearn.model_selection import check_cv
@@ -238,7 +237,7 @@ class BaseGridSearch(BaseForecaster):
 
         def _fit_and_score(params):
             # Clone forecaster.
-            forecaster = clone(self.forecaster)
+            forecaster = self.forecaster.clone()
 
             # Set parameters.
             forecaster.set_params(**params)
@@ -308,7 +307,7 @@ class BaseGridSearch(BaseForecaster):
         self.best_index_ = results.loc[:, f"rank_{scoring_name}"].argmin()
         self.best_score_ = results.loc[self.best_index_, f"mean_{scoring_name}"]
         self.best_params_ = results.loc[self.best_index_, "params"]
-        self.best_forecaster_ = clone(self.forecaster).set_params(**self.best_params_)
+        self.best_forecaster_ = self.forecaster.clone().set_params(**self.best_params_)
 
         # Refit model with best parameters.
         if self.refit:
@@ -325,7 +324,7 @@ class BaseGridSearch(BaseForecaster):
             params = results["params"].iloc[i]
             rank = results[f"rank_{scoring_name}"].iloc[i]
             rank = str(int(rank))
-            forecaster = clone(self.forecaster).set_params(**params)
+            forecaster = self.forecaster.clone().set_params(**params)
             # Refit model with best parameters.
             if self.refit:
                 forecaster.fit(y, X, fh)


### PR DESCRIPTION
Update: This actually does not seem to have been a problem with #1449. We can keep using `sklearn` clone.
Will close once it is confirmed that we can fix #1449 without.

---

This PR adds a `clone` method to `BaseObject`, which extends `sklearn` clone to deal with dynamic tags properly.

This is one potential way to address the issue in #1449, in which behaviour controlling tags inside grid/random search estimators are not cloned properly, and lead to unexpected error messages when multivariate forecasters are cloned.

As a proof-of-concept, the `sklearn` `clone`-s in the tuning module are also replaced by the new `BaseObject.clone`.

An added advantage is our new ability to modify the behaviour of `clone` in the `BaseObject`, in a modular fashion.