### PR TITLE
[ENH] Extended deep_equals, with precise indication of why equality fails

### DIFF
--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -51,12 +51,14 @@ def deep_equals(x, y, return_msg=False):
                     if class/object, names of attributes and methods are not equal
             .dtype - dtype of pandas or numpy object is not equal
             .index - index of pandas object is not equal
-            .series_equals, .df_equals - .equals call on pandas objects returns False
+            .series_equals, .df_equals, .index_equals - .equals of pd returns False
             [i] - if tuple/list: i-th element not equal
             [key] - if dict: value at key is not equal
             [colname] - if pandas.DataFrame: column with name colname is not equal
             != - call to generic != returns False
     """
+
+    print(type(x))
 
     def ret(is_equal, msg):
         if return_msg:
@@ -103,6 +105,8 @@ def deep_equals(x, y, return_msg=False):
             return ret(True, "")
         else:
             return ret(x.equals(y), f".df_equals, x = {x} != y = {y}")
+    elif isinstance(x, pd.Index):
+        return ret(x.equals(y), f".index_equals, x = {x} != y = {y}")
     elif isinstance(x, np.ndarray):
         if x.dtype != y.dtype:
             return ret(False, f".dtype, x.dtype = {x.dtype} != y.dtype = {y.dtype}")

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -97,7 +97,7 @@ def deep_equals(x, y, return_msg=False):
         # if columns are equal and at least one is object, recurse over Series
         if sum(x.dtypes == "object") > 0:
             for c in x.columns:
-                is_equal, msg = deep_equals(x[c], y[c])
+                is_equal, msg = deep_equals(x[c], y[c], return_msg=True)
                 if not is_equal:
                     return ret(False, f'["{c}"]' + msg)
             return ret(True, "")

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -15,6 +15,8 @@ __all__ = ["deep_equals"]
 import numpy as np
 import pandas as pd
 
+# from sktime.base import BaseObject
+
 
 def deep_equals(x, y, return_msg=False):
     """Test two objects for equality in value.
@@ -53,7 +55,6 @@ def deep_equals(x, y, return_msg=False):
             [i] - if tuple/list: i-th element not equal
             [key] - if dict: value at key is not equal
             [colname] - if pandas.DataFrame: column with name colname is not equal
-            [attr] - if class or object: entry at field attr is not equal
             != - call to generic != returns False
     """
 
@@ -109,10 +110,6 @@ def deep_equals(x, y, return_msg=False):
         return ret(*_tuple_equals(x, y, return_msg=True))
     elif isinstance(x, dict):
         return ret(*_dict_equals(x, y, return_msg=True))
-    elif hasattr(x, "__dict__") and hasattr(y, "__dict__"):
-        xdict = x.__dict__
-        ydict = y.__dict__
-        return ret(*_dict_equals(xdict, ydict, return_msg=True))
     elif x != y:
         return ret(False, f" !=, {x} != {y}")
 

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -64,13 +64,13 @@ def deep_equals(x, y, return_msg=False):
             return is_equal
 
     if type(x) != type(y):
-        return ret(False, ".type")
+        return ret(False, f".type, x.type = {type(x)} != y.type = {type(y)}")
 
     # we now know all types are the same
     # so now we compare values
     if isinstance(x, pd.Series):
         if x.dtype != y.dtype:
-            return ret(False, ".dtype")
+            return ret(False, f".dtype, x.dtype= {x.dtype} != y.dtype = {y.dtype}")
         # if columns are object, recurse over entries and index
         if x.dtype == "object":
             index_equal = x.index.equals(y.index)
@@ -78,15 +78,17 @@ def deep_equals(x, y, return_msg=False):
                 list(x.values), list(y.values), return_msg=True
             )
             if not index_equal:
-                msg = ".index"
+                msg = f".index, x.index: {x.index}, y.index: {y.index}"
             elif not values_equal:
                 msg = ".values" + values_msg
             return ret(index_equal and values_equal, msg)
         else:
-            return ret(x.equals(y), ".series_equals")
+            return ret(x.equals(y), f".series_equals, x = {x} != y = {y}")
     elif isinstance(x, pd.DataFrame):
         if not x.columns.equals(y.columns):
-            return ret(False, ".columns")
+            return ret(
+                False, f".columns, x.columns = {x.columns} != y.columns = {y.columns}"
+            )
         # if columns are equal and at least one is object, recurse over Series
         if sum(x.dtypes == "object") > 0:
             for c in x.columns:
@@ -95,10 +97,10 @@ def deep_equals(x, y, return_msg=False):
                     return ret(False, f'["{c}"]' + msg)
             return ret(True, "")
         else:
-            return ret(x.equals(y), ".df_equals")
+            return ret(x.equals(y), f".df_equals, x = {x} != y = {y}")
     elif isinstance(x, np.ndarray):
         if x.dtype != y.dtype:
-            return ret(False, ".dtype")
+            return ret(False, f".dtype, x.dtype = {x.dtype} != y.dtype = {y.dtype}")
         return ret(np.array_equal(x, y, equal_nan=True), ".values")
     # recursion through lists, tuples and dicts
     elif isinstance(x, (list, tuple)):
@@ -148,7 +150,7 @@ def _tuple_equals(x, y, return_msg=False):
     n = len(x)
 
     if n != len(y):
-        return ret(False, ".len")
+        return ret(False, f".len, x.len = {n} != y.len = {len(y)}")
 
     # we now know dicts are same length
     for i in range(n):
@@ -201,7 +203,7 @@ def _dict_equals(x, y, return_msg=False):
     ykeys = set(y.keys())
 
     if xkeys != ykeys:
-        return ret(False, ".keys")
+        return ret(False, f".keys, x.keys = {xkeys} != y.keys = {ykeys}")
 
     # we now know all keys are the same
     for key in xkeys:

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -45,13 +45,15 @@ def deep_equals(x, y, return_msg=False):
             .type - type is not equal
             .len - length is not equal
             .value - value is not equal
-            .keys - keys of dict are not equal
+            .keys - if dict, keys of dict are not equal
+                    if class/object, names of attributes and methods are not equal
             .dtype - dtype of pandas or numpy object is not equal
             .index - index of pandas object is not equal
             .series_equals, .df_equals - .equals call on pandas objects returns False
             [i] - if tuple/list: i-th element not equal
             [key] - if dict: value at key is not equal
             [colname] - if pandas.DataFrame: column with name colname is not equal
+            [attr] - if class or object: entry at field attr is not equal
             != - call to generic != returns False
     """
 
