### PR TITLE
WIP: add logistic growth cap and floor for fbprophet

### DIFF
--- a/sktime/forecasting/fbprophet.py
+++ b/sktime/forecasting/fbprophet.py
@@ -108,6 +108,8 @@ class Prophet(_ProphetAdapter):
         add_country_holidays=None,
         # Args of fbprophet
         growth="linear",
+        growth_floor=0.0,
+        growth_cap=None,
         changepoints=None,
         n_changepoints=25,
         changepoint_range=0.8,
@@ -130,6 +132,8 @@ class Prophet(_ProphetAdapter):
         self.add_country_holidays = add_country_holidays
 
         self.growth = growth
+        self.growth_floor=growth_floor,
+        self.growth_cap=growth_cap,
         self.changepoints = changepoints
         self.n_changepoints = n_changepoints
         self.changepoint_range = changepoint_range


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1079


#### What does this implement/fix? Explain your changes.
Adds the possibility to define the required "cap" and "floor" parameters for Prophet when its growth is set to logistic.

#### What should a reviewer concentrate their feedback on?
Whether the proposed changes are the correct way of accepting the cap and floor parameters. 

Additionally, the only check in place is a ValueError is currently raised when "cap" is not specified ("floor" is not required, as it defaults to 0). I believe Prophet will handle all other input errors, but it might be good to test certain wrong inputs.

#### Any other comments?
This fix is blocked by another uncovered bug in the `convert_to` method that is used in the BaseForecaster, that leads to the output as an empty DataFrame. Will open another issue for this

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.
