### PR TITLE
convert 2D to 3D rather than throw exception

### DIFF
--- a/sktime/utils/validation/panel.py
+++ b/sktime/utils/validation/panel.py
@@ -12,9 +12,11 @@ import numpy as np
 import pandas as pd
 from sklearn.utils.validation import check_consistent_length
 
-from sktime.datatypes._panel._convert import from_3d_numpy_to_nested
-from sktime.datatypes._panel._convert import from_nested_to_3d_numpy
 from sktime.datatypes._panel._check import is_nested_dataframe
+from sktime.datatypes._panel._convert import (
+    from_3d_numpy_to_nested,
+    from_nested_to_3d_numpy,
+)
 
 VALID_X_TYPES = (pd.DataFrame, np.ndarray)  # nested pd.DataFrame and 3d np.array
 VALID_Y_TYPES = (pd.Series, np.ndarray)  # 1-d vector

--- a/sktime/utils/validation/panel.py
+++ b/sktime/utils/validation/panel.py
@@ -76,7 +76,7 @@ def check_X(
             X = X.reshape(X.shape[0], 1, X.shape[1])
         elif X.ndim == 1 or X.ndim > 3:
             raise ValueError(
-                f"If passed as a np.array, X must be a2 or 3-dimensional "
+                f"If passed as a np.array, X must be a 2 or 3-dimensional "
                 f"array, but found shape: {X.shape}"
             )
         if coerce_to_pandas:

--- a/sktime/utils/validation/panel.py
+++ b/sktime/utils/validation/panel.py
@@ -70,9 +70,11 @@ def check_X(
     # check first if we have the right number of dimensions, otherwise we
     # may not be able to get the shape of the second dimension below
     if isinstance(X, np.ndarray):
-        if not X.ndim == 3:
+        if not X.ndim == 2:
+            X = trainX.reshape(X.shape[0], 1, X.shape[1])
+        elif X.ndim == 1 or X.ndim > 3:
             raise ValueError(
-                f"If passed as a np.array, X must be a 3-dimensional "
+                f"If passed as a np.array, X must be a2 or 3-dimensional "
                 f"array, but found shape: {X.shape}"
             )
         if coerce_to_pandas:

--- a/sktime/utils/validation/panel.py
+++ b/sktime/utils/validation/panel.py
@@ -73,7 +73,7 @@ def check_X(
     # may not be able to get the shape of the second dimension below
     if isinstance(X, np.ndarray):
         if not X.ndim == 2:
-            X = trainX.reshape(X.shape[0], 1, X.shape[1])
+            X = X.reshape(X.shape[0], 1, X.shape[1])
         elif X.ndim == 1 or X.ndim > 3:
             raise ValueError(
                 f"If passed as a np.array, X must be a2 or 3-dimensional "

--- a/sktime/utils/validation/panel.py
+++ b/sktime/utils/validation/panel.py
@@ -72,7 +72,7 @@ def check_X(
     # check first if we have the right number of dimensions, otherwise we
     # may not be able to get the shape of the second dimension below
     if isinstance(X, np.ndarray):
-        if not X.ndim == 2:
+        if X.ndim == 2:
             X = X.reshape(X.shape[0], 1, X.shape[1])
         elif X.ndim == 1 or X.ndim > 3:
             raise ValueError(

--- a/sktime/utils/validation/tests/test_panel.py
+++ b/sktime/utils/validation/tests/test_panel.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
+"""Unit tests for sktime.utils.validation.panel check functions."""
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning", "TonyBagnall"]
 __all__ = ["test_check_X_bad_input_args"]
 
 import numpy as np

--- a/sktime/utils/validation/tests/test_panel.py
+++ b/sktime/utils/validation/tests/test_panel.py
@@ -22,6 +22,7 @@ y = pd.Series(dtype=np.int)
 
 @pytest.mark.parametrize("X", BAD_INPUT_ARGS)
 def test_check_X_bad_input_args(X):
+    """Test for the correct reaction for bad input in check_X."""
     with pytest.raises(ValueError):
         check_X(X)
 
@@ -30,6 +31,7 @@ def test_check_X_bad_input_args(X):
 
 
 def test_check_enforce_min_instances():
+    """Test minimum instances enforced in check_X."""
     X, y = make_classification_problem(n_instances=3)
     msg = r"instance"
     with pytest.raises(ValueError, match=msg):
@@ -43,6 +45,7 @@ def test_check_enforce_min_instances():
 
 
 def test_check_X_enforce_univariate():
+    """Test univariate enforced in check_X."""
     X, y = make_classification_problem(n_columns=2)
     msg = r"univariate"
     with pytest.raises(ValueError, match=msg):
@@ -53,6 +56,7 @@ def test_check_X_enforce_univariate():
 
 
 def test_check_X_enforce_min_columns():
+    """Test minimum columns enforced in check_X."""
     X, y = make_classification_problem(n_columns=2)
     msg = r"columns"
     with pytest.raises(ValueError, match=msg):

--- a/sktime/utils/validation/tests/test_panel.py
+++ b/sktime/utils/validation/tests/test_panel.py
@@ -15,7 +15,6 @@ from sktime.utils.validation.panel import check_y
 
 BAD_INPUT_ARGS = [
     [0, 1, 2],  # list
-    np.empty((3, 2)),  # 2d np.array
     np.empty(2),  # 1d np.array
     np.empty((3, 2, 3, 2)),  # 4d np.array
     pd.DataFrame(np.empty((2, 3))),  # non-nested pd.DataFrame

--- a/sktime/utils/validation/tests/test_panel.py
+++ b/sktime/utils/validation/tests/test_panel.py
@@ -9,9 +9,7 @@ import pandas as pd
 import pytest
 
 from sktime.utils._testing.panel import make_classification_problem
-from sktime.utils.validation.panel import check_X
-from sktime.utils.validation.panel import check_X_y
-from sktime.utils.validation.panel import check_y
+from sktime.utils.validation.panel import check_X, check_X_y, check_y
 
 BAD_INPUT_ARGS = [
     [0, 1, 2],  # list


### PR DESCRIPTION
#### Reference Issues/PRs

https://github.com/alan-turing-institute/sktime/issues/1596

#### What does this implement/fix? Explain your changes.

This is a very simple fix to allow 2D numpy input to represent univariate, equal length time series, where each row is a series. If a 2D is passed, it is just converted in check_X to 3D. All the classifiers that only accept univariate equal length simply convert any input into a 2D numpy anyway, so this is the easiest way to allow for 2D input without having to change a large number of classifiers. I believe the conversion is a constant time operation i.e. it does not clone the data, but just changes the iteration (although feel free to disabuse me). I had meant to bring this in as part of a bigger change to the base classifier, https://github.com/alan-turing-institute/sktime/pull/1594 but I have run into some testing errors that are beyond my competence to solve, at least without pain. So this is a compromise. 

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Assuming the testing doesn't break, the issue is really whether we want to accept 2D input for univariate, equal length series, rather than insist on 3D. I feel quite strongly we should, it greatly simplifies the getting started use case, but if there are general objections we can ditch the plan. 

