### PR TITLE
[BUG] transformer base class changes and bugfixes

### DIFF
--- a/sktime/datatypes/_series_as_panel/_convert.py
+++ b/sktime/datatypes/_series_as_panel/_convert.py
@@ -77,8 +77,7 @@ def convert_Panel_to_Series(obj, store=None):
         obj.index = obj.index.droplevel(level=0)
 
     if isinstance(obj, np.ndarray):
-        shape = obj.shape
-        if not len(shape) == 3 or not shape[0] == 1:
+        if obj.ndim != 3 or obj.shape[0] != 1:
             raise ValueError("if obj is np.ndarray, must be of dim 3, with shape[0]=1")
         obj = np.reshape(obj, (obj.shape[1], obj.shape[2]))
 

--- a/sktime/datatypes/_series_as_panel/_convert.py
+++ b/sktime/datatypes/_series_as_panel/_convert.py
@@ -78,7 +78,7 @@ def convert_Panel_to_Series(obj, store=None):
 
     if isinstance(obj, np.ndarray):
         shape = obj.shape
-        if not len(shape == 3) or not shape[2] == 1:
+        if not len(shape) == 3 or not shape[2] == 1:
             raise ValueError("if obj is np.ndarray, must be of dim 3, with shape[2]=1")
         obj = np.reshape(obj, (obj.shape[0], obj.shape[1]))
 

--- a/sktime/datatypes/_series_as_panel/_convert.py
+++ b/sktime/datatypes/_series_as_panel/_convert.py
@@ -78,8 +78,8 @@ def convert_Panel_to_Series(obj, store=None):
 
     if isinstance(obj, np.ndarray):
         shape = obj.shape
-        if not len(shape) == 3 or not shape[2] == 1:
-            raise ValueError("if obj is np.ndarray, must be of dim 3, with shape[2]=1")
-        obj = np.reshape(obj, (obj.shape[0], obj.shape[1]))
+        if not len(shape) == 3 or not shape[0] == 1:
+            raise ValueError("if obj is np.ndarray, must be of dim 3, with shape[0]=1")
+        obj = np.reshape(obj, (obj.shape[1], obj.shape[2]))
 
     return obj

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -211,10 +211,11 @@ class BaseTransformer(BaseEstimator):
 
         # 3. internal only has Series but X is Panel: loop over instances
         elif X_input_scitype == "Panel" and "Panel" not in X_inner_scitypes:
