### PR TITLE
[ENH] Testing all test instances in testing framework

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -285,6 +285,44 @@ class BaseObject(_BaseEstimator):
 
         return cls(**params)
 
+    @classmethod
+    def create_test_instances_and_names(cls):
+        """Create list of all test instances and a list of names for them.
+
+        Returns
+        -------
+        objs : list of instances of cls
+            i-th instance is cls(**cls.get_test_params()[i])
+        names : list of str, same length as objs
+            i-th element is name of i-th instance of obj in tests
+            convention is {cls.__name__}-{i} if more than one instance
+            otherwise {cls.__name__}
+        """
+        objs = []
+        param_list = cls.get_test_params()
+        if not isinstance(param_list, (dict, list)):
+            raise RuntimeError(
+                f"Error in {cls.__name__}.get_test_params, "
+                "return must be param dict for class, or list thereof"
+            )
+        if isinstance(param_list, dict):
+            param_list = [param_list]
+        for params in param_list:
+            if not isinstance(params, dict):
+                raise RuntimeError(
+                    f"Error in {cls.__name__}.get_test_params, "
+                    "return must be param dict for class, or list thereof"
+                )
+            objs += [cls(**params)]
+
+        num_instances = len(param_list)
+        if num_instances > 1:
+            names = [cls.__name__ + "-" + str(i) for i in range(num_instances)]
+        else:
+            names = [cls.__name__]
+
+        return objs, names
+
 
 class BaseEstimator(BaseObject):
     """Base class for defining estimators in sktime.

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -27,9 +27,9 @@ Tag inspection and setter methods
     set/clone dynamic tags        - clone_tags(estimator, tag_names=None)
 
 Testing with default parameters methods
-    getting default parameters           - get_test_params()
-    get instance with default parameters - create_test_instance()
-
+    getting default parameters (all sets)         - get_test_params()
+    get one test instance with default parameters - create_test_instance()
+    get list of all test instances plus name list - create_test_instances_and_names()
 ---
 
     class name: BaseEstimator

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -145,6 +145,7 @@ class _Pipeline(
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
         from sklearn.preprocessing import StandardScaler
+
         from sktime.forecasting.naive import NaiveForecaster
         from sktime.transformations.series.adapt import TabularToSeriesAdaptor
         from sktime.transformations.series.boxcox import BoxCoxTransformer
@@ -300,6 +301,7 @@ class ForecastingPipeline(_Pipeline):
         forecaster.update(y=y, X=X, update_params=update_params)
         self.steps_[-1] = (name, forecaster)
         return self
+
 
 # removed transform and inverse_transform as long as y can only be a pd.Series
 # def transform(self, Z, X=None):

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -131,6 +131,38 @@ class _Pipeline(
         self._set_params("steps", **kwargs)
         return self
 
+    # both children use the same step params for testing, so putting it here
+    @classmethod
+    def get_test_params(cls):
+        """Return testing parameter settings for the estimator.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        from sklearn.preprocessing import StandardScaler
+        from sktime.forecasting.naive import NaiveForecaster
+        from sktime.transformations.series.adapt import TabularToSeriesAdaptor
+        from sktime.transformations.series.boxcox import BoxCoxTransformer
+
+        STEPS1 = [
+            ("transformer", TabularToSeriesAdaptor(StandardScaler())),
+            ("forecaster", NaiveForecaster()),
+        ]
+        params1 = {"steps": STEPS1}
+
+        STEPS2 = [
+            ("transformer", BoxCoxTransformer()),
+            ("forecaster", NaiveForecaster()),
+        ]
+        params2 = {"steps": STEPS2}
+
+        return [params1, params2]
+
 
 class ForecastingPipeline(_Pipeline):
     """Pipeline for forecasting with exogenous data.
@@ -268,7 +300,6 @@ class ForecastingPipeline(_Pipeline):
         forecaster.update(y=y, X=X, update_params=update_params)
         self.steps_[-1] = (name, forecaster)
         return self
-
 
 # removed transform and inverse_transform as long as y can only be a pd.Series
 # def transform(self, Z, X=None):

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -57,14 +57,12 @@ from sktime.forecasting.compose import (
     DirRecTabularRegressionForecaster,
     DirRecTimeSeriesRegressionForecaster,
     EnsembleForecaster,
-    ForecastingPipeline,
     MultioutputTabularRegressionForecaster,
     MultioutputTimeSeriesRegressionForecaster,
     MultiplexForecaster,
     RecursiveTabularRegressionForecaster,
     RecursiveTimeSeriesRegressionForecaster,
     StackingForecaster,
-    TransformedTargetForecaster,
 )
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.fbprophet import Prophet
@@ -205,8 +203,6 @@ ESTIMATOR_TEST_PARAMS = {
     DirRecTimeSeriesRegressionForecaster: {
         "estimator": make_pipeline(Tabularizer(), REGRESSOR)
     },
-    TransformedTargetForecaster: {"steps": STEPS},
-    ForecastingPipeline: {"steps": STEPS},
     EnsembleForecaster: {"forecasters": FORECASTERS},
     StackingForecaster: {"forecasters": FORECASTERS},
     AutoEnsembleForecaster: {"forecasters": FORECASTERS},

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -90,14 +90,22 @@ def pytest_generate_tests(metafunc):
         estimator_classes_to_test = [
             est for est in ALL_ESTIMATORS if not is_excluded(est)
         ]
-        estimator_class_names = [est.__name__ for est in estimator_classes_to_test]
         # create instances from the classes
-        estimator_instances_to_test = [
-            est.create_test_instance() for est in estimator_classes_to_test
-        ]
+        estimator_instances_to_test = []
+        estimator_instance_names = []
+        # retrieve all estimator parameters if multiple, construct instances
+        for est in estimator_classes_to_test:
+            param_list = est.get_test_params()
+            if isinstance(param_list, dict):
+                param_list = param_list
+            for i, params in enumerate(param_list):
+                estimator_instances_to_test += [est(**params)]
+                estimator_instance_names += [est.__name__ + "-" + str(i)]
         # parameterize test with the list of instances
         metafunc.parametrize(
-            "estimator_instance", estimator_instances_to_test, ids=estimator_class_names
+            "estimator_instance",
+            estimator_instances_to_test,
+            ids=estimator_instance_names,
         )
 
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -49,48 +49,6 @@ ALL_ESTIMATORS = all_estimators(
 )
 
 
-def _create_all_test_instances(cls):
-    """Create list of all test instances.
-
-    Parameters
-    ----------
-    cls : sktime class inheriting from BaseObject
-
-    Returns
-    -------
-    objs : list of instances of cls
-        i-th instance is cls(**cls.get_test_params()[i])
-    names : list of str, same length as objs
-        i-th element is name of i-th instance of obj in tests
-        convention is {cls.__name__}-{i} if more than one instance
-        otherwise {cls.__name__}
-    """
-    objs = []
-    param_list = cls.get_test_params()
-    if not isinstance(param_list, (dict, list)):
-        raise RuntimeError(
-            f"Error in {cls.__name__}.get_test_params, "
-            "return must be param dict for class, or list thereof"
-        )
-    if isinstance(param_list, dict):
-        param_list = [param_list]
-    for params in param_list:
-        if not isinstance(params, dict):
-            raise RuntimeError(
-                f"Error in {cls.__name__}.get_test_params, "
-                "return must be param dict for class, or list thereof"
-            )
-        objs += [cls(**params)]
-
-    num_instances = len(param_list)
-    if num_instances > 1:
-        names = [cls.__name__ + "-" + str(i) for i in range(num_instances)]
-    else:
-        names = [cls.__name__]
-
-    return objs, names
-
-
 def pytest_generate_tests(metafunc):
     """Test parameterization routine for pytest.
 
