### PR TITLE
Fix typo in Setting up a development environment section

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -393,7 +393,7 @@ In the ``anaconda prompt`` terminal:
 
 4. Install required packages:
 
-   1. :code:`pip install numpy=1.19.3`
+   1. :code:`pip install numpy==1.19.3`
    2. :code:`pip install cython`
    3. :code:`pip install -r build_tools/requirements.txt`
 


### PR DESCRIPTION
### Fix typo in Setting up a development environment section on Windows

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

In Install required packages section:

Running `pip install numpy=1.19.3` gives this error:

(base) C:\Development\alan-turing-institute\sktime>pip install numpy=1.19.3
ERROR: Invalid requirement: 'numpy=1.19.3'
Hint: = is not a valid operator. Did you mean == ?

Hence `pip install numpy=1.19.3` should be `pip install numpy==1.19.3`.


<!--
Thanks for contributing!
-->