-            if y is not None:
+            if y is not None and self.get_tag("y_inner_mtype") != "None":
                 raise ValueError(
-                    "no default behaviour if _fit does not support Panel, "
-                    " but X is Panel and y is not None"
+                    "no default behaviour if _fit does not support Panel and "
+                    'self.get_tag("y_inner_mtype") is not "None",'
+                    " but found X of Panel type, and y not None"
                 )
             X = convert_to(
                 X, to_type="df-list", as_scitype="Panel", store=self._converter_store_X

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -213,9 +213,12 @@ class BaseTransformer(BaseEstimator):
         elif X_input_scitype == "Panel" and "Panel" not in X_inner_scitypes:
             if y is not None and self.get_tag("y_inner_mtype") != "None":
                 raise ValueError(
-                    "no default behaviour if _fit does not support Panel and "
-                    'self.get_tag("y_inner_mtype") is not "None",'
-                    " but found X of Panel type, and y not None"
+                    f"{type(self).__name__} does not support Panel X if y is not None, "
+                    f"since {type(self).__name__} supports only Series. "
+                    "Auto-vectorization to extend Series X to Panel X can only be "
+                    'carried out if y is None, or "y_inner_mtype" tag is "None". '
+                    "Consider extending _fit and _transform to handle the following "
+                    "input types natively: Panel X and non-None y."
                 )
             X = convert_to(
                 X, to_type="df-list", as_scitype="Panel", store=self._converter_store_X
@@ -647,9 +650,12 @@ class BaseTransformer(BaseEstimator):
         elif X_input_scitype == "Panel" and "Panel" not in X_inner_scitypes:
             if y is not None and self.get_tag("y_inner_mtype") != "None":
                 raise ValueError(
-                    "no default behaviour if _fit does not support Panel and "
-                    'self.get_tag("y_inner_mtype") is not "None",'
-                    " but found X of Panel type, and y not None"
+                    f"{type(self).__name__} does not support Panel X if y is not None, "
+                    f"since {type(self).__name__} supports only Series. "
+                    "Auto-vectorization to extend Series X to Panel X can only be "
+                    'carried out if y is None, or "y_inner_mtype" tag is "None". '
+                    "Consider extending _fit and _transform to handle the following "
+                    "input types natively: Panel X and non-None y."
                 )
             X = convert_to(
                 X, to_type="df-list", as_scitype="Panel", store=self._converter_store_X
@@ -675,9 +681,12 @@ class BaseTransformer(BaseEstimator):
             X_input_mtype = mtype(X, as_scitype=["Series", "Panel"])
         if y is not None and self.get_tag("y_inner_mtype") != "None":
             raise ValueError(
-                "no default behaviour if _fit does not support Panel and "
-                'self.get_tag("y_inner_mtype") is not "None",'
-                " but found X of Panel type, and y not None"
+                f"{type(self).__name__} does not support Panel X if y is not None, "
+                f"since {type(self).__name__} supports only Series. "
+                "Auto-vectorization to extend Series X to Panel X can only be "
+                'carried out if y is None, or "y_inner_mtype" tag is "None". '
+                "Consider extending _fit and _transform to handle the following "
+                "input types natively: Panel X and non-None y."
             )
 
         X = convert_to(

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -789,11 +789,15 @@ class BaseTransformer(BaseEstimator):
         if output_scitype == "Series":
             # if the transformer outputs multivariate series,
             #   we cannot convert back to pd.Series, do pd.DataFrame instead then
-            _, _, metadata = check_is_mtype(
-                Xt, ["pd.DataFrame", "pd.Series", "np.ndarray"], return_metadata=True
-            )
-            if not metadata["is_univariate"] and X_input_mtype == "pd.Series":
-                X_output_mtype = "pd.DataFrame"
+            #   this happens only for Series, not Panel
+            if X_input_scitype == "Series":
+                _, _, metadata = check_is_mtype(
+                    Xt,
+                    ["pd.DataFrame", "pd.Series", "np.ndarray"],
+                    return_metadata=True,
+                )
+                if not metadata["is_univariate"] and X_input_mtype == "pd.Series":
+                    X_output_mtype = "pd.DataFrame"
             else:
                 X_output_mtype = X_input_mtype
             Xt = convert_to(

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -645,10 +645,11 @@ class BaseTransformer(BaseEstimator):
 
         # 3. internal only has Series but X is Panel: loop over instances
         elif X_input_scitype == "Panel" and "Panel" not in X_inner_scitypes:
-            if y is not None:
+            if y is not None and self.get_tag("y_inner_mtype") != "None":
                 raise ValueError(
-                    "no default behaviour if _fit does not support Panel, "
-                    " but X is Panel and y is not None"
+                    "no default behaviour if _fit does not support Panel and "
+                    'self.get_tag("y_inner_mtype") is not "None",'
+                    " but found X of Panel type, and y not None"
                 )
             X = convert_to(
                 X, to_type="df-list", as_scitype="Panel", store=self._converter_store_X
@@ -672,10 +673,11 @@ class BaseTransformer(BaseEstimator):
         """Vectorized application of transform or inverse, and convert back."""
         if X_input_mtype is None:
             X_input_mtype = mtype(X, as_scitype=["Series", "Panel"])
-        if y is not None:
-            ValueError(
-                "no default behaviour if _fit does not support Panel, "
-                " but X is Panel and y is not None"
+        if y is not None and self.get_tag("y_inner_mtype") != "None":
+            raise ValueError(
+                "no default behaviour if _fit does not support Panel and "
+                'self.get_tag("y_inner_mtype") is not "None",'
+                " but found X of Panel type, and y not None"
             )
 
         X = convert_to(

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -684,11 +684,13 @@ class BaseTransformer(BaseEstimator):
 
         # depending on whether fitting happens, apply fitted or unfitted instances
         if not self.get_tag("fit-in-transform"):
-            # these are the transformers-per-instanced, fitted in fit
+            # these are the transformers-per-instance, fitted in fit
             transformers = self.transformers_
             if len(transformers) != len(X):
                 raise RuntimeError(
-                    "found different number of instances in transform than in fit"
+                    "found different number of instances in transform than in fit. "
+                    f"number of instances seen in fit: {len(transformers)}; "
+                    f"number of instances seen in transform: {len(X)}"
                 )
             if inverse:
                 Xt = [transformers[i].inverse_transform(X[i]) for i in range(len(X))]

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -784,6 +784,9 @@ class BaseTransformer(BaseEstimator):
 
         # if we converted Series to "one-instance-Panel", revert that
         if X_was_Series and output_scitype == "Series":
+            Xt = convert_to(
+                Xt, to_type=["pd-multiindex", "numpy3D", "df-list"], as_scitype="Panel"
+            )
             Xt = convert_Panel_to_Series(Xt)
 
         if output_scitype == "Series":

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -787,7 +787,10 @@ class BaseTransformer(BaseEstimator):
             Xt = convert_Panel_to_Series(Xt)
 
         if output_scitype == "Series":
-            # if the transformer outputs multivariate series,
+            # output mtype is input mtype
+            X_output_mtype = X_input_mtype
+
+            # exception to this: if the transformer outputs multivariate series,
             #   we cannot convert back to pd.Series, do pd.DataFrame instead then
             #   this happens only for Series, not Panel
             if X_input_scitype == "Series":
@@ -798,8 +801,7 @@ class BaseTransformer(BaseEstimator):
                 )
                 if not metadata["is_univariate"] and X_input_mtype == "pd.Series":
                     X_output_mtype = "pd.DataFrame"
-            else:
-                X_output_mtype = X_input_mtype
+
             Xt = convert_to(
                 Xt,
                 to_type=X_output_mtype,


### PR DESCRIPTION
This PR collects bugfixes and changes to `BaseTransformer` arising from #1854.

Bugfixes:
* the output logic for `Panel` returns of `_transform` and `_inverse_transform` was incorrect. The line that was introduced to deal with multivariate outputs when `Series` are passed accidentally blocked all `Panel` returns. The check is now done only if the return is `Series`.
* when a `Series` is passed to `transform` and the internal `_transform` supports only `Panel`, and the internal mtype is `nested_univ`, the back-conversion function `Panel`->`Series` could not cope, since it was not compatible with the `nested_univ` mtype. An additional `convert_to` fixes this.
* checks and conversion for `convert_Panel_to_Series`, was incorrect for `np.ndarray` input (3D `Panel` -> 2D, `Series`)
* relaxed condition when attempting `convert_panel_to_Series` and passing `y`: the case that `y` is not `None` but we know that it is ignored anyway (`self.get_tag("y_inner_mtype")=None`) no longer throws an error.