### PR TITLE
DRAFT [MNT] Updated `build_tools/requirements.txt` to move from `fbprophet` to `prophet`

### DIFF
--- a/.binder/prelim_requirements.txt
+++ b/.binder/prelim_requirements.txt
@@ -1,16 +1,16 @@
-convertdate >= 2.3.2
+convertdate>=2.3.2
 cython>=0.29.0
 deprecated>=1.2.13
 dtw_python>=1.1.5
 esig==0.9.7
 hcrystalball>=0.1.9
-LunarCalendar >= 0.0.9
+LunarCalendar>=0.0.9
 matplotlib
 notebook
-numba==0.53
+numba>=0.53
 numpy==1.19.3
-pystan==2.19.1.1
-seaborn
+pystan>=2.19.1.1,<3.0.0.0
+seaborn>=0.11.0
 stumpy>=1.5.1,<=1.9.2
 tbats>=1.1.0
 tsfresh>=0.17.0

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,6 +1,6 @@
-fbprophet>=0.7.1
-pandas==1.1.5
+prophet>=1.0.0
+pandas>=1.1.5
 pmdarima>=1.8.0,!=1.8.1
 scikit-learn>=0.24.*
-scikit-posthocs
+scikit-posthocs>=0.6.5
 statsmodels==0.12.1

--- a/build_tools/hard_dependencies.txt
+++ b/build_tools/hard_dependencies.txt
@@ -1,7 +1,7 @@
 cython>=0.29.0
-numba==0.53
+numba>=0.53
 numpy==1.19.3
-pandas==1.1.5
-scikit-learn==0.24.*
-statsmodels==0.12.1
+pandas>=1.1.5
+scikit-learn>=0.24.*
+statsmodels>=0.12.1
 wheel

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -1,21 +1,29 @@
-cython>=0.29.0
+# core dependencies
 deprecated>=1.2.13
-dtw_python>=1.1.5
-esig==0.9.7
-fbprophet>=0.7.1
-hcrystalball>=0.1.9
-numba==0.53
+numba>=0.53
 numpy==1.19.3
-pandas==1.1.5
+pandas>=1.1.5
+scikit-learn>=0.24.0
+statsmodels>=0.12.1
+
+# all_extras
+dtw-python>=1.1.5
+esig==0.9.7
+prophet>=1.0.0
+hcrystalball>=0.1.9
+matplotlib>=3.3.2
 pmdarima>=1.8.0,!=1.8.1
 pyod>=0.8.0
-pystan>=2.14,<3.0
-pytest
-pytest-cov
-scikit-learn==0.24.*
-scikit-posthocs
-statsmodels==0.12.1
+pystan>=2.19.1.1,<=3.0.0.0
+scikit_posthocs>=0.6.5
+seaborn>=0.11.0
 stumpy>=1.5.1,<=1.9.2
 tbats>=1.1.0
 tsfresh>=0.17.0
