### PR TITLE
[DOC] Added core dev affiliations; minor updates to role holder page

### DIFF
--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -116,8 +116,8 @@ Core Developers
      - Technical University of Munich
 
 Explanation of columns:
-* column 1: primary GitHub user identifier used for contributions to `sktime`
-* column 2: full name of individual
+* column 1: full name of individual. May be anonymized upon contributor request.
+* column 2: primary GitHub user identifier used for contributions to `sktime`
 * column 3: affiliation which `sktime` contributions are subject to, that is,
 primary affiliation(s) of the role under which `sktime` contributions are made by the individual.
 * column 4: primary affiliation of the individual. This does not need to be equal to the primary affiliation of the `sktime` contributing role.
@@ -158,8 +158,8 @@ Former Core Developers (inactive)
      - Meta/Facebook
 
 Explanation of columns:
-* column 1: primary GitHub user identifier used for contributions to `sktime`
-* column 2: full name of individual
+* column 1: full name of individual. May be anonymized upon contributor request.
+* column 2: primary GitHub user identifier used for contributions to `sktime`
 * column 3: affiliation which `sktime` contributions are subject to, that is,
 primary affiliation(s) of the role under which `sktime` contributions are made by the individual.
 * column 4: primary affiliation of the individual. This does not need to be equal to the primary affiliation of the `sktime` contributing role.

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -106,6 +106,10 @@ Core Developers
      - :user:`MatthewMiddlehurst`
      - University of East Anglia
      - University of East Anglia
+   * - Patrick Schäfer
+     - :user:`patrickzib`
+     - Humboldt University of Berlin
+     - Humboldt University of Berlin
    * - Svea Marie Meyer
      - :user:`SveaMeyer13`
      - Individual

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -131,11 +131,11 @@ Former Core Developers (inactive)
    * - Name
      - GitHub ID
      - Affiliation of former contribution
-     - Affiliation of primary role
+     - Affiliation of former primary role
    * - Ayushmaan Seth
      - :user:`ayushmaanseth`
      - Individual
-     - Amazon
+     - University College London
    * - Hongyi Yang
      - :user:`hyang1996`
      - Individual
@@ -143,11 +143,11 @@ Former Core Developers (inactive)
    * - Mathew Smith
      - :user:`matteogales`
      - Individual
-     - Brevan Howard
+     - Individual
    * - Patrick Rockenschaub
      - :user:`prockenschaub`
      - University College London
-     - Sensyne Health; Charite Berlin
+     - University College London
    * - Ryan Kuhns
      - :user:`rnkuhns`
      - Individual
@@ -162,4 +162,4 @@ Explanation of columns:
 * column 2: primary GitHub user identifier used for contributions to `sktime`
 * column 3: affiliation which `sktime` contributions are subject to, that is,
 primary affiliation(s) of the role under which `sktime` contributions are made by the individual.
-* column 4: primary affiliation of the individual. This does not need to be equal to the primary affiliation of the `sktime` contributing role.
+* column 4: primary affiliation of the individual, at time of becoming inactive. This does not need to be equal to the primary affiliation of the `sktime` contributing role.

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -145,5 +145,3 @@ Former Core Developers (inactive)
      - :user:`rnkuhns`
      - Individual
      - Farm Credit Administration (USA)
-
-

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -152,7 +152,7 @@ Former Core Developers (inactive)
      - :user:`rnkuhns`
      - Individual
      - Farm Credit Administration (USA)
-   * - [anonymous]
+   * - [anonymous upon contributor request]
      - :user:`big-o`
      - Individual
      - Meta/Facebook

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -111,6 +111,13 @@ Core Developers
      - Individual
      - Technical University of Munich
 
+Explanation of columns:
+* column 1: primary GitHub user identifier used for contributions to `sktime`
+* column 2: full name of individual
+* column 3: affiliation which `sktime` contributions are subject to, that is,
+primary affiliation(s) of the role under which `sktime` contributions are made by the individual.
+* column 4: primary affiliation of the individual. This does not need to be equal to the primary affiliation of the `sktime` contributing role.
+
 Former Core Developers (inactive)
 ---------------------------------
 
@@ -145,3 +152,10 @@ Former Core Developers (inactive)
      - :user:`rnkuhns`
      - Individual
      - Farm Credit Administration (USA)
+
+Explanation of columns:
+* column 1: primary GitHub user identifier used for contributions to `sktime`
+* column 2: full name of individual
+* column 3: affiliation which `sktime` contributions are subject to, that is,
+primary affiliation(s) of the role under which `sktime` contributions are made by the individual.
+* column 4: primary affiliation of the individual. This does not need to be equal to the primary affiliation of the `sktime` contributing role.

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -155,7 +155,7 @@ Former Core Developers (inactive)
    * - [anonymous upon contributor request]
      - :user:`big-o`
      - Individual
