### PR TITLE
Experiments tidy

### DIFF
--- a/sktime/benchmarking/experiments.py
+++ b/sktime/benchmarking/experiments.py
@@ -135,10 +135,10 @@ def run_clustering_experiment(
 def load_and_run_clustering_experiment(
     problem_path,
     results_path,
-    cls_name,
     dataset,
     clusterer,
     resample_id=0,
+    cls_name=None,
     overwrite=False,
     format=".ts",
     train_file=False,
@@ -156,13 +156,13 @@ def load_and_run_clustering_experiment(
         Location of problem files, full path.
     results_path : str
         Location of where to write results. Any required directories will be created
-    cls_name : str
-        determines which clusterer to use if clusterer is None. In this
-        case, set_clusterer is called with this cls_name
     dataset : str
         Name of problem. Files must be  <problem_path>/<dataset>/<dataset>+
         "_TRAIN"+format, same for "_TEST"
     clusterer : the clusterer
+    cls_name : str, default =None
+        determines what to call the write directory. If None, it is set to
+        type(clusterer).__name__
     resample_id : int, default = 0
         Seed for resampling. If set to 0, the default train/test split from file is
         used. Also used in output file name.
@@ -176,6 +176,9 @@ def load_and_run_clustering_experiment(
         whether to generate train files or not. If true, it performs a 10xCV on the
         train and saves
     """
+    if cls_name is None:
+        cls_name = type(clusterer).__name__
+
     # Set up the file path in standard format
     if not overwrite:
         full_path = (
@@ -403,10 +406,10 @@ def run_classification_experiment(
 def load_and_run_classification_experiment(
     problem_path,
     results_path,
-    cls_name,
     dataset,
     classifier,
     resample_id=0,
+    cls_name=None,
     overwrite=False,
     build_train=False,
     predefined_resample=False,
@@ -422,16 +425,15 @@ def load_and_run_classification_experiment(
         Location of problem files, full path.
     results_path : str
         Location of where to write results. Any required directories will be created.
-    cls_name : str
-        Name of classifier used in writing results. This assumes
-        predict_proba is implemented, to avoid predicting twice. May break some
-        classifiers though.
     dataset : str
         Name of problem. Files must be  <problem_path>/<dataset>/<dataset>+"_TRAIN.ts",
         same for "_TEST".
     classifier : BaseClassifier
         Classifier to be used in the experiment, if none is provided one is selected
         using cls_name using resample_id as a seed.
+    cls_name : str, default = None
+        Name of classifier used in writing results. If none the name is taken from
+        the classifier
     resample_id : int, default=0
         Seed for resampling. If set to 0, the default train/test split from file is
         used. Also used in output file name.
@@ -447,6 +449,8 @@ def load_and_run_classification_experiment(
         the file format must include the resample_id at the end of the dataset name i.e.
         <problem_path>/<dataset>/<dataset>+<resample_id>+"_TRAIN.ts".
     """
+    if cls_name is None:
+        cls_name = type(classifier).__name__
     # Check which files exist, if both exist, exit
     build_test = True
     if not overwrite:

--- a/sktime/benchmarking/experiments.py
+++ b/sktime/benchmarking/experiments.py
@@ -305,14 +305,10 @@ def run_classification_experiment(
             second.replace("\r", " ")
 
             # Line 3 format:
-
-
-
-            # 4. setBenchmarkTime
             preds = classifier.classes_[np.argmax(probs, axis=1)]
             acc = accuracy_score(y_test, preds)
             third = (
-                str(acc) # 1. accuracy
+                str(acc)  # 1. accuracy
                 + ","
                 + str(build_time)  # 2. fit time
                 + ","

--- a/sktime/benchmarking/experiments.py
+++ b/sktime/benchmarking/experiments.py
@@ -137,7 +137,7 @@ def load_and_run_clustering_experiment(
     results_path,
     cls_name,
     dataset,
-    clusterer=None,
+    clusterer,
     resample_id=0,
     overwrite=False,
     format=".ts",
@@ -162,6 +162,7 @@ def load_and_run_clustering_experiment(
     dataset : str
         Name of problem. Files must be  <problem_path>/<dataset>/<dataset>+
         "_TRAIN"+format, same for "_TEST"
+    clusterer : the clusterer
     resample_id : int, default = 0
         Seed for resampling. If set to 0, the default train/test split from file is
         used. Also used in output file name.
@@ -216,9 +217,6 @@ def load_and_run_clustering_experiment(
     le.fit(trainY)
     trainY = le.transform(trainY)
     testY = le.transform(testY)
-    if clusterer is None:
-        clusterer = set_clusterer(cls_name, resample_id)
-
     run_clustering_experiment(
         trainX,
         clusterer,

--- a/sktime/benchmarking/experiments.py
+++ b/sktime/benchmarking/experiments.py
@@ -7,7 +7,6 @@ __author__ = ["TonyBagnall"]
 __all__ = [
     "run_clustering_experiment",
     "load_and_run_clustering_experiment",
-    "set_clusterer",
     "run_classification_experiment",
     "load_and_run_classification_experiment",
 ]
@@ -22,7 +21,6 @@ from sklearn import preprocessing
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import cross_val_predict
 
-from sktime.clustering import TimeSeriesKMeans, TimeSeriesKMedoids
 from sktime.utils.data_io import load_from_tsfile_to_dataframe as load_ts
 from sktime.utils.data_io import write_results_to_uea_format
 from sktime.utils.sampling import stratified_resample
@@ -231,47 +229,6 @@ def load_and_run_clustering_experiment(
         dataset_name=dataset,
         results_path=results_path,
     )
-
-
-def set_clusterer(cls, resample_id=None):
-    """Construct a clusterer.
-
-    Basic way of creating the clusterer to build using the default settings. This
-    set up is to help with batch jobs for multiple problems to facilitate easy
-    reproducability through run_clustering_experiment. You can set up bespoke
-    clusterers and pass them to run_clustering_experiment if you prefer. It also
-    serves to illustrate the base clusterer parameters
-
-    Parameters
-    ----------
-    cls : str
-        indicating which clusterer you want
-    resample_id : int or None, default = None
-        clusterer random seed
-
-    Return
-    ------
-    A clusterer.
-    """
-    name = cls.lower()
-    # Distance based
-    if name == "kmeans" or name == "k-means":
-        return TimeSeriesKMeans(
-            n_clusters=5,
-            max_iter=50,
-            averaging_algorithm="mean",
-            random_state=resample_id,
-        )
-    if name == "kmedoids" or name == "k-medoids":
-        return TimeSeriesKMedoids(
-            n_clusters=5,
-            max_iter=50,
-            averaging_algorithm="mean",
-            random_state=resample_id,
-        )
-
-    else:
-        raise Exception("UNKNOWN CLUSTERER")
 
 
 def run_classification_experiment(

--- a/sktime/benchmarking/experiments.py
+++ b/sktime/benchmarking/experiments.py
@@ -315,7 +315,7 @@ def run_classification_experiment(
                 + str(test_time)  # 3. predict time
                 + ",-1,-1,"  # 4. 5. benchmark time, memory (to do)
                 + str(len(classifier.classes_))  # 6. number of classes
-                + ",,-1,-1"  # 7. 8. error estimate method, build plus estimate time
+                + ",,-1,-1"  # 7. 8. 9.
             )
             le = preprocessing.LabelEncoder()
             le.fit(y_test)

--- a/sktime/benchmarking/experiments.py
+++ b/sktime/benchmarking/experiments.py
@@ -304,18 +304,27 @@ def run_classification_experiment(
             second.replace("\n", " ")
             second.replace("\r", " ")
 
+            # Line 3 format:
+
+
+
+            # 4. setBenchmarkTime
             preds = classifier.classes_[np.argmax(probs, axis=1)]
             acc = accuracy_score(y_test, preds)
             third = (
-                str(acc)
+                str(acc) # 1. accuracy
                 + ","
-                + str(build_time)
+                + str(build_time)  # 2. fit time
                 + ","
-                + str(test_time)
-                + ",-1,-1,"
-                + str(len(classifier.classes_))
-                + ",,-1,-1"
+                + str(test_time)  # 3. predict time
+                + ",-1,-1,"  # 4. 5. benchmark time, memory (to do)
+                + str(len(classifier.classes_))  # 6. number of classes
+                + ",,-1,-1"  # 7. 8. error estimate method, build plus estimate time
             )
+            le = preprocessing.LabelEncoder()
+            le.fit(y_test)
+            predicted = le.transform(preds)
+            actual = le.transform(y_test)
 
             write_results_to_uea_format(
                 second_line=second,
@@ -327,10 +336,10 @@ def run_classification_experiment(
                 output_path=results_path,
                 estimator_name=cls_name,
                 resample_seed=resample_id,
-                y_pred=preds,
+                y_pred=predicted,
                 predicted_probs=probs,
                 dataset_name=dataset,
-                y_true=y_test,
+                y_true=actual,
                 split="TEST",
                 full_path=False,
             )
@@ -371,6 +380,10 @@ def run_classification_experiment(
             + ","
             + str(build_time + train_time)
         )
+        le = preprocessing.LabelEncoder()
+        le.fit(y_train)
+        predicted = le.transform(train_preds)
+        actual = le.transform(y_train)
 
         write_results_to_uea_format(
             second_line=second,
@@ -382,10 +395,10 @@ def run_classification_experiment(
             output_path=results_path,
             estimator_name=cls_name,
             resample_seed=resample_id,
-            y_pred=train_preds,
+            y_pred=predicted,
             predicted_probs=train_probs,
             dataset_name=dataset,
-            y_true=y_train,
+            y_true=actual,
             split="TRAIN",
             full_path=False,
         )

--- a/sktime/benchmarking/experiments.py
+++ b/sktime/benchmarking/experiments.py
@@ -3,14 +3,13 @@
 
 Results are saved a standardised format used by both tsml and sktime.
 """
-__author__ = ["Tony Bagnall"]
+__author__ = ["TonyBagnall"]
 __all__ = [
     "run_clustering_experiment",
     "load_and_run_clustering_experiment",
     "set_clusterer",
     "run_classification_experiment",
     "load_and_run_classification_experiment",
-    "set_classifier",
 ]
 
 
@@ -20,44 +19,9 @@ from datetime import datetime
 
 import numpy as np
 from sklearn import preprocessing
-from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import cross_val_predict
 
-from sktime.classification.dictionary_based import (
-    MUSE,
-    WEASEL,
-    BOSSEnsemble,
-    ContractableBOSS,
-    TemporalDictionaryEnsemble,
-)
-from sktime.classification.distance_based import (
-    ElasticEnsemble,
-    KNeighborsTimeSeriesClassifier,
-    ProximityForest,
-    ProximityStump,
-    ProximityTree,
-    ShapeDTW,
-)
-from sktime.classification.feature_based import (
-    Catch22Classifier,
-    MatrixProfileClassifier,
-    SignatureClassifier,
-    TSFreshClassifier,
-)
-from sktime.classification.hybrid import HIVECOTEV1, HIVECOTEV2
-from sktime.classification.interval_based import (
-    CanonicalIntervalForest,
-    DrCIF,
-    RandomIntervalSpectralEnsemble,
-    SupervisedTimeSeriesForest,
-    TimeSeriesForestClassifier,
-)
-from sktime.classification.kernel_based import Arsenal, ROCKETClassifier
-from sktime.classification.shapelet_based import (
-    MrSEQLClassifier,
-    ShapeletTransformClassifier,
-)
 from sktime.clustering import TimeSeriesKMeans, TimeSeriesKMedoids
 from sktime.utils.data_io import load_from_tsfile_to_dataframe as load_ts
 from sktime.utils.data_io import write_results_to_uea_format
@@ -477,7 +441,7 @@ def load_and_run_classification_experiment(
     results_path,
     cls_name,
     dataset,
-    classifier=None,
+    classifier,
     resample_id=0,
     overwrite=False,
     build_train=False,
@@ -495,13 +459,13 @@ def load_and_run_classification_experiment(
     results_path : str
         Location of where to write results. Any required directories will be created.
     cls_name : str
-        Determines which classifier to use, as defined in set_classifier. This assumes
+        Name of classifier used in writing results. This assumes
         predict_proba is implemented, to avoid predicting twice. May break some
         classifiers though.
     dataset : str
         Name of problem. Files must be  <problem_path>/<dataset>/<dataset>+"_TRAIN.ts",
         same for "_TEST".
-    classifier : BaseClassifier, default=None
+    classifier : BaseClassifier
         Classifier to be used in the experiment, if none is provided one is selected
         using cls_name using resample_id as a seed.
     resample_id : int, default=0
@@ -569,9 +533,6 @@ def load_and_run_classification_experiment(
                 X_train, y_train, X_test, y_test, resample_id
             )
 
-    if classifier is None:
-        classifier = set_classifier(cls_name, resample_id, build_train)
-
     run_classification_experiment(
         X_train,
         y_train,
@@ -585,114 +546,3 @@ def load_and_run_classification_experiment(
         train_file=build_train,
         test_file=build_test,
     )
-
-
-def set_classifier(cls, resample_id=None, train_file=False):
-    """Construct a classifier.
-
-    Basic way of creating the classifier to build using the default settings. This
-    set up is to help with batch jobs for multiple problems to facilitate easy
-    reproducibility for use with load_and_run_classification_experiment. You can pass a
-    classifier object instead to run_classification_experiment.
-
-    Parameters
-    ----------
-    cls : str
-        String indicating which classifier you want.
-    resample_id : int or None, default=None
-        Classifier random seed.
-    train_file : bool, default=False
-        Whether a train file is being produced.
-
-    Return
-    ------
-    classifier : A BaseClassifier.
-        The classifier matching the input classifier name.
-    """
-    name = cls.lower()
-    # Dictionary based
-    if name == "boss" or name == "bossensemble":
-        return BOSSEnsemble(random_state=resample_id)
-    elif name == "cboss" or name == "contractableboss":
-        return ContractableBOSS(random_state=resample_id)
-    elif name == "tde" or name == "temporaldictionaryensemble":
-        return TemporalDictionaryEnsemble(
-            random_state=resample_id, save_train_predictions=train_file
-        )
-    elif name == "weasel":
-        return WEASEL(random_state=resample_id)
-    elif name == "muse":
-        return MUSE(random_state=resample_id)
-    # Distance based
-    elif name == "pf" or name == "proximityforest":
-        return ProximityForest(random_state=resample_id)
-    elif name == "pt" or name == "proximitytree":
-        return ProximityTree(random_state=resample_id)
-    elif name == "ps" or name == "proximityStump":
-        return ProximityStump(random_state=resample_id)
-    elif name == "dtwcv" or name == "kneighborstimeseriesclassifier":
-        return KNeighborsTimeSeriesClassifier(distance="dtwcv")
-    elif name == "dtw" or name == "1nn-dtw":
-        return KNeighborsTimeSeriesClassifier(distance="dtw")
-    elif name == "msm" or name == "1nn-msm":
-        return KNeighborsTimeSeriesClassifier(distance="msm")
-    elif name == "ee" or name == "elasticensemble":
-        return ElasticEnsemble(random_state=resample_id)
-    elif name == "shapedtw":
-        return ShapeDTW()
-    # Feature based
-    elif name == "catch22":
-        return Catch22Classifier(
-            random_state=resample_id, estimator=RandomForestClassifier(n_estimators=500)
-        )
-    elif name == "matrixprofile":
-        return MatrixProfileClassifier(random_state=resample_id)
-    elif name == "signature":
-        return SignatureClassifier(
-            random_state=resample_id,
-            estimator=RandomForestClassifier(n_estimators=500),
-        )
-    elif name == "tsfresh":
-        return TSFreshClassifier(
-            random_state=resample_id, estimator=RandomForestClassifier(n_estimators=500)
-        )
-    elif name == "tsfresh-r":
-        return TSFreshClassifier(
-            random_state=resample_id,
-            estimator=RandomForestClassifier(n_estimators=500),
-            relevant_feature_extractor=True,
-        )
-    # Hybrid
-    elif name == "hc1" or name == "hivecotev1":
-        return HIVECOTEV1(random_state=resample_id)
-    elif name == "hc2" or name == "hivecotev2":
-        return HIVECOTEV2(random_state=resample_id)
-    # Interval based
-    elif name == "rise" or name == "randomintervalspectralforest":
-        return RandomIntervalSpectralEnsemble(
-            random_state=resample_id, n_estimators=500
-        )
-    elif name == "tsf" or name == "timeseriesforestclassifier":
-        return TimeSeriesForestClassifier(random_state=resample_id, n_estimators=500)
-    elif name == "cif" or name == "canonicalintervalforest":
-        return CanonicalIntervalForest(random_state=resample_id, n_estimators=500)
-    elif name == "stsf" or name == "supervisedtimeseriesforest":
-        return SupervisedTimeSeriesForest(random_state=resample_id, n_estimators=500)
-    elif name == "drcif":
-        return DrCIF(
-            random_state=resample_id, n_estimators=500, save_transformed_data=train_file
-        )
-    # Kernel based
-    elif name == "rocket":
-        return ROCKETClassifier(random_state=resample_id)
-    elif name == "arsenal":
-        return Arsenal(random_state=resample_id, save_transformed_data=train_file)
-    # Shapelet based
-    elif name == "stc" or name == "shapelettransformclassifier":
-        return ShapeletTransformClassifier(
-            random_state=resample_id, save_transformed_data=train_file
-        )
-    elif name == "mrseql" or name == "mrseqlclassifier":
-        return MrSEQLClassifier(seql_mode="fs", symrep=["sax", "sfa"])
-    else:
-        raise Exception("UNKNOWN CLASSIFIER")

--- a/sktime/contrib/classification_experiments.py
+++ b/sktime/contrib/classification_experiments.py
@@ -5,7 +5,7 @@ This file is configured for runs of the main method with command line arguments,
 single debugging runs. Results are written in a standard format.
 """
 
-__author__ = ["Tony Bagnall"]
+__author__ = ["TonyBagnall"]
 
 import os
 import sys
@@ -16,12 +16,15 @@ os.environ["OMP_NUM_THREADS"] = "1"  # must be done before numpy import!!
 
 import sktime.datasets.tsc_dataset_names as dataset_lists
 from sktime.benchmarking.experiments import load_and_run_classification_experiment
+from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.utils.data_io import load_from_tsfile_to_dataframe as load_ts
 
 """Prototype mechanism for testing classifiers on the UCR format. This mirrors the
 mechanism used in Java,
 https://github.com/TonyBagnall/uea-tsc/tree/master/src/main/java/experiments
-but is not yet as engineered. However, if you generate results using the method
+but isfrom sktime.classification.interval_based import (
+    CanonicalIntervalForest,
+ not yet as engineered. However, if you generate results using the method
 recommended here, they can be directly and automatically compared to the results
 generated in java.
 """
@@ -94,8 +97,9 @@ if __name__ == "__main__":
     else:  # Local run
         print(" Local Run")
         data_dir = "../datasets/data/"
-        results_dir = ""
-        classifier = "CIF"
+        results_dir = "C:/Temp/"
+        cls_name = "CIF"
+        classifier = CanonicalIntervalForest()
         dataset = "UnitTest"
         resample = 0
         tf = False
@@ -105,7 +109,8 @@ if __name__ == "__main__":
             overwrite=True,
             problem_path=data_dir,
             results_path=results_dir,
-            cls_name=classifier,
+            cls_name=cls_name,
+            classifier=classifier,
             dataset=dataset,
             resample_id=resample,
             build_train=tf,

--- a/sktime/contrib/clustering_experiments.py
+++ b/sktime/contrib/clustering_experiments.py
@@ -8,21 +8,14 @@ runs of the main method with command line arguments, or for single debugging run
 __author__ = ["TonyBagnall"]
 import os
 import sys
-import pandas as pd
-from sklearn.model_selection import cross_val_predict
-import sklearn.preprocessing
-import sklearn.utils
-import sktime.datasets.tsc_dataset_names as dataset_lists
-from sktime.utils.data_io import load_from_tsfile_to_dataframe as load_ts
 
-from sktime.clustering import (
-    TimeSeriesKMeans,
-    TimeSeriesKMedoids,
-)
+import sktime.datasets.tsc_dataset_names as dataset_lists
 from sktime.benchmarking.experiments import (
-    run_clustering_experiment,
     load_and_run_clustering_experiment,
+    run_clustering_experiment,
 )
+from sktime.clustering import TimeSeriesKMeans
+from sktime.utils.data_io import load_from_tsfile_to_dataframe as load_ts
 
 # We sometimes want to force execution in a single thread. sklearn often threads in ways
 # beyond the users control. This forces single thread execution, which is required,
@@ -31,7 +24,6 @@ from sktime.benchmarking.experiments import (
 os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["NUMEXPR_NUM_THREADS"] = "1"
 os.environ["OMP_NUM_THREADS"] = "1"
-import numpy as np
 
 
 def demo_loading():

--- a/sktime/contrib/clustering_experiments.py
+++ b/sktime/contrib/clustering_experiments.py
@@ -5,7 +5,7 @@ code to run experiments for clustering, saving results in a standard format.
 The main method is run_clustering_experiment. However, this file is also configured for
 runs of the main method with command line arguments, or for single debugging runs.
 """
-__author__ = ["Tony Bagnall"]
+__author__ = ["TonyBagnall"]
 import os
 import sys
 import pandas as pd

--- a/sktime/contrib/set_classifier.py
+++ b/sktime/contrib/set_classifier.py
@@ -142,4 +142,3 @@ def set_classifier(cls, resample_id=None, train_file=False):
         )
     else:
         raise Exception("UNKNOWN CLASSIFIER")
-

--- a/sktime/contrib/set_classifier.py
+++ b/sktime/contrib/set_classifier.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+"""Set classifier function."""
+
+from sklearn.ensemble import RandomForestClassifier
+
+from sktime.classification.dictionary_based import (
+    MUSE,
+    WEASEL,
+    BOSSEnsemble,
+    ContractableBOSS,
+    TemporalDictionaryEnsemble,
+)
+from sktime.classification.distance_based import (
+    ElasticEnsemble,
+    KNeighborsTimeSeriesClassifier,
+    ProximityForest,
+    ProximityStump,
+    ProximityTree,
+    ShapeDTW,
+)
+from sktime.classification.feature_based import (
+    Catch22Classifier,
+    MatrixProfileClassifier,
+    SignatureClassifier,
+    TSFreshClassifier,
+)
+from sktime.classification.hybrid import HIVECOTEV1, HIVECOTEV2
+from sktime.classification.interval_based import (
+    CanonicalIntervalForest,
+    DrCIF,
+    RandomIntervalSpectralForest,
+    SupervisedTimeSeriesForest,
+    TimeSeriesForestClassifier,
+)
+from sktime.classification.kernel_based import Arsenal, ROCKETClassifier
+from sktime.classification.shapelet_based import ShapeletTransformClassifier
+
+
+def set_classifier(cls, resample_id=None, train_file=False):
+    """Construct a classifier.
+
+    Basic way of creating the classifier to build using the default settings. This
+    set up is to help with batch jobs for multiple problems to facilitate easy
+    reproducibility for use with load_and_run_classification_experiment. You can pass a
+    classifier object instead to run_classification_experiment.
+
+    Parameters
+    ----------
+    cls : str
+        String indicating which classifier you want.
+    resample_id : int or None, default=None
+        Classifier random seed.
+    train_file : bool, default=False
+        Whether a train file is being produced.
+
+    Return
+    ------
+    classifier : A BaseClassifier.
+        The classifier matching the input classifier name.
+    """
+    name = cls.lower()
+    # Dictionary based
+    if name == "boss" or name == "bossensemble":
+        return BOSSEnsemble(random_state=resample_id)
+    elif name == "cboss" or name == "contractableboss":
+        return ContractableBOSS(random_state=resample_id)
+    elif name == "tde" or name == "temporaldictionaryensemble":
+        return TemporalDictionaryEnsemble(
+            random_state=resample_id, save_train_predictions=train_file
+        )
+    elif name == "weasel":
+        return WEASEL(random_state=resample_id)
+    elif name == "muse":
+        return MUSE(random_state=resample_id)
+    # Distance based
+    elif name == "pf" or name == "proximityforest":
+        return ProximityForest(random_state=resample_id)
+    elif name == "pt" or name == "proximitytree":
+        return ProximityTree(random_state=resample_id)
+    elif name == "ps" or name == "proximityStump":
+        return ProximityStump(random_state=resample_id)
+    elif name == "dtwcv" or name == "kneighborstimeseriesclassifier":
+        return KNeighborsTimeSeriesClassifier(distance="dtwcv")
+    elif name == "dtw" or name == "1nn-dtw":
+        return KNeighborsTimeSeriesClassifier(distance="dtw")
+    elif name == "msm" or name == "1nn-msm":
+        return KNeighborsTimeSeriesClassifier(distance="msm")
+    elif name == "ee" or name == "elasticensemble":
+        return ElasticEnsemble(random_state=resample_id)
+    elif name == "shapedtw":
+        return ShapeDTW()
+    # Feature based
+    elif name == "catch22":
+        return Catch22Classifier(
+            random_state=resample_id, estimator=RandomForestClassifier(n_estimators=500)
+        )
+    elif name == "matrixprofile":
+        return MatrixProfileClassifier(random_state=resample_id)
+    elif name == "signature":
+        return SignatureClassifier(
+            random_state=resample_id,
+            classifier=RandomForestClassifier(n_estimators=500),
+        )
+    elif name == "tsfresh":
+        return TSFreshClassifier(
+            random_state=resample_id, estimator=RandomForestClassifier(n_estimators=500)
+        )
+    elif name == "tsfresh-r":
+        return TSFreshClassifier(
+            random_state=resample_id,
+            estimator=RandomForestClassifier(n_estimators=500),
+            relevant_feature_extractor=True,
+        )
+    # Hybrid
+    elif name == "hc1" or name == "hivecotev1":
+        return HIVECOTEV1(random_state=resample_id)
+    elif name == "hc2" or name == "hivecotev2":
+        return HIVECOTEV2(random_state=resample_id)
+    # Interval based
+    elif name == "rise" or name == "randomintervalspectralforest":
+        return RandomIntervalSpectralForest(random_state=resample_id, n_estimators=500)
+    elif name == "tsf" or name == "timeseriesforestclassifier":
+        return TimeSeriesForestClassifier(random_state=resample_id, n_estimators=500)
+    elif name == "cif" or name == "canonicalintervalforest":
+        return CanonicalIntervalForest(random_state=resample_id, n_estimators=500)
+    elif name == "stsf" or name == "supervisedtimeseriesforest":
+        return SupervisedTimeSeriesForest(random_state=resample_id, n_estimators=500)
+    elif name == "drcif":
+        return DrCIF(
+            random_state=resample_id, n_estimators=500, save_transformed_data=train_file
+        )
+    # Kernel based
+    elif name == "rocket":
+        return ROCKETClassifier(random_state=resample_id)
+    elif name == "arsenal":
+        return Arsenal(random_state=resample_id, save_transformed_data=train_file)
+    # Shapelet based
+    elif name == "stc" or name == "shapelettransformclassifier":
+        return ShapeletTransformClassifier(
+            random_state=resample_id, save_transformed_data=train_file
+        )
+    else:
+        raise Exception("UNKNOWN CLASSIFIER")

--- a/sktime/contrib/set_classifier.py
+++ b/sktime/contrib/set_classifier.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Set classifier function."""
+__author__ = ["TonyBagnall"]
 
 from sklearn.ensemble import RandomForestClassifier
 

--- a/sktime/contrib/set_classifier.py
+++ b/sktime/contrib/set_classifier.py
@@ -142,3 +142,4 @@ def set_classifier(cls, resample_id=None, train_file=False):
         )
     else:
         raise Exception("UNKNOWN CLASSIFIER")
+

--- a/sktime/contrib/set_clusterer.py
+++ b/sktime/contrib/set_clusterer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Set classifier function."""
+__author__ = ["TonyBagnall"]
 
 
 from sktime.clustering import TimeSeriesKMeans, TimeSeriesKMedoids

--- a/sktime/contrib/set_clusterer.py
+++ b/sktime/contrib/set_clusterer.py
@@ -42,6 +42,5 @@ def set_clusterer(cls, resample_id=None):
             averaging_algorithm="mean",
             random_state=resample_id,
         )
-
     else:
         raise Exception("UNKNOWN CLUSTERER")

--- a/sktime/contrib/set_clusterer.py
+++ b/sktime/contrib/set_clusterer.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Set classifier function."""
+
+
+from sktime.clustering import TimeSeriesKMeans, TimeSeriesKMedoids
+
+
+def set_clusterer(cls, resample_id=None):
+    """Construct a clusterer.
+
+    Basic way of creating the clusterer to build using the default settings. This
+    set up is to help with batch jobs for multiple problems to facilitate easy
+    reproducability through run_clustering_experiment. You can set up bespoke
+    clusterers and pass them to run_clustering_experiment if you prefer. It also
+    serves to illustrate the base clusterer parameters
+
+    Parameters
+    ----------
+    cls : str
+        indicating which clusterer you want
+    resample_id : int or None, default = None
+        clusterer random seed
+
+    Return
+    ------
+    A clusterer.
+    """
+    name = cls.lower()
+    # Distance based
+    if name == "kmeans" or name == "k-means":
+        return TimeSeriesKMeans(
+            n_clusters=5,
+            max_iter=50,
+            averaging_algorithm="mean",
+            random_state=resample_id,
+        )
+    if name == "kmedoids" or name == "k-medoids":
+        return TimeSeriesKMedoids(
+            n_clusters=5,
+            max_iter=50,
+            averaging_algorithm="mean",
+            random_state=resample_id,
+        )
+
+    else:
+        raise Exception("UNKNOWN CLUSTERER")


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

simple change to benchmarking/experiments.py to move set classifier and set clusterer into contrib. The problem they introduce (apart from ugly code and general poor usability) is to require all soft dependencies to run experiments.py. This is a pain. Now the actual classifier/clusterer has to be passed, and the string name is only used to set the results location. 