### PR TITLE
[ENH] Composable distances interface prototype for numba distance module

### DIFF
--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -54,7 +54,6 @@ class BasePairwiseTransformer(BaseEstimator):
     # default tag values - these typically make the "safest" assumption
     _tags = {
         "symmetric": False,  # is the transformer symmetric, i.e., t(x,y)=t(y,x) always?
-        "X_inner_mtype": "df-list",  # which mtype is used internally in _transform?
     }
 
     def __init__(self):
@@ -171,6 +170,7 @@ class BasePairwiseTransformerPanel(BaseEstimator):
     # default tag values - these typically make the "safest" assumption
     _tags = {
         "symmetric": False,  # is the transformer symmetric, i.e., t(x,y)=t(y,x) always?
+        "X_inner_mtype": "df-list",  # which mtype is used internally in _transform?
     }
 
     def __init__(self):

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -135,7 +135,7 @@ class BasePairwiseTransformer(BaseEstimator):
     def _transform(self, X, X2=None):
         """Compute distance/kernel matrix.
 
-            Core logic
+        private _transform containing core logic, called from transform
 
         Behaviour: returns pairwise distance/kernel matrix
             between samples in X and X2 (equal to X if not passed)
@@ -156,6 +156,7 @@ class BasePairwiseTransformer(BaseEstimator):
     def fit(self, X=None, X2=None):
         """Fit method for interface compatibility (no logic inside)."""
         # no fitting logic, but in case fit is called or expected
+        self._is_fitted = True
         return self
 
 
@@ -187,9 +188,22 @@ class BasePairwiseTransformerPanel(BaseEstimator):
 
         Parameters
         ----------
-        X: list of pd.DataFrame or 2D np.arrays, of length n
-        X2: list of pd.DataFrame or 2D np.arrays, of length m, optional
-            default X2 = X
+        X : Series or Panel, any supported mtype, of n instances
+            Data to transform, of python type as follows:
+                Series: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
+                Panel: pd.DataFrame with 2-level MultiIndex, list of pd.DataFrame,
+                    nested pd.DataFrame, or pd.DataFrame in long/wide format
+                subject to sktime mtype format specifications, for further details see
+                    examples/AA_datatypes_and_datasets.ipynb
+        X2 : Series or Panel, any supported mtype, of m instances
+                optional, default: X = X2
+            Data to transform, of python type as follows:
+                Series: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
+                Panel: pd.DataFrame with 2-level MultiIndex, list of pd.DataFrame,
+                    nested pd.DataFrame, or pd.DataFrame in long/wide format
+                subject to sktime mtype format specifications, for further details see
+                    examples/AA_datatypes_and_datasets.ipynb
+            X and X2 need not have the same mtype
 
         Returns
         -------
@@ -213,9 +227,22 @@ class BasePairwiseTransformerPanel(BaseEstimator):
 
         Parameters
         ----------
-        X: list of pd.DataFrame or 2D np.arrays, of length n
-        X2: list of pd.DataFrame or 2D np.arrays, of length m, optional
-            default X2 = X
+        X : Series or Panel, any supported mtype, of n instances
+            Data to transform, of python type as follows:
+                Series: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
+                Panel: pd.DataFrame with 2-level MultiIndex, list of pd.DataFrame,
+                    nested pd.DataFrame, or pd.DataFrame in long/wide format
+                subject to sktime mtype format specifications, for further details see
+                    examples/AA_datatypes_and_datasets.ipynb
+        X2 : Series or Panel, any supported mtype, of m instances
+                optional, default: X = X2
+            Data to transform, of python type as follows:
+                Series: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
+                Panel: pd.DataFrame with 2-level MultiIndex, list of pd.DataFrame,
+                    nested pd.DataFrame, or pd.DataFrame in long/wide format
+                subject to sktime mtype format specifications, for further details see
+                    examples/AA_datatypes_and_datasets.ipynb
+            X and X2 need not have the same mtype
 
         Returns
         -------
@@ -243,15 +270,19 @@ class BasePairwiseTransformerPanel(BaseEstimator):
     def _transform(self, X, X2=None):
         """Compute distance/kernel matrix.
 
-            Core logic
+        private _transform containing core logic, called from transform
 
         Behaviour: returns pairwise distance/kernel matrix
             between samples in X and X2 (equal to X if not passed)
 
         Parameters
         ----------
