### PR TITLE
[ENH] replace deprecated np.int, np.float

### DIFF
--- a/sktime/benchmarking/evaluation.py
+++ b/sktime/benchmarking/evaluation.py
@@ -8,8 +8,7 @@ import itertools
 import numpy as np
 import pandas as pd
 from scipy import stats
-from scipy.stats import ranksums
-from scipy.stats import ttest_ind
+from scipy.stats import ranksums, ttest_ind
 
 from sktime.benchmarking.base import BaseResults
 from sktime.exceptions import NotEvaluatedError

--- a/sktime/benchmarking/evaluation.py
+++ b/sktime/benchmarking/evaluation.py
@@ -676,7 +676,7 @@ class Evaluator:
         clique = clique[n > 1, :]
         n = np.size(clique, 0)
 
-        for i in range(np.int(np.ceil(n_strategies / 2))):
+        for i in range(int(np.ceil(n_strategies / 2))):
             plt.plot(
                 [
                     (n_strategies - r[i]) / (n_strategies - 1),
@@ -707,7 +707,7 @@ class Evaluator:
             )
 
         # labels displayed on the left
-        for i in range(np.int(np.ceil(n_strategies / 2)), n_strategies):
+        for i in range(int(np.ceil(n_strategies / 2)), n_strategies):
             plt.plot(
                 [
                     (n_strategies - r[i]) / (n_strategies - 1),

--- a/sktime/benchmarking/orchestration.py
+++ b/sktime/benchmarking/orchestration.py
@@ -259,7 +259,7 @@ class Orchestrator:
             #     n_predictions = len(y_pred)
             #     y_proba = (n_predictions, n_classes)
             #     y_proba = np.zeros(y_proba)
-            #     y_proba[:, np.array(y_pred, dtype=np.int)] = 1
+            #     y_proba[:, np.array(y_pred, dtype=int)] = 1
 
         else:
             return None

--- a/sktime/benchmarking/orchestration.py
+++ b/sktime/benchmarking/orchestration.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
+"""Benchmarking orchestration module."""
 __all__ = ["Orchestrator"]
-__author__ = ["Viktor Kazakov", "Markus Löning"]
+__author__ = ["viktorkaz", "mloning"]
 
-from sklearn.base import clone
-from sktime.benchmarking.tasks import TSCTask
-from sktime.benchmarking.tasks import TSRTask
-import pandas as pd
 import logging
+
+import pandas as pd
+from sklearn.base import clone
+
+from sktime.benchmarking.tasks import TSCTask, TSRTask
 
 log = logging.getLogger()
 console = logging.StreamHandler()
@@ -14,9 +16,7 @@ log.addHandler(console)
 
 
 class Orchestrator:
-    """
-    Fit and predict one or more estimators on one or more datasets
-    """
+    """Fit and predict one or more estimators on one or more datasets."""
 
     def __init__(self, tasks, datasets, strategies, cv, results):
         # validate datasets and tasks
@@ -41,7 +41,7 @@ class Orchestrator:
         self._dataset_counter = 0
 
     def _iter(self):
-        """Iterator for orchestration"""
+        """Orchestration iterator."""
         # TODO: check if datasets are skipped entirely because predictions
         #  already exists before loading data,
         #  maybe do a dry-run first to find out which datasets to skip?
@@ -67,8 +67,7 @@ class Orchestrator:
                     yield (task, dataset, data, strategy, cv_fold, train_idx, test_idx)
 
     def fit(self, overwrite_fitted_strategies=False, verbose=False):
-        """Fit strategies on datasets"""
-
+        """Fit strategies on datasets."""
         for (
             task,
             dataset,
@@ -107,7 +106,7 @@ class Orchestrator:
     def predict(
         self, overwrite_predictions=False, predict_on_train=False, verbose=False
     ):
-        """Predict from saved fitted strategies"""
+        """Predict from saved fitted strategies."""
         raise NotImplementedError(
             "Predicting from saved fitted strategies is not implemented yet"
         )
@@ -120,8 +119,7 @@ class Orchestrator:
         overwrite_fitted_strategies=False,
         verbose=False,
     ):
-        """Fit and predict"""
-
+        """Fit and predict."""
         # check that for fitted strategies overwrite option is only set when
         # save option is set
         if overwrite_fitted_strategies and not save_fitted_strategies:
@@ -239,7 +237,7 @@ class Orchestrator:
 
     @staticmethod
     def _predict_proba_one(strategy, task, data, y_true, y_pred):
-        """Predict strategy on one dataset"""
+        """Predict strategy on one dataset."""
         # TODO always try to get probabilistic predictions first, compute
         #  deterministic predictions using
         #  argmax to avoid rerunning predictions, only if no predict_proba
@@ -266,8 +264,7 @@ class Orchestrator:
 
     @staticmethod
     def _validate_strategy_names(strategies):
-        """Validate strategy names"""
-
+        """Validate strategy names."""
         # Check uniqueness of strategy names
         names = [strategy.name for strategy in strategies]
         if not len(names) == len(set(names)):
@@ -297,7 +294,7 @@ class Orchestrator:
 
     @staticmethod
     def _validate_tasks_and_datasets(tasks, datasets):
-        """Validate tasks"""
+        """Validate tasks."""
         # check input types
         if not isinstance(datasets, list):
             raise ValueError(f"datasets must be a list, but found: {type(datasets)}")
@@ -332,8 +329,7 @@ class Orchestrator:
         fit_or_predict,
         verbose,
     ):
-        """Helper function to print progress"""
-
+        """Print progress."""
         if verbose:
             fit_or_predict = fit_or_predict.capitalize()
             if train_or_test == "train" and fit_or_predict == "predict":

--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -467,7 +467,7 @@ class ComposableTimeSeriesForestClassifier(BaseTimeSeriesForest, BaseClassifier)
         self.classes_ = []
         self.n_classes_ = []
 
-        y_store_unique_indices = np.zeros(y.shape, dtype=np.int)
+        y_store_unique_indices = np.zeros(y.shape, dtype=int)
         for k in range(self.n_outputs_):
             classes_k, y_store_unique_indices[:, k] = np.unique(
                 y[:, k], return_inverse=True

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -229,7 +229,7 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
             self.outputs_2d_ = True
 
         self.classes_ = []
-        self._y = np.empty(y.shape, dtype=np.int)
+        self._y = np.empty(y.shape, dtype=int)
         for k in range(self._y.shape[1]):
             classes, self._y[:, k] = np.unique(y[:, k], return_inverse=True)
             self.classes_.append(classes)

--- a/sktime/clustering/tests/test_cluster_averaging.py
+++ b/sktime/clustering/tests/test_cluster_averaging.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Tests for cluster averaging."""
 import numpy as np
 
 from sktime.clustering.partitioning._averaging_metrics import (
@@ -9,6 +10,7 @@ from sktime.clustering.tests._clustering_tests import generate_univaritate_serie
 
 
 def test_barycenter_averaging():
+    """Test barycenter averaging."""
     rng = np.random.RandomState(0)
     X = generate_univaritate_series(n=100, size=5, rng=rng, dtype=int)
 
@@ -17,6 +19,7 @@ def test_barycenter_averaging():
 
 
 def test_mean_averaging():
+    """Test mean averaging."""
     rng = np.random.RandomState(1)
     X = generate_univaritate_series(n=100, size=5, rng=rng, dtype=int)
 

--- a/sktime/clustering/tests/test_cluster_averaging.py
+++ b/sktime/clustering/tests/test_cluster_averaging.py
@@ -10,7 +10,7 @@ from sktime.clustering.tests._clustering_tests import generate_univaritate_serie
 
 def test_barycenter_averaging():
     rng = np.random.RandomState(0)
-    X = generate_univaritate_series(n=100, size=5, rng=rng, dtype=np.int)
+    X = generate_univaritate_series(n=100, size=5, rng=rng, dtype=int)
 
     BCA = BarycenterAveraging(X)
     BCA.average()
@@ -18,7 +18,7 @@ def test_barycenter_averaging():
 
 def test_mean_averaging():
     rng = np.random.RandomState(1)
-    X = generate_univaritate_series(n=100, size=5, rng=rng, dtype=np.int)
+    X = generate_univaritate_series(n=100, size=5, rng=rng, dtype=int)
 
     mean = MeanAveraging(X)
     average = mean.average()

--- a/sktime/contrib/vector_classifiers/_rotation_forest.py
+++ b/sktime/contrib/vector_classifiers/_rotation_forest.py
@@ -494,7 +494,7 @@ class RotationForest(BaseEstimator):
             group_size_count[current_size] -= 1
 
             n = self.min_group + current_size
-            groups.append(np.zeros(n, dtype=np.int))
+            groups.append(np.zeros(n, dtype=int))
             for k in range(0, n):
                 if current_attribute < permutation.shape[0]:
                     groups[i][k] = permutation[current_attribute]

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -11,8 +11,7 @@ from functools import lru_cache
 import numpy as np
 import pandas as pd
 
-from sktime.utils.datetime import _coerce_duration_to_int
-from sktime.utils.datetime import _get_freq
+from sktime.utils.datetime import _coerce_duration_to_int, _get_freq
 from sktime.utils.validation.series import VALID_INDEX_TYPES
 
 RELATIVE_TYPES = (pd.Int64Index, pd.RangeIndex)

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -92,11 +92,11 @@ def _check_values(values):
 
     # convert single integer to pandas index, no further checks needed
     elif isinstance(values, (int, np.integer)):
-        return pd.Int64Index([values], dtype=np.int)
+        return pd.Int64Index([values], dtype=int)
 
     # convert np.array or list to pandas index
     elif isinstance(values, (list, np.ndarray)):
-        values = pd.Int64Index(values, dtype=np.int)
+        values = pd.Int64Index(values, dtype=int)
 
     # otherwise, raise type error
     else:

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -143,7 +143,7 @@ def test_check_fh_values_input_conversion_to_pandas_index(arg):
 TIMEPOINTS = [
     pd.Period("2000", freq="M"),
     pd.Timestamp("2000-01-01", freq="D"),
-    np.int(1),
+    int(1),
     3,
 ]
 

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for ForecastingHorizon object."""
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 
 import numpy as np
 import pandas as pd
@@ -28,7 +29,7 @@ from sktime.utils.validation.series import VALID_INDEX_TYPES
 
 
 def _assert_index_equal(a, b):
-    """Helper function to compare forecasting horizons"""
+    """Compare forecasting horizons."""
     assert isinstance(a, pd.Index)
     assert isinstance(b, pd.Index)
     assert a.equals(b)
@@ -39,6 +40,7 @@ def _assert_index_equal(a, b):
 )
 @pytest.mark.parametrize("steps", TEST_FHS)
 def test_fh(index_type, fh_type, is_relative, steps):
+    """Testing ForecastingHorizon conversions."""
     # generate data
     y = make_forecasting_problem(index_type=index_type)
     assert isinstance(y.index, INDEX_TYPE_LOOKUP.get(index_type))
@@ -94,6 +96,7 @@ def test_fh(index_type, fh_type, is_relative, steps):
 
 
 def test_fh_method_delegation():
+    """Test ForecastinHorizon delegated methods."""
     fh = ForecastingHorizon(1)
     for method in DELEGATED_METHODS:
         assert hasattr(fh, method)
@@ -111,6 +114,7 @@ BAD_INPUT_ARGS = (
 
 @pytest.mark.parametrize("arg", BAD_INPUT_ARGS)
 def test_check_fh_values_bad_input_types(arg):
+    """Negative test for bad ForecastingHorizon arguments."""
     with raises(TypeError):
         ForecastingHorizon(arg)
 
@@ -123,6 +127,7 @@ DUPLICATE_INPUT_ARGS = (
 
 @pytest.mark.parametrize("arg", DUPLICATE_INPUT_ARGS)
 def test_check_fh_values_duplicate_input_values(arg):
+    """Negative test for ForecastingHorizon input arguments."""
     with raises(ValueError):
         ForecastingHorizon(arg)
 
@@ -139,6 +144,7 @@ GOOD_INPUT_ARGS = (
 
 @pytest.mark.parametrize("arg", GOOD_INPUT_ARGS)
 def test_check_fh_values_input_conversion_to_pandas_index(arg):
+    """Test conversion to pandas index."""
     output = ForecastingHorizon(arg, is_relative=False).to_pandas()
     assert type(output) in VALID_INDEX_TYPES
 
@@ -154,6 +160,7 @@ TIMEPOINTS = [
 @pytest.mark.parametrize("timepoint", TIMEPOINTS)
 @pytest.mark.parametrize("by", [-3, -1, 0, 1, 3])
 def test_shift(timepoint, by):
+    """Test shifting of ForecastingHorizon."""
     ret = _shift(timepoint, by=by)
 
     # check output type, pandas index types inherit from each other,
@@ -178,6 +185,7 @@ DURATIONS = [
 
 @pytest.mark.parametrize("duration", DURATIONS)
 def test_coerce_duration_to_int(duration):
+    """Test coercion of duration to int."""
     ret = _coerce_duration_to_int(duration, freq=_get_freq(duration))
 
     # check output type is always integer
@@ -194,6 +202,7 @@ def test_coerce_duration_to_int(duration):
 @pytest.mark.parametrize("n_timepoints", [3, 5])
 @pytest.mark.parametrize("index_type", INDEX_TYPE_LOOKUP.keys())
 def test_get_duration(n_timepoints, index_type):
+    """Test getting of duration."""
     index = _make_index(n_timepoints, index_type)
     duration = _get_duration(index)
     # check output type is duration type

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -10,17 +10,20 @@ from pytest import raises
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.base._fh import DELEGATED_METHODS
-from sktime.utils.datetime import _coerce_duration_to_int
-from sktime.utils.datetime import _get_duration
-from sktime.utils.datetime import _get_freq
-from sktime.utils.datetime import _shift
 from sktime.forecasting.model_selection import temporal_train_test_split
-from sktime.forecasting.tests._config import INDEX_TYPE_LOOKUP
-from sktime.forecasting.tests._config import TEST_FHS
-from sktime.forecasting.tests._config import VALID_INDEX_FH_COMBINATIONS
-from sktime.utils._testing.forecasting import make_forecasting_problem
-from sktime.utils._testing.forecasting import _make_fh
+from sktime.forecasting.tests._config import (
+    INDEX_TYPE_LOOKUP,
+    TEST_FHS,
+    VALID_INDEX_FH_COMBINATIONS,
+)
+from sktime.utils._testing.forecasting import _make_fh, make_forecasting_problem
 from sktime.utils._testing.series import _make_index
+from sktime.utils.datetime import (
+    _coerce_duration_to_int,
+    _get_duration,
+    _get_freq,
+    _shift,
+)
 from sktime.utils.validation.series import VALID_INDEX_TYPES
 
 

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -201,7 +201,7 @@ class _NaiveForecaster(_BaseWindowForecaster):
 
         # reshape last window, one column per season
         last_window = last_window.reshape(
-            np.int(np.ceil(self.window_length_ / self.sp_)), self.sp_
+            int(np.ceil(self.window_length_ / self.sp_)), self.sp_
         )
 
         return last_window
@@ -224,7 +224,7 @@ class _NaiveForecaster(_BaseWindowForecaster):
         # assume fh is sorted, i.e. max(fh) == fh[-1]
         # only slicing all the last seasons into last_window
         if fh[-1] > self.sp_:
-            reps = np.int(np.ceil(fh[-1] / self.sp_))
+            reps = int(np.ceil(fh[-1] / self.sp_))
             y_pred = np.tile(y_pred, reps=reps)
 
         # get zero-based index by subtracting the minimum

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -64,7 +64,7 @@ from sktime.datatypes._series_as_panel import (
 )
 
 # single/multiple primitives
-Primitive = Union[np.integer, int, np.float, float, str]
+Primitive = Union[np.integer, int, float, str]
 Primitives = np.ndarray
 
 # tabular/cross-sectional data

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Interval and window segmenter transformers."""
 import math
 
 import numpy as np
@@ -79,7 +80,8 @@ class IntervalSegmenter(_PanelToPanelTransformer):
         return self
 
     def transform(self, X, y=None):
-        """
+        """Transform input series.
+
         Transform X, segments time-series in each column into random
         intervals using interval indices generated
         during `fit`.
@@ -95,7 +97,6 @@ class IntervalSegmenter(_PanelToPanelTransformer):
           Transformed pandas DataFrame with same number of rows and one
           column for each generated interval.
         """
-
         # Check inputs.
         self.check_is_fitted()
 
@@ -124,7 +125,9 @@ class IntervalSegmenter(_PanelToPanelTransformer):
 
 
 class RandomIntervalSegmenter(IntervalSegmenter):
-    """Transformer that segments time-series into random intervals with
+    """Random interval segmenter transformer.
+
+    Transformer that segments time-series into random intervals with
     random starting points and lengths. Some
     intervals may overlap and may be duplicates.
 
@@ -230,7 +233,8 @@ class RandomIntervalSegmenter(IntervalSegmenter):
 
 
 def _rand_intervals_rand_n(x, random_state=None):
-    """
+    """Sample a random number of intervals.
+
     Compute a random number of intervals from index (x) with
     random starting points and lengths. Intervals are unique, but may
     overlap.
@@ -268,7 +272,8 @@ def _rand_intervals_rand_n(x, random_state=None):
 def _rand_intervals_fixed_n(
     x, n_intervals, min_length=1, max_length=None, random_state=None
 ):
-    """
+    """Sample a fixed number of intervals.
+
     Compute a fixed number (n) of intervals from index (x) with
     random starting points and lengths. Intervals may overlap and may
     not be unique.
@@ -295,7 +300,8 @@ def _rand_intervals_fixed_n(
 
 
 class SlidingWindowSegmenter(_PanelToPanelTransformer):
-    """
+    """Sliding window segmenter transformer.
+
     This class is to transform a univariate series into a
     multivariate one by extracting sets of subsequences.
     It does this by firstly padding the time series on either end
@@ -333,8 +339,7 @@ class SlidingWindowSegmenter(_PanelToPanelTransformer):
         super(SlidingWindowSegmenter, self).__init__()
 
     def transform(self, X, y=None):
-        """
-        Function to perform the transformation on the time series data.
+        """Transform time series.
 
         Parameters
         ----------
@@ -381,8 +386,7 @@ class SlidingWindowSegmenter(_PanelToPanelTransformer):
         return df.transpose()
 
     def _extract_subsequences(self, instance, n_timepoints):
-        """
-        Function to extract a set of subsequences from a list of instances.
+        """Extract a set of subsequences from a list of instances.
 
         Adopted from -
         https://stackoverflow.com/questions/4923617/efficient-numpy-2d-array-
@@ -394,9 +398,7 @@ class SlidingWindowSegmenter(_PanelToPanelTransformer):
         return np.lib.stride_tricks.as_strided(instance, shape=shape, strides=strides)
 
     def _check_parameters(self, n_timepoints):
-        """
-        Function for checking the values of parameters inserted
-        into SlidingWindowSegmenter.
+        """Check the values of parameters for interval segmenter.
 
         Throws
         ------
@@ -418,9 +420,8 @@ class SlidingWindowSegmenter(_PanelToPanelTransformer):
 
 
 def _get_n_from_n_timepoints(n_timepoints, n="sqrt"):
-    """
-    Get number of intervals from number of time points for various allowed
-    input arguments.
+    """Get number of intervals from number of time points.
+
     Helpful to compute number of intervals relative to time series length,
     e.g. using floats or functions.
 

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -490,5 +490,5 @@ def _get_n_from_n_timepoints(n_timepoints, n="sqrt"):
         )
 
     # make sure n_intervals is an integer and there is at least one interval
-    n_intervals_ = np.maximum(1, np.int(n_intervals_))
+    n_intervals_ = np.maximum(1, int(n_intervals_))
     return n_intervals_

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -5,10 +5,12 @@ import numpy as np
 import pandas as pd
 from sklearn.utils import check_random_state
 
+from sktime.datatypes._panel._convert import (
+    _concat_nested_arrays,
+    _get_column_names,
+    _get_time_index,
+)
 from sktime.transformations.base import _PanelToPanelTransformer
-from sktime.datatypes._panel._convert import _concat_nested_arrays
-from sktime.datatypes._panel._convert import _get_column_names
-from sktime.datatypes._panel._convert import _get_time_index
 from sktime.utils.validation import check_window_length
 from sktime.utils.validation.panel import check_X
 

--- a/sktime/utils/_testing/forecasting.py
+++ b/sktime/utils/_testing/forecasting.py
@@ -145,7 +145,7 @@ def _make_fh(cutoff, steps, fh_type, is_relative):
     fh_class = INDEX_TYPE_LOOKUP[fh_type]
 
     if isinstance(steps, (int, np.integer)):
-        steps = np.array([steps], dtype=np.int)
+        steps = np.array([steps], dtype=int)
 
     if is_relative:
         return ForecastingHorizon(fh_class(steps), is_relative=is_relative)

--- a/sktime/utils/data_io.py
+++ b/sktime/utils/data_io.py
@@ -977,9 +977,9 @@ def generate_example_long_table(num_cases=50, series_len=20, num_dims=2):
     rows_per_case = series_len * num_dims
     total_rows = num_cases * series_len * num_dims
 
-    case_ids = np.empty(total_rows, dtype=np.int)
-    idxs = np.empty(total_rows, dtype=np.int)
-    dims = np.empty(total_rows, dtype=np.int)
+    case_ids = np.empty(total_rows, dtype=int)
+    idxs = np.empty(total_rows, dtype=int)
+    dims = np.empty(total_rows, dtype=int)
     vals = np.random.rand(total_rows)
 
     for i in range(total_rows):

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -51,7 +51,7 @@ def _coerce_duration_to_int(duration, freq=None):
             if isinstance(duration, pd.Timedelta):
                 return int(duration / pd.Timedelta(count, unit))
             if isinstance(duration, pd.TimedeltaIndex):
-                return (duration / pd.Timedelta(count, unit)).astype(np.int)
+                return (duration / pd.Timedelta(count, unit)).astype(int)
         except ValueError:
             raise ValueError(
                 "Index type not supported. Please consider using pd.PeriodIndex."

--- a/sktime/utils/slope_and_trend.py
+++ b/sktime/utils/slope_and_trend.py
@@ -70,7 +70,7 @@ def _slope(y, axis=0):
         y = y.reshape(-1, 1)
 
     # Generate time index with correct shape for broadcasting
-    shape = np.ones(y.ndim, dtype=np.int)
+    shape = np.ones(y.ndim, dtype=int)
     shape[axis] *= -1
     x = np.arange(y.shape[axis]).reshape(shape) + 1
 

--- a/sktime/utils/slope_and_trend.py
+++ b/sktime/utils/slope_and_trend.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Slope and trend utilities."""
 __all__ = [
     "_slope",
     "_fit_trend",
@@ -10,7 +11,7 @@ from sklearn.utils import check_array
 
 
 def _fit_trend(x, order=0):
-    """Fit linear regression with polynomial terms of given order
+    """Fit linear regression with polynomial terms of given order.
 
         x : array_like, shape=[n_samples, n_obs]
         Time series data, each sample is fitted separately
@@ -26,7 +27,7 @@ def _fit_trend(x, order=0):
         (linear), three columns mean order 2 (quadratic), etc
 
     See Also
-    -------
+    --------
     add_trend
     remove_trend
     """
@@ -52,7 +53,8 @@ def _fit_trend(x, order=0):
 
 
 def _slope(y, axis=0):
-    """Find the slope for each series of y
+    """Find the slope for each series of y.
+
     Parameters
     ----------
     y: np.ndarray
@@ -61,7 +63,7 @@ def _slope(y, axis=0):
         Axis along which to compute slope
 
     Returns
-    ----------
+    -------
     slope : np.ndarray
         Time series slope
     """

--- a/sktime/utils/validation/tests/test_panel.py
+++ b/sktime/utils/validation/tests/test_panel.py
@@ -18,7 +18,7 @@ BAD_INPUT_ARGS = [
     np.empty((3, 2, 3, 2)),  # 4d np.array
     pd.DataFrame(np.empty((2, 3))),  # non-nested pd.DataFrame
 ]
-y = pd.Series(dtype=np.int)
+y = pd.Series(dtype=int)
 
 
 @pytest.mark.parametrize("X", BAD_INPUT_ARGS)


### PR DESCRIPTION
Take that, deprecation warnings.

This PR does what they were begging us to do since months - replacing deprecated `np.int` by `int` and `np.float` by `float`.

The deprecation message assures it's safe to do so ... let's see.
