### PR TITLE
check_is_scitype, cleaning up dists_kernels input checks/conversions

### DIFF
--- a/sktime/datatypes/__init__.py
+++ b/sktime/datatypes/__init__.py
@@ -3,7 +3,9 @@
 
 __author__ = ["fkiraly"]
 
-from sktime.datatypes._check import check_is, check_is_mtype, check_raise, mtype
+from sktime.datatypes._check import (
+    check_is, check_is_mtype, check_is_scitype, check_raise, mtype
+)
 from sktime.datatypes._convert import convert, convert_to
 from sktime.datatypes._examples import get_examples
 from sktime.datatypes._registry import (
@@ -17,6 +19,7 @@ from sktime.datatypes._registry import (
 __all__ = [
     "check_is",
     "check_is_mtype",
+    "check_is_scitype",
     "check_raise",
     "convert",
     "convert_to",

--- a/sktime/datatypes/__init__.py
+++ b/sktime/datatypes/__init__.py
@@ -4,7 +4,11 @@
 __author__ = ["fkiraly"]
 
 from sktime.datatypes._check import (
-    check_is, check_is_mtype, check_is_scitype, check_raise, mtype
+    check_is,
+    check_is_mtype,
+    check_is_scitype,
+    check_raise,
+    mtype,
 )
 from sktime.datatypes._convert import convert, convert_to
 from sktime.datatypes._examples import get_examples

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -353,6 +353,7 @@ def check_is_scitype(
     ------
     TypeError if scitype input argument is not of expected type
     """
+
     def ret(valid, msg, metadata, return_metadata):
         if return_metadata:
             return valid, msg, metadata

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -353,7 +353,7 @@ def check_is_scitype(
     keys = [x for x in valid_keys if x[1] in scitype]
 
     # storing the msg retursn
-    msg =[]
+    msg = []
     found_mtype = []
     found_scitype = []
 

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -105,6 +105,35 @@ def check_is(
     )
 
 
+def _coerce_list_of_str(obj, var_name="obj"):
+    """Check whether object is string or list of string.
+
+    Parameters
+    ----------
+    obj - object to check
+    var_name: str, optional, default="obj" - name of input in error messages
+
+    Returns
+    -------
+    list of str
+        equal to obj if was a list; equal to [obj] if obj was a str
+        note: if obj was a list, return is not a copy, but identical
+
+    Raises
+    ------
+    TypeError if obj is not a str or list of str
+    """
+    if isinstance(obj, str):
+        obj = [obj]
+    elif isinstance(obj, list):
+        if not np.all([isinstance(x, str) for x in obj]):
+            raise TypeError(f"{var_name} must be a string or list of strings")
+    else:
+        raise TypeError(f"{var_name} must be a string or list of strings")
+
+    return obj
+
+
 def check_is_mtype(
     obj,
     mtype: Union[str, List[str]],
@@ -151,13 +180,7 @@ def check_is_mtype(
         else:
             return valid
 
-    if isinstance(mtype, str):
-        mtype = [mtype]
-    elif isinstance(mtype, list):
-        if not np.all([isinstance(x, str) for x in mtype]):
-            raise TypeError("mtype must be a string or list of strings")
-    else:
-        raise TypeError("mtype must be a string or list of strings")
+    mtype = _coerce_list_of_str(mtype, var_name="mtype")
 
     valid_keys = check_dict.keys()
 
@@ -336,13 +359,7 @@ def check_is_scitype(
         else:
             return valid
 
-    if isinstance(scitype, str):
-        scitype = [scitype]
-    elif isinstance(scitype, list):
-        if not np.all([isinstance(x, str) for x in scitype]):
-            raise ValueError("scitype must be a string or list of strings")
-    else:
-        raise ValueError("mtype must be a string or list of strings")
+    scitype = _coerce_list_of_str(scitype, var_name="scitype")
 
     for x in scitype:
         _check_scitype_valid(x)

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -308,7 +308,6 @@ def check_is_scitype(
     Parameters
     ----------
     obj - object to check
-    mtype: str or list of str, mtype to check obj as
     scitype: str or list of str, scitype to check obj as
     return_metadata - bool, optional, default=False
         if False, returns only "valid" return

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -141,7 +141,7 @@ def check_is_mtype(
     Raises
     ------
     TypeError if no checks defined for mtype/scitype combination
-    ValueError if mtype input argument is not of expected type
+    TypeError if mtype input argument is not of expected type
     """
     _check_scitype_valid(scitype)
 
@@ -155,9 +155,9 @@ def check_is_mtype(
         mtype = [mtype]
     elif isinstance(mtype, list):
         if not np.all([isinstance(x, str) for x in mtype]):
-            raise ValueError("list must be a string or list of strings")
+            raise TypeError("mtype must be a string or list of strings")
     else:
-        raise ValueError("mtype must be a string or list of strings")
+        raise TypeError("mtype must be a string or list of strings")
 
     valid_keys = check_dict.keys()
 
@@ -295,3 +295,104 @@ def mtype(obj, as_scitype: str = None):
         raise TypeError("No valid mtype could be identified")
 
     return res[0]
+
+
+def check_is_scitype(
+    obj,
+    scitype: Union[str, List[str]],
+    return_metadata=False,
+    var_name="obj",
+):
+    """Check object for compliance with mtype specification, return metadata.
+
+    Parameters
+    ----------
+    obj - object to check
+    mtype: str or list of str, mtype to check obj as
+    scitype: str or list of str, scitype to check obj as
+    return_metadata - bool, optional, default=False
+        if False, returns only "valid" return
+        if True, returns all three return objects
+    var_name: str, optional, default="obj" - name of input in error messages
+
+    Returns
+    -------
+    valid: bool - whether obj is a valid object of mtype/scitype
+    msg: str or list of str - error messages if object is not valid, otherwise None
+            str if mtype is str; list of len(mtype) with message per mtype if list
+            returned only if return_metadata is True
+    metadata: dict - metadata about obj if valid, otherwise None
+            returned only if return_metadata is True
+        fields:
+            "mtype": str, mtype of obj if inferred
+            "scitype": str, scitype of obj if inferred
+
+    Raises
+    ------
+    TypeError if scitype input argument is not of expected type
+    """
+    def ret(valid, msg, metadata, return_metadata):
+        if return_metadata:
+            return valid, msg, metadata
+        else:
+            return valid
+
+    if isinstance(scitype, str):
+        scitype = [scitype]
+    elif isinstance(scitype, list):
+        if not np.all([isinstance(x, str) for x in scitype]):
+            raise ValueError("scitype must be a string or list of strings")
+    else:
+        raise ValueError("mtype must be a string or list of strings")
+
+    for x in scitype:
+        _check_scitype_valid(x)
+
+    valid_keys = check_dict.keys()
+
+    # find all the mtype keys corresponding to the scitypes
+    keys = [x for x in valid_keys if x[1] in scitype]
+
+    # storing the msg retursn
+    msg =[]
+    found_mtype = []
+    found_scitype = []
+
+    for key in keys:
+        res = check_dict[key](obj, return_metadata=return_metadata, var_name=var_name)
+
+        if return_metadata:
+            check_passed = res[0]
+        else:
+            check_passed = res
+
+        if check_passed:
+            final_result = res
+            found_mtype.append([0])
+            found_scitype.append(key[1])
+        elif return_metadata:
+            msg.append(res[1])
+
+    # there are three options on the result of check_is_mtype:
+    # a. two or more mtypes are found - this is unexpected and an error with checks
+    if len(found_mtype) > 1:
+        raise TypeError(
+            f"Error in check_is_mtype, more than one mtype identified: {found_mtype}"
+        )
+    # b. one mtype is found - then return that mtype
+    elif len(found_mtype) == 1:
+        if return_metadata:
+            # add the mtype return to the metadata
+            final_result[2]["mtype"] = found_mtype[0]
+            # add the scitype return to the metadata
+            final_result[2]["scitype"] = found_scitype[0]
+            # final_result already has right shape and dependency on return_metadata
+            return final_result
+        else:
+            return True
+    # c. no mtype is found - then return False and all error messages if requested
+    else:
+        if len(msg) == 1:
+            msg = msg[0]
+
+        return ret(False, msg, None, return_metadata)

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -195,7 +195,7 @@ def _pairwise_panel_x_check(X, var_name="X"):
     elif X_scitype != "Panel":
         raise RuntimeError("Unexpected error in check_is_scitype, check validity")
 
-    X_coerced = convert_to(X, to_type="list-of-df", as_scitype="Panel")
+    X_coerced = convert_to(X, to_type="df-list", as_scitype="Panel")
 
     return X_coerced
 

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -37,6 +37,8 @@ import numpy as np
 import pandas as pd
 
 from sktime.base import BaseEstimator
+from sktime.datatypes import check_is_scitype, convert_to
+from sktime.datatypes._series_as_panel import convert_Series_to_Panel
 from sktime.utils.validation.series import check_series
 
 
@@ -156,7 +158,7 @@ class BasePairwiseTransformer(BaseEstimator):
         return self
 
 
-def _pairwise_panel_x_check(X):
+def _pairwise_panel_x_check(X, var_name="X"):
     """Check and coerce input data.
 
     Method used to check the input and convert
@@ -166,6 +168,7 @@ def _pairwise_panel_x_check(X):
     ----------
     X: List of dfs, Numpy of dfs, 3d numpy
         The value to be checked
+    var_name: str, variable name to print in error messages
 
     Returns
     -------
@@ -173,35 +176,28 @@ def _pairwise_panel_x_check(X):
         of the other formats, otherwise identical to X
 
     """
+    check_res = check_is_scitype(
+        X, ["Series", "Panel"], return_metadata=True, var_name=var_name
+    )
+    X_valid = check_res[0]
+    metadata = check_res[2]
 
-    def arr_check(arr):
-        for i, Xi in enumerate(arr):
-            if not isinstance(Xi, pd.DataFrame):
-                raise TypeError(
-                    "X must be a list of pd.DataFrame or numpy "
-                    "of pd.Dataframe or 3d numpy"
-                )
-            X[i] = check_series(Xi)
+    X_scitype = metadata["scitype"]
 
-    return_X = []
+    if not X_valid:
+        raise TypeError("X/X2 must be of Series or Panel scitype")
 
-    if isinstance(X, np.ndarray):
-        X_check = np.array(X, copy=True)
-        if X_check.ndim == 3:
-            for arr in X_check:
-                return_X.append(pd.DataFrame(arr))
-        else:
-            arr_check(X_check)
-            return_X = X_check.tolist()
-    elif isinstance(X, list):
-        arr_check(X)
-        return_X = X
-    else:
-        raise TypeError(
-            "X must be a list of pd.DataFrame or numpy of pd.Dataframe or 3d numpy"
-        )
+    # if the input is a single series, convert it to a Panel
+    if X_scitype == "Series":
+        X = convert_Series_to_Panel(X)
 
-    return return_X
+    # can't be anything else if check_is_scitype is working properly
+    elif X_scitype != "Panel":
+        raise RuntimeError("Unexpected error in check_is_scitype, check validity")
+
+    X_coerced = convert_to(X, to_type="list-of-df", as_scitype="Panel")
+
+    return X_coerced
 
 
 class BasePairwiseTransformerPanel(BaseEstimator):
@@ -276,12 +272,10 @@ class BasePairwiseTransformerPanel(BaseEstimator):
             X2 = X
             self.X_equals_X2 = True
         else:
-            X2 = _pairwise_panel_x_check(X2)
-            if len(X2) == len(X):
-                for i in range(len(X2)):
-                    if not X[i].equals(X2[i]):
-                        break
-                self.X_equals_X2 = True
+            X2 = _pairwise_panel_x_check(X2, var_name="X2")
+            # todo, possibly:
+            # check X, X2 for equality, then set X_equals_X2
+            # could use deep_equals
 
         return self._transform(X=X, X2=X2)
 

--- a/sktime/dists_kernels/tests/test_all_dist_kernels.py
+++ b/sktime/dists_kernels/tests/test_all_dist_kernels.py
@@ -4,7 +4,9 @@
 import numpy as np
 import pytest
 
+from sktime.datatypes import convert_to
 from sktime.registry import all_estimators
+from sktime.utils._testing.series import _make_series
 from sktime.utils._testing.panel import make_transformer_problem
 
 PAIRWISE_TRANSFORMERS = all_estimators(
@@ -16,38 +18,30 @@ PAIRWISE_TRANSFORMERS_PANEL = all_estimators(
 
 EXPECTED_SHAPE = (4, 5)
 
-X1_tab = make_transformer_problem(
-    n_instances=4,
+X1_tab = _make_series(
     n_columns=4,
-    n_timepoints=5,
+    n_timepoints=4,
     random_state=1,
     return_numpy=True,
-    panel=False,
 )
-X2_tab = make_transformer_problem(
-    n_instances=5,
-    n_columns=5,
+X2_tab = _make_series(
+    n_columns=4,
     n_timepoints=5,
     random_state=2,
     return_numpy=True,
-    panel=False,
 )
 
-X1_tab_df = make_transformer_problem(
-    n_instances=4,
+X1_tab_df = _make_series(
     n_columns=4,
-    n_timepoints=5,
+    n_timepoints=4,
     random_state=1,
     return_numpy=False,
-    panel=False,
 )
-X2_tab_df = make_transformer_problem(
-    n_instances=5,
-    n_columns=5,
+X2_tab_df = _make_series(
+    n_columns=4,
     n_timepoints=5,
     random_state=2,
-    return_numpy=True,
-    panel=False,
+    return_numpy=False,
 )
 
 VALID_INPUTS_TABULAR = [(X1_tab, X2_tab), (X1_tab_df, X2_tab_df)]
@@ -60,27 +54,20 @@ def test_pairwise_transformers_tabular(x, y, pairwise_transformer):
     _general_pairwise_transformer_tests(x, y, pairwise_transformer)
 
 
-X1_num_pan = make_transformer_problem(
-    n_instances=4, n_columns=4, n_timepoints=5, random_state=1, return_numpy=True
-)
-X2_num_pan = make_transformer_problem(
-    n_instances=5, n_columns=5, n_timepoints=5, random_state=2, return_numpy=True
-)
-
 X1_list_df = make_transformer_problem(
     n_instances=4, n_columns=4, n_timepoints=5, random_state=1, return_numpy=False
 )
 X2_list_df = make_transformer_problem(
-    n_instances=5, n_columns=5, n_timepoints=5, random_state=2, return_numpy=False
+    n_instances=5, n_columns=4, n_timepoints=5, random_state=2, return_numpy=False
 )
 
-X1_num_df = np.array(X1_list_df)
-X2_num_df = np.array(X2_list_df)
+X1_num_pan = convert_to(X1_list_df, to_type="numpy3D")
+X2_num_pan = convert_to(X2_list_df, to_type="numpy3D")
+
 
 VALID_INPUTS_PANEL = [
     (X1_num_pan, X2_num_pan),
     (X1_list_df, X2_list_df),
-    (X1_num_df, X2_num_df),
 ]
 
 
@@ -93,6 +80,8 @@ def test_pairwise_transformers_panel(x, y, pairwise_transformer):
 
 def _general_pairwise_transformer_tests(x, y, pairwise_transformer):
     # test return matrix
+    print(x)
+    print(y)
     transformer = pairwise_transformer.create_test_instance()
     transformation = transformer.transform(x, y)
 
@@ -112,10 +101,6 @@ def _general_pairwise_transformer_tests(x, y, pairwise_transformer):
 
     transformer = pairwise_transformer.create_test_instance()
     transformation = transformer.transform(x)
-    _x_equals_x2_test(transformation, x, transformer)
-
-    transformer = pairwise_transformer.create_test_instance()
-    transformation = transformer.transform(x, x)
     _x_equals_x2_test(transformation, x, transformer)
 
 

--- a/sktime/dists_kernels/tests/test_all_dist_kernels.py
+++ b/sktime/dists_kernels/tests/test_all_dist_kernels.py
@@ -6,8 +6,8 @@ import pytest
 
 from sktime.datatypes import convert_to
 from sktime.registry import all_estimators
-from sktime.utils._testing.series import _make_series
 from sktime.utils._testing.panel import make_transformer_problem
+from sktime.utils._testing.series import _make_series
 
 PAIRWISE_TRANSFORMERS = all_estimators(
     estimator_types="transformer-pairwise", return_names=False
@@ -80,8 +80,6 @@ def test_pairwise_transformers_panel(x, y, pairwise_transformer):
 
 def _general_pairwise_transformer_tests(x, y, pairwise_transformer):
     # test return matrix
-    print(x)
-    print(y)
     transformer = pairwise_transformer.create_test_instance()
     transformation = transformer.transform(x, y)
 

--- a/sktime/dists_kernels/tests/test_compose_tab_to_panel.py
+++ b/sktime/dists_kernels/tests/test_compose_tab_to_panel.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import numpy as np
+from sktime.datatypes import convert_to
 from sktime.dists_kernels.compose_tab_to_panel import AggrDist
 from sktime.dists_kernels.scipy_dist import ScipyDist
 from sktime.utils._testing.panel import make_transformer_problem
@@ -23,22 +24,15 @@ AGGFUNCS = [
 ]
 
 
-X1_num_pan = make_transformer_problem(
-    n_instances=4, n_columns=4, n_timepoints=5, random_state=1, return_numpy=True
-)
-X2_num_pan = make_transformer_problem(
-    n_instances=5, n_columns=5, n_timepoints=5, random_state=2, return_numpy=True
-)
-
 X1_list_df = make_transformer_problem(
     n_instances=4, n_columns=4, n_timepoints=5, random_state=1, return_numpy=False
 )
 X2_list_df = make_transformer_problem(
-    n_instances=5, n_columns=5, n_timepoints=5, random_state=2, return_numpy=False
+    n_instances=5, n_columns=4, n_timepoints=5, random_state=2, return_numpy=False
 )
 
-X1_num_df = np.array(X1_list_df)
-X2_num_df = np.array(X2_list_df)
+X1_num_pan = convert_to(X1_list_df, to_type="numpy3D")
+X2_num_pan = convert_to(X2_list_df, to_type="numpy3D")
 
 
 def test_aggr():
@@ -48,12 +42,9 @@ def test_aggr():
     # test list of df
     _run_aggr_dist_test(X1_list_df, X2_list_df)
 
-    # test numpy of df
-    _run_aggr_dist_test(X1_num_df, X2_num_df)
-
 
 def _run_aggr_dist_test(x, y):
-    # default parameters
+    # default parametersc
     default_params = AggrDist(transformer=ScipyDist())
     default_params_transformation = np.around(
         (default_params.transform(x, y)), decimals=3
@@ -62,10 +53,10 @@ def _run_aggr_dist_test(x, y):
     assert np.array_equal(
         np.array(
             [
-                [1.649, 1.525, 1.518, 1.934, 1.636],
-                [1.39, 1.395, 1.313, 1.617, 1.418],
-                [1.492, 1.489, 1.323, 1.561, 1.437],
-                [1.559, 1.721, 1.544, 1.589, 1.642],
+                [1.714, 1.49, 1.53, 1.699, 1.849],
+                [1.479, 1.36, 1.358, 1.476, 1.471],
+                [1.553, 1.476, 1.354, 1.523, 1.425],
+                [1.641, 1.704, 1.603, 1.698, 1.37],
             ]
         ),
         default_params_transformation,

--- a/sktime/dists_kernels/tests/test_compose_tab_to_panel.py
+++ b/sktime/dists_kernels/tests/test_compose_tab_to_panel.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """Testes for tabular-to-panel distance aggregation/reduction."""
 import numpy as np
+
 from sktime.datatypes import convert_to
 from sktime.dists_kernels.compose_tab_to_panel import AggrDist
 from sktime.dists_kernels.scipy_dist import ScipyDist
 from sktime.registry import all_estimators
 from sktime.utils._testing.panel import make_transformer_problem
-
 
 PAIRWISE_TRANSFORMERS_TAB = all_estimators(
     estimator_types="transformer-pairwise", return_names=False

--- a/sktime/dists_kernels/tests/test_compose_tab_to_panel.py
+++ b/sktime/dists_kernels/tests/test_compose_tab_to_panel.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+"""Testes for tabular-to-panel distance aggregation/reduction."""
 import numpy as np
 from sktime.datatypes import convert_to
 from sktime.dists_kernels.compose_tab_to_panel import AggrDist
 from sktime.dists_kernels.scipy_dist import ScipyDist
-from sktime.utils._testing.panel import make_transformer_problem
 from sktime.registry import all_estimators
+from sktime.utils._testing.panel import make_transformer_problem
+
 
 PAIRWISE_TRANSFORMERS_TAB = all_estimators(
     estimator_types="transformer-pairwise", return_names=False
@@ -36,6 +38,7 @@ X2_num_pan = convert_to(X2_list_df, to_type="numpy3D")
 
 
 def test_aggr():
+    """Test that AggrDist produces expected pre-computed result on fixtures."""
     # test 3d numpy
     _run_aggr_dist_test(X1_num_pan, X2_num_pan)
 

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -58,10 +58,11 @@ def all_estimators(
     ----------
     estimator_types: string, list of string, optional (default=None)
         Which kind of estimators should be returned.
-        - If None, no filter is applied and all estimators are returned.
-        - Possible values are 'classifier', 'regressor', 'transformer' and
-        'forecaster' to get estimators only of these specific types, or a list of
-        these to get the estimators that fit at least one of the types.
+        if None, no filter is applied and all estimators are returned.
+        if str or list of str, strings define scitypes specified in search
+                only estimators that are of (at least) one of the scitypes are returned
+            possible str values are entries of registry.BASE_CLASS_SCITYPE_LIST
+                for instance 'classifier', 'regressor', 'transformer', 'forecaster'
     return_names: bool, optional (default=True)
         If True, return estimators as list of (name, estimator class) tuples.
         If False, return list of estimators classes.

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -61,7 +61,7 @@ def all_estimators(
         if None, no filter is applied and all estimators are returned.
         if str or list of str, strings define scitypes specified in search
                 only estimators that are of (at least) one of the scitypes are returned
-            possible str values are entries of registry.BASE_CLASS_SCITYPE_LIST
+            possible str values are entries of registry.BASE_CLASS_REGISTER (first col)
                 for instance 'classifier', 'regressor', 'transformer', 'forecaster'
     return_names: bool, optional (default=True)
         If True, return estimators as list of (name, estimator class) tuples.


### PR DESCRIPTION
This PR makes the following two changes:
* introduces `check_is_scitype`, a shorthand counterpart of `check_is_mtype`, see also recent renaming in #1692
* replaces custom check/conversion functionality in pairwise transformers with `datatypes` functionality

The above refactoring also uncovered that the input conversions for `dists_kernels` were faulty:
* `numpy`/`DataFrame` conversions were using wrong order of `numpy` dimensions
* fixtures were `X` = 4-dimensional, `X2` = 5-dimensional panel which doesn't make sense for Euclidean distance (what is the distance between 4-vector and 5-vector??). This was not caught since the input conversions were faulty, and the same conversions were used in the tests.