-        X: list of pd.DataFrame or 2D np.arrays, of length n
-        X2: list of pd.DataFrame or 2D np.arrays, of length m, optional
+        X : guaranteed to be Series or Panel of mtype X_inner_mtype, n instances
+            if X_inner_mtype is list, _transform must support all types in it
+            Data to be transformed
+        X2 : guaranteed to be Series or Panel of mtype X_inner_mtype, m instances
+            if X_inner_mtype is list, _transform must support all types in it
+            Data to be transformed
             default X2 = X
 
         Returns
@@ -264,6 +295,7 @@ class BasePairwiseTransformerPanel(BaseEstimator):
     def fit(self, X=None, X2=None):
         """Fit method for interface compatibility (no logic inside)."""
         # no fitting logic, but in case fit is called or expected
+        self._is_fitted = True
         return self
 
     def _pairwise_panel_x_check(self, X, var_name="X"):

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -54,6 +54,7 @@ class BasePairwiseTransformer(BaseEstimator):
     # default tag values - these typically make the "safest" assumption
     _tags = {
         "symmetric": False,  # is the transformer symmetric, i.e., t(x,y)=t(y,x) always?
+        "X_inner_mtype": "df-list",  # which mtype is used internally in _transform?
     }
 
     def __init__(self):
@@ -158,48 +159,6 @@ class BasePairwiseTransformer(BaseEstimator):
         return self
 
 
-def _pairwise_panel_x_check(X, var_name="X"):
-    """Check and coerce input data.
-
-    Method used to check the input and convert
-    numpy 3d or numpy list of df to list of dfs
-
-    Parameters
-    ----------
-    X: List of dfs, Numpy of dfs, 3d numpy
-        The value to be checked
-    var_name: str, variable name to print in error messages
-
-    Returns
-    -------
-    X: List of pd.Dataframe, coerced to this format if one
-        of the other formats, otherwise identical to X
-
-    """
-    check_res = check_is_scitype(
-        X, ["Series", "Panel"], return_metadata=True, var_name=var_name
-    )
-    X_valid = check_res[0]
-    metadata = check_res[2]
-
-    X_scitype = metadata["scitype"]
-
-    if not X_valid:
-        raise TypeError("X/X2 must be of Series or Panel scitype")
-
-    # if the input is a single series, convert it to a Panel
-    if X_scitype == "Series":
-        X = convert_Series_to_Panel(X)
-
-    # can't be anything else if check_is_scitype is working properly
-    elif X_scitype != "Panel":
-        raise RuntimeError("Unexpected error in check_is_scitype, check validity")
-
-    X_coerced = convert_to(X, to_type="df-list", as_scitype="Panel")
-
-    return X_coerced
-
-
 class BasePairwiseTransformerPanel(BaseEstimator):
     """Base pairwise transformer for panel data template class.
 
@@ -266,13 +225,13 @@ class BasePairwiseTransformerPanel(BaseEstimator):
         X_equals_X2: bool = True if X2 was not passed, False if X2 was passed
             for use to make internal calculations efficient, e.g., in _transform
         """
-        X = _pairwise_panel_x_check(X)
+        X = self._pairwise_panel_x_check(X)
 
         if X2 is None:
             X2 = X
             self.X_equals_X2 = True
         else:
-            X2 = _pairwise_panel_x_check(X2, var_name="X2")
+            X2 = self._pairwise_panel_x_check(X2, var_name="X2")
             # todo, possibly:
             # check X, X2 for equality, then set X_equals_X2
             # could use deep_equals
@@ -304,3 +263,44 @@ class BasePairwiseTransformerPanel(BaseEstimator):
         """Fit method for interface compatibility (no logic inside)."""
         # no fitting logic, but in case fit is called or expected
         return self
