### PR TITLE
load from UCR fix

### DIFF
--- a/sktime/contrib/vector_classifiers/_rotation_forest.py
+++ b/sktime/contrib/vector_classifiers/_rotation_forest.py
@@ -229,8 +229,8 @@ class RotationForest(BaseEstimator):
                 estimators, pcas, groups, transformed_data = zip(*fit)
 
                 self.estimators_ += estimators
-                self._pcas = pcas
-                self._groups = groups
+                self._pcas += pcas
+                self._groups += groups
                 self.transformed_data += transformed_data
 
                 self._n_estimators += self._n_jobs

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -122,7 +122,7 @@ def _list_downloaded_datasets(extract_path):
     return datasets
 
 
-def load_UCR_UEA_dataset(name, split=None, return_X_y=False, extract_path=None):
+def load_UCR_UEA_dataset(name, split=None, return_X_y=True, extract_path=None):
     """Load dataset from UCR UEA time series archive.
 
     Downloads and extracts dataset if not already downloaded. Data is assumed to be
@@ -208,6 +208,7 @@ def _load_dataset(name, split, return_X_y, extract_path=None):
             result = load_from_tsfile_to_dataframe(abspath)
             X = pd.concat([X, pd.DataFrame(result[0])])
             y = pd.concat([y, pd.Series(result[1])])
+        y = pd.Series.to_numpy(y, dtype=np.str)
     else:
         raise ValueError("Invalid `split` value =", split)
 

--- a/sktime/utils/data_io.py
+++ b/sktime/utils/data_io.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 """Functions for the input and output of data and results.
-
+todo: This file will be removed in version 0.10 and functionality moved to
 datasets/_data_io.py
 """
 
 import itertools
 import os
 import textwrap
+from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -34,7 +35,6 @@ def load_from_tsfile_to_dataframe(
     replace_missing_vals_with="NaN",
 ):
     """Load data from a .ts file into a Pandas DataFrame.
-
     Parameters
     ----------
     full_file_path_and_name: str