@@ -107,8 +109,16 @@ def deep_equals(x, y, return_msg=False):
         return ret(*_tuple_equals(x, y, return_msg=True))
     elif isinstance(x, dict):
         return ret(*_dict_equals(x, y, return_msg=True))
+    elif hasattr(x, "__dir__") and hasattr(y, "__dir__"):
+        xkeys = dir(x)
+        ykeys = dir(y)
+        xattrs = [getattr(x, key) for key in xkeys]
+        yattrs = [getattr(y, key) for key in ykeys]
+        xdict = dict(zip(xkeys, xattrs))
+        ydict = dict(zip(ykeys, yattrs))
+        return ret(*_dict_equals(xdict, ydict, return_msg=True))
     elif x != y:
-        return ret(False, " !=")
+        return ret(False, f" !=, {x} != {y}")
 
     return ret(True, "")
 

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 
 
-def deep_equals(x, y):
+def deep_equals(x, y, return_msg=False):
     """Test two objects for equality in value.
 
     Correct if x/y are one of the following valid types:
@@ -30,52 +30,76 @@ def deep_equals(x, y):
 
     Parameters
     ----------
-    x: object
-    y: object
+    x : object
+    y : object
+    return_msg : bool, optional, default=False
+        whether to return informative message about what is not equal
 
     Returns
     -------
-    bool - True if x and y are equal in value
+    is_equal: bool - True if x and y are equal in value
         x and y do not need to be equal in reference
+    msg : str, only returned if return_msg = True
+        indication of what is the reason for not being equal
     """
+
+    def ret(is_equal, msg):
+        if return_msg:
+            if is_equal:
+                msg = ""
+            return is_equal, msg
+        else:
+            return is_equal
+
     if type(x) != type(y):
-        return False
+        return ret(False, "type")
 
     # we now know all types are the same
     # so now we compare values
     if isinstance(x, pd.Series):
         if x.dtype != y.dtype:
-            return False
+            return ret(False, "dtype")
         # if columns are object, recurse over entries and index
         if x.dtype == "object":
             index_equal = x.index.equals(y.index)
-            return index_equal and deep_equals(list(x.values), list(y.values))
+            values_equal, values_msg = deep_equals(
+                list(x.values), list(y.values), return_msg=True
+            )
+            if not index_equal:
+                msg = ".index"
+            elif not values_equal:
+                msg = ".values" + values_msg
+            return ret(index_equal and values_equal, msg)
         else:
