### PR TITLE
[ENH] GroupedForecaster

### DIFF
--- a/sktime/forecasting/meta/grouped_forecaster.py
+++ b/sktime/forecasting/meta/grouped_forecaster.py
@@ -9,6 +9,9 @@ import pandas as pd
 from sklearn import clone
 
 from sktime.forecasting.base import BaseForecaster
+from sktime.forecasting.base._base import DEFAULT_ALPHA
+from sktime.forecasting.model_evaluation import evaluate
+from sktime.forecasting.model_selection._tune import BaseGridSearch
 
 
 def as_list(val):
@@ -43,57 +46,56 @@ class GroupedForecaster(BaseForecaster):
 
     Splits data and aggregates time series into groups by values of a single column
     and fits one estimator per group.
+    If the estimator is a gridsearch:
+        1. First perform gridsearch per group.
+        2. Each grid's best hyperparameters
+        3. When reusing the model (by fitting or predicting): only use best models from
+            step 2, don't refit grid search.
 
     :param estimator: the model/pipeline to be applied per group
-    :param groups: the column of the dataframe to select as a grouping parameter set
+    :param depth: integer defining the depth of aggregation:
+                  0 is top-level, 1 is 1 split below, etc
     :param aggregations: dictionary mapping col names to aggregation methods/functions
-    :param use_global_model: whether or not to fall back to a general model in case the
-                            group parameter is not found during `.predict()`
+    :param fallback_model: model to use when an error is raised during fitting of group
     """
+
+    _tags = {
+        "scitype:y": "both",
+        "ignores-exogeneous-X": False,
+        "y_inner_mtype": "pd.Series",
+        "requires-fh-in-fit": False,
+    }
 
     def __init__(
         self,
         estimator,
-        groups,
-        aggregations,
-        use_global_model=True,
+        depth,
+        fallback_model=None,
     ):
         self.estimator = estimator
-        self.groups = groups
-        self.aggregations = aggregations
-        self.use_global_model = use_global_model
+        self.depth = depth
+        self.fallback_model = fallback_model
         super(GroupedForecaster, self).__init__()
+        self.estimators_ = None
+        self.grids = {}
 
-    def __aggregate_X(self, X, grouper):
-        return X.groupby(grouper).agg(
-            {key: val for key, val in self.aggregations.items() if key != "y"}
-        )
-
-    def __aggregate_y(self, y, grouper):
-        return y.groupby(grouper).agg(self.aggregations["y"])
-
-    def __fit_single_group(self, group, y, X=None, fh=None):
+    def __fit_single_ts(self, group, y, X=None, fh=None):
         try:
-            return clone(self.estimator).fit(y, X, fh)
+            X = None if X.empty else X
+            if not self.estimators_ and isinstance(self.estimator, BaseGridSearch):
+                estimator = clone(self.estimator).fit(y, X, fh)
+
+                # Save grid to later access grid CV results
+                self.grids[group] = estimator
+                return estimator.best_forecaster_
+
+            if self.estimators_ and isinstance(self.estimator, BaseGridSearch):
+                return clone(self.estimators_[group]).fit(y, X, fh)
+
+            else:
+                return clone(self.estimator).fit(y, X, fh)
         except Exception as e:
-            raise type(e)(f"Exception for group {group}: {e}")
-
-    def __fit_grouped_estimator(self, y, X, fh=None):
-        # Aggregate data on group-level to avoid multiple observations per timepoint
-        grouper = X[self.groups]
-        y = self.__aggregate_y(y, grouper)
-        X = self.__aggregate_X(X, grouper)
-
-        # Use these indices for every group
-        group_indices = X.groupby(self.groups).indices
-
-        grouped_estimators = {
-            # Fit a clone of the transformer to each group
-            group: self.__fit_single_group(group, y[indices], X[indices, :], fh)
-            for group, indices in group_indices.items()
-        }
-
-        return grouped_estimators
+            raise type(e)(f"Exception for time serie of group {group}: {e}")
 
     def _fit(self, y, X, fh=None):
         """
