### PR TITLE
[BUG] bugfixes for various bugs discovered in scenario testing

### DIFF
--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -9,6 +9,8 @@ __author__ = ["fkiraly"]
 import numpy as np
 import pandas as pd
 
+from sklearn import clone
+
 from sktime.alignment.base import BaseAligner
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
@@ -234,6 +236,7 @@ class AlignerDTWfromDist(BaseAligner):
         super(AlignerDTWfromDist, self).__init__()
 
         self.dist_trafo = dist_trafo
+        self.dist_trafo_ = clone(self.dist_trafo)
         self.step_pattern = step_pattern
         self.window_type = window_type
         self.open_begin = open_begin
@@ -256,7 +259,7 @@ class AlignerDTWfromDist(BaseAligner):
         from dtw import dtw
 
         # these variables from self are accessed
-        dist_trafo = self.dist_trafo
+        dist_trafo = self.dist_trafo_
         step_pattern = self.step_pattern
         window_type = self.window_type
         open_begin = self.open_begin

--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -8,7 +8,6 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 import pandas as pd
-
 from sklearn import clone
 
 from sktime.alignment.base import BaseAligner

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -821,7 +821,7 @@ class BaseForecaster(BaseEstimator):
         if X is not None:
             X = check_series(X, enforce_index_type=enforce_index_type, var_name="X")
             if self.get_tag("X-y-must-have-same-index"):
-                check_equal_time_index(X, y)
+                check_equal_time_index(X, y, mode="contains")
         # end checking X
 
         # convert X & y to supported inner type, if necessary

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -75,9 +75,6 @@ class _HeterogenousEnsembleForecaster(BaseForecaster, _HeterogenousMetaEstimator
         self, fh=None, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA
     ):
         """Collect results from forecaster.predict() calls."""