-            return x.equals(y)
+            return ret(x.equals(y), ".series_equals")
     elif isinstance(x, pd.DataFrame):
         if not x.columns.equals(y.columns):
-            return False
+            return ret(False, ".columns")
         # if columns are equal and at least one is object, recurse over Series
         if sum(x.dtypes == "object") > 0:
-            return np.all([deep_equals(x[c], y[c]) for c in x.columns])
+            for c in x.columns:
+                is_equal, msg = deep_equals(x[c], y[c])
+                if not is_equal:
+                    return ret(False, f'["{c}"]' + msg)
+            return ret(True, "")
         else:
-            return x.equals(y)
+            return ret(x.equals(y), ".df_equals")
     elif isinstance(x, np.ndarray):
         if x.dtype != y.dtype:
-            return False
-        return np.array_equal(x, y, equal_nan=True)
+            return ret(False, ".dtype")
+        return ret(np.array_equal(x, y, equal_nan=True), ".values")
     # recursion through lists, tuples and dicts
     elif isinstance(x, (list, tuple)):
-        return _tuple_equals(x, y)
+        return ret(*_tuple_equals(x, y, return_msg=True))
     elif isinstance(x, dict):
-        return _dict_equals(x, y)
+        return ret(*_dict_equals(x, y, return_msg=True))
     elif x != y:
-        return False
+        return ret(False, " !=")
 
-    return True
+    return ret(True, "")
 
 
-def _tuple_equals(x, y):
+def _tuple_equals(x, y, return_msg=False):
     """Test two tuples or lists for equality.
 
     Correct if tuples/lists contain the following valid types:
@@ -93,10 +117,19 @@ def _tuple_equals(x, y):
     bool - True if x and y are equal in value
         x and y do not need to be equal in reference
     """
+
+    def ret(is_equal, msg):
+        if return_msg:
+            if is_equal:
+                msg = ""
+            return is_equal, msg
+        else:
+            return is_equal
+
     n = len(x)
 
     if n != len(y):
-        return False
+        return ret(False, ".len")
 
     # we now know dicts are same length
     for i in range(n):
@@ -104,13 +137,14 @@ def _tuple_equals(x, y):
         yi = y[i]
 
         # recurse through xi/yi
-        if not deep_equals(xi, yi):
-            return False
+        is_equal, msg = deep_equals(xi, yi, return_msg=True)
+        if not is_equal:
+            return ret(False, f"[{i}]" + msg)
 
-    return True
+    return ret(True, "")
 
 
-def _dict_equals(x, y):
+def _dict_equals(x, y, return_msg=False):
     """Test two dicts for equality.
 
     Correct if dicts contain the following valid types:
@@ -127,11 +161,20 @@ def _dict_equals(x, y):
     -------
     bool - True if x and y have equal keys and values
     """
+
+    def ret(is_equal, msg):
+        if return_msg:
+            if is_equal:
+                msg = ""
+            return is_equal, msg
+        else:
+            return is_equal
+
     xkeys = set(x.keys())
     ykeys = set(y.keys())
 
     if xkeys != ykeys:
-        return False
+        return ret(False, ".keys")
 
     # we now know all keys are the same
     for key in xkeys:
@@ -139,7 +182,8 @@ def _dict_equals(x, y):
         yi = y[key]
 
         # recurse through xi/yi
-        if not deep_equals(xi, yi):
-            return False
+        is_equal, msg = deep_equals(xi, yi, return_msg=True)
+        if not is_equal:
+            return ret(False, f"[{key}]" + msg)
 
-    return True
+    return ret(True, "")

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -109,14 +109,6 @@ def deep_equals(x, y, return_msg=False):
         return ret(*_tuple_equals(x, y, return_msg=True))
     elif isinstance(x, dict):
         return ret(*_dict_equals(x, y, return_msg=True))
