### PR TITLE
[BUG] fixed mtype return field in `check_is_scitype`

### DIFF
--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -231,10 +231,10 @@ class BaseClassifier(BaseEstimator):
         ValueError if the capabilities in self._tags do not handle the data.
         """
         X = _internal_convert(X)
-        self.metadata_ = _check_classifier_input(X)
-        missing = self.metadata_["has_nans"]
-        multivariate = not self.metadata_["is_univariate"]
-        unequal = not self.metadata_["is_equal_length"]
+        X_metadata = _check_classifier_input(X)
+        missing = X_metadata["has_nans"]
+        multivariate = not X_metadata["is_univariate"]
+        unequal = not X_metadata["is_equal_length"]
         # Check this classifier can handle characteristics
         self._check_capabilities(missing, multivariate, unequal)
         # Convert data as dictated by the classifier tags

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -100,10 +100,10 @@ class BaseClassifier(BaseEstimator):
         # convenience conversions to allow user flexibility:
         # if X is 2D array, convert to 3D, if y is Series, convert to numpy
         X, y = _internal_convert(X, y)
-        self.metadata_ = _check_classifier_input(X, y)
-        missing = self.metadata_["has_nans"]
-        multivariate = not self.metadata_["is_univariate"]
-        unequal = not self.metadata_["is_equal_length"]
+        X_metadata = _check_classifier_input(X, y)
+        missing = X_metadata["has_nans"]
+        multivariate = not X_metadata["is_univariate"]
+        unequal = not X_metadata["is_equal_length"]
         # Check this classifier can handle characteristics
         self._check_capabilities(missing, multivariate, unequal)
         # Convert data as dictated by the classifier tags

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -457,7 +457,7 @@ def check_is_scitype(
 
         if check_passed:
             final_result = res
-            found_mtype.append([0])
+            found_mtype.append(key[0])
             found_scitype.append(key[1])
         elif return_metadata:
             msg.append(res[1])


### PR DESCRIPTION
The `"mtype"` return field of the optional metadata dict returned by `check_is_scitype` was incorrectly always returning the integer 0 instead of the inferred mtype, due to a type.

This has been fixed in this PR.

The bug masked another bug in the new classifier base class introduced by PR https://github.com/alan-turing-institute/sktime/pull/1594: the `predict` etc (non-state changing) methods were writing to `self`, via the boilerplate code that, for some reason, stored the `check_is_mtype` metadata to `self` in the input checks.
This has been changed to merely using it temporarily, which fixes the masked bug, too.