+
+# dev
+cython>=0.29.0
+pre-commit
+pytest
+pytest-cov
 wheel

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from pkg_resources import parse_version
 MIN_PYTHON_VERSION = "3.6"
 MIN_REQUIREMENTS = {
     "numpy": "1.19.3",
-    "pandas": "1.1.0",
+    "pandas": "1.1.5",
     "scikit-learn": "0.24.0",
     "statsmodels": "0.12.1",
     "numba": "0.53",
@@ -43,7 +43,7 @@ EXTRAS_REQUIRE = {
         "hcrystalball>=0.1.9",
         "stumpy>=1.5.1,<=1.9.2",
         "tbats>=1.1.0",
-        "fbprophet>=0.7.1",
+        "prophet>=1.0.0",
         "pyod>=0.8.0",
         "dtw_python>=1.1.5",
     ],

--- a/sktime/forecasting/fbprophet.py
+++ b/sktime/forecasting/fbprophet.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Implements Prophet forecaster by wrapping fbprophet."""
+"""Implements Prophet forecaster by wrapping prophet."""
 
 __author__ = ["aiwalter"]
 __all__ = ["Prophet"]
@@ -10,7 +10,7 @@ from sktime.forecasting.base._base import DEFAULT_ALPHA
 from sktime.forecasting.base.adapters import _ProphetAdapter
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("fbprophet")
+_check_soft_dependencies("prophet")
 
 
 class Prophet(_ProphetAdapter):
@@ -164,7 +164,7 @@ class Prophet(_ProphetAdapter):
         self.verbose = verbose
 
         # import inside method to avoid hard dependency
-        from fbprophet.forecaster import Prophet as _Prophet
+        from prophet.forecaster import Prophet as _Prophet
 
         self._ModelClass = _Prophet
 


### PR DESCRIPTION
#### Reference Issues
Attempts to fix #1631.

#### What does this implement/fix? Explain your changes.

Specific to prophet:

* Set upper limit on pystan version
* Moved from `fbprohet>=0.7.1` to `prophet>=1.0.0`.

More generally:

* groups dependencies so it's clear when each dependency is used (mirrors #1620):
  * `core dependencies` for the base sktime
  * `all_extras` for extensions
  * `dev` for contributors
* Relaxed constraint on all libraries except `numpy` (see #1787 and #1794)

#### What should a reviewer concentrate their feedback on?

We should test this across multiple OS and Python versions. I could test macOS with Python 3.8.12

#### Other notice

When `pip install -r build_tools/requirements.txt` is run, packages are collected; then **wheels are built**. When doing so, **`prophet` wheel fails to build because it is build before numpy is installed**. `pip` then installs the other dependencies and `prophet` too, but without building the wheel and using `setup.py`.

<details>
<summary> Full log</summary>

```
$ pip install -r build_tools/requirements.txt
Collecting deprecated>=1.2.13
  Using cached Deprecated-1.2.13-py2.py3-none-any.whl (9.6 kB)
Collecting numba>=0.53
  Downloading numba-0.54.1-cp38-cp38-macosx_10_14_x86_64.whl (2.3 MB)
     |████████████████████████████████| 2.3 MB 2.0 MB/s
Collecting numpy==1.19.3
  Using cached numpy-1.19.3-cp38-cp38-macosx_10_9_x86_64.whl (15.9 MB)
Collecting pandas>=1.1.5
  Downloading pandas-1.3.5-cp38-cp38-macosx_10_9_x86_64.whl (11.2 MB)
     |████████████████████████████████| 11.2 MB 10.9 MB/s
Collecting scikit-learn>=0.24.0
  Downloading scikit_learn-1.0.2-cp38-cp38-macosx_10_13_x86_64.whl (7.9 MB)
     |████████████████████████████████| 7.9 MB 7.9 MB/s
Collecting statsmodels>=0.12.1
  Downloading statsmodels-0.13.1-cp38-cp38-macosx_10_15_x86_64.whl (9.6 MB)
     |████████████████████████████████| 9.6 MB 3.1 MB/s
Collecting dtw-python>=1.1.5
  Using cached dtw_python-1.1.10-cp38-cp38-macosx_10_9_x86_64.whl (307 kB)
Collecting esig==0.9.7
  Using cached esig-0.9.7-cp38-cp38-macosx_10_15_x86_64.whl (7.5 MB)
Collecting prophet>=1.0.0
  Using cached prophet-1.0.1.tar.gz (65 kB)
  Preparing metadata (setup.py) ... done
Collecting hcrystalball>=0.1.9
  Using cached hcrystalball-0.1.10-py2.py3-none-any.whl (786 kB)
Collecting matplotlib>=3.3.2
  Using cached matplotlib-3.5.1-cp38-cp38-macosx_10_9_x86_64.whl (7.3 MB)
Collecting pmdarima!=1.8.1,>=1.8.0
  Using cached pmdarima-1.8.4-cp38-cp38-macosx_10_15_x86_64.whl (595 kB)
Collecting pyod>=0.8.0
  Downloading pyod-0.9.6.tar.gz (113 kB)
     |████████████████████████████████| 113 kB 10.5 MB/s
  Preparing metadata (setup.py) ... done
Collecting pystan<=3.0.0.0,>=2.19.1.1
  Downloading pystan-3.0.0-py3-none-any.whl (12 kB)
Collecting scikit_posthocs>=0.6.5
  Using cached scikit_posthocs-0.6.7-py3-none-any.whl
Collecting seaborn>=0.11.0
  Using cached seaborn-0.11.2-py3-none-any.whl (292 kB)
Collecting stumpy<=1.9.2,>=1.5.1
  Using cached stumpy-1.9.2-py3-none-any.whl (113 kB)
Collecting tbats>=1.1.0
  Using cached tbats-1.1.0-py3-none-any.whl (43 kB)
Collecting tsfresh>=0.17.0
  Downloading tsfresh-0.19.0-py2.py3-none-any.whl (97 kB)
     |████████████████████████████████| 97 kB 6.3 MB/s
Collecting cython>=0.29.0
  Downloading Cython-0.29.26-py2.py3-none-any.whl (983 kB)
     |████████████████████████████████| 983 kB 12.5 MB/s
Collecting pre-commit
  Using cached pre_commit-2.16.0-py2.py3-none-any.whl (191 kB)
Collecting pytest
  Using cached pytest-6.2.5-py3-none-any.whl (280 kB)
Collecting pytest-cov
  Using cached pytest_cov-3.0.0-py3-none-any.whl (20 kB)
Requirement already satisfied: wheel in /usr/local/Caskroom/miniconda/base/envs/sktime/lib/python3.8/site-packages (from -r build_tools/requirements.txt (line 29)) (0.37.0)
Collecting wrapt<2,>=1.10
  Using cached wrapt-1.13.3-cp38-cp38-macosx_10_9_x86_64.whl (33 kB)
Requirement already satisfied: setuptools in /usr/local/Caskroom/miniconda/base/envs/sktime/lib/python3.8/site-packages (from numba>=0.53->-r build_tools/requirements.txt (line 3)) (59.4.0)
Collecting llvmlite<0.38,>=0.37.0rc1
  Downloading llvmlite-0.37.0-cp38-cp38-macosx_10_9_x86_64.whl (19.1 MB)
     |████████████████████████████████| 19.1 MB 11.6 MB/s
Collecting python-dateutil>=2.7.3
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Collecting pytz>=2017.3
  Using cached pytz-2021.3-py2.py3-none-any.whl (503 kB)
Collecting scipy>=1.1.0
  Using cached scipy-1.7.3-cp38-cp38-macosx_10_9_x86_64.whl (33.0 MB)
Collecting threadpoolctl>=2.0.0
  Using cached threadpoolctl-3.0.0-py3-none-any.whl (14 kB)
Collecting joblib>=0.11
  Using cached joblib-1.1.0-py2.py3-none-any.whl (306 kB)
Collecting patsy>=0.5.2
  Using cached patsy-0.5.2-py2.py3-none-any.whl (233 kB)
Collecting cmdstanpy==0.9.68
  Using cached cmdstanpy-0.9.68-py3-none-any.whl (49 kB)
Collecting pystan<=3.0.0.0,>=2.19.1.1
  Using cached pystan-2.19.1.1-cp38-cp38-macosx_10_9_x86_64.whl (37.4 MB)
Collecting LunarCalendar>=0.0.9
  Using cached LunarCalendar-0.0.9-py2.py3-none-any.whl (18 kB)
Collecting convertdate>=2.1.2
  Using cached convertdate-2.3.2-py3-none-any.whl (47 kB)
Collecting holidays>=0.10.2
  Using cached holidays-0.11.3.1-py3-none-any.whl (155 kB)
Collecting setuptools-git>=1.2
  Using cached setuptools_git-1.2-py2.py3-none-any.whl (10 kB)
Collecting tqdm>=4.36.1
  Using cached tqdm-4.62.3-py2.py3-none-any.whl (76 kB)
Collecting ujson
  Downloading ujson-5.1.0-cp38-cp38-macosx_10_9_x86_64.whl (46 kB)
     |████████████████████████████████| 46 kB 4.3 MB/s
Collecting workalendar>=10.1
  Using cached workalendar-16.2.0-py3-none-any.whl (205 kB)
Collecting packaging>=20.0
  Using cached packaging-21.3-py3-none-any.whl (40 kB)
Collecting kiwisolver>=1.0.1
  Using cached kiwisolver-1.3.2-cp38-cp38-macosx_10_9_x86_64.whl (61 kB)
Collecting fonttools>=4.22.0
  Downloading fonttools-4.28.5-py3-none-any.whl (890 kB)
     |████████████████████████████████| 890 kB 8.6 MB/s
Collecting cycler>=0.10
  Using cached cycler-0.11.0-py3-none-any.whl (6.4 kB)
Collecting pillow>=6.2.0
  Using cached Pillow-8.4.0-cp38-cp38-macosx_10_10_x86_64.whl (3.0 MB)
Collecting pyparsing>=2.2.1
  Using cached pyparsing-3.0.6-py3-none-any.whl (97 kB)
Collecting urllib3
  Using cached urllib3-1.26.7-py2.py3-none-any.whl (138 kB)
Collecting six
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting cloudpickle
  Using cached cloudpickle-2.0.0-py3-none-any.whl (25 kB)
Collecting requests>=2.9.1
  Using cached requests-2.26.0-py2.py3-none-any.whl (62 kB)
Collecting dask[dataframe]>=2.9.0
  Using cached dask-2021.12.0-py3-none-any.whl (1.0 MB)
Collecting matrixprofile<2.0.0,>=1.1.10
  Using cached matrixprofile-1.1.10-cp38-cp38-macosx_10_12_x86_64.whl (710 kB)
Collecting distributed>=2.11.0
  Using cached distributed-2021.12.0-py3-none-any.whl (802 kB)
Collecting identify>=1.0.0
  Using cached identify-2.4.1-py2.py3-none-any.whl (98 kB)
Collecting virtualenv>=20.0.8
  Using cached virtualenv-20.12.0-py2.py3-none-any.whl (6.5 MB)
Collecting nodeenv>=0.11.1
  Using cached nodeenv-1.6.0-py2.py3-none-any.whl (21 kB)
Collecting toml
  Using cached toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting cfgv>=2.0.0
  Using cached cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
Collecting pyyaml>=5.1
  Using cached PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl (192 kB)
Collecting attrs>=19.2.0
  Downloading attrs-21.4.0-py2.py3-none-any.whl (60 kB)
     |████████████████████████████████| 60 kB 7.8 MB/s
Collecting iniconfig
  Using cached iniconfig-1.1.1-py2.py3-none-any.whl (5.0 kB)
Collecting py>=1.8.2
  Using cached py-1.11.0-py2.py3-none-any.whl (98 kB)
Collecting pluggy<2.0,>=0.12
  Using cached pluggy-1.0.0-py2.py3-none-any.whl (13 kB)
Collecting coverage[toml]>=5.2.1
  Using cached coverage-6.2-cp38-cp38-macosx_10_9_x86_64.whl (179 kB)
Collecting pymeeus<=1,>=0.3.13
  Using cached PyMeeus-0.5.11-py3-none-any.whl
Collecting tomli
  Using cached tomli-2.0.0-py3-none-any.whl (12 kB)
Collecting fsspec>=0.6.0
  Using cached fsspec-2021.11.1-py3-none-any.whl (132 kB)
Collecting partd>=0.3.10
  Using cached partd-1.2.0-py3-none-any.whl (19 kB)
Collecting toolz>=0.8.2
  Using cached toolz-0.11.2-py3-none-any.whl (55 kB)
Collecting psutil>=5.0
  Downloading psutil-5.9.0-cp38-cp38-macosx_10_9_x86_64.whl (238 kB)
     |████████████████████████████████| 238 kB 12.6 MB/s
Collecting msgpack>=0.6.0
  Using cached msgpack-1.0.3-cp38-cp38-macosx_10_9_x86_64.whl (73 kB)
Collecting zict>=0.1.3
  Using cached zict-2.0.0-py3-none-any.whl (10 kB)
Collecting tornado>=6.0.3
  Using cached tornado-6.1-cp38-cp38-macosx_10_9_x86_64.whl (416 kB)
Collecting click>=6.6
  Using cached click-8.0.3-py3-none-any.whl (97 kB)
Collecting sortedcontainers!=2.0.0,!=2.0.1
  Using cached sortedcontainers-2.4.0-py2.py3-none-any.whl (29 kB)
Collecting tblib>=1.6.0
  Using cached tblib-1.7.0-py2.py3-none-any.whl (12 kB)
Collecting jinja2
  Using cached Jinja2-3.0.3-py3-none-any.whl (133 kB)
Collecting hijri-converter
  Using cached hijri_converter-2.2.2-py3-none-any.whl (13 kB)
Collecting korean-lunar-calendar
  Using cached korean_lunar_calendar-0.2.1-py3-none-any.whl (8.0 kB)
Collecting ephem>=3.7.5.3
  Using cached ephem-4.1.3-cp38-cp38-macosx_10_9_x86_64.whl (1.4 MB)
Collecting protobuf==3.11.2
  Using cached protobuf-3.11.2-cp38-cp38-macosx_10_9_x86_64.whl (1.3 MB)
Collecting charset-normalizer~=2.0.0
  Using cached charset_normalizer-2.0.9-py3-none-any.whl (39 kB)
Collecting idna<4,>=2.5
  Using cached idna-3.3-py3-none-any.whl (61 kB)
Collecting certifi>=2017.4.17
  Using cached certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
Collecting distlib<1,>=0.3.1
  Using cached distlib-0.3.4-py2.py3-none-any.whl (461 kB)
Collecting platformdirs<3,>=2
  Using cached platformdirs-2.4.1-py3-none-any.whl (14 kB)
Collecting filelock<4,>=3.2
  Using cached filelock-3.4.2-py3-none-any.whl (9.9 kB)
Collecting pyluach
  Using cached pyluach-1.3.0-py3-none-any.whl (17 kB)
Collecting backports.zoneinfo
  Using cached backports.zoneinfo-0.2.1-cp38-cp38-macosx_10_14_x86_64.whl (35 kB)
Collecting lunardate
  Using cached lunardate-0.2.0-py3-none-any.whl (5.6 kB)
Collecting locket
  Using cached locket-0.2.1-py2.py3-none-any.whl (4.1 kB)
Collecting heapdict
  Using cached HeapDict-1.0.1-py3-none-any.whl (3.9 kB)
Collecting MarkupSafe>=2.0
  Using cached MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl (13 kB)
Building wheels for collected packages: prophet, pyod
  Building wheel for prophet (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /usr/local/Caskroom/miniconda/base/envs/sktime/bin/python3.8 -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/l4/2jcxzqs530l09q204wy86qlr0000gn/T/pip-install-7ikup1wr/prophet_d99fb3c7364549b39a42bd6c9dad5090/setup.py'"'"'; __file__='"'"'/private/var/folders/l4/2jcxzqs530l09q204wy86qlr0000gn/T/pip-install-7ikup1wr/prophet_d99fb3c7364549b39a42bd6c9dad5090/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /private/var/folders/l4/2jcxzqs530l09q204wy86qlr0000gn/T/pip-wheel-ee8f3wh4
       cwd: /private/var/folders/l4/2jcxzqs530l09q204wy86qlr0000gn/T/pip-install-7ikup1wr/prophet_d99fb3c7364549b39a42bd6c9dad5090/
  Complete output (40 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib
  creating build/lib/prophet
  creating build/lib/prophet/stan_model
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/private/var/folders/l4/2jcxzqs530l09q204wy86qlr0000gn/T/pip-install-7ikup1wr/prophet_d99fb3c7364549b39a42bd6c9dad5090/setup.py", line 123, in <module>
      setup(
    File "/usr/local/Caskroom/miniconda/base/envs/sktime/lib/python3.8/site-packages/setuptools/__init__.py", line 153, in setup
      return distutils.core.setup(**attrs)
    File "/usr/local/Caskroom/miniconda/base/envs/sktime/lib/python3.8/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/usr/local/Caskroom/miniconda/base/envs/sktime/lib/python3.8/distutils/dist.py", line 966, in run_commands
      self.run_command(cmd)
    File "/usr/local/Caskroom/miniconda/base/envs/sktime/lib/python3.8/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/usr/local/Caskroom/miniconda/base/envs/sktime/lib/python3.8/site-packages/wheel/bdist_wheel.py", line 299, in run
      self.run_command('build')
    File "/usr/local/Caskroom/miniconda/base/envs/sktime/lib/python3.8/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/usr/local/Caskroom/miniconda/base/envs/sktime/lib/python3.8/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/usr/local/Caskroom/miniconda/base/envs/sktime/lib/python3.8/distutils/command/build.py", line 135, in run
      self.run_command(cmd_name)
    File "/usr/local/Caskroom/miniconda/base/envs/sktime/lib/python3.8/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/usr/local/Caskroom/miniconda/base/envs/sktime/lib/python3.8/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/private/var/folders/l4/2jcxzqs530l09q204wy86qlr0000gn/T/pip-install-7ikup1wr/prophet_d99fb3c7364549b39a42bd6c9dad5090/setup.py", line 48, in run
      build_models(target_dir)
    File "/private/var/folders/l4/2jcxzqs530l09q204wy86qlr0000gn/T/pip-install-7ikup1wr/prophet_d99fb3c7364549b39a42bd6c9dad5090/setup.py", line 36, in build_models
      from prophet.models import StanBackendEnum
    File "/private/var/folders/l4/2jcxzqs530l09q204wy86qlr0000gn/T/pip-install-7ikup1wr/prophet_d99fb3c7364549b39a42bd6c9dad5090/prophet/__init__.py", line 8, in <module>
      from prophet.forecaster import Prophet
    File "/private/var/folders/l4/2jcxzqs530l09q204wy86qlr0000gn/T/pip-install-7ikup1wr/prophet_d99fb3c7364549b39a42bd6c9dad5090/prophet/forecaster.py", line 14, in <module>
      import numpy as np
  ModuleNotFoundError: No module named 'numpy'
  ----------------------------------------
  ERROR: Failed building wheel for prophet
  Running setup.py clean for prophet
  Building wheel for pyod (setup.py) ... done
  Created wheel for pyod: filename=pyod-0.9.6-py3-none-any.whl size=132985 sha256=7bd4df459db5487aff3edf629896f87373b6ca9e13f0a20b30b4d43b134a6cf1
  Stored in directory: /Users/luca/Library/Caches/pip/wheels/f2/6f/e7/a2c646c837e3853233d009fec9977fb4f4c6039c7ce9023f35
Successfully built pyod
Failed to build prophet
Installing collected packages: six, toolz, pytz, python-dateutil, pyparsing, numpy, locket, threadpoolctl, scipy, pyyaml, pymeeus, pillow, patsy, partd, pandas, packaging, MarkupSafe, llvmlite, kiwisolver, joblib, heapdict, fsspec, fonttools, cycler, cloudpickle, zict, urllib3, ujson, tornado, tomli, toml, tblib, statsmodels, sortedcontainers, scikit-learn, pyluach, py, psutil, protobuf, pluggy, platformdirs, numba, msgpack, matplotlib, lunardate, korean-lunar-calendar, jinja2, iniconfig, idna, hijri-converter, filelock, ephem, distlib, dask, cython, coverage, convertdate, click, charset-normalizer, certifi, backports.zoneinfo, attrs, wrapt, workalendar, virtualenv, tqdm, stumpy, setuptools-git, seaborn, requests, pytest, pystan, pmdarima, nodeenv, matrixprofile, LunarCalendar, identify, holidays, distributed, cmdstanpy, cfgv, tsfresh, tbats, scikit-posthocs, pytest-cov, pyod, prophet, pre-commit, hcrystalball, esig, dtw-python, deprecated
    Running setup.py install for prophet ... done
  DEPRECATION: prophet was installed using the legacy 'setup.py install' method, because a wheel could not be built for it. A possible replacement is to fix the wheel build issue reported above. Discussion can be found at https://github.com/pypa/pip/issues/8368
Successfully installed LunarCalendar-0.0.9 MarkupSafe-2.0.1 attrs-21.4.0 backports.zoneinfo-0.2.1 certifi-2021.10.8 cfgv-3.3.1 charset-normalizer-2.0.9 click-8.0.3 cloudpickle-2.0.0 cmdstanpy-0.9.68 convertdate-2.3.2 coverage-6.2 cycler-0.11.0 cython-0.29.26 dask-2021.12.0 deprecated-1.2.13 distlib-0.3.4 distributed-2021.12.0 dtw-python-1.1.10 ephem-4.1.3 esig-0.9.7 filelock-3.4.2 fonttools-4.28.5 fsspec-2021.11.1 hcrystalball-0.1.10 heapdict-1.0.1 hijri-converter-2.2.2 holidays-0.11.3.1 identify-2.4.1 idna-3.3 iniconfig-1.1.1 jinja2-3.0.3 joblib-1.1.0 kiwisolver-1.3.2 korean-lunar-calendar-0.2.1 llvmlite-0.37.0 locket-0.2.1 lunardate-0.2.0 matplotlib-3.5.1 matrixprofile-1.1.10 msgpack-1.0.3 nodeenv-1.6.0 numba-0.54.1 numpy-1.19.3 packaging-21.3 pandas-1.3.5 partd-1.2.0 patsy-0.5.2 pillow-8.4.0 platformdirs-2.4.1 pluggy-1.0.0 pmdarima-1.8.4 pre-commit-2.16.0 prophet-1.0.1 protobuf-3.11.2 psutil-5.9.0 py-1.11.0 pyluach-1.3.0 pymeeus-0.5.11 pyod-0.9.6 pyparsing-3.0.6 pystan-2.19.1.1 pytest-6.2.5 pytest-cov-3.0.0 python-dateutil-2.8.2 pytz-2021.3 pyyaml-6.0 requests-2.26.0 scikit-learn-1.0.2 scikit-posthocs-0.6.7 scipy-1.7.3 seaborn-0.11.2 setuptools-git-1.2 six-1.16.0 sortedcontainers-2.4.0 statsmodels-0.13.1 stumpy-1.9.2 tbats-1.1.0 tblib-1.7.0 threadpoolctl-3.0.0 toml-0.10.2 tomli-2.0.0 toolz-0.11.2 tornado-6.1 tqdm-4.62.3 tsfresh-0.19.0 ujson-5.1.0 urllib3-1.26.7 virtualenv-20.12.0 workalendar-16.2.0 wrapt-1.13.3 zict-2.0.0
```

</details>

#### To do

- [ ] update all other requirements across different files (see #1482)

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc). 
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