@@ -46,7 +46,6 @@ def load_from_tsfile_to_dataframe(
     replace_missing_vals_with: str
        The value that missing values in the text file should be replaced
        with prior to parsing.
-
     Returns
     -------
     DataFrame, ndarray
@@ -58,6 +57,11 @@ def load_from_tsfile_to_dataframe(
         all time-series and (if relevant) a column "class_vals" the
         associated class values.
     """
+    warn(
+        "This function has moved to datasets/_data_io, this version will be removed "
+        "in V0.10",
+        FutureWarning,
+    )
     # Initialize flags and variables used when parsing the file
     metadata_started = False
     data_started = False
@@ -747,7 +751,6 @@ def load_from_arff_to_dataframe(
     replace_missing_vals_with="NaN",
 ):
     """Load data from a .ts file into a Pandas DataFrame.
-
     Parameters
     ----------
     full_file_path_and_name: str
@@ -763,7 +766,6 @@ def load_from_arff_to_dataframe(
     replace_missing_vals_with: str
        The value that missing values in the text file should be replaced
        with prior to parsing.
-
     Returns
     -------
     DataFrame, ndarray
@@ -775,6 +777,11 @@ def load_from_arff_to_dataframe(
         all time-series and (if relevant) a column "class_vals" the
         associated class values.
     """
+    warn(
+        "This function has moved to datasets/_data_io, this version will be removed "
+        "in V0.10",
+        FutureWarning,
+    )
     instance_list = []
     class_val_list = []
 
@@ -863,7 +870,6 @@ def load_from_ucr_tsv_to_dataframe(
     full_file_path_and_name, return_separate_X_and_y=True
 ):
     """Load data from a .tsv file into a Pandas DataFrame.
-
     Parameters
     ----------
     full_file_path_and_name: str
@@ -872,7 +878,6 @@ def load_from_ucr_tsv_to_dataframe(
         true then X and Y values should be returned as separate Data Frames (
         X) and a numpy array (y), false otherwise.
         This is only relevant for data.
-
     Returns
     -------
     DataFrame, ndarray
@@ -884,6 +889,11 @@ def load_from_ucr_tsv_to_dataframe(
         all time-series and (if relevant) a column "class_vals" the
         associated class values.
     """
+    warn(
+        "This function has moved to datasets/_data_io, this version will be removed "
+        "in V0.10",
+        FutureWarning,
+    )
     df = pd.read_csv(full_file_path_and_name, sep="\t", header=None)
     y = df.pop(0).values
     df.columns -= 1
@@ -897,19 +907,22 @@ def load_from_ucr_tsv_to_dataframe(
 
 def load_from_long_to_dataframe(full_file_path_and_name, separator=","):
     """Load data from a long format file into a Pandas DataFrame.
-
     Parameters
     ----------
     full_file_path_and_name: str
         The full pathname of the .csv file to read.
     separator: str
         The character that the csv uses as a delimiter
-
     Returns
     -------
     DataFrame
         A dataframe with sktime-formatted data
     """
+    warn(
+        "This function has moved to datasets/_data_io, this version will be removed "
+        "in V0.10",
+        FutureWarning,
+    )
     data = pd.read_csv(full_file_path_and_name, sep=separator, header=0)
     # ensure there are 4 columns in the long_format table
     if len(data.columns) != 4:
@@ -933,7 +946,6 @@ def load_from_long_to_dataframe(full_file_path_and_name, separator=","):
 # left here for now, better elsewhere later perhaps
 def generate_example_long_table(num_cases=50, series_len=20, num_dims=2):
     """Generate example from long table format file.
-
     Parameters
     ----------
     num_cases: int
@@ -942,11 +954,15 @@ def generate_example_long_table(num_cases=50, series_len=20, num_dims=2):
         Length of the series.
     num_dims: int
         Number of dimensions.
-
     Returns
     -------
     DataFrame
     """
+    warn(
+        "This function has moved to datasets/_data_io, this version will be removed "
+        "in V0.10",
+        FutureWarning,
+    )
     rows_per_case = series_len * num_dims
     total_rows = num_cases * series_len * num_dims
 
@@ -971,24 +987,25 @@ def generate_example_long_table(num_cases=50, series_len=20, num_dims=2):
 
 def make_multi_index_dataframe(n_instances=50, n_columns=3, n_timepoints=20):
     """Generate example multi-index DataFrame.
-
     Parameters
     ----------
     n_instances : int
         Number of instances.
-
     n_columns : int
         Number of columns (series) in multi-indexed DataFrame.
-
     n_timepoints : int
         Number of timepoints per instance-column pair.
-
     Returns
     -------
     mi_df : pd.DataFrame
         The multi-indexed DataFrame with
         shape (n_instances*n_timepoints, n_column).
     """
+    warn(
+        "This function has moved to datasets/_data_io, this version will be removed "
+        "in V0.10",
+        FutureWarning,
+    )
     # Make long DataFrame
     long_df = generate_example_long_table(
         num_cases=n_instances, series_len=n_timepoints, num_dims=n_columns
@@ -1016,7 +1033,6 @@ def write_results_to_uea_format(
     third_line="N/A",
 ):
     """Write the predictions for an experiment in the standard format used by sktime.
-
     Parameters
     ----------
     estimator_name : str,
@@ -1049,6 +1065,11 @@ def write_results_to_uea_format(
     third_line : str
         summary performance information (see comment below)
     """
+    warn(
+        "This function has moved to datasets/_data_io, this version will be removed "
+        "in V0.10",
+        FutureWarning,
+    )
     if len(y_true) != len(y_pred):
         raise IndexError(
             "The number of predicted values is not the same as the "
@@ -1156,7 +1177,6 @@ def write_tabular_transformation_to_arff(
 ):
     """
     Transform a dataset using a tabular transformer and write the result to a arff file.
-
     Parameters
     ----------
     data: pandas dataframe or 3d numpy array
@@ -1180,11 +1200,15 @@ def write_tabular_transformation_to_arff(
         Addon at the end of the filename, i.e. _TRAIN or _TEST.
     fit_transform: bool, default=True
         Whether to fit the transformer prior to calling transform.
-
     Returns
     -------
     None
     """
+    warn(
+        "This function has moved to datasets/_data_io, this version will be removed "
+        "in V0.10",
+        FutureWarning,
+    )
     # ensure transformation provided is a transformer
     if not isinstance(transformation, BaseTransformer):
         raise ValueError("Transformation must be a BaseTransformer")
@@ -1269,7 +1293,6 @@ def write_dataframe_to_tsfile(
 ):
     """
     Output a dataset in dataframe format to .ts file.
-
     Parameters
     ----------
     data: pandas dataframe
@@ -1301,15 +1324,17 @@ def write_dataframe_to_tsfile(
         Comment text to be inserted before the header in a block.
     fold: str or None, default=None
         Addon at the end of the filename, i.e. _TRAIN or _TEST.
-
     Returns
     -------
     None
-
     Notes
     -----
     This version currently does not support writing timestamp data.
     """
+    warn(
+        "This function has moved to datasets/_data_io, this version will be removed "
+        "in V0.10"
+    )
     # ensure data provided is a dataframe
     if not isinstance(data, pd.DataFrame):
         raise ValueError("Data provided must be a DataFrame")
@@ -1348,7 +1373,6 @@ def write_ndarray_to_tsfile(
 ):
     """
     Output a dataset in ndarray format to .ts file.
-
     Parameters
     ----------
     data: pandas dataframe
@@ -1376,15 +1400,17 @@ def write_ndarray_to_tsfile(
         Comment text to be inserted before the header in a block.
     fold: str or None, default=None
         Addon at the end of the filename, i.e. _TRAIN or _TEST.
-
     Returns
     -------
     None
-
     Notes
     -----
     This version currently does not support writing timestamp data.
     """
+    warn(
+        "This function has moved to datasets/_data_io, this version will be removed "
+        "in V0.10"
+    )
     # ensure data provided is a ndarray
     if not isinstance(data, np.ndarray):
         raise ValueError("Data provided must be a ndarray")

--- a/sktime/utils/data_io.py
+++ b/sktime/utils/data_io.py
@@ -1422,7 +1422,7 @@ def write_ndarray_to_tsfile(
     Returns
     -------
     None
-    
+
     Notes
     -----
     This version currently does not support writing timestamp data.

--- a/sktime/utils/data_io.py
+++ b/sktime/utils/data_io.py
@@ -35,6 +35,7 @@ def load_from_tsfile_to_dataframe(
     replace_missing_vals_with="NaN",
 ):
     """Load data from a .ts file into a Pandas DataFrame.
+
     Parameters
     ----------
     full_file_path_and_name: str
@@ -751,6 +752,7 @@ def load_from_arff_to_dataframe(
     replace_missing_vals_with="NaN",
 ):
     """Load data from a .ts file into a Pandas DataFrame.
+
     Parameters
     ----------
     full_file_path_and_name: str
@@ -766,6 +768,7 @@ def load_from_arff_to_dataframe(
     replace_missing_vals_with: str
        The value that missing values in the text file should be replaced
        with prior to parsing.
+
     Returns
     -------
     DataFrame, ndarray
@@ -870,6 +873,7 @@ def load_from_ucr_tsv_to_dataframe(
     full_file_path_and_name, return_separate_X_and_y=True
 ):
     """Load data from a .tsv file into a Pandas DataFrame.
+
     Parameters
     ----------
     full_file_path_and_name: str
@@ -878,6 +882,7 @@ def load_from_ucr_tsv_to_dataframe(
         true then X and Y values should be returned as separate Data Frames (
         X) and a numpy array (y), false otherwise.
         This is only relevant for data.
+
     Returns
     -------
     DataFrame, ndarray
@@ -907,12 +912,14 @@ def load_from_ucr_tsv_to_dataframe(
 
 def load_from_long_to_dataframe(full_file_path_and_name, separator=","):
     """Load data from a long format file into a Pandas DataFrame.
+
     Parameters
     ----------
     full_file_path_and_name: str
         The full pathname of the .csv file to read.
     separator: str
         The character that the csv uses as a delimiter
+
     Returns
     -------
     DataFrame
@@ -946,6 +953,7 @@ def load_from_long_to_dataframe(full_file_path_and_name, separator=","):
 # left here for now, better elsewhere later perhaps
 def generate_example_long_table(num_cases=50, series_len=20, num_dims=2):
     """Generate example from long table format file.
+
     Parameters
     ----------
     num_cases: int
@@ -954,6 +962,7 @@ def generate_example_long_table(num_cases=50, series_len=20, num_dims=2):
         Length of the series.
     num_dims: int
         Number of dimensions.
+
     Returns
     -------
     DataFrame
@@ -987,6 +996,7 @@ def generate_example_long_table(num_cases=50, series_len=20, num_dims=2):
 
 def make_multi_index_dataframe(n_instances=50, n_columns=3, n_timepoints=20):
     """Generate example multi-index DataFrame.
+
     Parameters
     ----------
     n_instances : int
@@ -995,6 +1005,7 @@ def make_multi_index_dataframe(n_instances=50, n_columns=3, n_timepoints=20):
         Number of columns (series) in multi-indexed DataFrame.
     n_timepoints : int
         Number of timepoints per instance-column pair.
+
     Returns
     -------
     mi_df : pd.DataFrame
@@ -1033,6 +1044,7 @@ def write_results_to_uea_format(
     third_line="N/A",
 ):
     """Write the predictions for an experiment in the standard format used by sktime.
+
     Parameters
     ----------
     estimator_name : str,
@@ -1177,6 +1189,7 @@ def write_tabular_transformation_to_arff(
 ):
     """
     Transform a dataset using a tabular transformer and write the result to a arff file.
+
     Parameters
     ----------
     data: pandas dataframe or 3d numpy array
@@ -1200,6 +1213,7 @@ def write_tabular_transformation_to_arff(
         Addon at the end of the filename, i.e. _TRAIN or _TEST.
     fit_transform: bool, default=True
         Whether to fit the transformer prior to calling transform.
+
     Returns
     -------
     None
@@ -1293,6 +1307,7 @@ def write_dataframe_to_tsfile(
 ):
     """
     Output a dataset in dataframe format to .ts file.
+
     Parameters
     ----------
     data: pandas dataframe
@@ -1324,9 +1339,11 @@ def write_dataframe_to_tsfile(
         Comment text to be inserted before the header in a block.
     fold: str or None, default=None
         Addon at the end of the filename, i.e. _TRAIN or _TEST.
+
     Returns
     -------
     None
+
     Notes
     -----
     This version currently does not support writing timestamp data.
@@ -1373,6 +1390,7 @@ def write_ndarray_to_tsfile(
 ):
     """
     Output a dataset in ndarray format to .ts file.
+
     Parameters
     ----------
     data: pandas dataframe
@@ -1400,9 +1418,11 @@ def write_ndarray_to_tsfile(
         Comment text to be inserted before the header in a block.
     fold: str or None, default=None
         Addon at the end of the filename, i.e. _TRAIN or _TEST.
+
     Returns
     -------
     None
+    
     Notes
     -----
     This version currently does not support writing timestamp data.

--- a/sktime/utils/data_io.py
+++ b/sktime/utils/data_io.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 """Functions for the input and output of data and results.
 
-todo: This file will be removed in version 0.10 and functionality moved to
 datasets/_data_io.py
 """
 
 import itertools
 import os
 import textwrap
-from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -60,11 +58,6 @@ def load_from_tsfile_to_dataframe(
         all time-series and (if relevant) a column "class_vals" the
         associated class values.
     """
-    warn(
-        "This function has moved to datasets/_data_io, this version will be removed "
-        "in V0.10",
-        FutureWarning,
-    )
     # Initialize flags and variables used when parsing the file
     metadata_started = False
     data_started = False
@@ -782,11 +775,6 @@ def load_from_arff_to_dataframe(
         all time-series and (if relevant) a column "class_vals" the
         associated class values.
     """
-    warn(
-        "This function has moved to datasets/_data_io, this version will be removed "
-        "in V0.10",
-        FutureWarning,
-    )
     instance_list = []
     class_val_list = []
 
@@ -896,11 +884,6 @@ def load_from_ucr_tsv_to_dataframe(
         all time-series and (if relevant) a column "class_vals" the
         associated class values.
     """
-    warn(
-        "This function has moved to datasets/_data_io, this version will be removed "
-        "in V0.10",
-        FutureWarning,
-    )
     df = pd.read_csv(full_file_path_and_name, sep="\t", header=None)
     y = df.pop(0).values
     df.columns -= 1
@@ -927,11 +910,6 @@ def load_from_long_to_dataframe(full_file_path_and_name, separator=","):
     DataFrame
         A dataframe with sktime-formatted data
     """
-    warn(
-        "This function has moved to datasets/_data_io, this version will be removed "
-        "in V0.10",
-        FutureWarning,
-    )
     data = pd.read_csv(full_file_path_and_name, sep=separator, header=0)
     # ensure there are 4 columns in the long_format table
     if len(data.columns) != 4:
@@ -969,11 +947,6 @@ def generate_example_long_table(num_cases=50, series_len=20, num_dims=2):
     -------
     DataFrame
     """
-    warn(
-        "This function has moved to datasets/_data_io, this version will be removed "
-        "in V0.10",
-        FutureWarning,
-    )
     rows_per_case = series_len * num_dims
     total_rows = num_cases * series_len * num_dims
 
@@ -1016,11 +989,6 @@ def make_multi_index_dataframe(n_instances=50, n_columns=3, n_timepoints=20):
         The multi-indexed DataFrame with
         shape (n_instances*n_timepoints, n_column).
     """
-    warn(
-        "This function has moved to datasets/_data_io, this version will be removed "
-        "in V0.10",
-        FutureWarning,
-    )
     # Make long DataFrame
     long_df = generate_example_long_table(
         num_cases=n_instances, series_len=n_timepoints, num_dims=n_columns
@@ -1081,11 +1049,6 @@ def write_results_to_uea_format(
     third_line : str
         summary performance information (see comment below)
     """
-    warn(
-        "This function has moved to datasets/_data_io, this version will be removed "
-        "in V0.10",
-        FutureWarning,
-    )
     if len(y_true) != len(y_pred):
         raise IndexError(
             "The number of predicted values is not the same as the "
@@ -1222,11 +1185,6 @@ def write_tabular_transformation_to_arff(
     -------
     None
     """
-    warn(
-        "This function has moved to datasets/_data_io, this version will be removed "
-        "in V0.10",
-        FutureWarning,
-    )
     # ensure transformation provided is a transformer
     if not isinstance(transformation, BaseTransformer):
         raise ValueError("Transformation must be a BaseTransformer")
@@ -1352,10 +1310,6 @@ def write_dataframe_to_tsfile(
     -----
     This version currently does not support writing timestamp data.
     """
-    warn(
-        "This function has moved to datasets/_data_io, this version will be removed "
-        "in V0.10"
-    )
     # ensure data provided is a dataframe
     if not isinstance(data, pd.DataFrame):
         raise ValueError("Data provided must be a DataFrame")
@@ -1431,10 +1385,6 @@ def write_ndarray_to_tsfile(
     -----
     This version currently does not support writing timestamp data.
     """
-    warn(
-        "This function has moved to datasets/_data_io, this version will be removed "
-        "in V0.10"
-    )
     # ensure data provided is a ndarray
     if not isinstance(data, np.ndarray):
         raise ValueError("Data provided must be a ndarray")

--- a/sktime/utils/data_io.py
+++ b/sktime/utils/data_io.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Functions for the input and output of data and results.
+
 todo: This file will be removed in version 0.10 and functionality moved to
 datasets/_data_io.py
 """
@@ -47,6 +48,7 @@ def load_from_tsfile_to_dataframe(
     replace_missing_vals_with: str
        The value that missing values in the text file should be replaced
        with prior to parsing.
+
     Returns
     -------
     DataFrame, ndarray


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1603 

#### What does this implement/fix? Explain your changes.
A few minor fixes
1. corrects a bug in contracted rotation forest: this was only a problem with small contracts and should not effect testing.
2. casts the target variable to numpy strings rather than Series strings when loading the concatenated train and test using load_UCR_UEA_dataset (#1603). This is needed to fix the problem in STC with numba, and it is more consistent, since these are returned when either train or test is loaded
3. removes the deprecation warning is data.io. tbh there is a lot in here that could be improved, so I think a gradual move over, with duplication is preferable
4. change the default return_X_y in load_UCR_UEA_dataset to True. I think its a legacy of Weka conversion to append the target variable, This could conceivably break something somewhere, although I cannot think of a reason to do it and the variable can still be set to False so its a very edgy edge case.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

I think (4) is the most controversial?

