### PR TITLE
[BUG] fix `FeatureUnion` test failure mk2

### DIFF
--- a/sktime/series_as_features/compose/_pipeline.py
+++ b/sktime/series_as_features/compose/_pipeline.py
@@ -53,18 +53,24 @@ class FeatureUnion(_PanelToPanelTransformer):
         self.preserve_dataframe = preserve_dataframe
         self.transformer_list = transformer_list
 
-        transformer_list_ = []
-        for x in transformer_list:
-            transformer_list_ += [(x[0], clone(x[1]))]
-
-        self.wrapped_FU = _FeatureUnion(
-            transformer_list_, n_jobs=n_jobs, transformer_weights=transformer_weights
-        )
-
         super(FeatureUnion, self).__init__()
 
     def fit(self, X, y=None, **fit_params):
         """Fit parameters."""
+
+        n_jobs = self.n_jobs
+        transformer_weights = self.transformer_weights
+        transformer_list = self.transformer_list
+
+        transformer_list_ = []
+        for x in transformer_list:
+            transformer_list_ += [(x[0], clone(x[1]))]
+        self.transformer_list_ = transformer_list_
+        transformer_list_ = self.transformer_list_
+
+        self.wrapped_FU = _FeatureUnion(
+            transformer_list_, n_jobs=n_jobs, transformer_weights=transformer_weights
+        )
         self.wrapped_FU.fit(X, y, **fit_params)
         self._is_fitted = True
         return self


### PR DESCRIPTION
This fixes #1662 which PR #1665 did not fix.
That #1665 did not fix #1662 was not detected due to faulty remote CI and, I guess, @TonyBagnall not checking locally.

Note: the remote CI fault is being fixed in #1695 but this is *not merged yet* so the same problem could happen again.

The fix in thie PR replaces inheritance in `FeatureUnion` by the wrapper pattern.

That fixes the bug #1662, since it was caused by `FeatureUnion` having side effects on constructor arguments which were expected to remain unchanged. The side effects were coming from the package external parent class, so the only simple way to avoid this seems to wrap it and clone the arguments before passing them.

The original arguments don't get changed, since the side effects apply to the cloned versions only.