### PR TITLE
[ENH] transformer base class to allow multivariate output if input is always univariate

### DIFF
--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -368,7 +368,6 @@ class ForecastingGridSearchCV(BaseGridSearch):
     ...     ForecastingGridSearchCV,
     ...     ExpandingWindowSplitter)
     >>> from sktime.forecasting.naive import NaiveForecaster
-
     >>> y = load_airline()
     >>> fh = [1,2,3]
     >>> cv = ExpandingWindowSplitter(
@@ -383,6 +382,47 @@ class ForecastingGridSearchCV(BaseGridSearch):
     >>> gscv.fit(y)
     ForecastingGridSearchCV(...)
     >>> y_pred = gscv.predict(fh)
+
+        Advanced model meta-tuning (model selection) with multiple forecasters
+        together with hyper-parametertuning at same time using sklearn notation:
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.exp_smoothing import ExponentialSmoothing
+    >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> from sktime.forecasting.model_selection import ExpandingWindowSplitter
+    >>> from sktime.forecasting.model_selection import ForecastingGridSearchCV
+    >>> from sktime.forecasting.compose import TransformedTargetForecaster
+    >>> from sktime.forecasting.theta import ThetaForecaster
+    >>> from sktime.transformations.series.impute import Imputer
+    >>> y = load_airline()
+    >>> pipe = TransformedTargetForecaster(steps=[
+    ...     ("imputer", Imputer()),
+    ...     ("forecaster", NaiveForecaster())])
+    >>> cv = ExpandingWindowSplitter(
+    ...     initial_window=48,
+    ...     step_length=12,
+    ...     start_with_window=True,
+    ...     fh=[1,2,3])
+    >>> gscv = ForecastingGridSearchCV(
+    ...     forecaster=pipe,
+    ...     param_grid=[{
+    ...         "forecaster": [NaiveForecaster(sp=12)],
+    ...         "forecaster__strategy": ["drift", "last", "mean"],
+    ...     },
+    ...     {
+    ...         "imputer__method": ["mean", "drift"],
+    ...         "forecaster": [ThetaForecaster(sp=12)],
+    ...     },
+    ...     {
+    ...         "imputer__method": ["mean", "last"],
+    ...         "forecaster": [ExponentialSmoothing(sp=12)],
+    ...         "forecaster__trend": ["add", "mul"],
+    ...     },
+    ...     ],
+    ...     cv=cv,
+    ...     n_jobs=-1)
+    >>> gscv.fit(y)
+    ForecastingGridSearchCV(...)
+    >>> y_pred = gscv.predict(fh=[1,2,3])
     """
 
     _required_parameters = ["forecaster", "cv", "param_grid"]

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -474,7 +474,7 @@ class BaseTransformer(BaseEstimator):
             check_res = check_is_mtype(
                 ["pd.DataFrame", "pd.Series", "np.ndarray"], return_metadata=True
             )
-            if not check_res["is_univariate"] and X_input_mtype == "pd.Series":
+            if not check_res[2]["is_univariate"] and X_input_mtype == "pd.Series":
                 X_output_mtype = "pd.DataFrame"
             else:
                 X_output_mtype = X_input_mtype

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -471,10 +471,10 @@ class BaseTransformer(BaseEstimator):
         if output_scitype == "Series":
             # if the transformer outputs multivariate series,
             #   we cannot convert back to pd.Series, do pd.DataFrame instead then
-            check_res = check_is_mtype(
+            _, _, metadata = check_is_mtype(
                 ["pd.DataFrame", "pd.Series", "np.ndarray"], return_metadata=True
             )
-            if not check_res[2]["is_univariate"] and X_input_mtype == "pd.Series":
+            if not metadata["is_univariate"] and X_input_mtype == "pd.Series":
                 X_output_mtype = "pd.DataFrame"
             else:
                 X_output_mtype = X_input_mtype

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -469,9 +469,18 @@ class BaseTransformer(BaseEstimator):
             Xt = convert_Panel_to_Series(Xt)
 
         if output_scitype == "Series":
+            # if the transformer outputs multivariate series,
+            #   we cannot convert back to pd.Series, do pd.DataFrame instead then
+            check_res = check_is_mtype(
+                ["pd.DataFrame", "pd.Series", "np.ndarray"], return_metadata=True
+            )
+            if not check_res["is_univariate"] and X_input_mtype == "pd.Series":
+                X_output_mtype = "pd.DataFrame"
+            else:
+                X_output_mtype = X_input_mtype
             Xt = convert_to(
                 Xt,
-                to_type=X_input_mtype,
+                to_type=X_output_mtype,
                 as_scitype=X_input_scitype,
             )
         elif output_scitype == "Primitives":


### PR DESCRIPTION
Fixes #1697 by introducing the following base class behaviour: returning `pd.DataFrame` output if transform output is multivariate but input was `pd.Series`.