### PR TITLE
[BUG] fix fh -> self.fh in `predict_interval` and `predict_quantiles`

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -348,15 +348,17 @@ class BaseForecaster(BaseEstimator):
             Row index is fh. Entries are quantile forecasts, for var in col index,
                 at quantile probability in second col index, for the row index.
         """
+        self.check_is_fitted()
+        # input checks
         if alpha is None:
             alpha = [0.05, 0.95]
-
-        self.check_is_fitted()
         self._set_fh(fh)
         alpha = check_alpha(alpha)
+
         # input check and conversion for X
         X_inner = self._check_X(X=X)
-        quantiles = self._predict_quantiles(fh=fh, X=X_inner, alpha=alpha)
+
+        quantiles = self._predict_quantiles(fh=self.fh, X=X_inner, alpha=alpha)
         return quantiles
 
     def predict_interval(
@@ -396,14 +398,15 @@ class BaseForecaster(BaseEstimator):
             Row index is fh. Entries are quantile forecasts, for var in col index,
                 at quantile probability in second col index, for the row index.
         """
-        # input check for X
-
-        self._set_fh(fh)
-        X_inner = self._check_X(X=X)
         self.check_is_fitted()
-
+        # input checks
+        self._set_fh(fh)
         coverage = check_alpha(coverage)
-        pred_int = self._predict_interval(fh=fh, X=X_inner, coverage=coverage)
+
+        # check and convert X
+        X_inner = self._check_X(X=X)
+
+        pred_int = self._predict_interval(fh=self.fh, X=X_inner, coverage=coverage)
         return pred_int
 
     def update(self, y, X=None, update_params=True):


### PR DESCRIPTION
There was a small mistake in `predict_interval` and `predict_quantiles` which would lead to buggy behaviour if `fh` was already passed in `fit`.

The problem was using `fh` (passed in the function) instead of using `self.fh` which contains the `fh` if it was already passed in `fit`.

I admit that this convention seems very counterintuitive and exists more out of historical legacy.
For this to be more consistent, we should perhaps move to a syntax
`fh = self._check_fh(fh)` instead of `self._set_fh(fh)`
(and expect all developers ot know that the latter modifies `self.fh` which must be used instead of `fh` after that)

However, this is not done in this PR, the scope is only to fix the inconsistency in `predict_interval` and `predict_quantiles`.

FYI, @kejsitake, @SveaMeyer13, @mloning, @aiwalter, @eenticott-shell, comments are appreciated (on this PR or the issue with `_set_fh`).