+
+    def _pairwise_panel_x_check(self, X, var_name="X"):
+        """Check and coerce input data.
+
+        Method used to check the input and convert Series/Panel input
+            to internally used format, as defined in X_inner_mtype tag
+
+        Parameters
+        ----------
+        X: List of dfs, Numpy of dfs, 3d numpy
+            The value to be checked
+        var_name: str, variable name to print in error messages
+
+        Returns
+        -------
+        X: Panel data container of a supported format in X_inner_mtype
+            usually df-list, list of pd.DataFrame, unless overridden
+        """
+        check_res = check_is_scitype(
+            X, ["Series", "Panel"], return_metadata=True, var_name=var_name
+        )
+        X_valid = check_res[0]
+        metadata = check_res[2]
+
+        X_scitype = metadata["scitype"]
+
+        if not X_valid:
+            raise TypeError("X/X2 must be of Series or Panel scitype")
+
+        # if the input is a single series, convert it to a Panel
+        if X_scitype == "Series":
+            X = convert_Series_to_Panel(X)
+
+        # can't be anything else if check_is_scitype is working properly
+        elif X_scitype != "Panel":
+            raise RuntimeError("Unexpected error in check_is_scitype, check validity")
+
+        X_inner_mtype = self.get_tag("X_inner_mtype")
+        X_coerced = convert_to(X, to_type=X_inner_mtype, as_scitype="Panel")
+
+        return X_coerced

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -54,6 +54,7 @@ class BasePairwiseTransformer(BaseEstimator):
     # default tag values - these typically make the "safest" assumption
     _tags = {
         "symmetric": False,  # is the transformer symmetric, i.e., t(x,y)=t(y,x) always?
+        "fit-in-transform": True,  # is "fit" empty? Yes, for all pairwise transforms
     }
 
     def __init__(self):
@@ -171,6 +172,7 @@ class BasePairwiseTransformerPanel(BaseEstimator):
     _tags = {
         "symmetric": False,  # is the transformer symmetric, i.e., t(x,y)=t(y,x) always?
         "X_inner_mtype": "df-list",  # which mtype is used internally in _transform?
+        "fit-in-transform": True,  # is "fit" empty? Yes, for all pairwise transforms
     }
 
     def __init__(self):

