### PR TITLE
Add deprecation message to ambiguous arg reference in `ForecastingPipeline`, removed `Z` kwarg

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -203,7 +203,7 @@ class ForecastingPipeline(_Pipeline):
             # transform X
             for step_idx, name, transformer in self._iter_transformers():
                 t = clone(transformer)
-                X = t.fit_transform(X, y)
+                X = t.fit_transform(X=X, y=y)
                 self.steps_[step_idx] = (name, t)
 
         # fit forecaster
@@ -240,6 +240,8 @@ class ForecastingPipeline(_Pipeline):
         if self._X is not None:
             # transform X before doing prediction
             for _, _, transformer in self._iter_transformers():
+                # todo: deprecation in 0.10.0
+                # add kwarg X= after deprecation of old trafo interface
                 X = transformer.transform(X)
 
         return forecaster.predict(fh, X, return_pred_int=return_pred_int, alpha=alpha)

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -203,7 +203,7 @@ class ForecastingPipeline(_Pipeline):
             # transform X
             for step_idx, name, transformer in self._iter_transformers():
                 t = clone(transformer)
-                X = t.fit_transform(X=X, y=y)
+                X = t.fit_transform(X, y)
                 self.steps_[step_idx] = (name, t)
 
         # fit forecaster
@@ -240,7 +240,7 @@ class ForecastingPipeline(_Pipeline):
         if self._X is not None:
             # transform X before doing prediction
             for _, _, transformer in self._iter_transformers():
-                X = transformer.transform(Z=X)
+                X = transformer.transform(X)
 
         return forecaster.predict(fh, X, return_pred_int=return_pred_int, alpha=alpha)
 


### PR DESCRIPTION
Update: this is not a bug, as originally thought.

Following some discussion, I've added a deprecation message that was missing in `ForecastingPipeline` and changed the `Z` kwarg to first arg, to prevent the code breaking in 0.10.0.

---

I think the transformers refactor introduced a bug:
in series-to-series transformers, the order of arguments was not changed, but the names were.
So args calls are fine since downwards compatible, but kwargs calls may break.

One reference in the `ForecastingPipeline` was kwargs, which makes pipelines with any transformers that are not yet refactored break.

This PR fixes the issue, by replacing the kwargs reference with an args reference.

I've also searched the repository, there are no other kwargs references to the sub-set of transformers that had `Z` previously as the first argument.