### PR TITLE
1478 statsmodels max_requirements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,7 @@ install:
 
   # Install requirements from inside conda environment
   - cmd: activate testenv
-  - cmd: conda install -c conda-forge "matplotlib>=3.3.2" "seaborn>=0.11.0" "tsfresh>=0.17.0" "hcrystalball>=0.1.9" "stumpy>=1.5.1" "fbprophet>=0.7.1" "numba==0.53" "numpy>=1.19.3" "pandas>=1.1.0,<1.2" "statsmodels>=0.12.1" "scikit-learn>=0.23.0" "scikit-posthocs>=0.6.5" "pystan>=2.14,<3.0"
+  - cmd: conda install -c conda-forge "matplotlib>=3.3.2" "seaborn>=0.11.0" "tsfresh>=0.17.0" "hcrystalball>=0.1.9" "stumpy>=1.5.1" "fbprophet>=0.7.1" "numba==0.53" "numpy>=1.19.3" "pandas>=1.1.0,<1.2" "statsmodels==0.12.1" "scikit-learn>=0.23.0" "scikit-posthocs>=0.6.5" "pystan>=2.14,<3.0"
 
   - cmd: pip install -r %REQUIREMENTS%
 

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -3,4 +3,4 @@ pandas==1.1.5
 pmdarima>=1.8.0,!=1.8.1
 scikit-learn>=0.24.*
 scikit-posthocs
-statsmodels>=0.12.1
+statsmodels==0.12.1

--- a/build_tools/hard_dependencies.txt
+++ b/build_tools/hard_dependencies.txt
@@ -3,5 +3,5 @@ numba==0.53
 numpy==1.19.3
 pandas==1.1.5
 scikit-learn==0.24.*
-statsmodels>=0.12.1
+statsmodels==0.12.1
 wheel

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -12,7 +12,7 @@ pytest
 pytest-cov
 scikit-learn==0.24.*
 scikit-posthocs
-statsmodels>=0.12.1
+statsmodels==0.12.1
 stumpy>=1.5.1
 tbats>=1.1.0
 tsfresh>=0.17.0

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ MIN_REQUIREMENTS = {
     "statsmodels": "0.12.1",
     "numba": "0.53",
 }
+MAX_REQUIREMENTS = {
+    "statsmodels": "0.12.1",
+}
 EXTRAS_REQUIRE = {
     "all_extras": [
         "cython>=0.29.0",
@@ -86,6 +89,10 @@ INSTALL_REQUIRES = [
     *[
         "{}>={}".format(package, version)
         for package, version in MIN_REQUIREMENTS.items()
+    ],
+    *[
+        "{}<={}".format(package, version)
+        for package, version in MAX_REQUIREMENTS.items()
     ],
     "wheel",
 ]


### PR DESCRIPTION
This is a temporary fix for #1478, what looks like a bug introduced with `statsmodels` 0.13.0 through an interface hange that has not yet propagated to `tsfresh`.

Besides setting a max `statsmodels` version of 0.12.1 (the latest version before 0.13.0), it adds a `MAX_REQUIREMENTS` list to the `setup.py`.