### PR TITLE
DRAFT for diagnosing CI/CD: Revert "Add predict_quantiles to FBprophet"

### DIFF
--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -7,6 +7,7 @@ __author__ = ["mloning", "aiwalter"]
 __all__ = ["_ProphetAdapter"]
 
 import os
+from contextlib import contextmanager
 
 import pandas as pd
 
@@ -75,7 +76,7 @@ class _ProphetAdapter(BaseForecaster):
 
         return self
 
-    def _predict(self, fh=None, X=None):
+    def _predict(self, fh=None, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA):
         """Forecast time series at future horizon.
 
         Parameters
@@ -86,6 +87,10 @@ class _ProphetAdapter(BaseForecaster):
             one-step ahead forecast, i.e. np.array([1]).
         X : pd.DataFrame, optional
             Exogenous data, by default None
+        return_pred_int : bool, optional
+            Returns a pd.DataFrame with confidence intervalls, by default False
+        alpha : float, optional
+            Alpha level for confidence intervalls, by default DEFAULT_ALPHA
 
         Returns
         -------
@@ -109,83 +114,19 @@ class _ProphetAdapter(BaseForecaster):
             X = X.copy()
             df, X = _merge_X(df, X)
 
-        out = self._forecaster.predict(df)
+        # don't compute confidence intervals if not asked for
+        with self._return_pred_int(return_pred_int):
+            out = self._forecaster.predict(df)
 
         out.set_index("ds", inplace=True)
         y_pred = out.loc[:, "yhat"]
 
-        y_pred = pd.DataFrame(y_pred)
-        y_pred.reset_index(inplace=True)
-        y_pred.index = y_pred["ds"].values
-        y_pred.drop("ds", axis=1, inplace=True)
-        return y_pred
-
-    def _predict_quantiles(self, fh, X=None, alpha=DEFAULT_ALPHA):
-        """
-        Compute/return prediction quantiles for a forecast.
-
-        Must be run *after* the forecaster has been fitted.
-
-        If alpha is iterable, multiple quantiles will be calculated.
-
-        Parameters
-        ----------
-        fh : int, list, np.array or ForecastingHorizon
-            Forecasting horizon, default = y.index (in-sample forecast)
-        X : pd.DataFrame, optional (default=None)
-            Exogenous time series
-        alpha : float or list of float, optional (default=[0.05, 0.95])
-            A probability or list of, at which quantile forecasts are computed.
-
-        Returns
-        -------
-        quantiles : pd.DataFrame
-            Column has multi-index: first level is variable name from y in fit,
-                second level being the values of alpha passed to the function.
-            Row index is fh. Entries are quantile forecasts, for var in col index,
-                at quantile probability in second col index, for the row index.
-        """
-        fh = self.fh.to_absolute(cutoff=self.cutoff).to_pandas()
-        if not isinstance(fh, pd.DatetimeIndex):
-            raise ValueError("absolute `fh` must be represented as a pd.DatetimeIndex")
-
-        # convert alpha to the one needed for predict intervals
-        coverage = []
-        for a in alpha:
-            if a < 0.5:
-                coverage.append((0.5 - a) * 2)
-            elif a > 0.5:
-                coverage.append((a - 0.5) * 2)
-            else:
-                coverage.append(0)
-
-        df = pd.DataFrame({"ds": fh}, index=fh)
-
-        # Merge X with df (of created future DatetimeIndex values)
-        if X is not None:
-            X = X.copy()
-            df, X = _merge_X(df, X)
-
-        pred_quantiles = pd.DataFrame()
-        for a, c in zip(alpha, coverage):
-            self._forecaster.interval_width = c
-            self._forecaster.uncertainty_samples = self.uncertainty_samples
-            out = self._forecaster.predict(df)
-            out.set_index("ds", inplace=True)
+        if return_pred_int:
             pred_int = out.loc[:, ["yhat_lower", "yhat_upper"]]
             pred_int.columns = pred_int.columns.str.strip("yhat_")
-            pred_int.columns = ["lower", "upper"]
-            if a < 0.5:
-                pred_quantiles[a] = pred_int["lower"]
-            else:
-                pred_quantiles[a] = pred_int["upper"]
-        index = pd.MultiIndex.from_product([["Quantiles"], alpha])
-        pred_quantiles.columns = index
-        # moves ds column to a lower index and then remove
-        pred_quantiles.reset_index(inplace=True)
-        pred_quantiles.index = pred_quantiles["ds"].values
-        pred_quantiles.drop("ds", axis=1, inplace=True)
-        return pred_quantiles
+            return y_pred, pred_int
+        else:
+            return y_pred
 
     def get_fitted_params(self):
         """Get fitted parameters.
