### PR TITLE
Fixes prophet bug concerning the internal change of exogenous X

### DIFF
--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -42,8 +42,6 @@ class _ProphetAdapter(BaseForecaster):
         -------
         self : returns an instance of self.
         """
-        if X:
-            X = X.copy()
         self._instantiate_model()
         self._check_changepoints()
         y, X = check_y_X(y, X, enforce_index_type=pd.DatetimeIndex)
@@ -65,6 +63,7 @@ class _ProphetAdapter(BaseForecaster):
 
         # Add regressor (multivariate)
         if X is not None:
+            X = X.copy()
             df, X = _merge_X(df, X)
             for col in X.columns:
                 self._forecaster.add_regressor(col)
@@ -103,8 +102,6 @@ class _ProphetAdapter(BaseForecaster):
         Exception
             Error when merging data
         """
-        if X:
-            X = X.copy()
         self._update_X(X, enforce_index_type=pd.DatetimeIndex)
 
         fh = self.fh.to_absolute(cutoff=self.cutoff).to_pandas()
@@ -114,6 +111,7 @@ class _ProphetAdapter(BaseForecaster):
 
         # Merge X with df (of created future DatetimeIndex values)
         if X is not None:
+            X = X.copy()
             df, X = _merge_X(df, X)
 
         # don't compute confidence intervals if not asked for

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -42,6 +42,8 @@ class _ProphetAdapter(BaseForecaster):
         -------
         self : returns an instance of self.
         """
+        if X:
+            X = X.copy()
         self._instantiate_model()
         self._check_changepoints()
         y, X = check_y_X(y, X, enforce_index_type=pd.DatetimeIndex)
@@ -101,6 +103,8 @@ class _ProphetAdapter(BaseForecaster):
         Exception
             Error when merging data
         """
+        if X:
+            X = X.copy()
         self._update_X(X, enforce_index_type=pd.DatetimeIndex)
 
         fh = self.fh.to_absolute(cutoff=self.cutoff).to_pandas()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/alan-turing-institute/sktime/issues/1673

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

- Reproduced the error described in  https://github.com/alan-turing-institute/sktime/issues/1673
- Creates a copy of X in _Prophet_Adapter before changes are made to it.
- Verified that the code snippet int he issue document a bug doesn't throw the error after this change.
- Checks if X contained a column ds were already implemented in _merge_X, so I didn't implement a new one

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->



<!--
Thanks for contributing!
-->
