### PR TITLE
[BUG] fix `FeatureUnion` test failure mk3

### DIFF
--- a/sktime/series_as_features/compose/_pipeline.py
+++ b/sktime/series_as_features/compose/_pipeline.py
@@ -94,3 +94,29 @@ class FeatureUnion(_FeatureUnion, _PanelToPanelTransformer):
 
         else:
             return np.hstack(Xs)
+
+    @classmethod
+    def get_test_params(cls):
+        """Test parameters for FeatureUnion."""
+        from sklearn.preprocessing import StandardScaler
+
+        SERIES_TO_SERIES_TRANSFORMER = StandardScaler()
+
+        from sktime.transformations.panel.compose import SeriesToSeriesRowTransformer
+
+        TRANSFORMERS = [
+            (
+                "transformer1",
+                SeriesToSeriesRowTransformer(
+                    SERIES_TO_SERIES_TRANSFORMER, check_transformer=False
+                ),
+            ),
+            (
+                "transformer2",
+                SeriesToSeriesRowTransformer(
+                    SERIES_TO_SERIES_TRANSFORMER, check_transformer=False
+                ),
+            ),
+        ]
+
+        return {"transformers": TRANSFORMERS}

--- a/sktime/series_as_features/compose/_pipeline.py
+++ b/sktime/series_as_features/compose/_pipeline.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 from scipy import sparse
+from sklearn import clone
 from sklearn.pipeline import FeatureUnion as _FeatureUnion
 
 from sktime.transformations.base import _PanelToPanelTransformer
@@ -39,16 +40,22 @@ class FeatureUnion(_FeatureUnion, _PanelToPanelTransformer):
         Save constructed dataframe.
     """
 
-    _required_parameters = ["transformer_list"]
+    _required_parameters = ["transformers"]
 
     def __init__(
         self,
-        transformer_list,
+        transformers,
         n_jobs=None,
         transformer_weights=None,
         preserve_dataframe=True,
     ):
+
+        self.transformers = transformers
         self.preserve_dataframe = preserve_dataframe
+
+        transformer_list = []
+        for x in transformers:
+            transformer_list += [(x[0], clone(x[1]))]
         super(FeatureUnion, self).__init__(
             transformer_list, n_jobs=n_jobs, transformer_weights=transformer_weights
         )

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -188,7 +188,6 @@ STEPS = [
 ESTIMATOR_TEST_PARAMS = {
     ColumnEnsembleForecaster: {"forecasters": FORECASTER},
     OnlineEnsembleForecaster: {"forecasters": FORECASTERS},
-    FeatureUnion: {"transformer_list": TRANSFORMERS},
     DirectTabularRegressionForecaster: {"estimator": REGRESSOR},
     MultioutputTabularRegressionForecaster: {"estimator": REGRESSOR},
     RecursiveTabularRegressionForecaster: {"estimator": REGRESSOR},

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -86,7 +86,6 @@ from sktime.registry import (
     TRANSFORMER_MIXIN_LIST,
 )
 from sktime.regression.compose import ComposableTimeSeriesForestRegressor
-from sktime.series_as_features.compose import FeatureUnion
 from sktime.transformations.panel.compose import (
     ColumnTransformer,
     SeriesToPrimitivesRowTransformer,


### PR DESCRIPTION
Another attempted fix for #1662 which PR #1665 did not fix.
That #1665 did not fix #1662 was not detected due to faulty remote CI and, I guess, @TonyBagnall not checking locally.
#1700 fixed the `fit_idempotent` test but introduced other test failures.

Note: the remote CI fault is being fixed in #1695 but this is *not merged yet* so the same problem could happen again.

The fix in thie PR leaves the inheritance pattern, but renames the argument `transformer_list` to `transformers` and puts cloning between the two )clones `transformers` to `transformer_list`). Since the inherited methods look for `transformer_list` in the object, this fix does not work with the original argument name.