@@ -221,6 +162,17 @@ class _ProphetAdapter(BaseForecaster):
             self.specified_changepoints = False
         return self
 
+    @contextmanager
+    def _return_pred_int(self, return_pred_int):
+        if not return_pred_int:
+            # setting uncertainty samples to zero avoids computing pred ints
+            self._forecaster.uncertainty_samples = 0
+        try:
+            yield
+        finally:
+            if not return_pred_int:
+                self._forecaster.uncertainty_samples = self.uncertainty_samples
+
 
 def _merge_X(df, X):
     """Merge X and df on the DatetimeIndex.
@@ -245,14 +197,12 @@ def _merge_X(df, X):
     """
     # Merging on the index is unreliable, possibly due to loss of freq information in fh
     X.columns = X.columns.astype(str)
-    if "ds" in X.columns and pd.api.types.is_numeric_dtype(X["ds"]):
-        longest_column_name = max(X.columns, key=len)
-        X.loc[:, str(longest_column_name) + "_"] = X.loc[:, "ds"]
-        # raise ValueError("Column name 'ds' is reserved in fbprophet")
+    if "ds" in X.columns:
+        raise ValueError("Column name 'ds' is reserved in fbprophet")
     X.loc[:, "ds"] = X.index
-    df = df.merge(X, how="inner", on="ds", copy=True)
-    X = X.drop(columns="ds")
-    return df, X
+    # df = df.merge(X, how="inner", on="ds", copy=False)
+    df = df.merge(X, how="inner", on="ds")
+    return df, X.drop(columns="ds")
 
 
 class _suppress_stdout_stderr(object):

--- a/sktime/forecasting/fbprophet.py
+++ b/sktime/forecasting/fbprophet.py
@@ -6,7 +6,6 @@
 __author__ = ["aiwalter"]
 __all__ = ["Prophet"]
 
-
 from sktime.forecasting.base._base import DEFAULT_ALPHA
 from sktime.forecasting.base.adapters import _ProphetAdapter
 from sktime.utils.validation._dependencies import _check_soft_dependencies
@@ -141,7 +140,6 @@ class Prophet(_ProphetAdapter):
         uncertainty_samples=1000,
         stan_backend=None,
         verbose=0,
-        interval_width=0,
     ):
         self.freq = freq
         self.add_seasonality = add_seasonality
@@ -164,7 +162,6 @@ class Prophet(_ProphetAdapter):
         self.uncertainty_samples = uncertainty_samples
         self.stan_backend = stan_backend
         self.verbose = verbose
-        self.interval_width = interval_width
 
         # import inside method to avoid hard dependency
         from fbprophet.forecaster import Prophet as _Prophet

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -273,7 +273,8 @@ def _check_pred_ints(
         # check time index
         _assert_correct_pred_time_index(pred_int.index, y_train.index[-1], fh)
         # check values
-        assert np.all(pred_int["upper"] >= pred_int["lower"])
+        assert np.all(pred_int["upper"] > y_pred)
+        assert np.all(pred_int["lower"] < y_pred)
 
         # check if errors are weakly monotonically increasing
         # pred_errors = y_pred - pred_int["lower"]
@@ -313,7 +314,6 @@ def test_predict_pred_interval(Forecaster, fh, alpha):
             if f._has_predict_quantiles_been_refactored():
                 y_pred = f.predict()
                 pred_ints = f.predict_interval(fh, coverage=alpha)
-
                 pred_ints = f._convert_new_to_old_pred_int(pred_ints, alpha)
             else:
                 y_pred, pred_ints = f.predict(return_pred_int=True, alpha=alpha)


### PR DESCRIPTION
Reverting #1910, to diagnose whether it is causing the recent CI/CD congestion.