### PR TITLE
Fix appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,8 +22,6 @@ environment:
     TWINE_USERNAME: __token__
 
   matrix:
-    - PYTHON_VERSION: "3.6"
-      MINICONDA_VERSION: C:\Miniconda36-x64
     - PYTHON_VERSION: "3.7"
       MINICONDA_VERSION: C:\Miniconda37-x64
     - PYTHON_VERSION: "3.8.10"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,7 +62,7 @@ install:
 
   # Install requirements from inside conda environment
   - cmd: activate testenv
-  - cmd: conda install -c conda-forge "matplotlib>=3.3.2" "seaborn>=0.11.0" "tsfresh>=0.17.0" "hcrystalball>=0.1.9" "stumpy>=1.5.1" "numba==0.53" "numpy>=1.19.3" "pandas>=1.1.0,<1.2" "statsmodels==0.12.1" "scikit-learn>=0.23.0" "scikit-posthocs>=0.6.5" "pystan>=2.14,<3.0" "deprecated>=1.2.13" "fbprophet>=0.7.1"
+  - cmd: conda install -c conda-forge "matplotlib>=3.3.2" "seaborn>=0.11.0" "tsfresh>=0.17.0" "hcrystalball>=0.1.9" "stumpy==1.9.2" "numba==0.53" "numpy>=1.19.3" "pandas>=1.1.0,<1.2" "statsmodels==0.12.1" "scikit-learn>=0.23.0" "scikit-posthocs>=0.6.5" "pystan>=2.14,<3.0" "deprecated>=1.2.13" "fbprophet>=0.7.1"
 
   - cmd: pip install -r %REQUIREMENTS%
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,8 +22,6 @@ environment:
     TWINE_USERNAME: __token__
 
   matrix:
-    - PYTHON_VERSION: "3.7"
-      MINICONDA_VERSION: C:\Miniconda37-x64
     - PYTHON_VERSION: "3.8.10"
       MINICONDA_VERSION: C:\Miniconda38-x64
       # For Python 3.8, we need a different image, check out available pre-installed Python
@@ -50,7 +48,8 @@ install:
   # purpose but is problematic because it tends to cancel builds pushed
   # directly to main instead of just PR builds.
   # credits: JuliaLang developers.
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+  - ps:
+      if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
       https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=500).builds | `
       Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
       throw "There are newer queued builds for this pull request, failing early." }
@@ -77,14 +76,15 @@ install:
   # to use for sktime
   - cmd: python setup.py build_ext --compiler=msvc
   - cmd: python setup.py bdist_wheel bdist_wininst
-  - ps: ls dist  # list built artifacts
+  - ps: ls dist # list built artifacts
 
   # Install the built wheel package to test it
   - cmd: pip install --pre --no-index --no-deps --find-links dist/ sktime
 
 test_script:
   # If there is a newer build queued for the same PR, cancel this one.
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+  - ps:
+      if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
       https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=500).builds | `
       Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
       throw "There are newer queued builds for this pull request, failing early." }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,10 @@ environment:
     TWINE_USERNAME: __token__
 
   matrix:
+    - PYTHON_VERSION: "3.6"
+      MINICONDA_VERSION: C:\Miniconda36-x64
+    - PYTHON_VERSION: "3.7"
+      MINICONDA_VERSION: C:\Miniconda37-x64
     - PYTHON_VERSION: "3.8.10"
       MINICONDA_VERSION: C:\Miniconda38-x64
       # For Python 3.8, we need a different image, check out available pre-installed Python

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,7 @@ install:
 
   # Install requirements from inside conda environment
   - cmd: activate testenv
-  - cmd: conda install -c conda-forge "matplotlib>=3.3.2" "seaborn>=0.11.0" "tsfresh>=0.17.0" "hcrystalball>=0.1.9" "stumpy==1.9.2" "numba==0.53" "numpy>=1.19.3" "pandas>=1.1.0,<1.2" "statsmodels==0.12.1" "scikit-learn>=0.23.0" "scikit-posthocs>=0.6.5" "pystan>=2.14,<3.0" "deprecated>=1.2.13" "fbprophet>=0.7.1"
+  - cmd: conda install -c conda-forge "matplotlib>=3.3.2" "seaborn>=0.11.0" "tsfresh>=0.17.0" "hcrystalball>=0.1.9" "stumpy>=1.5.1,<=1.9.2" "numba==0.53" "numpy>=1.19.3" "pandas>=1.1.0,<1.2" "statsmodels==0.12.1" "scikit-learn>=0.23.0" "scikit-posthocs>=0.6.5" "pystan>=2.14,<3.0" "deprecated>=1.2.13" "fbprophet>=0.7.1"
 
   - cmd: pip install -r %REQUIREMENTS%
 

--- a/.binder/prelim_requirements.txt
+++ b/.binder/prelim_requirements.txt
@@ -11,6 +11,6 @@ numba==0.53
 numpy==1.19.3
 pystan==2.19.1.1
 seaborn
-stumpy>=1.5.1
+stumpy>=1.5.1,<=1.9.2
 tbats>=1.1.0
 tsfresh>=0.17.0

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -15,7 +15,7 @@ pytest-cov
 scikit-learn==0.24.*
 scikit-posthocs
 statsmodels==0.12.1
-stumpy>=1.5.1
+stumpy>=1.5.1,<=1.9.2
 tbats>=1.1.0
 tsfresh>=0.17.0
 wheel

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ EXTRAS_REQUIRE = {
         "seaborn>=0.11.0",
         "tsfresh>=0.17.0",
         "hcrystalball>=0.1.9",
-        "stumpy>=1.5.1",
+        "stumpy>=1.5.1,<=1.9.2",
         "tbats>=1.1.0",
         "fbprophet>=0.7.1",
         "pyod>=0.8.0",


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
* Fixes stumpy>=1.5.1,<=1.9.2

#### Comments
When comparing the last successful appveyor run (https://ci.appveyor.com/project/mloning/sktime/builds/41606163/job/66bdyvexm97h7u07?fullLog=true) with the the next run after than (type hint changes) (https://ci.appveyor.com/project/mloning/sktime/builds/41607852/job/ov25h6yajbf2ibpm?fullLog=true), they both use different stumpy versions (0.9.2 and 0.10.0). 

appveyor runs used to take around 30-40 mins, they are now timing out after 1 hour.