-    elif hasattr(x, "__dir__") and hasattr(y, "__dir__"):
-        xkeys = dir(x)
-        ykeys = dir(y)
-        xattrs = [getattr(x, key) for key in xkeys]
-        yattrs = [getattr(y, key) for key in ykeys]
-        xdict = dict(zip(xkeys, xattrs))
-        ydict = dict(zip(ykeys, yattrs))
-        return ret(*_dict_equals(xdict, ydict, return_msg=True))
     elif x != y:
         return ret(False, f" !=, {x} != {y}")
 

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -58,8 +58,6 @@ def deep_equals(x, y, return_msg=False):
             != - call to generic != returns False
     """
 
-    print(type(x))
-
     def ret(is_equal, msg):
         if return_msg:
             if is_equal:

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -109,6 +109,10 @@ def deep_equals(x, y, return_msg=False):
         return ret(*_tuple_equals(x, y, return_msg=True))
     elif isinstance(x, dict):
         return ret(*_dict_equals(x, y, return_msg=True))
+    elif hasattr(x, "__dict__") and hasattr(y, "__dict__"):
+        xdict = x.__dict__
+        ydict = y.__dict__
+        return ret(*_dict_equals(xdict, ydict, return_msg=True))
     elif x != y:
         return ret(False, f" !=, {x} != {y}")
 

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -80,10 +80,12 @@ def deep_equals(x, y, return_msg=False):
             values_equal, values_msg = deep_equals(
                 list(x.values), list(y.values), return_msg=True
             )
-            if not index_equal:
-                msg = f".index, x.index: {x.index}, y.index: {y.index}"
-            elif not values_equal:
+            if not values_equal:
                 msg = ".values" + values_msg
+            elif not index_equal:
+                msg = f".index, x.index: {x.index}, y.index: {y.index}"
+            else:
+                msg = ""
             return ret(index_equal and values_equal, msg)
         else:
             return ret(x.equals(y), f".series_equals, x = {x} != y = {y}")

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -41,6 +41,18 @@ def deep_equals(x, y, return_msg=False):
         x and y do not need to be equal in reference
     msg : str, only returned if return_msg = True
         indication of what is the reason for not being equal
+            concatenation of the following strings:
+            .type - type is not equal
+            .len - length is not equal
+            .value - value is not equal
+            .keys - keys of dict are not equal
+            .dtype - dtype of pandas or numpy object is not equal
+            .index - index of pandas object is not equal
+            .series_equals, .df_equals - .equals call on pandas objects returns False
+            [i] - if tuple/list: i-th element not equal
+            [key] - if dict: value at key is not equal
+            [colname] - if pandas.DataFrame: column with name colname is not equal
+            != - call to generic != returns False
     """
 
     def ret(is_equal, msg):
@@ -52,13 +64,13 @@ def deep_equals(x, y, return_msg=False):
             return is_equal
 
     if type(x) != type(y):
-        return ret(False, "type")
+        return ret(False, ".type")
 
     # we now know all types are the same
     # so now we compare values
     if isinstance(x, pd.Series):
         if x.dtype != y.dtype:
-            return ret(False, "dtype")
+            return ret(False, ".dtype")
         # if columns are object, recurse over entries and index
         if x.dtype == "object":
             index_equal = x.index.equals(y.index)
@@ -111,11 +123,18 @@ def _tuple_equals(x, y, return_msg=False):
     ----------
     x: tuple or list
     y: tuple or list
+    return_msg : bool, optional, default=False
+        whether to return informative message about what is not equal
 
     Returns
     -------
-    bool - True if x and y are equal in value
+    is_equal: bool - True if x and y are equal in value
         x and y do not need to be equal in reference
+    msg : str, only returned if return_msg = True
+        indication of what is the reason for not being equal
+            concatenation of the following elements:
+            .len - length is not equal
+            [i] - i-th element not equal
     """
 
     def ret(is_equal, msg):
@@ -156,10 +175,18 @@ def _dict_equals(x, y, return_msg=False):
     ----------
     x: dict
     y: dict
+    return_msg : bool, optional, default=False
+        whether to return informative message about what is not equal
 
     Returns
     -------
-    bool - True if x and y have equal keys and values
+    is_equal: bool - True if x and y are equal in value
+        x and y do not need to be equal in reference
+    msg : str, only returned if return_msg = True
+        indication of what is the reason for not being equal
+            concatenation of the following strings:
+            .keys - keys are not equal
+            [key] - values at key is not equal
     """
 
     def ret(is_equal, msg):


### PR DESCRIPTION
This PR extends the `deep_equals` utility used in testing with an optional second return argument, an error message that states at which location precisely two potentially highly nested objects are not equal.

This is useful since printouts in tests may involve `repr`-s of nested estimators or nested dicts, lists, tuples, which are really hard to parse. Already two dicts with 6 elements, where elements may be in different display order, can easily cause headache in reading the diagnostic output from a test failure.

This PR tries to alleviate that tedious, repeated staring at printouts of dicts, arrays, data frames and whatnot.