@@ -106,16 +108,31 @@ class GroupedForecaster(BaseForecaster):
         """
         self.fallback_ = None
 
-        if self.use_global_model:
-            self.fallback_ = clone(self.estimator).fit(y, X, fh)
+        if self.fallback_model:
+            self.fallback_ = clone(self.fallback_model).fit(y, X, fh)
 
-        self.estimators_ = self.__fit_grouped_estimator(y, X, fh)
+        # y needs to come in X as a workaround for sktime's current data checks
+        y = X.filter(regex="^y")
+        X = X.filter(regex="^(?!y).*")
+
+        # Get data from desired depth-level
+        y_cols_to_predict = [col for col in y.columns if col.count("__") == self.depth]
+        X_cols_to_predict = [col for col in X.columns if col.count("__") == self.depth]
+        X = X.loc[:, X_cols_to_predict]
+
+        self.estimators_ = {
+            # Fit a clone of the transformer to each time serie
+            group: self.__fit_single_ts(
+                group, y.loc[:, group], X.loc[:, X.columns.str.endswith(group[1:])], fh
+            )
+            for group in y_cols_to_predict
+        }
 
         self.groups_ = as_list(self.estimators_.keys())
 
         return self
 
-    def __predict_single_group(self, group, fh=None, X=None):
+    def __predict_single_ts(self, group, fh=None, X=None):
         """Predict a single group by getting its estimator from the fitted dict."""
         try:
             group_predictor = self.estimators_[group]
@@ -125,12 +142,12 @@ class GroupedForecaster(BaseForecaster):
             else:
                 raise ValueError(
                     f"Found new group {group} during predict with"
-                    "use_global_model = False"
+                    "fallback_model = None"
                 )
+        X = None if X.empty else X
+        return pd.DataFrame(group_predictor.predict(X=X, fh=fh))
 
-        return pd.DataFrame(group_predictor.predict(X))
-
-    def _predict(self, fh=None, X=None):
+    def _predict(self, fh=None, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA):
         """
         Predict for all groups on new data.
 
@@ -138,17 +155,52 @@ class GroupedForecaster(BaseForecaster):
         :param X: XXX
         :return: array, shape=(n_samples,) the predicted data
         """
-        X = self.__aggregate_X(X, X[self.groups])
-        if X:
-            group_indices = X.groupby(self.groups).indices
-            return (
-                pd.concat(
-                    [
-                        self.__predict_single_group(group, fh, X.loc[indices, :])
-                        for group, indices in group_indices.items()
-                    ],
-                    axis=0,
+        if return_pred_int:
+            raise NotImplementedError()
+        # y needs to come in X as a workaround for sktime's current data checks
+        X = X.filter(regex="^(?!y).*")
+
+        # Get data from desired depth-level
+        X_cols_to_use = [col for col in X.columns if col.count("__") == self.depth]
+        X = X.loc[:, X_cols_to_use]
+
+        return pd.concat(
+            [
+                self.__predict_single_ts(
+                    group, fh, X.loc[:, X.columns.str.endswith(group[1:])]
                 )
-                .sort_index()
-                .values.squeeze()
+                for group in self.groups_
+            ],
+            axis=1,
+        ).sum(axis=1)
+
+    def _get_cv_results_agg(self, y, X, scoring=None, cv=None):
+        if not isinstance(self.estimator, BaseGridSearch):
+            raise ValueError("forecaster should be a BaseGridSearch to get cv results")
+        aggregated_results = evaluate(
+            self,
+            cv if cv else self.estimator.cv,
+            y,
+            X,
+            scoring=scoring if scoring else self.estimator.scoring,
+        ).reset_index(drop=True)
+        return aggregated_results
+
+    def _get_cv_results_clustered(self):
+        if not isinstance(self.estimator, BaseGridSearch):
+            raise ValueError("forecaster should be a BaseGridSearch to get cv results")
+        clustered_results = (
+            pd.concat(
+                [
+                    (
+                        grid.cv_results_.assign(
+                            **grid.cv_results_.params.apply(pd.Series), group=group
+                        )
+                    )
+                    for group, grid in self.grids.items()
+                ]
             )
+            if self.grids
+            else None
+        ).reset_index(drop=True)
+        return clustered_results


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
Let's say we want to forecast daily worldwide sales for company X. We have daily sales data per country where X operates: our dataset contains three columns: `date`, `sales`, and `country`. Now we could consider three modelling options:
1. Aggregate all daily sales and estimate with a single model
2. Cluster countries with similar patterns or characteristics, aggregate per cluster and model per cluster
3. Model all countries separately

Currently, `sktime` only supports option 1. For 2 and 3, it is still necessary to write a custom framework to try different aggregations of X and y and compare performance of strategy 1,2, and 3. In this draft PR I'd like to propose a meta-estimator that removes the need for such custom frameworks.

This PR basically imitates the `GroupedEstimator` meta-estimator from the `scikit-lego` such that it is compatible with `sktime`. For further understanding of the approach I'd recommend to take one minute to read through `scikit-lego`'s documentation:
https://scikit-lego.readthedocs.io/en/latest/meta.html#Grouped-Prediction

#### Does your contribution introduce a new dependency? If yes, which one?

#### What should a reviewer concentrate their feedback on?

#### Any other comments?
Very interested in your feedback!

#### PR checklist
- [ ] Finish `GroupedForecaster`
- [ ] Writing tests for `GroupedForecaster`
- [ ] Adjustment of `forecasting.model_evaluation.evaluate` to support aggregation of y (and X)
- [ ] Adjustment of check_y_X to support duplicate datetimeindex when `isinstance(forecaster, GroupedForecaster)`

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.

