### PR TITLE
[BUG] `check_is_mtype` to return scitype

### DIFF
--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -232,6 +232,7 @@ def check_is_mtype(
     #  for each check we remember whether it passed and what it returned
     msg = []
     found_mtype = []
+    found_scitype = []
 
     for m in mtype:
         if scitype is None:
@@ -252,6 +253,7 @@ def check_is_mtype(
 
         if check_passed:
             found_mtype.append(m)
+            found_scitype.append(scitype_of_m)
             final_result = res
         elif return_metadata:
             msg.append(res[1])
@@ -267,6 +269,7 @@ def check_is_mtype(
         if return_metadata:
             # add the mtype return to the metadata
             final_result[2]["mtype"] = found_mtype[0]
+            final_result[2]["scitype"] = found_scitype[0]
             # final_result already has right shape and dependency on return_metadata
             return final_result
         else:

--- a/sktime/datatypes/tests/test_check.py
+++ b/sktime/datatypes/tests/test_check.py
@@ -181,9 +181,11 @@ def test_check_metadata_inference(scitype, mtype, fixture_index):
         check_result = check_is_mtype(fixture, mtype, scitype, return_metadata=True)
         metadata = check_result[2]
 
-        # remove mtype key if exists, since comparison is on scitype level
+        # remove mtype & scitype key if exists, since comparison is on scitype level
         if "mtype" in metadata:
             del metadata["mtype"]
+        if "scitype" in metadata:
+            del metadata["scitype"]
 
         msg = (
             f"check_is_mtype returns wrong metadata on scitype {scitype}, "


### PR DESCRIPTION
In discrepancy to the docstring, by mistake, `check_is_mtype` did not actually return the scitype in its metadata dict.

This has been added.

In the future I'll probably refactor `check_is_mtype` and `check_is_scitype` to use the same internal logic and be semi-aliases, and introduce some tests - the scope of this PR is to only fix the bug (vs specification).