### PR TITLE
lower bound pandas to 1.2.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,7 @@ install:
 
   # Install requirements from inside conda environment
   - cmd: activate testenv
-  - cmd: conda install -c conda-forge "matplotlib>=3.3.2" "seaborn>=0.11.0" "tsfresh>=0.17.0" "hcrystalball>=0.1.9" "stumpy>=1.5.1" "numba==0.53" "numpy>=1.19.3" "pandas>=1.1.0,<1.2" "statsmodels==0.12.1" "scikit-learn>=0.23.0" "scikit-posthocs>=0.6.5" "pystan>=2.14,<3.0" "deprecated>=1.2.13" "fbprophet>=0.7.1"
+  - cmd: conda install -c conda-forge "matplotlib>=3.3.2" "seaborn>=0.11.0" "tsfresh>=0.17.0" "hcrystalball>=0.1.9" "stumpy>=1.5.1" "numba==0.53" "numpy>=1.19.3" "pandas>=1.2" "statsmodels==0.12.1" "scikit-learn>=0.23.0" "scikit-posthocs>=0.6.5" "pystan>=2.14,<3.0" "deprecated>=1.2.13" "fbprophet>=0.7.1"
 
   - cmd: pip install -r %REQUIREMENTS%
 

--- a/.binder/prelim_requirements.txt
+++ b/.binder/prelim_requirements.txt
@@ -1,14 +1,15 @@
-convertdate >= 2.3.2
+convertdate>=2.3.2
 cython>=0.29.0
 deprecated>=1.2.13
 dtw_python>=1.1.5
 esig==0.9.7
 hcrystalball>=0.1.9
-LunarCalendar >= 0.0.9
+LunarCalendar>=0.0.9
 matplotlib
 notebook
 numba==0.53
 numpy==1.19.3
+pandas>=1.2.0
 pystan==2.19.1.1
 seaborn
 stumpy>=1.5.1

--- a/build_tools/hard_dependencies.txt
+++ b/build_tools/hard_dependencies.txt
@@ -1,7 +1,7 @@
 cython>=0.29.0
 numba==0.53
 numpy==1.19.3
-pandas==1.1.5
+pandas>=1.2
 scikit-learn==0.24.*
 statsmodels==0.12.1
 wheel

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -6,7 +6,7 @@ fbprophet>=0.7.1
 hcrystalball>=0.1.9
 numba==0.53
 numpy==1.19.3
-pandas==1.1.5
+pandas>=1.2.0
 pmdarima>=1.8.0,!=1.8.1
 pyod>=0.8.0
 pystan>=2.14,<3.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from pkg_resources import parse_version
 MIN_PYTHON_VERSION = "3.6"
 MIN_REQUIREMENTS = {
     "numpy": "1.19.3",
-    "pandas": "1.1.0",
+    "pandas": "1.2.0",
     "scikit-learn": "0.24.0",
     "statsmodels": "0.12.1",
     "numba": "0.53",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
resolves difference in testing described in 
https://github.com/alan-turing-institute/sktime/issues/1642
(but not the actual bug, see https://github.com/alan-turing-institute/sktime/pull/1644 for that)

and hopefully fixes https://github.com/alan-turing-institute/sktime/issues/1645

uses this 
https://github.com/alan-turing-institute/sktime/issues/1482

#### What does this implement/fix? Explain your changes.
this fixes pandas to be at least 1.2. It was fixed to 1.1.5 in testing, and this causes testing anomalies
