### PR TITLE
[ENH] speeding up tests - smaller data, quick parameter settings

### DIFF
--- a/sktime/transformations/panel/shapelets.py
+++ b/sktime/transformations/panel/shapelets.py
@@ -947,6 +947,21 @@ class ShapeletTransform(_PanelToTabularTransformer):
                     return min_dist
         return sum_dist
 
+    @classmethod
+    def get_test_params(cls):
+        """Return testing parameter settings for the estimator.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params = {"max_shapelet_length" : 5, "max_shapelets_to_store_per_class" : 3}
+        return params
+
 
 class ContractedShapeletTransform(ShapeletTransform):
     """Contracted Shapelet Transform.


### PR DESCRIPTION
An attempt to speed up testing in general, through:

* setting parameters for estimators that make them run fast
* choosing smaller data sets for tests
* removing redundancy in repetitions, e.g., fitting