### PR TITLE
[BUG] model_selection/split passed the entire DataFrame as index if DataFrame was provided

### DIFF
--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -98,9 +98,11 @@ def _repr(self):
 
 def _check_y(y):
     """Check input to `split` function."""
-    if isinstance(y, pd.Series):
-        y = y.index
-    return check_time_index(y)
+    if isinstance(y, (pd.Series, pd.DataFrame)):
+        y_index = y.index
+    if isinstance(y, np.ndarray):
+        y_index = pd.Index(y)
+    return check_time_index(y_index)
 
 
 def _check_fh(fh):


### PR DESCRIPTION
Bad style case distinction and variable overwrite caused the entire `DataFrame` to be passed to `check_time_index` in `_check_y` of the splitters.

This is one of the cause of undetected failures in #1449.

This is now fixed.