### PR TITLE
[BUG] remove duplicated input checks from `BaseClassifier.score`

### DIFF
--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -208,9 +208,6 @@ class BaseClassifier(BaseEstimator):
 
         self.check_is_fitted()
 
-        # boilerplate input checks for predict-like methods
-        X = self._check_convert_X_for_predict(X)
-
         return accuracy_score(y, self.predict(X), normalize=True)
 
     def _check_convert_X_for_predict(self, X):


### PR DESCRIPTION
This PR removes unnecessary duplicated input checks from `BaseClassifier.score`.

Since `score` calls `predict`, which directly does the same input checks again at the beginning, this is superfluous.

It also caused a downstream error with `ColumnEnsembleClassifier` which is not yet refactored to the new interface, hence inherits the "univariate" tag despite being multivariate. Since the original `ColumnEnsembleClassifier` overrides `fit`/`predict` but not `score`, this will cause an exception if multivariate data are being passed to `score`.
The `score` function is used in notebook 3, and causes the notebook to break, hence.

This downstream error is also fixed by the removal of the duplication.