### PR TITLE
Fix `test_wilcoxon` compatibility between pandas versions

### DIFF
--- a/sktime/benchmarking/tests/test_evaluator.py
+++ b/sktime/benchmarking/tests/test_evaluator.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
-from sktime.benchmarking.results import RAMResults
-from sktime.benchmarking.evaluation import Evaluator
-from sktime.benchmarking.metrics import PairwiseMetric
-from sklearn.metrics import accuracy_score
-from sktime.series_as_features.model_selection import PresplitFilesCV
+"""Test evaluator."""
+
 import numpy as np
 import pandas as pd
+from sklearn.metrics import accuracy_score
+
+from sktime.benchmarking.evaluation import Evaluator
+from sktime.benchmarking.metrics import PairwiseMetric
+from sktime.benchmarking.results import RAMResults
+from sktime.series_as_features.model_selection import PresplitFilesCV
 
 
 def dummy_results():
+    """Results that are dummy."""
     results = RAMResults()
     results.cv = PresplitFilesCV()
     results.save_predictions(
@@ -101,6 +105,7 @@ def dummy_results():
 
 
 def evaluator_setup(score_function):
+    """Set up the evaluator."""
     evaluator = Evaluator(dummy_results())
     metric = PairwiseMetric(func=score_function, name="score_function")
     metrics_by_strategy = evaluator.evaluate(metric=metric)
@@ -109,7 +114,7 @@ def evaluator_setup(score_function):
 
 
 def test_rank():
-
+    """Test rank."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
     expected_ranks = pd.DataFrame(
         {
@@ -122,6 +127,7 @@ def test_rank():
 
 
 def test_accuracy_score():
+    """Test accuracy score."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
 
     expected_accuracy = pd.DataFrame(
@@ -136,6 +142,7 @@ def test_accuracy_score():
 
 
 def test_sign_test():
+    """Test sign_test."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
     results = evaluator.sign_test()[1].values
     expected = np.full((3, 3), 0.5)
@@ -143,6 +150,7 @@ def test_sign_test():
 
 
 def test_ranksum_test():
+    """Test ranksum_test."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
     expected = np.array(
         [
@@ -157,6 +165,7 @@ def test_ranksum_test():
 
 
 def test_t_test_bonfer():
+    """Test t_test_bonfer."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
     expected = np.array([[False, True, True], [True, False, True], [True, True, False]])
     result = evaluator.t_test_with_bonferroni_correction().values
@@ -164,6 +173,7 @@ def test_t_test_bonfer():
 
 
 def test_nemenyi():
+    """Test nemenyi."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
     expected = np.array(
         [
@@ -179,19 +189,24 @@ def test_nemenyi():
 
 
 def test_plots():
+    """Test plots."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
     evaluator.plot_boxplots()
     evaluator.t_test()
 
 
 def test_wilcoxon():
+    """Test wilcoxon."""
+    expected = pd.DataFrame(
+        data={"statistic": [0.0, 0.0, 0.0], "p_val": [0.5, 0.5, 0.5]}
+    )
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
-    results = evaluator.wilcoxon_test().iloc[:, 2:].values
-    expected = np.array([[0.5, 0], [0.5, 0], [0.5, 0]])
-    assert np.array_equal(results, expected)
+    results = evaluator.wilcoxon_test()
+    assert results[expected.columns].equals(expected)
 
 
 def test_run_times():
+    """Test run_times."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
     result = evaluator.fit_runtime()
     expected = np.array(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Fixes #1651 
See also: #1198 


#### What does this implement/fix? Explain your changes.

Updated asset condition to take into account column reordering. 

#### Does your contribution introduce a new dependency? If yes, which one?

no

#### What should a reviewer concentrate their feedback on?

Sorry for all the additional edits but `pre-commit` made me do it.

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [x] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.


<!--
Thanks for contributing!
-->
