### PR TITLE
changed dashes in every "tag_name" to underscores

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -111,7 +111,7 @@ Added
 * Added pd.DataFrame transformation for Imputer and HampelFilter (#830) @aiwalter
 * Added default params for some transformers (#834) @aiwalter
 * Added several docstring examples (#835) @aiwalter
-* Added skip-inverse-transform tag for Imputer and HampelFilter (#788) @aiwalter
+* Added skip_inverse_transform tag for Imputer and HampelFilter (#788) @aiwalter
 * Added a reference to alibi-detect (#815) @satya-pattnaik
 
 All contributors: @GuzalBulatova, @RNKuhns, @aaronreidsmith, @aiwalter, @kachayev, @ltsaprounis, @luiszugasti, @mloning, @satya-pattnaik and @yashlamba

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -63,9 +63,9 @@ class MyTSC(BaseClassifier):
 
     # todo: fill out estimator tags here
     _tags = {
-        "handles-missing-data": False,  # can estimator handle missing data?
-        "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
-        "enforce-index-type": None,  # index type that needs to be enforced in X/y
+        "handles_missing_data": False,  # can estimator handle missing data?
+        "X_y_must_have_same_index": True,  # can estimator handle different X/y index?
+        "enforce_index_type": None,  # index type that needs to be enforced in X/y
     }
     # in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -69,13 +69,13 @@ class MyForecaster(BaseForecaster):
     #  delete the tags that you *didn't* change - these defaults are inherited
     _tags = {
         "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
-        "univariate-only": True,  # does estimator use the exogeneous X?
-        "handles-missing-data": False,  # can estimator handle missing data?
+        "univariate_only": True,  # does estimator use the exogeneous X?
+        "handles_missing_data": False,  # can estimator handle missing data?
         "y_inner_mtype": "pd.Series",  # which types do _fit, _predict, assume for y?
         "X_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for X?
-        "requires-fh-in-fit": True,  # is forecasting horizon already required in fit?
-        "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
-        "enforce-index-type": None,  # index type that needs to be enforced in X/y
+        "requires_fh_in_fit": True,  # is forecasting horizon already required in fit?
+        "X_y_must_have_same_index": True,  # can estimator handle different X/y index?
+        "enforce_index_type": None,  # index type that needs to be enforced in X/y
     }
     # in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -74,7 +74,7 @@ class BaseClassifier(BaseEstimator):
     """
 
     _tags = {
-        "coerce-X-to-numpy": True,
+        "coerce_X_to_numpy": True,
     }
 
     def __init__(self):
@@ -102,7 +102,7 @@ class BaseClassifier(BaseEstimator):
         creates fitted model (attributes ending in "_")
         sets is_fitted flag to true
         """
-        coerce_to_numpy = self.get_class_tag("coerce-X-to-numpy", False)
+        coerce_to_numpy = self.get_class_tag("coerce_X_to_numpy", False)
 
         X, y = check_X_y(X, y, coerce_to_numpy=coerce_to_numpy)
 
@@ -127,7 +127,7 @@ class BaseClassifier(BaseEstimator):
         -------
         y : array-like, shape =  [n_instances] - predicted class labels
         """
-        coerce_to_numpy = self.get_class_tag("coerce-X-to-numpy", False)
+        coerce_to_numpy = self.get_class_tag("coerce_X_to_numpy", False)
 
         X = check_X(X, coerce_to_numpy=coerce_to_numpy)
         self.check_is_fitted()

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -66,14 +66,14 @@ class BaseForecaster(BaseEstimator):
     # default tag values - these typically make the "safest" assumption
     _tags = {
         "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
-        "univariate-only": True,  # does estimator use the exogeneous X?
+        "univariate_only": True,  # does estimator use the exogeneous X?
         "capability:pred_int": False,  # can the estimator produce prediction intervals?
-        "handles-missing-data": False,  # can estimator handle missing data?
+        "handles_missing_data": False,  # can estimator handle missing data?
         "y_inner_mtype": "pd.Series",  # which types do _fit/_predict, support for y?
         "X_inner_mtype": "pd.DataFrame",  # which types do _fit/_predict, support for X?
-        "requires-fh-in-fit": True,  # is forecasting horizon already required in fit?
-        "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
-        "enforce-index-type": None,  # index type that needs to be enforced in X/y
+        "requires_fh_in_fit": True,  # is forecasting horizon already required in fit?
+        "X_y_must_have_same_index": True,  # can estimator handle different X/y index?
+        "enforce_index_type": None,  # index type that needs to be enforced in X/y
     }
 
     def __init__(self):
@@ -138,7 +138,7 @@ class BaseForecaster(BaseEstimator):
 
         # checking X
         X = check_series(X, enforce_index_type=enforce_index_type, var_name="X")
-        if self.get_tag("X-y-must-have-same-index"):
+        if self.get_tag("X_y_must_have_same_index"):
             check_equal_time_index(X, y)
         # end checking X
 
@@ -383,7 +383,7 @@ class BaseForecaster(BaseEstimator):
 
         # checking X
         X = check_series(X, enforce_index_type=enforce_index_type, var_name="X")
-        if self.get_tag("X-y-must-have-same-index"):
+        if self.get_tag("X_y_must_have_same_index"):
             check_equal_time_index(X, y)
         # end checking X
 
@@ -723,7 +723,7 @@ class BaseForecaster(BaseEstimator):
         ----------
         fh : None, int, list, np.ndarray or ForecastingHorizon
         """
-        requires_fh = self.get_tag("requires-fh-in-fit")
+        requires_fh = self.get_tag("requires_fh_in_fit")
 
         msg = (
             f"This is because fitting of the `"

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -18,10 +18,10 @@ class _ProphetAdapter(BaseForecaster):
     """Base class for interfacing fbprophet and neuralprophet."""
 
     _tags = {
-        "univariate-only": False,
+        "univariate_only": False,
         "capability:pred_int": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def _fit(self, y, X=None, fh=None, **fit_params):

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -15,10 +15,10 @@ class _PmdArimaAdapter(BaseForecaster):
     """Base class for interfacing pmdarima."""
 
     _tags = {
-        "univariate-only": True,
+        "univariate_only": True,
         "capability:pred_int": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self):

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -16,9 +16,9 @@ class _StatsModelsAdapter(BaseForecaster):
 
     _fitted_param_names = ()
     _tags = {
-        "univariate-only": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "univariate_only": True,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self):

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -17,10 +17,10 @@ class _TbatsAdapter(BaseForecaster):
     """Base class for interfacing tbats forecasting algorithms."""
 
     _tags = {
-        "univariate-only": True,
+        "univariate_only": True,
         "capability:pred_int": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -47,9 +47,9 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
 
     _required_parameters = ["forecasters"]
     _tags = {
-        "univariate-only": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "univariate_only": True,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self, forecasters, n_jobs=None, aggfunc="mean"):

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -79,9 +79,9 @@ class MultiplexForecaster(_HeterogenousEnsembleForecaster):
     """
 
     _tags = {
-        "univariate-only": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "univariate_only": True,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -142,9 +142,9 @@ class ForecastingPipeline(_Pipeline):
 
     _required_parameters = ["steps"]
     _tags = {
-        "univariate-only": False,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "univariate_only": False,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self, steps):
@@ -253,7 +253,7 @@ class ForecastingPipeline(_Pipeline):
 #     self.check_is_fitted()
 #     Zt = check_series(Z, enforce_multivariate=True)
 #     for _, _, transformer in self._iter_transformers(reverse=True):
-#         if not _has_tag(transformer, "skip-inverse-transform"):
+#         if not _has_tag(transformer, "skip_inverse_transform"):
 #             Zt = transformer.inverse_transform(Zt)
 #     return Zt
 
@@ -287,9 +287,9 @@ class TransformedTargetForecaster(_Pipeline, _SeriesToSeriesTransformer):
 
     _required_parameters = ["steps"]
     _tags = {
-        "univariate-only": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "univariate_only": True,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self, steps):
@@ -353,7 +353,7 @@ class TransformedTargetForecaster(_Pipeline, _SeriesToSeriesTransformer):
         for _, _, transformer in self._iter_transformers(reverse=True):
             # skip sktime transformers where inverse transform
             # is not wanted ur meaningful (e.g. Imputer, HampelFilter)
-            skip_trafo = transformer.get_tag("skip-inverse-transform", False)
+            skip_trafo = transformer.get_tag("skip_inverse_transform", False)
             if not skip_trafo:
                 y_pred = transformer.inverse_transform(y_pred)
         return y_pred
@@ -393,6 +393,6 @@ class TransformedTargetForecaster(_Pipeline, _SeriesToSeriesTransformer):
         self.check_is_fitted()
         zt = check_series(Z, enforce_univariate=True)
         for _, _, transformer in self._iter_transformers(reverse=True):
-            if not transformer.get_tag("skip-inverse-transform", False):
+            if not transformer.get_tag("skip_inverse_transform", False):
                 zt = transformer.inverse_transform(zt, X)
         return zt

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -170,7 +170,7 @@ class _Reducer(_BaseWindowForecaster):
 class _DirectReducer(_Reducer):
     strategy = "direct"
     _tags = {
-        "requires-fh-in-fit": True,  # is the forecasting horizon required in fit?
+        "requires_fh_in_fit": True,  # is the forecasting horizon required in fit?
     }
 
     def _transform(self, y, X=None):
@@ -263,7 +263,7 @@ class _DirectReducer(_Reducer):
 class _MultioutputReducer(_Reducer):
     strategy = "multioutput"
     _tags = {
-        "requires-fh-in-fit": True,  # is the forecasting horizon required in fit?
+        "requires_fh_in_fit": True,  # is the forecasting horizon required in fit?
     }
 
     def _transform(self, y, X=None):
@@ -347,7 +347,7 @@ class _MultioutputReducer(_Reducer):
 class _RecursiveReducer(_Reducer):
     strategy = "recursive"
     _tags = {
-        "requires-fh-in-fit": False,  # is the forecasting horizon required in fit?
+        "requires_fh_in_fit": False,  # is the forecasting horizon required in fit?
     }
 
     def _transform(self, y, X=None):
@@ -445,7 +445,7 @@ class _RecursiveReducer(_Reducer):
 class _DirRecReducer(_Reducer):
     strategy = "dirrec"
     _tags = {
-        "requires-fh-in-fit": True,  # is the forecasting horizon required in fit?
+        "requires_fh_in_fit": True,  # is the forecasting horizon required in fit?
     }
 
     def _transform(self, y, X=None):

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -34,9 +34,9 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
 
     _required_parameters = ["forecasters", "final_regressor"]
     _tags = {
-        "univariate-only": True,
-        "requires-fh-in-fit": True,
-        "handles-missing-data": False,
+        "univariate_only": True,
+        "requires_fh_in_fit": True,
+        "handles_missing_data": False,
     }
 
     def __init__(self, forecasters, final_regressor, n_jobs=None):

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -55,7 +55,7 @@ def test_pipeline():
 
 
 def test_skip_inverse_transform():
-    # testing that transformers which have the "skip-inverse-transform" tag
+    # testing that transformers which have the "skip_inverse_transform" tag
     # are working in a pipeline
     y = load_airline()
     # add nan and outlier

--- a/sktime/forecasting/croston.py
+++ b/sktime/forecasting/croston.py
@@ -36,7 +36,7 @@ class Croston(BaseForecaster):
     """
 
     _tags = {
-        "requires-fh-in-fit": False,  # is forecasting horizon already required in fit?
+        "requires_fh_in_fit": False,  # is forecasting horizon already required in fit?
     }
 
     def __init__(self, smoothing=0.1):

--- a/sktime/forecasting/hcrystalball.py
+++ b/sktime/forecasting/hcrystalball.py
@@ -96,9 +96,9 @@ def _adapt_y_pred(y_pred):
 class HCrystalBallForecaster(BaseForecaster):
 
     _tags = {
-        "univariate-only": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "univariate_only": True,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self, model):

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -25,9 +25,9 @@ from sktime.utils.validation.forecasting import check_scoring
 class BaseGridSearch(BaseForecaster):
 
     _tags = {
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
-        "univariate-only": True,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
+        "univariate_only": True,
     }
 
     def __init__(

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -58,7 +58,7 @@ class NaiveForecaster(_BaseWindowForecaster):
     >>> y_pred = forecaster.predict(fh=[1,2,3])
     """
 
-    _tags = {"requires-fh-in-fit": False}
+    _tags = {"requires_fh_in_fit": False}
 
     def __init__(self, strategy="last", window_length=None, sp=1):
         super(NaiveForecaster, self).__init__()

--- a/sktime/forecasting/online_learning/_online_ensemble.py
+++ b/sktime/forecasting/online_learning/_online_ensemble.py
@@ -24,9 +24,9 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
 
     _required_parameters = ["forecasters"]
     _tags = {
-        "univariate-only": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "univariate_only": True,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self, forecasters, ensemble_algorithm=None, n_jobs=None):

--- a/sktime/forecasting/online_learning/_prediction_weighted_ensembler.py
+++ b/sktime/forecasting/online_learning/_prediction_weighted_ensembler.py
@@ -18,9 +18,9 @@ class _PredictionWeightedEnsembler:
     """
 
     _tags = {
-        "univariate-only": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "univariate_only": True,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self, n_estimators=10, loss_func=None):
@@ -101,9 +101,9 @@ class HedgeExpertEnsemble(_PredictionWeightedEnsembler):
     """
 
     _tags = {
-        "univariate-only": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "univariate_only": True,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self, n_estimators=10, T=10, a=1, loss_func=None):
@@ -132,9 +132,9 @@ class NormalHedgeEnsemble(HedgeExpertEnsemble):
     """
 
     _tags = {
-        "univariate-only": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "univariate_only": True,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self, n_estimators=10, a=1, loss_func=None):
@@ -239,9 +239,9 @@ class NNLSEnsemble(_PredictionWeightedEnsembler):
     """
 
     _tags = {
-        "univariate-only": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "univariate_only": True,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self, n_estimators=10, loss_func=None):

--- a/sktime/forecasting/tests/test_sktime_forecasters.py
+++ b/sktime/forecasting/tests/test_sktime_forecasters.py
@@ -74,11 +74,11 @@ def test_oh_setting(Forecaster):
 
 # divide Forecasters into groups based on when fh is required
 FORECASTERS_REQUIRED = [
-    f for f in FORECASTERS if f.get_class_tag("requires-fh-in-fit", True)
+    f for f in FORECASTERS if f.get_class_tag("requires_fh_in_fit", True)
 ]
 
 FORECASTERS_OPTIONAL = [
-    f for f in FORECASTERS if not f.get_class_tag("requires-fh-in-fit", True)
+    f for f in FORECASTERS if not f.get_class_tag("requires_fh_in_fit", True)
 ]
 
 

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -92,10 +92,10 @@ class ThetaForecaster(ExponentialSmoothing):
 
     _fitted_param_names = ("initial_level", "smoothing_level")
     _tags = {
-        "univariate-only": True,
+        "univariate_only": True,
         "capability:pred_int": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self, initial_level=None, deseasonalize=True, sp=1):

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -46,9 +46,9 @@ class PolynomialTrendForecaster(BaseForecaster):
     """
 
     _tags = {
-        "univariate-only": True,
-        "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "univariate_only": True,
+        "requires_fh_in_fit": False,
+        "handles_missing_data": False,
     }
 
     def __init__(self, regressor=None, degree=1, with_intercept=True):

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -56,7 +56,7 @@ class _BaseForecastingErrorMetric(BaseMetric):
     _tags = {
         "requires-y-train": False,
         "requires-y-pred-benchmark": False,
-        "univariate-only": False,
+        "univariate_only": False,
     }
 
     greater_is_better = False
@@ -305,7 +305,7 @@ class _ScaledForecastingErrorMetric(_BaseForecastingErrorMetric):
     _tags = {
         "requires-y-train": True,
         "requires-y-pred-benchmark": False,
-        "univariate-only": False,
+        "univariate_only": False,
     }
 
     def __init__(self, func, name=None, multioutput="uniform_average", sp=1):
@@ -379,7 +379,7 @@ class _RelativeLossForecastingErrorMetric(
     _tags = {
         "requires-y-train": False,
         "requires-y-pred-benchmark": True,
-        "univariate-only": False,
+        "univariate_only": False,
     }
 
     def __init__(
@@ -1650,7 +1650,7 @@ class MeanRelativeAbsoluteError(_BaseForecastingErrorMetric):
     _tags = {
         "requires-y-train": False,
         "requires-y-pred-benchmark": True,
-        "univariate-only": False,
+        "univariate_only": False,
     }
 
     def __init__(self, multioutput="uniform_average"):
@@ -1728,7 +1728,7 @@ class MedianRelativeAbsoluteError(_BaseForecastingErrorMetric):
     _tags = {
         "requires-y-train": False,
         "requires-y-pred-benchmark": True,
-        "univariate-only": False,
+        "univariate_only": False,
     }
 
     def __init__(self, multioutput="uniform_average"):
@@ -1808,7 +1808,7 @@ class GeometricMeanRelativeAbsoluteError(_BaseForecastingErrorMetric):
     _tags = {
         "requires-y-train": False,
         "requires-y-pred-benchmark": True,
-        "univariate-only": False,
+        "univariate_only": False,
     }
 
     def __init__(self, multioutput="uniform_average"):
@@ -1898,7 +1898,7 @@ class GeometricMeanRelativeSquaredError(_SquaredForecastingErrorMetric):
     _tags = {
         "requires-y-train": False,
         "requires-y-pred-benchmark": True,
-        "univariate-only": False,
+        "univariate_only": False,
     }
 
     def __init__(self, multioutput="uniform_average", square_root=False):

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -47,55 +47,55 @@ import pandas as pd
 
 ESTIMATOR_TAG_REGISTER = [
     (
-        "univariate-only",  # todo: rename to "scitype:handles_exogeneous"
+        "univariate_only",  # todo: rename to "scitype:handles_exogeneous"
         "forecaster",
         "bool",
         "does forecaster use exogeneous data (X)?",
     ),
     (
-        "fit-in-transform",
+        "fit_in_transform",
         "transformer",
         "bool",
         "does fit contain no logic and can be skipped? yes/no",
     ),
     (
-        "transform-returns-same-time-index",
+        "transform_returns_same_time_index",
         "transformer",
         "bool",
         "does transform return same time index as input?",
     ),
     (
-        "handles-missing-data",
+        "handles_missing_data",
         "estimator",
         "bool",
         "can the estimator handle missing data (NA, np.nan) in inputs?",
     ),
     (
-        "skip-inverse-transform",
+        "skip_inverse_transform",
         "transformer",
         "bool",
         "behaviour flag: skips inverse_transform when called yes/no",
     ),
     (
-        "requires-fh-in-fit",
+        "requires_fh_in_fit",
         "forecaster",
         "bool",
         "does forecaster require fh passed already in fit? yes/no",
     ),
     (
-        "X-y-must-have-same-index",
+        "X_y_must_have_same_index",
         ["forecaster", "classifier", "regressor"],
         "bool",
         "do X/y in fit/update and X/fh in predict have to be same indices?",
     ),
     (
-        "enforce-index-type",
+        "enforce_index_type",
         ["forecaster", "classifier", "regressor"],
         "type",
         "passed to input checks, input conversion index type to enforce",
     ),
     (
-        "coerce-X-to-numpy",
+        "coerce_X_to_numpy",
         ["forecaster", "classifier", "regressor"],
         "bool",
         "should X be coerced to numpy type in check_X? yes/no",
@@ -131,19 +131,19 @@ ESTIMATOR_TAG_REGISTER = [
         "is the forecaster capable of returning prediction intervals in predict?",
     ),
     # (
-    #     "handles-panel",
+    #     "handles_panel",
     #     "annotator",
     #     "bool",
     #     "can handle panel annotations, i.e., list X/y?",
     # ),
     # (
-    #     "annotation-type",
+    #     "annotation_type",
     #     "annotator",
     #     "str",
     #     "which annotation type? can be 'point', 'segment' or 'both'",
     # ),
     # (
-    #     "annotation-kind",
+    #     "annotation_kind",
     #     "annotator",
     #     "str",
     #     "which annotations? can be 'outlier', 'change', 'label', 'none'",

--- a/sktime/transformations/panel/compose.py
+++ b/sktime/transformations/panel/compose.py
@@ -239,7 +239,7 @@ class _RowTransformer(BaseTransformer):
     """Base class for RowTransformer"""
 
     _required_parameters = ["transformer"]
-    _tags = {"fit-in-transform": True}
+    _tags = {"fit_in_transform": True}
 
     def __init__(self, transformer, check_transformer=True):
         self.transformer = transformer

--- a/sktime/transformations/panel/dictionary_based/_sax.py
+++ b/sktime/transformations/panel/dictionary_based/_sax.py
@@ -58,7 +58,7 @@ class SAX(_PanelToPanelTransformer):
 
     """
 
-    _tags = {"univariate-only": True, "fit-in-transform": True}
+    _tags = {"univariate_only": True, "fit_in_transform": True}
 
     def __init__(
         self,

--- a/sktime/transformations/panel/dictionary_based/_sfa.py
+++ b/sktime/transformations/panel/dictionary_based/_sfa.py
@@ -103,7 +103,7 @@ class SFA(_PanelToPanelTransformer):
         num_atts = 0
     """
 
-    _tags = {"univariate-only": True}
+    _tags = {"univariate_only": True}
 
     def __init__(
         self,

--- a/sktime/transformations/panel/matrix_profile.py
+++ b/sktime/transformations/panel/matrix_profile.py
@@ -214,7 +214,7 @@ class MatrixProfile(_PanelToTabularTransformer):
     corresponding time series.
     """
 
-    _tags = {"univariate-only": True, "fit-in-transform": True}
+    _tags = {"univariate_only": True, "fit_in_transform": True}
 
     def __init__(self, m=10):
         self.m = m  # subsequence length

--- a/sktime/transformations/panel/pca.py
+++ b/sktime/transformations/panel/pca.py
@@ -29,7 +29,7 @@ class PCATransformer(_PanelToPanelTransformer):
         documentation for a detailed description of all options.
     """
 
-    _tags = {"univariate-only": True}
+    _tags = {"univariate_only": True}
 
     def __init__(self, n_components=None, **kwargs):
         self.n_components = n_components

--- a/sktime/transformations/panel/rocket/_minirocket.py
+++ b/sktime/transformations/panel/rocket/_minirocket.py
@@ -37,7 +37,7 @@ class MiniRocket(_PanelToTabularTransformer):
     random_state             : int, random seed (optional, default None)
     """
 
-    _tags = {"univariate-only": True}
+    _tags = {"univariate_only": True}
 
     def __init__(
         self, num_features=10_000, max_dilations_per_kernel=32, random_state=None

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -28,7 +28,7 @@ class IntervalSegmenter(_PanelToPanelTransformer):
         and the second column giving end points of intervals
     """
 
-    _tags = {"univariate-only": True}
+    _tags = {"univariate_only": True}
 
     def __init__(self, intervals=10):
         self.intervals = intervals
@@ -324,7 +324,7 @@ class SlidingWindowSegmenter(_PanelToPanelTransformer):
     Proposed in the ShapeDTW algorithm.
     """
 
-    _tags = {"univariate-only": True, "fit-in-transform": True}
+    _tags = {"univariate_only": True, "fit_in_transform": True}
 
     def __init__(self, window_length=5):
         self.window_length = window_length

--- a/sktime/transformations/panel/shapelets.py
+++ b/sktime/transformations/panel/shapelets.py
@@ -90,7 +90,7 @@ class ShapeletTransform(_PanelToTabularTransformer):
     the stored shapelets after a dataset has been processed
     """
 
-    _tags = {"univariate-only": True}
+    _tags = {"univariate_only": True}
 
     def __init__(
         self,

--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -29,7 +29,7 @@ class PlateauFinder(_PanelToPanelTransformer):
         finder.
     """
 
-    _tags = {"fit-in-transform": True, "univariate-only": True}
+    _tags = {"fit_in_transform": True, "univariate_only": True}
 
     def __init__(self, value=np.nan, min_length=2):
         self.value = value
@@ -168,7 +168,7 @@ class RandomIntervalFeatureExtractor(_PanelToTabularTransformer):
         by `np.random`.
     """
 
-    _tags = {"univariate-only": True}
+    _tags = {"univariate_only": True}
 
     def __init__(
         self,
@@ -312,7 +312,7 @@ class FittedParamExtractor(_PanelToTabularTransformer):
     """
 
     _required_parameters = ["forecaster"]
-    _tags = {"fit-in-transform": True, "univariate-only": True}
+    _tags = {"fit_in_transform": True, "univariate_only": True}
 
     def __init__(self, forecaster, param_names, n_jobs=None):
         self.forecaster = forecaster

--- a/sktime/transformations/series/acf.py
+++ b/sktime/transformations/series/acf.py
@@ -33,7 +33,7 @@ class AutoCorrelationTransformer(_SeriesToSeriesTransformer):
     >>> y_hat = transformer.fit_transform(y)
     """
 
-    _tags = {"univariate-only": True, "fit-in-transform": True}
+    _tags = {"univariate_only": True, "fit_in_transform": True}
 
     def __init__(
         self,
@@ -109,7 +109,7 @@ class PartialAutoCorrelationTransformer(_SeriesToSeriesTransformer):
     >>> y_hat = transformer.fit_transform(y)
     """
 
-    _tags = {"univariate-only": True, "fit-in-transform": True}
+    _tags = {"univariate_only": True, "fit_in_transform": True}
 
     def __init__(
         self,

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -55,7 +55,7 @@ class TabularToSeriesAdaptor(_SeriesToSeriesTransformer):
     """
 
     _required_parameters = ["transformer"]
-    _tags = {"transform-returns-same-time-index": True}
+    _tags = {"transform_returns_same_time_index": True}
 
     def __init__(self, transformer):
         self.transformer = transformer

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -35,7 +35,7 @@ class BoxCoxTransformer(_SeriesToSeriesTransformer):
     >>> y_hat = transformer.fit_transform(y)
     """
 
-    _tags = {"transform-returns-same-time-index": True, "univariate-only": True}
+    _tags = {"transform_returns_same_time_index": True, "univariate_only": True}
 
     def __init__(self, bounds=None, method="mle", sp=None):
         self.bounds = bounds
@@ -109,7 +109,7 @@ class BoxCoxTransformer(_SeriesToSeriesTransformer):
 
 
 class LogTransformer(_SeriesToSeriesTransformer):
-    _tags = {"transform-returns-same-time-index": True}
+    _tags = {"transform_returns_same_time_index": True}
 
     def transform(self, Z, X=None):
         self.check_is_fitted()

--- a/sktime/transformations/series/compose.py
+++ b/sktime/transformations/series/compose.py
@@ -64,8 +64,8 @@ class OptionalPassthrough(_SeriesToSeriesTransformer):
 
     _required_parameters = ["transformer"]
     _tags = {
-        "univariate-only": False,
-        "fit-in-transform": True,
+        "univariate_only": False,
+        "fit_in_transform": True,
     }
 
     def __init__(self, transformer, passthrough=False):

--- a/sktime/transformations/series/cos.py
+++ b/sktime/transformations/series/cos.py
@@ -19,7 +19,7 @@ class CosineTransformer(_SeriesToSeriesTransformer):
     >>> y_hat = transformer.fit_transform(y)
     """
 
-    _tags = {"transform-returns-same-time-index": True, "fit-in-transform": True}
+    _tags = {"transform_returns_same_time_index": True, "fit_in_transform": True}
 
     def transform(self, Z, X=None):
         self.check_is_fitted()

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -41,7 +41,7 @@ class Deseasonalizer(_SeriesToSeriesTransformer):
     >>> y_hat = transformer.fit_transform(y)
     """
 
-    _tags = {"transform-returns-same-time-index": True, "univariate-only": True}
+    _tags = {"transform_returns_same_time_index": True, "univariate_only": True}
 
     def __init__(self, sp=1, model="additive"):
         self.sp = check_sp(sp)

--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -60,7 +60,7 @@ class Detrender(_SeriesToSeriesTransformer):
     """
 
     _required_parameters = ["forecaster"]
-    _tags = {"transform-returns-same-time-index": True}
+    _tags = {"transform_returns_same_time_index": True}
 
     def __init__(self, forecaster=None):
         self.forecaster = forecaster

--- a/sktime/transformations/series/exponent.py
+++ b/sktime/transformations/series/exponent.py
@@ -52,9 +52,9 @@ class ExponentTransformer(_SeriesToSeriesTransformer):
     """
 
     _tags = {
-        "fit-in-transform": False,
-        "transform-returns-same-time-index": True,
-        "univariate-only": False,
+        "fit_in_transform": False,
+        "transform_returns_same_time_index": True,
+        "univariate_only": False,
     }
 
     def __init__(self, power=0.5, offset="auto"):
@@ -226,9 +226,9 @@ class SqrtTransformer(ExponentTransformer):
     """
 
     _tags = {
-        "fit-in-transform": False,
-        "transform-returns-same-time-index": True,
-        "univariate-only": False,
+        "fit_in_transform": False,
+        "transform_returns_same_time_index": True,
+        "univariate_only": False,
     }
 
     def __init__(self, offset="auto"):

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -54,9 +54,9 @@ class Imputer(_SeriesToSeriesTransformer):
     """
 
     _tags = {
-        "fit-in-transform": True,
-        "handles-missing-data": True,
-        "skip-inverse-transform": True,
+        "fit_in_transform": True,
+        "handles_missing_data": True,
+        "skip_inverse_transform": True,
     }
 
     def __init__(

--- a/sktime/transformations/series/matrix_profile.py
+++ b/sktime/transformations/series/matrix_profile.py
@@ -34,7 +34,7 @@ class MatrixProfileTransformer(_SeriesToSeriesTransformer):
     >>> y_hat = transformer.fit_transform(y)
     """
 
-    _tags = {"univariate-only": True, "fit-in-transform": True}  # for unit test cases
+    _tags = {"univariate_only": True, "fit_in_transform": True}  # for unit test cases
 
     def __init__(self, window_length=3):
         self.window_length = window_length

--- a/sktime/transformations/series/outlier_detection.py
+++ b/sktime/transformations/series/outlier_detection.py
@@ -46,9 +46,9 @@ class HampelFilter(_SeriesToSeriesTransformer):
     """
 
     _tags = {
-        "fit-in-transform": True,
-        "handles-missing-data": True,
-        "skip-inverse-transform": True,
+        "fit_in_transform": True,
+        "handles_missing_data": True,
+        "skip_inverse_transform": True,
     }
 
     def __init__(self, window_length=10, n_sigma=3, k=1.4826, return_bool=False):

--- a/sktime/transformations/series/theta.py
+++ b/sktime/transformations/series/theta.py
@@ -33,9 +33,9 @@ class ThetaLinesTransformer(_SeriesToSeriesTransformer):
     """
 
     _tags = {
-        "transform-returns-same-time-index": True,
-        "univariate-only": True,
-        "fit-in-transform": True,
+        "transform_returns_same_time_index": True,
+        "univariate_only": True,
+        "fit_in_transform": True,
     }
 
     def __init__(self, theta=(0, 2)):

--- a/sktime/transformations/tests/test_all_transformers.py
+++ b/sktime/transformations/tests/test_all_transformers.py
@@ -57,7 +57,7 @@ def check_series_to_primitive_transform_univariate(Estimator, **kwargs):
 
 def _check_raises_error(Estimator, **kwargs):
     with pytest.raises(ValueError, match=r"univariate"):
-        if Estimator.get_class_tag("fit-in-transform", False):
+        if Estimator.get_class_tag("fit_in_transform", False):
             # As some estimators have an empty fit method, we here check if
             # they raise the appropriate error in transform rather than fit.
             _construct_fit_transform(Estimator, **kwargs)
@@ -68,7 +68,7 @@ def _check_raises_error(Estimator, **kwargs):
 
 def check_series_to_primitive_transform_multivariate(Estimator):
     n_columns = 3
-    if Estimator.get_class_tag("univariate-only", False):
+    if Estimator.get_class_tag("univariate_only", False):
         _check_raises_error(Estimator, n_columns=n_columns)
     else:
         out = _construct_fit_transform(Estimator, n_columns=n_columns)
@@ -81,7 +81,7 @@ def check_series_to_series_transform_univariate(Estimator):
     out = _construct_fit_transform(
         Estimator,
         n_timepoints=n_timepoints,
-        add_nan=Estimator.get_class_tag("handles-missing-data", False),
+        add_nan=Estimator.get_class_tag("handles_missing_data", False),
     )
     assert isinstance(out, (pd.Series, np.ndarray, pd.DataFrame))
 
@@ -89,7 +89,7 @@ def check_series_to_series_transform_univariate(Estimator):
 def check_series_to_series_transform_multivariate(Estimator):
     n_columns = 3
     n_timepoints = 15
-    if Estimator.get_class_tag("univariate-only", False):
+    if Estimator.get_class_tag("univariate_only", False):
         _check_raises_error(Estimator, n_timepoints=n_timepoints, n_columns=n_columns)
     else:
         out = _construct_fit_transform(
@@ -108,7 +108,7 @@ def check_panel_to_tabular_transform_univariate(Estimator):
 
 def check_panel_to_tabular_transform_multivariate(Estimator):
     n_instances = 5
-    if Estimator.get_class_tag("univariate-only", False):
+    if Estimator.get_class_tag("univariate_only", False):
         _check_raises_error(Estimator, n_instances=n_instances, n_columns=3)
     else:
         out = _construct_fit_transform(Estimator, n_instances=n_instances, n_columns=3)
@@ -129,7 +129,7 @@ def check_panel_to_panel_transform_univariate(Estimator):
 
 def check_panel_to_panel_transform_multivariate(Estimator):
     n_instances = 5
-    if Estimator.get_class_tag("univariate-only", False):
+    if Estimator.get_class_tag("univariate_only", False):
         _check_raises_error(Estimator, n_instances=n_instances, n_columns=3)
     else:
         out = _construct_fit_transform(Estimator, n_instances=n_instances, n_columns=3)
@@ -197,5 +197,5 @@ def _yield_transformer_checks(Estimator):
         yield from panel_to_tabular_checks
     if issubclass(Estimator, _PanelToPanelTransformer):
         yield from panel_to_panel_checks
-    if Estimator.get_class_tag("transform-returns-same-time-index", False):
+    if Estimator.get_class_tag("transform_returns_same_time_index", False):
         yield check_transform_returns_same_time_index

--- a/sktime/utils/_testing/estimator_checks.py
+++ b/sktime/utils/_testing/estimator_checks.py
@@ -423,7 +423,7 @@ def check_methods_do_not_change_state(Estimator):
             args = _make_args(estimator, method)
             getattr(estimator, method)(*args)
 
-            if method == "transform" and Estimator.get_class_tag("fit-in-transform"):
+            if method == "transform" and Estimator.get_class_tag("fit_in_transform"):
                 # Some transformations fit during transform, as they apply
                 # some transformation to each series passed to transform,
                 # so transform will actually change the state of these estimator.


### PR DESCRIPTION
This PR aimes to address #1397. 

All dashes in tags are replaced by underscores so that a vanilla call to `set_tags` with `tag_name=tag_value` will not break as `tag_name` does not contain any dash symbol.