-     - Meta/Facebook
+     - [redacted upon contributor request]
 
 Explanation of columns:
 * column 1: full name of individual. May be anonymized upon contributor request.

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -52,8 +52,8 @@ Core Developers
 
    * - Name
      - GitHub ID
-     - Current affiliation of contribution
-     - Affiliation of primary role
+     - Affiliation of contribution
+     - Individual's primary affiliation
    * - Aaron Bostrom
      - :user:`abostrom`
      - University of East Anglia
@@ -93,15 +93,15 @@ Core Developers
    * - Markus Löning
      - :user:`mloning`
      - Individual; Shell Research
-     - Freelancer; Shell Research (contracting)
+     - Individual; Shell Research (contracting)
    * - Lovkush Agarwal
      - :user:`lovkush-a`
      - Individual
-     - Freelancer; Shell Research (contracting)
+     - Individual; Shell Research (contracting)
    * - Martin Walter
      - :user:`aiwalter`
-     - Mercedes-Benz
-     - Mercedes-Benz
+     - Individual; formerly Mercedes-Benz
+     - Individual; formerly Mercedes-Benz
    * - Matthew Middlehurst
      - :user:`MatthewMiddlehurst`
      - University of East Anglia
@@ -120,7 +120,7 @@ Explanation of columns:
 * column 2: primary GitHub user identifier used for contributions to `sktime`
 * column 3: affiliation which `sktime` contributions are subject to, that is,
 primary affiliation(s) of the role under which `sktime` contributions are made by the individual.
-* column 4: primary affiliation of the individual. This does not need to be equal to the primary affiliation of the `sktime` contributing role.
+* column 4: primary affiliation of the individual, current. This does not need to be equal to the primary affiliation of the `sktime` contributing role.
 
 Former Core Developers (inactive)
 ---------------------------------
@@ -131,7 +131,7 @@ Former Core Developers (inactive)
    * - Name
      - GitHub ID
      - Affiliation of former contribution
-     - Affiliation of former primary role
+     - Individual's (former) primary affiliation
    * - Ayushmaan Seth
      - :user:`ayushmaanseth`
      - Individual

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -52,51 +52,63 @@ Core Developers
 
    * - Name
      - GitHub ID
-     - Affiliation
+     - Current affiliation of contribution
+     - Affiliation of primary role
    * - Aaron Bostrom
      - :user:`abostrom`
+     - University of East Anglia
      - University of East Anglia
    * - Anthony Bagnall
      - :user:`TonyBagnall`
      - University of East Anglia
+     - University of East Anglia
    * - Chris Holder
      - :user:`chrisholder`
+     - University of East Anglia
      - University of East Anglia
    * - Franz Kiraly
      - :user:`fkiraly`
      - Shell Research; University College London (honorary)
+     - Shell Research
    * - Freddy A Boulton
      - :user:`freddyaboulton`
+     - Alteryx
      - Alteryx
    * - George Oastler
      - :user:`goastler`
      - University of East Anglia
+     - University of East Anglia
    * - Guzal Bulatova
      - :user:`GuzalBulatova`
+     - Individual
      - Eneryield
    * - James Large
      - :user:`james-large`
+     - Individual
      - Alfa iQ
    * - Jason Lines
      - :user:`jasonlines`
      - University of East Anglia
+     - University of East Anglia
    * - Markus Löning
      - :user:`mloning`
+     - Individual; Shell Research
      - Freelancer; Shell Research (contracting)
    * - Lovkush Agarwal
      - :user:`lovkush-a`
+     - Individual
      - Freelancer; Shell Research (contracting)
    * - Martin Walter
      - :user:`aiwalter`
      - Mercedes-Benz
+     - Mercedes-Benz
    * - Matthew Middlehurst
-     - :user:`mattewmiddlehurst`
+     - :user:`MatthewMiddlehurst`
      - University of East Anglia
-   * - Ryan Kuhns
-     - :user:`rnkuhns`
-     - Farm Credit Administration (USA)
+     - University of East Anglia
    * - Svea Marie Meyer
      - :user:`SveaMeyer13`
+     - Individual
      - Technical University of Munich
 
 Former Core Developers (inactive)
@@ -107,19 +119,31 @@ Former Core Developers (inactive)
 
    * - Name
      - GitHub ID
-     - Affiliation
+     - Affiliation of former contribution
+     - Affiliation of primary role
    * - Ayushmaan Seth
      - :user:`ayushmaanseth`
+     - Individual
      - Amazon
    * - Hongyi Yang
      - :user:`hyang1996`
+     - Individual
      - ETH Zurich
    * - Mathew Smith
      - :user:`matteogales`
