### PR TITLE
[ENH] TSC refactor:  TSF, RSF

### DIFF
--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -182,7 +182,6 @@ class BaseClassifier(BaseEstimator):
 
         # boilerplate input checks for predict-like methods
         X = self._check_convert_X_for_predict(X)
-
         return self._predict_proba(X)
 
     def score(self, X, y) -> float:

--- a/sktime/classification/interval_based/_risf.py
+++ b/sktime/classification/interval_based/_risf.py
@@ -124,7 +124,7 @@ class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):
 
     def predict(self, X, **kwargs) -> np.ndarray:
         """Wrap predict to call BaseClassifier.predict."""
-        BaseClassifier.predict(self, X, **kwargs)
+        return BaseClassifier.predict(self, X, **kwargs)
 
     def predict_proba(self, X, **kwargs) -> np.ndarray:
         """Wrap predict_proba to call BaseClassifier.predict_proba."""

--- a/sktime/classification/interval_based/_risf.py
+++ b/sktime/classification/interval_based/_risf.py
@@ -21,7 +21,6 @@ from sktime.classification.interval_based._rise import (
     _predict_proba_for_estimator,
     _select_interval,
 )
-from sktime.utils.validation.panel import check_X, check_X_y
 
 
 @deprecated(
@@ -114,7 +113,25 @@ class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):
             "RandomIntervalSpectralForest is currently not supported."
         )
 
-    def fit(self, X, y):
+    def fit(self, X, y, **kwargs):
+        """Wrap fit to call BaseClassifier.fit.
+
+        This is a fix to get around the problem with multiple inheritance. The
+        problem is that if we just override _fit, this class inherits the fit from
+        the sklearn class ForestClassifier. This is the simplest solution,
+        albeit a little hacky.
+        """
+        BaseClassifier.fit(self, X, y, **kwargs)
+
+    def predict(self, X, **kwargs) -> np.ndarray:
+        """Wrap predict to call BaseClassifier.predict."""
+        BaseClassifier.predict(self, X, **kwargs)
+
+    def predict_proba(self, X, **kwargs) -> np.ndarray:
+        """Wrap predict_proba to call BaseClassifier.predict_proba."""
+        return BaseClassifier.predict_proba(self, X, **kwargs)
+
+    def _fit(self, X, y):
         """Build a forest of trees from the training set (X, y).
 
         using random intervals and spectral features.
@@ -133,7 +150,6 @@ class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):
         -------
         self : object
         """
-        X, y = check_X_y(X, y, enforce_univariate=True, coerce_to_numpy=True)
         X = X.squeeze(1)
 
         n_instances, self.series_length = X.shape
@@ -148,13 +164,6 @@ class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):
         self.estimators_ = []
         self.n_classes = np.unique(y).shape[0]
         self.classes_ = class_distribution(np.asarray(y).reshape(-1, 1))[0][0]
-        # self.intervals = _produce_intervals(
-        #     self.n_estimators,
-        #     self.min_interval,
-        #     self.max_interval,
-        #     self.series_length,
-        #     rng
-        # )
         self.intervals = np.empty((self.n_estimators, 2), dtype=int)
         self.intervals[:] = [
             _select_interval(
@@ -199,7 +208,7 @@ class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):
         self._is_fitted = True
         return self
 
-    def predict(self, X):
+    def _predict(self, X):
         """Find predictions for all cases in X.
 
         Built on top of `predict_proba`.
@@ -219,7 +228,7 @@ class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):
         proba = self.predict_proba(X)
         return np.asarray([self.classes_[np.argmax(prob)] for prob in proba])
 
-    def predict_proba(self, X):
+    def _predict_proba(self, X):
         """Find probability estimates for each class for all cases in X.
 
         Parameters
@@ -242,18 +251,7 @@ class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):
         output : array of shape = [n_instances, n_classes]
             The class probabilities of all cases.
         """
-        # Check data
-        self.check_is_fitted()
-        X = check_X(X, enforce_univariate=True, coerce_to_numpy=True)
         X = X.squeeze(1)
-
-        n_instances, n_columns = X.shape
-        if n_columns != self.series_length:
-            raise TypeError(
-                "ERROR number of attributes in the train does not match "
-                "that in the test data."
-            )
-
         # Assign chunk of trees to jobs
         n_jobs, _, _ = _partition_estimators(self.n_estimators, self.n_jobs)
 

--- a/sktime/classification/interval_based/_risf.py
+++ b/sktime/classification/interval_based/_risf.py
@@ -112,7 +112,7 @@ class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):
         the sklearn class ForestClassifier. This is the simplest solution,
         albeit a little hacky.
         """
-        BaseClassifier.fit(self, X=X, y=y, **kwargs)
+        return BaseClassifier.fit(self, X=X, y=y, **kwargs)
 
     def predict(self, X, **kwargs) -> np.ndarray:
         """Wrap predict to call BaseClassifier.predict."""

