### PR TITLE
[BUG] Knn bugfix to allow GridsearchCV and usage with column ensemble.

### DIFF
--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -102,9 +102,9 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
         distance_params=None,
         **kwargs
     ):
-        self._distance_params = distance_params
-        if distance_params is None:
-            self._distance_params = {}
+        # self._distance_params = distance_params
+        # if distance_params is None:
+        #    self._distance_params = {}
         self.distance = distance
         self.distance_params = distance_params
 
@@ -141,11 +141,13 @@ class KNeighborsTimeSeriesClassifier(_KNeighborsClassifier, BaseClassifier):
         """
         # Transpose to work correctly with distance functions
         X = X.transpose((0, 2, 1))
-
         if isinstance(self.distance, str):
-            self.metric = distance_factory(
-                X[0], X[0], metric=self.distance, **self._distance_params
-            )
+            if self.distance_params is None:
+                self.metric = distance_factory(X[0], X[0], metric=self.distance)
+            else:
+                self.metric = distance_factory(
+                    X[0], X[0], metric=self.distance, **self.distance_params
+                )
 
         y = np.asarray(y)
         check_classification_targets(y)

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -317,10 +317,11 @@ def load_from_tsfile(
     return_y: boolean, default True
        whether to return the y variable, if it is present.
     return_data_type: default, None
-        what data structure to return X in. Valid alternatives to None (default
-        pd.DataFrame are numpy2d/np2d/numpyflat or numpy3d/np3d. These arguments will
-        raise an
-        error if the data cannot be stored in the requested type.
+        what data structure to return X in. Valid alternatives to None (default to
+        pd.DataFrame) are nested_univ (pd.DataFrame) are numpy2d/np2d/numpyflat or
+        numpy3d/np3d.
+        These arguments will raise an error if the data cannot be stored in the
+        requested type.
 
     Returns
     -------

--- a/sktime/distances/lower_bounding.py
+++ b/sktime/distances/lower_bounding.py
@@ -388,7 +388,11 @@ class LowerBounding(Enum):
         _y = self._check_input_timeseries(y)
         if self.int_val == 2:
             if not isinstance(sakoe_chiba_window_radius, float):
-                raise ValueError("The sakoe chiba window must be a float.")
+                raise ValueError(
+                    f"The sakoe chiba window must be a float, passed "
+                    f"{sakoe_chiba_window_radius} of type"
+                    f" {type(sakoe_chiba_window_radius)}."
+                )
             bounding_matrix = sakoe_chiba(_x, _y, sakoe_chiba_window_radius)
         elif self.int_val == 3:
             if not isinstance(itakura_max_slope, float):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #1713  
Fixes #578
Fixes #1057 


#### What does this implement/fix? Explain your changes.

Simple fix to allow for correct parameter setting with GridCV. It removes a temporary measure to allow KNN to pass tests and fixes thanks to the new distance factory. Note we should do some work on making the valid parameters clearer for the different distance measures

Below code all works

## code 
knn = KNeighborsTimeSeriesClassifier(distance="dtw", n_neighbors=1, distance_params={
    "window":0.5})
knn2 = KNeighborsTimeSeriesClassifier(distance="dtw", n_neighbors=1)

param_matrix = {"distance_params": [{"window": x/10.0} for x in range(0,10)]
                }

### CV Parameter search
grid = GridSearchCV(knn2, param_grid=param_matrix, cv=2, scoring="accuracy")
grid.fit(x_train, y_train)
print(pd.DataFrame(grid.cv_results_))
print(grid)
print(" params after CV = ",knn2.get_params())
knn4 = KNeighborsTimeSeriesClassifier(distance="dtw", n_neighbors=1, distance_params={
    "window":0.0})

estimators = [
    ("knn", knn, [0, 1, 2]),
    ("knn2", knn2, [3, 4]),
    ("knn4", knn4, [5]),
]
x_train, y_train = load_basic_motions(split="train")
x_test, y_test = load_basic_motions(split="test")

### train column ensemble
col_ens = ColumnEnsembleClassifier(estimators=estimators)
col_ens.fit(x_train, y_train)
print(" Score = ",col_ens.score(x_train, y_train))




 