--- a/sktime/dists_kernels/dtw.py
+++ b/sktime/dists_kernels/dtw.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+"""BaseEstimator interface to sktime dtw distances in distances module."""
+
+__author__ = ["fkiraly"]
+
+import numpy as np
+
+from typing import Union
+
+from sktime.distances import pairwise_distance
+from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+
+
+class DtwDist(BasePairwiseTransformerPanel):
+    r"""Interface to sktime native dtw distances, with derivative or weighting.
+
+    Interface to simple dynamic time warping (DTW) distance,
+    and the following weighted/derivative versions:
+    WDTW - weighted dynamic tyme warping
+    DDTW - derivative dynamic time warping
+    WDDTW - weighted derivative dynamic time warping
+
+    DTW:
+    Originally proposed in [1]_, DTW computes the distance between two time series by
+    considering their alignments during the calculation. This is done by measuring
+    the pointwise distance (normally using Euclidean) between all elements of the two
+    time series and then using dynamic programming to find the warping path
+    that minimises the total pointwise distance between realigned series.
+
+    DDTW is an adaptation of DTW originally proposed in [2]_. DDTW attempts to
+    improve on dtw by better account for the 'shape' of the time series.
+    This is done by considering y axis data points as higher level features of 'shape'.
+    To do this the first derivative of the sequence is taken, and then using this
+    derived sequence a dtw computation is done.
+
+    WDTW was first proposed in [3]_, it adds a multiplicative weight penalty based on
+    the warping distance. This means that time series with lower phase difference have
+    a smaller weight imposed (i.e less penalty imposed) and time series with larger
+    phase difference have a larger weight imposed (i.e. larger penalty imposed).
+
+    WDDTW was first proposed in [3]_ as an extension of DDTW. By adding a weight
+    to the derivative it means the alignment isn't only considering the shape of the
+    time series, but also the phase.
+
+    Mathematical definitions follow. Let :math:`x` and :math:`y` be tuples taking
+    values in the reals, not necessarily of equal length.
+    These are interpreted as series/sequences to compute distances between.
+
+    The DTW distance is defined as:
+
+    .. math::
+        dtw(x, y) = \sqrt{\sum_{(i, j) \in \pi} \|x_{i} - y_{j}\|^2}
+
+    todo: add formulae for other distances from distances module once they look correct.
+
+
+    Parameters
+    ----------
+    weighted : bool, optional, default=False
+        whether a weighted version of the distance is computed
+        False = unmodified distance, i.e., dtw distance or derivative dtw distance
+        True = weighted distance, i.e., weighted dtw or derivative weighted dtw
+    derivative : bool, optional, default=False
+        whether the distance or the derivative distance is computed
+        False = unmodified distance, i.e., dtw distance or weighted dtw distance
+        True = derivative distance, i.e., derivative dtw distane or derivative wdtw
+    window: int, defaults = None
+        Integer that is the radius of the sakoe chiba window (if using Sakoe-Chiba
+        lower bounding).
+    itakura_max_slope: float, defaults = None
+        Gradient of the slope for itakura parallelogram (if using Itakura
+        Parallelogram lower bounding).
+    bounding_matrix: np.ndarray (2d of size mxn where m is len(x) and n is len(y)),
+                                    defaults = None)
+        Custom bounding matrix to use. If defined then other lower_bounding params
+        are ignored. The matrix should be structure so that indexes considered in
+        bound should be the value 0. and indexes outside the bounding matrix should
+        be infinity.
+    g: float, optional, default = 0. Used only if weighted=True.
+        Constant that controls the curvature (slope) of the function; that is, g
+        controls the level of penalisation for the points with larger phase
+        difference.
+
+    References
+    ----------
+    .. [1] H. Sakoe, S. Chiba, "Dynamic programming algorithm optimization for
+           spoken word recognition," IEEE Transactions on Acoustics, Speech and
+           Signal Processing, vol. 26(1), pp. 43--49, 1978.
+    .. [2] Keogh, Eamonn & Pazzani, Michael. (2002). Derivative Dynamic Time Warping.
+        First SIAM International Conference on Data Mining.
+        1. 10.1137/1.9781611972719.1.
+    .. [3] Young-Seon Jeong, Myong K. Jeong, Olufemi A. Omitaomu, Weighted dynamic time
+    warping for time series classification, Pattern Recognition, Volume 44, Issue 9,
+    2011, Pages 2231-2240, ISSN 0031-3203, https://doi.org/10.1016/j.patcog.2010.09.022.
+    """
+
+    _tags = {
+        "symmetric": True,  # all the distances are symmetric
+    }
+
+    def __init__(
+        self,
+        weighted: bool = False,
+        derivative: bool = False,
+        window: Union[int, None] = None,
+        itakura_max_slope: Union[float, None] = None,
+        bounding_matrix: np.ndarray = None,
+        g: float = 0.0,
+    ):
+
+        self.weighted = weighted
+        self.derivative = derivative
+        self.window = window
+        self.itakura_max_slope = itakura_max_slope
+        self.bounding_matrix = bounding_matrix
+        self.g = g
+
+        if not weighted and not derivative:
+            metric_key = "dtw"
+        elif not weighted and derivative:
+            metric_key = "ddtw"
+        elif weighted and not derivative:
+            metric_key = "wdtw"
+        elif weighted and derivative:
+            metric_key = "wddtw"
+
+        self.metric_key = metric_key
+
+        kwargs = {
+            "window": window,
+            "itakura_max_slope": itakura_max_slope,
+            "bounding_matrix": bounding_matrix,
+        }
+
+        # g is used only for weighted dtw
+        if weighted:
+            kwargs["g"] = g
+
+        self.kwargs = kwargs
+
+        super(DtwDist, self).__init__()
+
+    def _transform(self, X, X2=None):
+        """Compute distance/kernel matrix.
+
+            Core logic
+
+        Behaviour: returns pairwise distance/kernel matrix
+            between samples in X and X2
+                if X2 is not passed, is equal to X
+                if X/X2 is a pd.DataFrame and contains non-numeric columns,
+                    these are removed before computation
+
+        Parameters
+        ----------
+        X: 3D np.array of shape [num_instances, num_vars, num_time_points]
+        X2: 3D np.array of shape [num_instances, num_vars, num_time_points], optional
+            default X2 = X
+
+        Returns
+        -------
+        distmat: np.array of shape [n, m]
+            (i,j)-th entry contains distance/kernel between X[i] and X2[j]
+        """
+        metric_key = self.metric_key
+        kwargs = self.kwargs
+
+        distmat = pairwise_distance(X, X2, metric=metric_key, **kwargs)
+
+        return distmat

--- a/sktime/dists_kernels/dtw.py
+++ b/sktime/dists_kernels/dtw.py
@@ -63,7 +63,7 @@ class DtwDist(BasePairwiseTransformerPanel):
     derivative : bool, optional, default=False
         whether the distance or the derivative distance is computed
         False = unmodified distance, i.e., dtw distance or weighted dtw distance
-        True = derivative distance, i.e., derivative dtw distane or derivative wdtw
+        True = derivative distance, i.e., derivative dtw distance or derivative wdtw
     window: int, defaults = None
         Integer that is the radius of the sakoe chiba window (if using Sakoe-Chiba
         lower bounding).

