### PR TITLE
[DOC] roles overview: added martin to cc

### DIFF
--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -21,6 +21,8 @@ Community Council
      - :user:`fkiraly`
    * - Markus Löning
      - :user:`mloning`
+   * - Martin Walter
+     - :user:`aiwalter`
 
 Code of Conduct Committee
 -------------------------


### PR DESCRIPTION
This PR adds @aiwalter to the CC section of the roles document after his appointment.