### PR TITLE
fix parameter mismatch in ShapeDTW

### DIFF
--- a/sktime/classification/distance_based/_shape_dtw.py
+++ b/sktime/classification/distance_based/_shape_dtw.py
@@ -114,13 +114,13 @@ class ShapeDTW(BaseClassifier):
 
     def __init__(
         self,
-        n_neighbours=1,
+        n_neighbors=1,
         subsequence_length=30,
         shape_descriptor_function="raw",
         shape_descriptor_functions=["raw", "derivative"],  # noqa from flake8 B006
         metric_params=None,
     ):
-        self.n_neighbors = n_neighbours
+        self.n_neighbors = n_neighbors
         self.subsequence_length = subsequence_length
         self.shape_descriptor_function = shape_descriptor_function
         self.shape_descriptor_functions = shape_descriptor_functions

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -125,7 +125,6 @@ from sktime.transformations.series.outlier_detection import HampelFilter
 # The following estimators currently do not pass all unit tests
 # What do they fail? ShapeDTW fails on 3d_numpy_input test, not set up for that
 EXCLUDE_ESTIMATORS = [
-    "ShapeDTW",
     "ElasticEnsemble",
     "ProximityForest",
     "ProximityStump",


### PR DESCRIPTION
simple bug fix in parameter names so that ShapeDTW can be removed from the EXCCLUDED_ESTIMATORS list 