### PR TITLE
[ENH] experimental: hierarchical time series scitype

### DIFF
--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -30,6 +30,7 @@ import numpy as np
 from deprecated.sphinx import deprecated
 
 from sktime.datatypes._alignment import check_dict_Alignment
+from sktime.datatypes._hierarchical import check_dict_Hierarchical
 from sktime.datatypes._panel import check_dict_Panel
 from sktime.datatypes._registry import mtype_to_scitype
 from sktime.datatypes._series import check_dict_Series
@@ -39,6 +40,7 @@ from sktime.datatypes._table import check_dict_Table
 check_dict = dict()
 check_dict.update(check_dict_Series)
 check_dict.update(check_dict_Panel)
+check_dict.update(check_dict_Hierarchical)
 check_dict.update(check_dict_Alignment)
 check_dict.update(check_dict_Table)
 

--- a/sktime/datatypes/_convert.py
+++ b/sktime/datatypes/_convert.py
@@ -69,6 +69,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.datatypes._check import mtype as infer_mtype
+from sktime.datatypes._hierarchical import convert_dict_Hierarchical
 from sktime.datatypes._panel import convert_dict_Panel
 from sktime.datatypes._registry import mtype_to_scitype
 from sktime.datatypes._series import convert_dict_Series
@@ -78,6 +79,7 @@ from sktime.datatypes._table import convert_dict_Table
 convert_dict = dict()
 convert_dict.update(convert_dict_Series)
 convert_dict.update(convert_dict_Panel)
+convert_dict.update(convert_dict_Hierarchical)
 convert_dict.update(convert_dict_Table)
 
 