-        if return_pred_int:
-            raise NotImplementedError()
-
         return [
             forecaster.predict(fh, X, return_pred_int=return_pred_int, alpha=alpha)
             for forecaster in self.forecasters_

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -7,14 +7,11 @@
 __author__ = ["mloning"]
 __all__ = ["_HeterogenousEnsembleForecaster"]
 
-from joblib import Parallel
-from joblib import delayed
-
+from joblib import Parallel, delayed
 from sklearn.base import clone
 
 from sktime.base import _HeterogenousMetaEstimator
-from sktime.forecasting.base._base import DEFAULT_ALPHA
-from sktime.forecasting.base._base import BaseForecaster
+from sktime.forecasting.base._base import DEFAULT_ALPHA, BaseForecaster
 
 
 class _HeterogenousEnsembleForecaster(BaseForecaster, _HeterogenousMetaEstimator):

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -148,7 +148,7 @@ class _Pipeline(
 
         from sktime.forecasting.naive import NaiveForecaster
         from sktime.transformations.series.adapt import TabularToSeriesAdaptor
-        from sktime.transformations.series.boxcox import BoxCoxTransformer
+        from sktime.transformations.series.exponent import ExponentTransformer
 
         STEPS1 = [
             ("transformer", TabularToSeriesAdaptor(StandardScaler())),
@@ -157,7 +157,7 @@ class _Pipeline(
         params1 = {"steps": STEPS1}
 
         STEPS2 = [
-            ("transformer", BoxCoxTransformer()),
+            ("transformer", ExponentTransformer()),
             ("forecaster", NaiveForecaster()),
         ]
         params2 = {"steps": STEPS2}

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -3,7 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements forecasters for combining forecasts via stacking."""
 
-__author__ = ["mloning"]
+__author__ = ["mloning", "fkiraly"]
 __all__ = ["StackingForecaster"]
 
 from warnings import warn
@@ -64,7 +64,7 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
 
     _required_parameters = ["forecasters"]
     _tags = {
-        "ignores-exogeneous-X": False,
+        "ignores-exogeneous-X": True,
         "requires-fh-in-fit": True,
         "handles-missing-data": False,
         "scitype:y": "univariate",
@@ -98,14 +98,15 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
 
         # split training series into training set to fit forecasters and
         # validation set to fit meta-learner
-        cv = SingleWindowSplitter(fh=self.fh.to_relative(self.cutoff))
+        cv = SingleWindowSplitter(fh=fh.to_relative(self.cutoff))
         train_window, test_window = next(cv.split(y))
         y_fcst = y.iloc[train_window]
         y_meta = y.iloc[test_window].values
+        X_meta = X.iloc[test_window]
 
         # fit forecasters on training window
-        self._fit_forecasters(forecasters, y_fcst, fh=self.fh, X=X)
-        X_meta = np.column_stack(self._predict_forecasters(X))
+        self._fit_forecasters(forecasters, y_fcst, fh=fh, X=X)
+        X_meta = np.column_stack(self._predict_forecasters(fh=fh, X=X_meta))
 
         # fit final regressor on on validation window
         self.regressor_.fit(X_meta, y_meta)
@@ -154,9 +155,8 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         y_pred_int : pd.DataFrame - only if return_pred_int=True
             Prediction intervals
         """
-        if return_pred_int:
-            raise NotImplementedError()
-        y_preds = np.column_stack(self._predict_forecasters(X))
+        y_preds = np.column_stack(self._predict_forecasters(fh=fh, X=X))
         y_pred = self.regressor_.predict(y_preds)
+        # index = y_preds.index
         index = self.fh.to_absolute(self.cutoff)
         return pd.Series(y_pred, index=index)

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -102,7 +102,10 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         train_window, test_window = next(cv.split(y))
         y_fcst = y.iloc[train_window]
         y_meta = y.iloc[test_window].values
-        X_meta = X.iloc[test_window]
+        if X is not None:
+            X_meta = X.iloc[test_window]
+        else:
+            X_meta = None
 
         # fit forecasters on training window
         self._fit_forecasters(forecasters, y_fcst, fh=fh, X=X)

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -91,9 +91,6 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         -------
         self : returns an instance of self.
         """
-        if X is not None:
-            raise NotImplementedError()
-
         _, forecasters = self._check_forecasters()
         self.regressor_ = check_regressor(
             regressor=self.regressor, random_state=self.random_state

--- a/sktime/transformations/series/func_transform.py
+++ b/sktime/transformations/series/func_transform.py
@@ -203,6 +203,6 @@ class FunctionTransformer(BaseTransformer):
         params1 = {}
 
         # log-transformer, with exp inverse
-        params2 = {"func": np.log1p, "inverse_func": np.expm1}
+        params2 = {"func": np.expm1, "inverse_func": np.log1p}
 
         return [params1, params2]

--- a/sktime/transformations/series/theta.py
+++ b/sktime/transformations/series/theta.py
@@ -97,26 +97,26 @@ class ThetaLinesTransformer(BaseTransformer):
             pd.Series, with single Theta-line, if self.theta is float
             pd.DataFrame of shape: [len(X), len(self.theta)], if self.theta is tuple
         """
-        z = X
         theta = _check_theta(self.theta)
 
         forecaster = PolynomialTrendForecaster()
-        forecaster.fit(z)
-        fh = ForecastingHorizon(z.index, is_relative=False)
-        trend = forecaster.predict(fh)
+        forecaster.fit(y=X)
+        fh = ForecastingHorizon(X.index, is_relative=False)
+        trend = forecaster.predict(fh=fh)
 
-        theta_lines = np.zeros((z.shape[0], len(theta)))
+        theta_lines = np.zeros((X.shape[0], len(theta)))
         for i, theta in enumerate(theta):
-            theta_lines[:, i] = _theta_transform(z, trend, theta)
+            theta_lines[:, i] = _theta_transform(X, trend, theta)
         if isinstance(self.theta, (float, int)):
-            return pd.Series(theta_lines.flatten(), index=z.index)
+            return pd.Series(theta_lines.flatten(), index=X.index)
         else:
-            return pd.DataFrame(theta_lines, columns=self.theta, index=z.index)
+            return pd.DataFrame(theta_lines, columns=self.theta, index=X.index)
 
 
 def _theta_transform(Z, trend, theta):
     # obtain one Theta-line
     theta_line = Z * theta + (1 - theta) * trend
+    theta_line = theta_line.values.flatten()
     return theta_line
 
 


### PR DESCRIPTION
Testing using scenarios https://github.com/alan-turing-institute/sktime/pull/1833 has uncovered a number of bugs that went undetected due to limited input case coverage prior. The smaller ones are fixed here.

This does *not* assume the scenario testing PR which is still a draft.

Bugs fixed:
* bug in `StackingForecaster`: passing `X` raised `NotImplementedError`, while instead the argument `X` should have been ignored. In fact, `X` could have been used in the forecaster, which is what happens now.
* bug in `StackingForecaster`, `X` was passed to the `fh` argument of `_predict_forecasters`; `fh` was using `self.fh` and not input to `_fit` and `_predict` (which comes from `self.fh`, but it should be passed/referenced)
* the pipelines inheriting from `_Pipeline` were using a test case pipeline that would break for multivariate input, since the component `BoxCoxTransformer` was univariate. This has been replaced by `ExponentTransformer`
* test example for `FunctionTransformer` was breaking if negative values were passed, since log was the `transform` and exp the `inverse_transform`, which would negative values to nan. The other way round there is no problem, so switched it.
* in `_HeterogeneousEnsembleForecaster`, `return_pred_int` based raises were removed, because all this does is iterate over `fit`s or `predict`s in the ensemble (which can pass the args on 1:1)
* `AlignerDTWfromDist` did not clone parameter `dist_trafo` before fitting, as is required by sklearn interface (`__init__` parameters should be cloned if estimators). Added a `clone`.
* `ThetaLinesTransformer._transform` would break for `X` being `pd.DataFrame`, despite a docstring claim that one-column `pd.DataFrame` were supported. Fixed.

Changes which are not bugfixes:
* changed check upon `"X-y-must-have-same-index"=True` in `BaseForecaster` to fail only when `X.index` does not contain `y.index`, instead requiring those to be equal.

Todo (not fixed):
* pipelines need to infer correctly whether they support univariate data or not. For instance, the `TransformedTargetForecaster` will not support multivariate forecasts if one of the transformers is univariate.