+     - Individual
      - Brevan Howard
    * - Omar Norton
      - :user:`big-o`
+     - Individual
      - Meta/Facebook
    * - Patrick Rockenschaub
      - :user:`prockenschaub`
+     - University College London
      - Sensyne Health; Charite Berlin
+   * - Ryan Kuhns
+     - :user:`rnkuhns`
+     - Individual
+     - Farm Credit Administration (USA)
+
+

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -1,8 +1,10 @@
 .. _team:
 
-=====
-Roles
-=====
+====================
+Role holder register
+====================
+
+This page lists individuals with `sktime` governance roles.
 
 The roles are described in sktime's :ref:`governance` document.
 A list of all contributors can be found `here <contributors.md>`_.

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -144,10 +144,6 @@ Former Core Developers (inactive)
      - :user:`matteogales`
      - Individual
      - Brevan Howard
-   * - Omar Norton
-     - :user:`big-o`
-     - Individual
-     - Meta/Facebook
    * - Patrick Rockenschaub
      - :user:`prockenschaub`
      - University College London
@@ -156,6 +152,10 @@ Former Core Developers (inactive)
      - :user:`rnkuhns`
      - Individual
      - Farm Credit Administration (USA)
+   * - [anonymous]
+     - :user:`big-o`
+     - Individual
+     - Meta/Facebook
 
 Explanation of columns:
 * column 1: primary GitHub user identifier used for contributions to `sktime`

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -50,34 +50,52 @@ Core Developers
 
    * - Name
      - GitHub ID
+     - Affiliation
    * - Aaron Bostrom
      - :user:`abostrom`
+     - University of East Anglia
    * - Anthony Bagnall
      - :user:`TonyBagnall`
+     - University of East Anglia
    * - Chris Holder
      - :user:`chrisholder`
-   * - Guzal Bulatova
-     - :user:`GuzalBulatova`
+     - University of East Anglia
    * - Franz Kiraly
      - :user:`fkiraly`
+     - Shell Research; University College London (honorary)
    * - Freddy A Boulton
      - :user:`freddyaboulton`
+     - Alteryx
    * - George Oastler
      - :user:`goastler`
-   * - Markus Löning
-     - :user:`mloning`
+     - University of East Anglia
+   * - Guzal Bulatova
+     - :user:`GuzalBulatova`
+     - Eneryield
    * - James Large
      - :user:`james-large`
+     - Alfa iQ
+   * - Jason Lines
+     - :user:`jasonlines`
+     - University of East Anglia  
+   * - Markus Löning
+     - :user:`mloning`
+     - Freelancer; Shell Research (contracting)
    * - Lovkush Agarwal
      - :user:`lovkush-a`
+     - Freelancer; Shell Research (contracting)
    * - Martin Walter
      - :user:`aiwalter`
+     - Mercedes-Benz
    * - Matthew Middlehurst
      - :user:`mattewmiddlehurst`
+     - University of East Anglia
    * - Ryan Kuhns
      - :user:`rnkuhns`
+     - Farm Credit Administration (USA)
    * - Svea Marie Meyer
      - :user:`SveaMeyer13`
+     - Technical University of Munich
 
 Former Core Developers (inactive)
 ---------------------------------
@@ -87,15 +105,19 @@ Former Core Developers (inactive)
 
    * - Name
      - GitHub ID
+     - Affiliation
    * - Ayushmaan Seth
      - :user:`ayushmaanseth`
+     - Amazon
    * - Hongyi Yang
      - :user:`hyang1996`
-   * - Jason Lines
-     - :user:`jasonlines`
+     - ETH Zurich
    * - Mathew Smith
      - :user:`matteogales`
+     - Brevan Howard
+   * - Omar Norton
+     - :user:`big-o`
+     - Meta/Facebook
    * - Patrick Rockenschaub
      - :user:`prockenschaub`
-   * -
-     - :user:`big-o`
+     - Sensyne Health; Charite Berlin

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -79,7 +79,7 @@ Core Developers
      - Alfa iQ
    * - Jason Lines
      - :user:`jasonlines`
-     - University of East Anglia  
+     - University of East Anglia
    * - Markus Löning
      - :user:`mloning`
      - Freelancer; Shell Research (contracting)


### PR DESCRIPTION
This PR makes the following changes to the "teams" page:

* changed header for better explanation of what the page is about - individuals and their roles, not the roles (role descriptions)
* added affiliations for all core developers: former affiliation of contribution and affiliation of primary job role (separate columns); for former core devs, affiliation of former contribution and affiliation of current primary job role
* added explanation of the two different affiliations to the table
* moved @jasonlines back to active
* moved @RNKuhns to inactive
* added @patrickzib 
* ordered lists by first name
* fixed incorrect GitHub ID of @MatthewMiddlehurst 