--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -23,9 +23,9 @@ __all__ = [
 
 from sktime.datatypes._alignment import example_dict_Alignment
 from sktime.datatypes._hierarchical import (
+    example_dict_Hierarchical,
     example_dict_lossy_Hierarchical,
     example_dict_metadata_Hierarchical,
-    example_dict_Hierarchical,
 )
 from sktime.datatypes._panel import (
     example_dict_lossy_Panel,

--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -22,6 +22,11 @@ __all__ = [
 ]
 
 from sktime.datatypes._alignment import example_dict_Alignment
+from sktime.datatypes._hierarchical import (
+    example_dict_lossy_Hierarchical,
+    example_dict_metadata_Hierarchical,
+    example_dict_Hierarchical,
+)
 from sktime.datatypes._panel import (
     example_dict_lossy_Panel,
     example_dict_metadata_Panel,
@@ -43,16 +48,19 @@ example_dict = dict()
 example_dict.update(example_dict_Alignment)
 example_dict.update(example_dict_Series)
 example_dict.update(example_dict_Panel)
+example_dict.update(example_dict_Hierarchical)
 example_dict.update(example_dict_Table)
 
 example_dict_lossy = dict()
 example_dict_lossy.update(example_dict_lossy_Series)
 example_dict_lossy.update(example_dict_lossy_Panel)
+example_dict_lossy.update(example_dict_lossy_Hierarchical)
 example_dict_lossy.update(example_dict_lossy_Table)
 
 example_dict_metadata = dict()
 example_dict_metadata.update(example_dict_metadata_Series)
 example_dict_metadata.update(example_dict_metadata_Panel)
+example_dict_metadata.update(example_dict_metadata_Hierarchical)
 example_dict_metadata.update(example_dict_metadata_Table)
 
 

--- a/sktime/datatypes/_hierarchical/__init__.py
+++ b/sktime/datatypes/_hierarchical/__init__.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""Module exports: Hierarchical type checkers, converters and mtype inference."""
+
+from sktime.datatypes._hierarchical._check import check_dict as check_dict_Hierarchical
+from sktime.datatypes._hierarchical._convert import (
+    convert_dict as convert_dict_Hierarchical,
+)
+from sktime.datatypes._hierarchical._examples import (
+    example_dict as example_dict_Hierarchical,
+)
+from sktime.datatypes._hierarchical._examples import (
+    example_dict_lossy as example_dict_lossy_Hierarchical,
+)
+from sktime.datatypes._hierarchical._examples import (
+    example_dict_metadata as example_dict_metadata_Hierarchical,
+)
+from sktime.datatypes._hierarchical._registry import (
+    MTYPE_LIST_HIERARCHICAL, MTYPE_REGISTER_HIERARCHICAL,
+)
+
+__all__ = [
+    "check_dict_Hierarchical",
+    "convert_dict_Hierarchical",
+    "infer_mtype_dict_Hierarchical",
+    "MTYPE_LIST_HIERARCHICAL",
+    "MTYPE_REGISTER_HIERARCHICAL",
+    "example_dict_Hierarchical",
+    "example_dict_lossy_Hierarchical",
+    "example_dict_metadata_Hierarchical",
+]

--- a/sktime/datatypes/_hierarchical/__init__.py
+++ b/sktime/datatypes/_hierarchical/__init__.py
@@ -15,7 +15,8 @@ from sktime.datatypes._hierarchical._examples import (
     example_dict_metadata as example_dict_metadata_Hierarchical,
 )
 from sktime.datatypes._hierarchical._registry import (
-    MTYPE_LIST_HIERARCHICAL, MTYPE_REGISTER_HIERARCHICAL,
+    MTYPE_LIST_HIERARCHICAL,
+    MTYPE_REGISTER_HIERARCHICAL,
 )
 
 __all__ = [

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -27,13 +27,15 @@ msg: str - error message if object is not valid, otherwise None
 metadata: dict - metadata about obj if valid, otherwise None
         returned only if return_metadata is True
     fields:
-        "is_univariate": bool, True iff all series in panel have one variable
+        "is_univariate": bool, True iff all series in hier.panel have one variable
         "is_equally_spaced": bool, True iff all series indices are equally spaced
         "is_equal_length": bool, True iff all series in panel are of equal length
         "is_empty": bool, True iff one or more of the series in the panel are empty
-        "is_one_series": bool, True iff there is only one series in the panel
+        "is_one_series": bool, True iff there is only one series in the hier.panel
+        "is_one_panel": bool, True iff there is only one flat panel in the hier.panel
         "has_nans": bool, True iff the panel contains NaN values
-        "n_instances": int, number of instances in the panel
+        "n_instances": int, number of instances in the hierarchical panel
+        "n_panels": int, number of flat panels in the hierarchical panel
 """
 
 __author__ = ["fkiraly"]
@@ -92,6 +94,7 @@ def check_pdmultiindex_Hierarchical(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     inst_inds = obj.index.droplevel(-1).unique()
+    panel_inds = inst_inds.droplevel(-1).unique()
 
     check_res = [
         check_pdDataFrame_Series(obj.loc[i], return_metadata=True) for i in inst_inds
@@ -112,7 +115,9 @@ def check_pdmultiindex_Hierarchical(obj, return_metadata=False, var_name="obj"):
     )
     metadata["is_empty"] = np.any([res[2]["is_empty"] for res in check_res])
     metadata["n_instances"] = len(inst_inds)
+    metadata["n_panels"] = len(panel_inds)
     metadata["is_one_series"] = len(inst_inds) == 1
+    metadata["is_one_panel"] = len(panel_inds) == 1
     metadata["has_nans"] = obj.isna().values.any()
     metadata["is_equal_length"] = _list_all_equal([len(obj.loc[i]) for i in inst_inds])
 

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+"""Machine type checkers for Series scitype.
+
+Exports checkers for Series scitype:
+
+check_dict: dict indexed by pairs of str
+  1st element = mtype - str
+  2nd element = scitype - str
+elements are checker/validation functions for mtype
+
+Function signature of all elements
+check_dict[(mtype, scitype)]
+
+Parameters
+----------
+obj - object to check
+return_metadata - bool, optional, default=False
+    if False, returns only "valid" return
+    if True, returns all three return objects
+var_name: str, optional, default="obj" - name of input in error messages
+
+Returns
+-------
+valid: bool - whether obj is a valid object of mtype/scitype
+msg: str - error message if object is not valid, otherwise None
+        returned only if return_metadata is True
+metadata: dict - metadata about obj if valid, otherwise None
+        returned only if return_metadata is True
+    fields:
+        "is_univariate": bool, True iff all series in panel have one variable
+        "is_equally_spaced": bool, True iff all series indices are equally spaced
+        "is_equal_length": bool, True iff all series in panel are of equal length
+        "is_empty": bool, True iff one or more of the series in the panel are empty
+        "is_one_series": bool, True iff there is only one series in the panel
+        "has_nans": bool, True iff the panel contains NaN values
+        "n_instances": int, number of instances in the panel
+"""
+
+__author__ = ["fkiraly"]
+
+__all__ = ["check_dict"]
+
+import numpy as np
+import pandas as pd
+
+from sktime.datatypes._series._check import check_pdDataFrame_Series
+
+VALID_INDEX_TYPES = (pd.Int64Index, pd.RangeIndex, pd.PeriodIndex, pd.DatetimeIndex)
+VALID_MULTIINDEX_TYPES = (pd.Int64Index, pd.RangeIndex)
+
+
+def _list_all_equal(obj):
+    """Check whether elements of list are all equal.
+
+    Parameters
+    ----------
+    obj: list - assumed, not checked
+
+    Returns
+    -------
+    bool, True if elements of obj are all equal
+    """
+    if len(obj) < 2:
+        return True
+
+    return np.all([s == obj[0] for s in obj])
+
+
+check_dict = dict()
+
+
+def _ret(valid, msg, metadata, return_metadata):
+    if return_metadata:
+        return valid, msg, metadata
+    else:
+        return valid
+
+
+def check_pdmultiindex_Hierarchical(obj, return_metadata=False, var_name="obj"):
+
+    if not isinstance(obj, pd.DataFrame):
+        msg = f"{var_name} must be a pd.DataFrame, found {type(obj)}"
+        return _ret(False, msg, None, return_metadata)
+
+    if not isinstance(obj.index, pd.MultiIndex):
+        msg = f"{var_name} must have a MultiIndex, found {type(obj.index)}"
+        return _ret(False, msg, None, return_metadata)
+
+    nlevels = obj.index.nlevels
+    if not nlevels > 2:
+        msg = f"{var_name} have a MultiIndex with 3 or more levels, found {nlevels}"
+        return _ret(False, msg, None, return_metadata)
+
+    inst_inds = obj.index.droplevel(-1).unique()
+
+    check_res = [
+        check_pdDataFrame_Series(obj.loc[i], return_metadata=True) for i in inst_inds
+    ]
+    bad_inds = [i[1] for i in enumerate(inst_inds) if not check_res[i[0]][0]]
+
+    if len(bad_inds) > 0:
+        msg = (
+            f"{var_name}.loc[i] must be Series of mtype pd.DataFrame,"
+            " not at i={bad_inds}"
+        )
+        return _ret(False, msg, None, return_metadata)
+
+    metadata = dict()
+    metadata["is_univariate"] = np.all([res[2]["is_univariate"] for res in check_res])
+    metadata["is_equally_spaced"] = np.all(
+        [res[2]["is_equally_spaced"] for res in check_res]
+    )
+    metadata["is_empty"] = np.any([res[2]["is_empty"] for res in check_res])
+    metadata["n_instances"] = len(inst_inds)
+    metadata["is_one_series"] = len(inst_inds) == 1
+    metadata["has_nans"] = obj.isna().values.any()
+    metadata["is_equal_length"] = _list_all_equal([len(obj.loc[i]) for i in inst_inds])
+
+    return _ret(True, None, metadata, return_metadata)
+
+
+check_dict[("pd_multiindex_hier", "Hierarchical")] = check_pdmultiindex_Hierarchical

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -78,7 +78,7 @@ def _ret(valid, msg, metadata, return_metadata):
         return valid
 
 
-def check_pdmultiindex_Hierarchical(obj, return_metadata=False, var_name="obj"):
+def check_pdmultiindex_hierarchical(obj, return_metadata=False, var_name="obj"):
 
     if not isinstance(obj, pd.DataFrame):
         msg = f"{var_name} must be a pd.DataFrame, found {type(obj)}"
@@ -124,4 +124,4 @@ def check_pdmultiindex_Hierarchical(obj, return_metadata=False, var_name="obj"):
     return _ret(True, None, metadata, return_metadata)
 
 
-check_dict[("pd_multiindex_hier", "Hierarchical")] = check_pdmultiindex_Hierarchical
+check_dict[("pd_multiindex_hier", "Hierarchical")] = check_pdmultiindex_hierarchical

--- a/sktime/datatypes/_hierarchical/_convert.py
+++ b/sktime/datatypes/_hierarchical/_convert.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+__all__ = [
+    "convert_dict",
+]
+
+from sktime.datatypes._hierarchical._registry import MTYPE_LIST_HIERARCHICAL
+
+# dictionary indexed by triples of types
+#  1st element = convert from - type
+#  2nd element = convert to - type
+#  3rd element = considered as this scitype - string
+# elements are conversion functions of machine type (1st) -> 2nd
+
+convert_dict = dict()
+
+
+def convert_identity(obj, store=None):
+
+    return obj
+
+
+# assign identity function to type conversion to self
+for tp in MTYPE_LIST_HIERARCHICAL:
+    convert_dict[(tp, tp, "Hierarchical")] = convert_identity

--- a/sktime/datatypes/_hierarchical/_examples.py
+++ b/sktime/datatypes/_hierarchical/_examples.py
@@ -61,10 +61,12 @@ example_dict_lossy[("pd_multiindex_hier", "Hierarchical", 0)] = False
 
 example_dict_metadata[("Hierarchical", 0)] = {
     "is_univariate": False,
+    "is_one_panel": False,
     "is_one_series": False,
     "is_equally_spaced": True,
     "is_equal_length": True,
     "is_empty": False,
     "has_nans": False,
     "n_instances": 6,
+    "n_panels": 2,
 }

--- a/sktime/datatypes/_hierarchical/_examples.py
+++ b/sktime/datatypes/_hierarchical/_examples.py
@@ -34,12 +34,24 @@ example_dict_metadata = dict()
 cols = ["foo", "bar", "timepoints"] + [f"var_{i}" for i in range(2)]
 
 Xlist = [
-    pd.DataFrame([["a", 0, 0, 1, 4], ["a", 0, 1, 2, 5], ["a", 0, 2, 3, 6]], columns=cols),
-    pd.DataFrame([["a", 1, 0, 1, 4], ["a", 1, 1, 2, 55], ["a", 1, 2, 3, 6]], columns=cols),
-    pd.DataFrame([["a", 2, 0, 1, 42], ["a", 2, 1, 2, 5], ["a", 2, 2, 3, 6]], columns=cols),
-    pd.DataFrame([["b", 0, 0, 1, 4], ["b", 0, 1, 2, 5], ["b", 0, 2, 3, 6]], columns=cols),
-    pd.DataFrame([["b", 1, 0, 1, 4], ["b", 1, 1, 2, 55], ["b", 1, 2, 3, 6]], columns=cols),
-    pd.DataFrame([["b", 2, 0, 1, 42], ["b", 2, 1, 2, 5], ["b", 2, 2, 3, 6]], columns=cols),
+    pd.DataFrame(
+        [["a", 0, 0, 1, 4], ["a", 0, 1, 2, 5], ["a", 0, 2, 3, 6]], columns=cols
+    ),
+    pd.DataFrame(
+        [["a", 1, 0, 1, 4], ["a", 1, 1, 2, 55], ["a", 1, 2, 3, 6]], columns=cols
+    ),
+    pd.DataFrame(
+        [["a", 2, 0, 1, 42], ["a", 2, 1, 2, 5], ["a", 2, 2, 3, 6]], columns=cols
+    ),
+    pd.DataFrame(
+        [["b", 0, 0, 1, 4], ["b", 0, 1, 2, 5], ["b", 0, 2, 3, 6]], columns=cols
+    ),
+    pd.DataFrame(
+        [["b", 1, 0, 1, 4], ["b", 1, 1, 2, 55], ["b", 1, 2, 3, 6]], columns=cols
+    ),
+    pd.DataFrame(
+        [["b", 2, 0, 1, 42], ["b", 2, 1, 2, 5], ["b", 2, 2, 3, 6]], columns=cols
+    ),
 ]
 X = pd.concat(Xlist)
 X = X.set_index(["foo", "bar", "timepoints"])

--- a/sktime/datatypes/_hierarchical/_examples.py
+++ b/sktime/datatypes/_hierarchical/_examples.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""Example generation for testing.
+
+Exports dict of examples, useful for testing as fixtures.
+
+example_dict: dict indexed by triple
+  1st element = mtype - str
+  2nd element = considered as this scitype - str
+  3rd element = int - index of example
+elements are data objects, considered examples for the mtype
+    all examples with same index are considered "same" on scitype content
+    if None, indicates that representation is not possible
+
+example_lossy: dict of bool indexed by pairs of str
+  1st element = mtype - str
+  2nd element = considered as this scitype - str
+  3rd element = int - index of example
+elements are bool, indicate whether representation has information removed
+    all examples with same index are considered "same" on scitype content
+
+overall, conversions from non-lossy representations to any other ones
+    should yield the element exactly, identidally (given same index)
+"""
+
+import pandas as pd
+
+example_dict = dict()
+example_dict_lossy = dict()
+example_dict_metadata = dict()
+
+###
+# example 0: multivariate, equally sampled
+
+cols = ["foo", "bar", "timepoints"] + [f"var_{i}" for i in range(2)]
+
+Xlist = [
+    pd.DataFrame([["a", 0, 0, 1, 4], ["a", 0, 1, 2, 5], ["a", 0, 2, 3, 6]], columns=cols),
+    pd.DataFrame([["a", 1, 0, 1, 4], ["a", 1, 1, 2, 55], ["a", 1, 2, 3, 6]], columns=cols),
+    pd.DataFrame([["a", 2, 0, 1, 42], ["a", 2, 1, 2, 5], ["a", 2, 2, 3, 6]], columns=cols),
+    pd.DataFrame([["b", 0, 0, 1, 4], ["b", 0, 1, 2, 5], ["b", 0, 2, 3, 6]], columns=cols),
+    pd.DataFrame([["b", 1, 0, 1, 4], ["b", 1, 1, 2, 55], ["b", 1, 2, 3, 6]], columns=cols),
+    pd.DataFrame([["b", 2, 0, 1, 42], ["b", 2, 1, 2, 5], ["b", 2, 2, 3, 6]], columns=cols),
+]
+X = pd.concat(Xlist)
+X = X.set_index(["foo", "bar", "timepoints"])
+
+example_dict[("pd_multiindex_hier", "Hierarchical", 0)] = X
+example_dict_lossy[("pd_multiindex_hier", "Hierarchical", 0)] = False
+
+example_dict_metadata[("Hierarchical", 0)] = {
+    "is_univariate": False,
+    "is_one_series": False,
+    "is_equally_spaced": True,
+    "is_equal_length": True,
+    "is_empty": False,
+    "has_nans": False,
+    "n_instances": 6,
+}

--- a/sktime/datatypes/_hierarchical/_registry.py
+++ b/sktime/datatypes/_hierarchical/_registry.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import pandas as pd
+
+__all__ = [
+    "MTYPE_REGISTER_HIERARCHICAL",
+    "MTYPE_LIST_HIERARCHICAL",
+]
+
+
+MTYPE_REGISTER_HIERARCHICAL = [
+    (
+        "pd_multiindex_hier",
+        "Hierarchical",
+        "pd.DataFrame with MultiIndex",
+    ),
+]
+
+MTYPE_LIST_HIERARCHICAL = pd.DataFrame(MTYPE_REGISTER_HIERARCHICAL)[0].values

--- a/sktime/datatypes/_registry.py
+++ b/sktime/datatypes/_registry.py
@@ -36,6 +36,10 @@ from sktime.datatypes._alignment._registry import (
     MTYPE_LIST_ALIGNMENT,
     MTYPE_REGISTER_ALIGNMENT,
 )
+from sktime.datatypes._hierarchical._registry import (
+    MTYPE_LIST_HIERARCHICAL,
+    MTYPE_REGISTER_HIERARCHICAL,
+)
 from sktime.datatypes._panel._registry import MTYPE_LIST_PANEL, MTYPE_REGISTER_PANEL
 from sktime.datatypes._series._registry import MTYPE_LIST_SERIES, MTYPE_REGISTER_SERIES
 from sktime.datatypes._table._registry import MTYPE_LIST_TABLE, MTYPE_REGISTER_TABLE
@@ -43,12 +47,14 @@ from sktime.datatypes._table._registry import MTYPE_LIST_TABLE, MTYPE_REGISTER_T
 MTYPE_REGISTER = []
 MTYPE_REGISTER += MTYPE_REGISTER_SERIES
 MTYPE_REGISTER += MTYPE_REGISTER_PANEL
+MTYPE_REGISTER += MTYPE_REGISTER_HIERARCHICAL
 MTYPE_REGISTER += MTYPE_REGISTER_ALIGNMENT
 MTYPE_REGISTER += MTYPE_REGISTER_TABLE
 
 
 __all__ = [
     "MTYPE_REGISTER",
+    "MTYPE_LIST_HIERARCHICAL",
     "MTYPE_LIST_PANEL",
     "MTYPE_LIST_SERIES",
     "MTYPE_LIST_ALIGNMENT",
@@ -60,6 +66,7 @@ __all__ = [
 SCITYPE_REGISTER = [
     ("Series", "uni- or multivariate time series"),
     ("Panel", "panel of uni- or multivariate time series"),
+    ("Hierarchical", "hierarchical panel of time series with 3 or more levels"),
     ("Alignment", "series or sequence alignment"),
     ("Table", "data table with primitive column types"),
 ]


### PR DESCRIPTION
This PR adds a scitype `Hierarchical` with a single mtype, with 2 or more levels of hierarchy.

The representation is a `pandas.DataFrame` with 3 or more levels, out of which the lowest one must correspond to an `sktime` supported time index type.

The scitype can be used in input checks and conversions.