### PR TITLE
[BUG] hotfix for bug when passing multivariate `y` to boxcox transformer

### DIFF
--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -100,6 +100,7 @@ class BoxCoxTransformer(_SeriesToSeriesTransformer):
         "transform-returns-same-time-index": True,
         "univariate-only": True,
         "X_inner_mtype": "pd.Series",
+        "y_inner_mtype": "pd.DataFrame",
         "fit-in-transform": False,
     }
 


### PR DESCRIPTION
Currently, passing multivariate `y` to the `BoxCoxTransformer` (refactored recently) will cause an error, since series-to-series transformers like it assume a univariate `y` by default, and a conversion is attempted to univariate `pd.Series` (which is impossible). This is unexpected, since the transformer ignores `y`.

This can be problematic in a `TransformedTargetPipeline` since there the forecaster's `X` - typically multivariate - is passed to the `y` of the transformers. (slightly surprising to me, but that's the status quo).

This implements a quick workaround, where the inner mtype for the `BoxCoxtransformer` is set to multivariate, that doesn't cause an error if a multivariate one is passed.

No other transformers are impacted currently, since `BoxCoxTransformer` is the only one refactored so far.

However, we need to think about how to fix this in the future. Options:
* assume multivariate `y` by default, this will do a silent input conversion (which may be superfluous but won't cause an error)
* introduce a tag on whether `y` is used internally, and in that case do not do a conversion at all (seems cleaner but introduces a new tag)