### PR TITLE
Fixes #1596

### DIFF
--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -62,9 +62,7 @@ class BaseClassifier(BaseEstimator):
 
         Parameters
         ----------
-        X : 2D np.array (univariate, equal length series) of shape = [n_instances,
-            series_length]
-            or 3D np.array (any number of dimensions, equal length series) of shape =
+        3D np.array (any number of dimensions, equal length series) of shape =
             [n_instances,n_dimensions,series_length]
             or pd.DataFrame with each column a dimension, each cell a pd.Series (any
             number of dimensions, equal or unequal length series)


### PR DESCRIPTION
Changed the documentation of sktime.classification.base.BaseClassifier.fit to clear the misunderstanding that it can accept a 2D numpy.array as input for X.