### PR TITLE
Fix DeprecationWarning of `pd.Series` in sktime/utils/tests/test_datetime.py:21

### DIFF
--- a/sktime/utils/tests/test_datetime.py
+++ b/sktime/utils/tests/test_datetime.py
@@ -3,9 +3,10 @@
 
 __author__ = ["xiaobenbenecho"]
 
-import pandas as pd
-import numpy as np
 import datetime
+
+import numpy as np
+import pandas as pd
 
 from sktime.utils.datetime import _get_freq
 
@@ -22,7 +23,8 @@ def test_get_freq():
         index=[
             datetime.datetime(2017, 1, 1) + datetime.timedelta(days=int(i))
             for i in np.arange(1, 100, 7)
-        ]
+        ],
+        dtype=float,
     ).index
     x4 = [
         datetime.datetime(2017, 1, 1) + datetime.timedelta(days=int(i))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Running
```
pytest sktime/utils/tests/test_datetime.py
```
produces a warning:
```
======================================================================================================= warnings summary =======================================================================================================
sktime/utils/tests/test_datetime.py::test_get_freq
  /home/skhrapov/PycharmProjects/github/sktime/sktime/utils/tests/test_datetime.py:21: DeprecationWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.
    x3 = pd.Series(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================================================= 1 passed, 1 warning in 0.46s =================================================================================================
```
Now the warning is gone.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