--- a/sktime/classification/interval_based/_risf.py
+++ b/sktime/classification/interval_based/_risf.py
@@ -104,14 +104,6 @@ class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):
         # We need to add is-fitted state when inheriting from scikit-learn
         self._is_fitted = False
 
-    @property
-    def feature_importances_(self):
-        """Feature importance not supported for the RISE classifier."""
-        raise NotImplementedError(
-            "The impurity-based feature importances of "
-            "RandomIntervalSpectralForest is currently not supported."
-        )
-
     def fit(self, X, y, **kwargs):
         """Wrap fit to call BaseClassifier.fit.
 

--- a/sktime/classification/interval_based/_risf.py
+++ b/sktime/classification/interval_based/_risf.py
@@ -112,15 +112,15 @@ class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):
         the sklearn class ForestClassifier. This is the simplest solution,
         albeit a little hacky.
         """
-        BaseClassifier.fit(self, X, y, **kwargs)
+        BaseClassifier.fit(self, X=X, y=y, **kwargs)
 
     def predict(self, X, **kwargs) -> np.ndarray:
         """Wrap predict to call BaseClassifier.predict."""
-        return BaseClassifier.predict(self, X, **kwargs)
+        return BaseClassifier.predict(self, X=X, **kwargs)
 
     def predict_proba(self, X, **kwargs) -> np.ndarray:
         """Wrap predict_proba to call BaseClassifier.predict_proba."""
-        return BaseClassifier.predict_proba(self, X, **kwargs)
+        return BaseClassifier.predict_proba(self, X=X, **kwargs)
 
     def _fit(self, X, y):
         """Build a forest of trees from the training set (X, y).

--- a/sktime/classification/interval_based/_risf.py
+++ b/sktime/classification/interval_based/_risf.py
@@ -25,8 +25,7 @@ from sktime.classification.interval_based._rise import (
 
 @deprecated(
     version="0.8.1",
-    reason="RandomIntervalSpectralForest will be moved or removed in v0.10.0, "
-    "to be replaced by the correctly named RandomIntervalSpectralEnsemble",
+    reason="RandomIntervalSpectralForest will be removed in v0.10.0",
     category=FutureWarning,
 )
 class RandomIntervalSpectralForest(ForestClassifier, BaseClassifier):

--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -104,7 +104,7 @@ class TimeSeriesForestClassifier(
         return BaseClassifier.predict_proba(self, X=X, **kwargs)
 
     def _fit(self, X, y):
-        BaseTimeSeriesForest._fit(self, X=X, Y=y)
+        BaseTimeSeriesForest._fit(self, X=X, y=y)
 
     def _predict(self, X):
         """Find predictions for all cases in X. Built on top of predict_proba.

