### PR TITLE
Grid/random search tag fix

### DIFF
--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -56,6 +56,20 @@ class BaseGridSearch(BaseForecaster):
         self.return_n_best_forecasters = return_n_best_forecasters
         super(BaseGridSearch, self).__init__()
 
+        tags_to_clone = [
+            "requires-fh-in-fit",
+            "capability:pred_int",
+            # "scitype:y", commented out until grid search works with multivariate
+            "univariate-only",
+            "handles-missing-data",
+            "y_inner_mtype",
+            "X_inner_mtype",
+            "X-y-must-have-same-index",
+            "enforce-index-type",
+        ]
+
+        self.clone_tags(forecaster, tags_to_clone)
+
     @if_delegate_has_method(delegate=("best_forecaster_", "forecaster"))
     def _update(self, y, X=None, update_params=False):
         """Call predict on the forecaster with the best found parameters."""
@@ -453,20 +467,6 @@ class ForecastingGridSearchCV(BaseGridSearch):
         )
         self.param_grid = param_grid
 
-        tags_to_clone = [
-            "requires-fh-in-fit",
-            "capability:pred_int",
-            "scitype:y",
-            "univariate-only",
-            "handles-missing-data",
-            "y_inner_mtype",
-            "X_inner_mtype",
-            "X-y-must-have-same-index",
-            "enforce-index-type",
-        ]
-
-        self.clone_tags(forecaster, tags_to_clone)
-
     def _run_search(self, evaluate_candidates):
         """Search all candidates in param_grid."""
         _check_param_grid(self.param_grid)
@@ -573,20 +573,6 @@ class ForecastingRandomizedSearchCV(BaseGridSearch):
         self.param_distributions = param_distributions
         self.n_iter = n_iter
         self.random_state = random_state
-
-        tags_to_clone = [
-            "requires-fh-in-fit",
-            "capability:pred_int",
-            "scitype:y",
-            "univariate-only",
-            "handles-missing-data",
-            "y_inner_mtype",
-            "X_inner_mtype",
-            "X-y-must-have-same-index",
-            "enforce-index-type",
-        ]
-
-        self.clone_tags(forecaster, tags_to_clone)
 
     def _run_search(self, evaluate_candidates):
         """Search n_iter candidates from param_distributions."""

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -60,7 +60,7 @@ class BaseGridSearch(BaseForecaster):
             "requires-fh-in-fit",
             "capability:pred_int",
             # "scitype:y", commented out until grid search works with multivariate
-            "univariate-only",
+            "ignores-exogeneous-X",
             "handles-missing-data",
             "y_inner_mtype",
             "X_inner_mtype",


### PR DESCRIPTION
This PR fixes the tags of tuning/grid search to be in line with current capabilities.

Most notably, it restricts the `"scitype:y"` tag to `"univariate"`, since the `evaluate` function used for tuning can only deal with univariate losses.

This partially addresses the issue uncovered in #1449.