### PR TITLE
[FIX] Add missing init files

### DIFF
--- a/sktime/alignment/tests/__init__.py
+++ b/sktime/alignment/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests."""

--- a/sktime/base/tests/__init__.py
+++ b/sktime/base/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests."""

--- a/sktime/datasets/tests/__init__.py
+++ b/sktime/datasets/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests."""

--- a/sktime/datatypes/tests/__init__.py
+++ b/sktime/datatypes/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests."""

--- a/sktime/distances/tests/__init__.py
+++ b/sktime/distances/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests."""


### PR DESCRIPTION
#### Reference Issues/PRs
Related to #1661, #1699

#### What does this implement/fix? Explain your changes.
* add missing init files identified via: `find sktime -type d '!' -exec test -e "{}/__init__.py" ";" -not -path "**/__pycache__" -not -path "**/datasets/data*" -print`