--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -93,18 +93,18 @@ class TimeSeriesForestClassifier(
         the sklearn class BaseTimeSeriesForest. This is the simplest solution,
         albeit a little hacky.
         """
-        BaseClassifier.fit(self, X, y, **kwargs)
+        BaseClassifier.fit(self, X=X, y=y, **kwargs)
 
     def predict(self, X, **kwargs) -> np.ndarray:
         """Wrap predict to call BaseClassifier.predict."""
-        return BaseClassifier.predict(self, X, **kwargs)
+        return BaseClassifier.predict(self, X=X, **kwargs)
 
     def predict_proba(self, X, **kwargs) -> np.ndarray:
         """Wrap predict_proba to call BaseClassifier.predict_proba."""
-        return BaseClassifier.predict_proba(self, X, **kwargs)
+        return BaseClassifier.predict_proba(self, X=X, **kwargs)
 
     def _fit(self, X, y):
-        BaseTimeSeriesForest._fit(self, X, y)
+        BaseTimeSeriesForest._fit(self, X=X, Y=y)
 
     def _predict(self, X):
         """Find predictions for all cases in X. Built on top of predict_proba.

--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -17,7 +17,6 @@ from sktime.series_as_features.base.estimators.interval_based import (
     BaseTimeSeriesForest,
 )
 from sktime.series_as_features.base.estimators.interval_based._tsf import _transform
-from sktime.utils.validation.panel import check_X
 
 
 class TimeSeriesForestClassifier(
@@ -86,7 +85,28 @@ class TimeSeriesForestClassifier(
 
     _base_estimator = DecisionTreeClassifier(criterion="entropy")
 
-    def predict(self, X):
+    def fit(self, X, y, **kwargs):
+        """Wrap fit to call BaseClassifier.fit.
+
+        This is a fix to get around the problem with multiple inheritance. The
+        problem is that if we just override _fit, this class inherits the fit from
+        the sklearn class BaseTimeSeriesForest. This is the simplest solution,
+        albeit a little hacky.
+        """
+        BaseClassifier.fit(self, X, y, **kwargs)
+
+    def predict(self, X, **kwargs) -> np.ndarray:
+        """Wrap predict to call BaseClassifier.predict."""
+        BaseClassifier.predict(self, X, **kwargs)
+
+    def predict_proba(self, X, **kwargs) -> np.ndarray:
+        """Wrap predict_proba to call BaseClassifier.predict_proba."""
+        return BaseClassifier.predict_proba(self, X, **kwargs)
+
+    def _fit(self, X, y):
+        BaseTimeSeriesForest._fit(self, X, y)
+
+    def _predict(self, X):
         """Find predictions for all cases in X. Built on top of predict_proba.
 
         Parameters
@@ -104,7 +124,7 @@ class TimeSeriesForestClassifier(
         proba = self.predict_proba(X)
         return np.asarray([self.classes_[np.argmax(prob)] for prob in proba])
 
-    def predict_proba(self, X):
+    def _predict_proba(self, X) -> np.ndarray:
         """Find probability estimates for each class for all cases in X.
 
         Parameters
@@ -122,18 +142,11 @@ class TimeSeriesForestClassifier(
         output : nd.array of shape = (n_instances, n_classes)
             Predicted probabilities
         """
-        self.check_is_fitted()
-        X = check_X(X, enforce_univariate=True, coerce_to_numpy=True)
         X = X.squeeze(1)
-
-        _, series_length = X.shape
-        if series_length != self.series_length:
-            raise ValueError(
-                "The number of time points in the training data does not match "
-                "that in the test data."
-            )
         y_probas = Parallel(n_jobs=self.n_jobs)(
-            delayed(_predict_proba)(X, self.estimators_[i], self.intervals_[i])
+            delayed(_predict_single_classifier_proba)(
+                X, self.estimators_[i], self.intervals_[i]
+            )
             for i in range(self.n_estimators)
         )
 
@@ -143,7 +156,7 @@ class TimeSeriesForestClassifier(
         return output
 
 
-def _predict_proba(X, estimator, intervals):
+def _predict_single_classifier_proba(X, estimator, intervals):
     """Find probability estimates for each class for all cases in X."""
     Xt = _transform(X, intervals)
     return estimator.predict_proba(Xt)

--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -97,7 +97,7 @@ class TimeSeriesForestClassifier(
 
     def predict(self, X, **kwargs) -> np.ndarray:
         """Wrap predict to call BaseClassifier.predict."""
-        BaseClassifier.predict(self, X, **kwargs)
+        return BaseClassifier.predict(self, X, **kwargs)
 
     def predict_proba(self, X, **kwargs) -> np.ndarray:
         """Wrap predict_proba to call BaseClassifier.predict_proba."""

--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -93,7 +93,7 @@ class TimeSeriesForestClassifier(
         the sklearn class BaseTimeSeriesForest. This is the simplest solution,
         albeit a little hacky.
         """
-        BaseClassifier.fit(self, X=X, y=y, **kwargs)
+        return BaseClassifier.fit(self, X=X, y=y, **kwargs)
 
     def predict(self, X, **kwargs) -> np.ndarray:
         """Wrap predict to call BaseClassifier.predict."""

--- a/sktime/classification/interval_based/tests/test_risf.py
+++ b/sktime/classification/interval_based/tests/test_risf.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""RandomIntervalSpectralEnsemble test code."""
+import numpy as np
+from numpy import testing
+
+from sktime.classification.interval_based import RandomIntervalSpectralForest
+from sktime.datasets import load_unit_test
+
+
+def test_risf_on_unit_test_data():
+    """Test of RandomIntervalSpectralEnsemble on unit test data."""
+    # load unit test data
+    X_train, y_train = load_unit_test(split="train")
+    X_test, y_test = load_unit_test(split="test")
+    indices = np.random.RandomState(0).choice(len(y_train), 10, replace=False)
+
+    # train RISE
+    rise = RandomIntervalSpectralForest(n_estimators=10, random_state=0)
+    rise.fit(X_train, y_train)
+
+    # assert probabilities are the same
+    probas = rise.predict_proba(X_test.iloc[indices])
+    testing.assert_array_equal(probas, rise_unit_test_probas)
+
+
+rise_unit_test_probas = np.array(
+    [
+        [
+            0.1,
+            0.9,
+        ],
+        [
+            0.8,
+            0.2,
+        ],
+        [
+            0.0,
+            1.0,
+        ],
+        [
+            0.7,
+            0.3,
+        ],
+        [
+            1.0,
+            0.0,
+        ],
+        [
+            1.0,
+            0.0,
+        ],
+        [
+            0.6,
+            0.4,
+        ],
+        [
+            0.0,
+            1.0,
+        ],
+        [
+            0.7,
+            0.3,
+        ],
+        [
+            0.9,
+            0.1,
+        ],
+    ]
+)

--- a/sktime/classification/interval_based/tests/test_tsf.py
+++ b/sktime/classification/interval_based/tests/test_tsf.py
@@ -17,7 +17,6 @@ def test_tsf_on_unit_test_data():
     # train TSF
     tsf = TimeSeriesForestClassifier(n_estimators=10, random_state=0)
     tsf.fit(X_train, y_train)
-
     # assert probabilities are the same
     probas = tsf.predict_proba(X_test.iloc[indices])
     testing.assert_array_equal(probas, tsf_unit_test_probas)

--- a/sktime/regression/interval_based/_tsf.py
+++ b/sktime/regression/interval_based/_tsf.py
@@ -14,7 +14,7 @@ from sktime.series_as_features.base.estimators.interval_based._tsf import (
     BaseTimeSeriesForest,
     _transform,
 )
-from sktime.utils.validation.panel import check_X
+from sktime.utils.validation.panel import check_X, check_X_y
 
 
 class TimeSeriesForestRegressor(BaseTimeSeriesForest, ForestRegressor, BaseRegressor):
@@ -68,6 +68,14 @@ class TimeSeriesForestRegressor(BaseTimeSeriesForest, ForestRegressor, BaseRegre
     """
 
     _base_estimator = DecisionTreeRegressor()
+
+    def fit(self, X, y, **kwargs):
+        """Wrap BaseForest._fit.
+
+        This is a temporary measure prior to the BaseRegressor refactor.
+        """
+        X, y = check_X_y(X, y, coerce_to_numpy=True, enforce_univariate=True)
+        BaseTimeSeriesForest._fit(self, X, y, **kwargs)
 
     def predict(self, X):
         """Predict.

--- a/sktime/regression/interval_based/_tsf.py
+++ b/sktime/regression/interval_based/_tsf.py
@@ -75,7 +75,7 @@ class TimeSeriesForestRegressor(BaseTimeSeriesForest, ForestRegressor, BaseRegre
         This is a temporary measure prior to the BaseRegressor refactor.
         """
         X, y = check_X_y(X, y, coerce_to_numpy=True, enforce_univariate=True)
-        BaseTimeSeriesForest._fit(self, X, y, **kwargs)
+        return BaseTimeSeriesForest._fit(self, X, y, **kwargs)
 
     def predict(self, X):
         """Predict.

--- a/sktime/series_as_features/base/estimators/interval_based/_tsf.py
+++ b/sktime/series_as_features/base/estimators/interval_based/_tsf.py
@@ -26,19 +26,10 @@ from sklearn.utils.validation import check_random_state
 from sktime.base._base import _clone_estimator
 from sktime.utils.slope_and_trend import _slope
 from sktime.utils.validation import check_n_jobs
-from sktime.utils.validation.panel import check_X_y
 
 
 class BaseTimeSeriesForest:
     """Base time series forest classifier."""
-
-    _tags = {
-        "capability:multivariate": False,
-        "capability:unequal_length": False,
-        "capability:missing_values": False,
-        "capability:train_estimate": False,
-        "capability:contractable": False,
-    }
 
     def __init__(
         self,
@@ -67,7 +58,7 @@ class BaseTimeSeriesForest:
         # We need to add is-fitted state when inheriting from scikit-learn
         self._is_fitted = False
 
-    def fit(self, X, y):
+    def _fit(self, X, y):
         """Build a forest of trees from the training set (X, y).
 
         Parameters
@@ -82,12 +73,6 @@ class BaseTimeSeriesForest:
         self : object
             An fitted instance of the classifier
         """
-        X, y = check_X_y(
-            X,
-            y,
-            enforce_univariate=not self._tags["capability:multivariate"],
-            coerce_to_numpy=True,
-        )
         X = X.squeeze(1)
         n_instances, self.series_length = X.shape
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
fixes #1068 and fixes #1609 
also fixes #1589 


#### What does this implement/fix? Explain your changes.
this adds wrapper methods for fit, predict and predict proba with the pattern used in https://github.com/alan-turing-institute/sktime/pull/1761

the problem is these classifiers use multiple inheritance, from BaseClassifier and sklearn classifiers. If we do not override the methods fit and predict then they are inherited from sklearn rather than BaseClassifier. These wrapper methods are the simplest way around this problem. They redirect fit to BaseClassifier fit. See #1761 for a discussion of alternatives. 

Not this also effects the TSF based regressor. This has been adapted to work, but the solution is temporary since  the BaseRegressor class will soon be refactored.

Also based on https://github.com/alan-turing-institute/sktime/issues/1589, the skeleton method feature_importances_ has been removed 

