### PR TITLE
[ENH] estimator scitype utility

### DIFF
--- a/sktime/registry/__init__.py
+++ b/sktime/registry/__init__.py
@@ -1,26 +1,23 @@
 # -*- coding: utf-8 -*-
 """Implements registry for sktime estimator base classes and tags."""
 
-from sktime.registry._tags import (
-    ESTIMATOR_TAG_REGISTER,
-    ESTIMATOR_TAG_LIST,
-    check_tag_is_valid,
-)
-
 from sktime.registry._base_classes import (
-    BASE_CLASS_REGISTER,
     BASE_CLASS_LIST,
     BASE_CLASS_LOOKUP,
+    BASE_CLASS_REGISTER,
     BASE_CLASS_SCITYPE_LIST,
-    TRANSFORMER_MIXIN_REGISTER,
     TRANSFORMER_MIXIN_LIST,
     TRANSFORMER_MIXIN_LOOKUP,
+    TRANSFORMER_MIXIN_REGISTER,
     TRANSFORMER_MIXIN_SCITYPE_LIST,
 )
-
 from sktime.registry._lookup import all_estimators, all_tags
-
 from sktime.registry._scitype import scitype
+from sktime.registry._tags import (
+    ESTIMATOR_TAG_LIST,
+    ESTIMATOR_TAG_REGISTER,
+    check_tag_is_valid,
+)
 
 __all__ = [
     "all_estimators",

--- a/sktime/registry/__init__.py
+++ b/sktime/registry/__init__.py
@@ -20,11 +20,13 @@ from sktime.registry._base_classes import (
 
 from sktime.registry._lookup import all_estimators, all_tags
 
+from sktime.registry._scitype import scitype
 
 __all__ = [
     "all_estimators",
     "all_tags",
     "check_tag_is_valid",
+    "scitype",
     "ESTIMATOR_TAG_LIST",
     "ESTIMATOR_TAG_REGISTER",
     "BASE_CLASS_REGISTER",

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Utility to determine scitype of estimator, based on base class type."""
+
+__author__ = ["fkiraly"]
+
+from inspect import isclass
+
+from sktime.registry._lookup import BASE_CLASS_REGISTER
+
+
+def scitype(obj):
+    """Determine scitype string of obj.
+
+    Parameters
+    ----------
+    obj : class or object inheriting from sktime BaseObject
+
+    Returns
+    -------
+    scitype : str, or list of str of sktime scitype strings from BASE_CLASS_REGISTER
+        str, sktime scitype string, if exactly one scitype can be determined for obj
+        list of str, of scitype strings, if more than one scityp are determined
+        obj has scitype if it inherits from class in same row of BASE_CLASS_REGISTER
+
+    Raises
+    ------
+    TypeError if no scitype can be determined for obj
+    """
+
+    if isclass(obj):
+        scitypes = [sci[0] for sci in BASE_CLASS_REGISTER if issubclass(obj, sci[1])]
+    else:
+        scitypes = [sci[0] for sci in BASE_CLASS_REGISTER if isinstance(obj, sci[1])]
+
+    if len(scitype) == 1:
+        return scitypes[0]
+
+    if len(scitype) == 0:
+        raise TypeError("Error, no scitype could be determined for obj")

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -5,7 +5,7 @@ __author__ = ["fkiraly"]
 
 from inspect import isclass
 
-from sktime.registry._lookup import BASE_CLASS_REGISTER
+from sktime.registry._base_classes import BASE_CLASS_REGISTER
 
 
 def scitype(obj):
@@ -26,14 +26,13 @@ def scitype(obj):
     ------
     TypeError if no scitype can be determined for obj
     """
-
     if isclass(obj):
         scitypes = [sci[0] for sci in BASE_CLASS_REGISTER if issubclass(obj, sci[1])]
     else:
         scitypes = [sci[0] for sci in BASE_CLASS_REGISTER if isinstance(obj, sci[1])]
 
-    if len(scitype) == 1:
+    if len(scitypes) == 1:
         return scitypes[0]
 
-    if len(scitype) == 0:
+    if len(scitypes) == 0:
         raise TypeError("Error, no scitype could be determined for obj")

--- a/sktime/registry/tests/test_lookup.py
+++ b/sktime/registry/tests/test_lookup.py
@@ -163,6 +163,6 @@ def test_scitype_inference(estimator_scitype):
     base_class = _check_estimator_types(estimator_scitype)[0]
     inferred_scitype = scitype(base_class)
 
-    assert inferred_scitype == estimator_scitype, (
-        "one of scitype, _check_estimator_types is incorrect, these should be inverses"
-    )
+    assert (
+        inferred_scitype == estimator_scitype
+    ), "one of scitype, _check_estimator_types is incorrect, these should be inverses"

--- a/sktime/registry/tests/test_lookup.py
+++ b/sktime/registry/tests/test_lookup.py
@@ -160,7 +160,6 @@ def test_all_estimators_exclude_estimators(exclude_estimators):
 @pytest.mark.parametrize("estimator_scitype", BASE_CLASS_SCITYPE_LIST)
 def test_scitype_inference(estimator_scitype):
     """Check that scitype inverts _check_estimator_types."""
-
     base_class = _check_estimator_types(estimator_scitype)[0]
     inferred_scitype = scitype(base_class)
 

--- a/sktime/registry/tests/test_lookup.py
+++ b/sktime/registry/tests/test_lookup.py
@@ -7,12 +7,13 @@ __author__ = ["fkiraly"]
 import pytest
 
 from sktime.base import BaseEstimator
-from sktime.registry import all_estimators, all_tags
+from sktime.registry import all_estimators, all_tags, scitype
 from sktime.registry._base_classes import (
     BASE_CLASS_LOOKUP,
     BASE_CLASS_SCITYPE_LIST,
     TRANSFORMER_MIXIN_SCITYPE_LIST,
 )
+from sktime.registry._lookup import _check_estimator_types
 
 VALID_SCITYPES_SET = set(
     BASE_CLASS_SCITYPE_LIST + TRANSFORMER_MIXIN_SCITYPE_LIST + ["estimator"]
@@ -154,3 +155,15 @@ def test_all_estimators_exclude_estimators(exclude_estimators):
         exclude_estimators = [exclude_estimators]
     for estimator in exclude_estimators:
         assert estimator not in names
+
+
+@pytest.mark.parametrize("estimator_scitype", BASE_CLASS_SCITYPE_LIST)
+def test_scitype_inference(estimator_scitype):
+    """Check that scitype inverts _check_estimator_types."""
+
+    base_class = _check_estimator_types(estimator_scitype)[0]
+    inferred_scitype = scitype(base_class)
+
+    assert inferred_scitype == estimator_scitype, (
+        "one of scitype, _check_estimator_types is incorrect, these should be inverses"
+    )


### PR DESCRIPTION
This PR adds a single utility `scitype` which produces the unique scitype string in `BASE_CLASS_REGISTER` and `BASE_CLASS_SCITYPE_LIST`, given a class or object inheriting from `BaseObject`.

This is useful in refacturing occurrences of this query which have been dealt with manually, for instance when combining a lookup call `all_estimators` or `all_tags` starting at the class, or for a near-future refactoring of `_make_args`.

This PR also introduces a test which links `scitype` to its (quasi) inverse, an existing utility function called `_check_estimator_type`.