--- a/sktime/dists_kernels/dtw.py
+++ b/sktime/dists_kernels/dtw.py
@@ -96,6 +96,7 @@ class DtwDist(BasePairwiseTransformerPanel):
 
     _tags = {
         "symmetric": True,  # all the distances are symmetric
+        "X_inner_mtype": "numpy3D",
     }
 
     def __init__(

--- a/sktime/dists_kernels/dtw.py
+++ b/sktime/dists_kernels/dtw.py
@@ -3,9 +3,9 @@
 
 __author__ = ["fkiraly"]
 
-import numpy as np
-
 from typing import Union
+
+import numpy as np
 
 from sktime.distances import pairwise_distance
 from sktime.dists_kernels._base import BasePairwiseTransformerPanel

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -58,7 +58,7 @@ ESTIMATOR_TAG_REGISTER = [
     ),
     (
         "fit-in-transform",
-        "transformer",
+        ["transformer", "transformer-pairwise", "transformer-pairwise-panel"],
         "bool",
         "does fit contain no logic and can be skipped? yes/no",
     ),

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -135,7 +135,7 @@ ESTIMATOR_TAG_REGISTER = [
     ),
     (
         "X_inner_mtype",
-        ["forecaster", "transformer"],
+        ["forecaster", "transformer", "transformer-pairwise-panel"],
         (
             "list",
             [

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -124,24 +124,8 @@ EXCLUDE_ESTIMATORS = [
 ]
 
 
-# This is temporary until BaseObject is implemented
-DIST_KERNELS_IGNORE_TESTS = [
-    "test_fit_updates_state",
-    "_make_fit_args",
-    "test_fit_returns_self",
-    "test_raises_not_fitted_error",
-    "test_fit_idempotent",
-    "test_fit_does_not_overwrite_hyper_params",
-    "test_methods_do_not_change_state",
-    "test_persistence_via_pickle",
-]
-
-
 EXCLUDED_TESTS = {
     "ContractedShapeletTransform": ["test_fit_idempotent"],
-    "ScipyDist": DIST_KERNELS_IGNORE_TESTS,
-    "AggrDist": DIST_KERNELS_IGNORE_TESTS,
-    "DistFromAligner": DIST_KERNELS_IGNORE_TESTS,
     "FeatureUnion": ["test_fit_does_not_overwrite_hyper_params"],
 }
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -25,7 +25,8 @@ from sklearn.utils.estimator_checks import check_set_params as _check_set_params
 
 from sktime.base import BaseEstimator
 from sktime.dists_kernels._base import (
-    BasePairwiseTransformer, BasePairwiseTransformerPanel
+    BasePairwiseTransformer,
+    BasePairwiseTransformerPanel,
 )
 from sktime.exceptions import NotFittedError
 from sktime.registry import all_estimators

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -24,6 +24,9 @@ from sklearn.utils.estimator_checks import (
 from sklearn.utils.estimator_checks import check_set_params as _check_set_params
 
 from sktime.base import BaseEstimator
+from sktime.dists_kernels._base import (
+    BasePairwiseTransformer, BasePairwiseTransformerPanel
+)
 from sktime.exceptions import NotFittedError
 from sktime.registry import all_estimators
 from sktime.tests._config import (
@@ -381,6 +384,12 @@ def test_fit_returns_self(estimator_instance):
 def test_raises_not_fitted_error(estimator_instance):
     """Check that we raise appropriate error for unfitted estimators."""
     estimator = estimator_instance
+
+    # pairwise transformers are exempted from this test, since they have no fitting
+    PWTRAFOS = (BasePairwiseTransformer, BasePairwiseTransformerPanel)
+    excepted = isinstance(estimator_instance, PWTRAFOS)
+    if excepted:
+        return None
 
     # call methods without prior fitting and check that they raise our
     # NotFittedError


### PR DESCRIPTION
This PR contains the new `sktime` native, `numba` based distances wrapped as composable distance classes in `dists_kernels`.

There is one new class, `DtwDist`, which wraps the four dynamic time warping distances in `distances` as `BaseEstimator` compatible objects in `dists_kernels`.

This PR also contains some minor modifications to the panel distance base class, `BasePairwiseTransformerPanel`, and testing:
* now allows arbitrary internal mtypes, since the `sktime` native distances require 3D `numpy`, not `df-list` internal format
* for that, moved `_pairwise_panel_x_check` into the class to be in line with other base classes' input checking and coercion
* `fit` related tests were escaped since before work on `BaseObject`. This has been removed, and remedied by adding the `"fit-in-transform"` tag to all pairwise transformers (set to `True` by default).

I would particularly appreciate a review by @TonyBagnall and @chrisholder.

PS: while doing this, I noted that the math in the `distances` module docstrings seems incorrect or incomplete, I've collated the points in issue #1857.