### PR TITLE
[ENH] add missing `fit` parameters to `statsmodels` Holt-Winters exponential smoothing interface

### DIFF
--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -146,7 +146,7 @@ class ExponentialSmoothing(_StatsModelsAdapter):
         self.initial_level = initial_level
         self.initial_trend = initial_trend
         self.initial_seasonal = initial_seasonal
-        self.initialization_method = initialization_method
+        self.initialization_method = initialization_method,
         self.smoothing_level = smoothing_level,
         self.smoothing_trend = smoothing_trend,
         self.smoothing_seasonal = smoothing_seasonal,

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -14,6 +14,8 @@ from sktime.forecasting.base.adapters import _StatsModelsAdapter
 class ExponentialSmoothing(_StatsModelsAdapter):
     """Holt-Winters exponential smoothing forecaster.
 
+    Direct interface for `statsmodels.tsa.holtwinters`.
+
     Default settings use simple exponential smoothing without trend and
     seasonality components.
 
@@ -49,6 +51,44 @@ class ExponentialSmoothing(_StatsModelsAdapter):
         level, trend, and seasonal state. 'estimated' uses the same heuristic
         as initial guesses, but then estimates the initial states as part of
         the fitting process.
+    smoothing_level : float, optional
+        The alpha value of the simple exponential smoothing, if the value
+        is set then this value will be used as the value.
+    smoothing_trend :  float, optional
+        The beta value of the Holt's trend method, if the value is
+        set then this value will be used as the value.
+    smoothing_seasonal : float, optional
+        The gamma value of the holt winters seasonal method, if the value
+        is set then this value will be used as the value.
+    damping_trend : float, optional
+        The phi value of the damped method, if the value is
+        set then this value will be used as the value.
+    optimized : bool, optional
+        Estimate model parameters by maximizing the log-likelihood.
+    remove_bias : bool, optional
+        Remove bias from forecast values and fitted values by enforcing
+        that the average residual is equal to zero.
+    start_params : array_like, optional
+        Starting values to used when optimizing the fit.  If not provided,
+        starting values are determined using a combination of grid search
+        and reasonable values based on the initial values of the data. See
+        the notes for the structure of the model parameters.
+    method : str, default "L-BFGS-B"
+        The minimizer used. Valid options are "L-BFGS-B" , "TNC",
+        "SLSQP" (default), "Powell", "trust-constr", "basinhopping" (also
+        "bh") and "least_squares" (also "ls"). basinhopping tries multiple
+        starting values in an attempt to find a global minimizer in
+        non-convex problems, and so is slower than the others.
+    minimize_kwargs : dict[str, Any]
+        A dictionary of keyword arguments passed to SciPy's minimize
+        function if method is one of "L-BFGS-B", "TNC",
+        "SLSQP", "Powell", or "trust-constr", or SciPy's basinhopping
+        or least_squares functions. The valid keywords are optimizer
+        specific. Consult SciPy's documentation for the full set of
+        options.
+    use_brute : bool, optional
+        Search for good starting values using a brute force (grid)
+        optimizer. If False, a naive set of starting values is used.
 
     References
     ----------
@@ -86,6 +126,16 @@ class ExponentialSmoothing(_StatsModelsAdapter):
         initial_seasonal=None,
         use_boxcox=None,
         initialization_method="estimated",
+        smoothing_level=None,
+        smoothing_trend=None,
+        smoothing_seasonal=None,
+        damping_trend=None,
+        optimized=True,
+        remove_bias=False,
+        start_params=None,
+        method=None,
+        minimize_kwargs=None,
+        use_brute=True,
     ):
         # Model params
         self.trend = trend
@@ -97,6 +147,16 @@ class ExponentialSmoothing(_StatsModelsAdapter):
         self.initial_trend = initial_trend
         self.initial_seasonal = initial_seasonal
         self.initialization_method = initialization_method
+        self.smoothing_level = smoothing_level,
+        self.smoothing_trend = smoothing_trend,
+        self.smoothing_seasonal = smoothing_seasonal,
+        self.damping_trend = damping_trend,
+        self.optimized = optimized,
+        self.remove_bias = remove_bias,
+        self.start_params = start_params,
+        self.method = method,
+        self.minimize_kwargs = minimize_kwargs,
+        self.use_brute = use_brute,
 
         super(ExponentialSmoothing, self).__init__()
 
@@ -114,4 +174,15 @@ class ExponentialSmoothing(_StatsModelsAdapter):
             initialization_method=self.initialization_method,
         )
 
-        self._fitted_forecaster = self._forecaster.fit()
+        self._fitted_forecaster = self._forecaster.fit(
+            smoothing_level=self.smoothing_level,
+            smoothing_trend=self.smoothing_trend,
+            smoothing_seasonal=self.smoothing_seasonal,
+            damping_trend=self.damping_trend,
+            optimized=self.optimized,
+            remove_bias=self.remove_bias,
+            start_params=self.start_params,
+            method=self.method,
+            minimize_kwargs=self.minimize_kwargs,
+            use_brute=self.use_brute,
+        )

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -146,17 +146,17 @@ class ExponentialSmoothing(_StatsModelsAdapter):
         self.initial_level = initial_level
         self.initial_trend = initial_trend
         self.initial_seasonal = initial_seasonal
-        self.initialization_method = initialization_method,
-        self.smoothing_level = smoothing_level,
-        self.smoothing_trend = smoothing_trend,
-        self.smoothing_seasonal = smoothing_seasonal,
-        self.damping_trend = damping_trend,
-        self.optimized = optimized,
-        self.remove_bias = remove_bias,
-        self.start_params = start_params,
-        self.method = method,
-        self.minimize_kwargs = minimize_kwargs,
-        self.use_brute = use_brute,
+        self.initialization_method = initialization_method
+        self.smoothing_level = smoothing_level
+        self.smoothing_trend = smoothing_trend
+        self.smoothing_seasonal = smoothing_seasonal
+        self.damping_trend = damping_trend
+        self.optimized = optimized
+        self.remove_bias = remove_bias
+        self.start_params = start_params
+        self.method = method
+        self.minimize_kwargs = minimize_kwargs
+        self.use_brute = use_brute
 
         super(ExponentialSmoothing, self).__init__()
 

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -158,7 +158,7 @@ class ExponentialSmoothing(_StatsModelsAdapter):
         self.minimize_kwargs = minimize_kwargs
         self.use_brute = use_brute
 
-        super(ExponentialSmoothing, self).__init__()
+        super().__init__()
 
     def _fit_forecaster(self, y, X=None):
         self._forecaster = _ExponentialSmoothing(


### PR DESCRIPTION
This PR adds parameters of `statsmodels.tsa.holtwinters` in `fit` as loopthrough to `sktime`'s `ExponentialSmoothing` interface.

So far, only the constructor parameters were accessible, not the parameters in `fit`.

Solves #1845.