### PR TITLE
1478 remove tsfresh from tests

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -110,6 +110,9 @@ EXCLUDE_ESTIMATORS = [
     "ProximityForest",
     "ProximityStump",
     "ProximityTree",
+    # temporary due to tsfresh related bug?
+    "TSfreshClassifier",
+    "TSFreshFeatureExtractor",
 ]
 
 


### PR DESCRIPTION
Another attempt at a temporary fix for the `tsfresh` issue - simply removing from tests.

Minor note, we should be using `pytest.xfail` for this and not custom test logic, @mloning ... but I've just added it in the place that we are currently using.