@@ -137,7 +95,7 @@ def pytest_generate_tests(metafunc):
         estimator_instance_names = []
         # retrieve all estimator parameters if multiple, construct instances
         for est in estimator_classes_to_test:
-            all_instances_of_est, instance_names = _create_all_test_instances(est)
+            all_instances_of_est, instance_names = est.create_test_instances_and_names()
             estimator_instances_to_test += all_instances_of_est
             estimator_instance_names += instance_names
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -82,11 +82,11 @@ def _create_all_test_instances(cls):
             )
         objs += [cls(**params)]
 
-        num_instances = len(param_list)
-        if num_instances > 1:
-            names = [cls.__name__ + "-" + str(i) for i in range(num_instances)]
-        else:
-            names = [cls.__name__]
+    num_instances = len(param_list)
+    if num_instances > 1:
+        names = [cls.__name__ + "-" + str(i) for i in range(num_instances)]
+    else:
+        names = [cls.__name__]
 
     return objs, names
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -71,7 +71,7 @@ def _create_all_test_instances(cls):
         raise RuntimeError(
             f"Error in {cls.__name__}.get_test_params, "
             "return must be param dict for class, or list thereof"
-        )    
+        )
     if isinstance(param_list, dict):
         param_list = [param_list]
     for params in param_list:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -67,13 +67,18 @@ def _create_all_test_instances(cls):
     """
     objs = []
     param_list = cls.get_test_params()
+    if not isinstance(param_list, (dict, list)):
+        raise RuntimeError(
+            f"Error in {cls.__name__}.get_test_params, "
+            "return must be param dict for class, or list thereof"
+        )    
     if isinstance(param_list, dict):
         param_list = [param_list]
     for params in param_list:
         if not isinstance(params, dict):
             raise RuntimeError(
                 f"Error in {cls.__name__}.get_test_params, "
-                "return must be param dict for cls"
+                "return must be param dict for class, or list thereof"
             )
         objs += [cls(**params)]
 


### PR DESCRIPTION
This PR extends functionality of the `test_all_estimators` test suite, specifically the fixture generation preamble `pytest_generate_tests`, to use all test instances and not just the first one returned by `create_test_instance`.

This is going to be useful for pipelines where we can have different instance cases, and to achieve better case coverage in terms of class parameters. So far we were restricted to covering a single parameter case which is quite brittle.

In terms of implementation, the current call to `create_test_instance` is replaced by a call to `get_test_params` and instance creation based on all parameter sets, not just one.

One minor design question that I have is whether the function `_create_all_test_instances` shouldn't actually be a method of `BaseObject` instead of moving around loosely in `test_all_estimators`. Probably so?

The new test functionality is tested by adding one test case to the pipelines in `pipeline`.
This is originally motivated by the possible (?) bug in #1730 and me wanting to add a pipeline with the refactored `BoxCoxTransformer` in it to the tests.