### PR TITLE
DRAFT for diagnosing CI/CD: empty set of estimators in test_all_estimators

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -102,11 +102,7 @@ def pytest_generate_tests(metafunc):
             estimator_instance_names += instance_names
 
         # parameterize test with the list of instances
-        metafunc.parametrize(
-            "estimator_instance",
-            estimator_instances_to_test,
-            ids=estimator_instance_names,
-        )
+        metafunc.parametrize("estimator_instance", [], [])
 
 
 def test_create_test_instance(estimator_class):

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -84,7 +84,7 @@ def pytest_generate_tests(metafunc):
             est for est in ALL_ESTIMATORS if not is_excluded(est)
         ]
         # parameterize test with the list of classes
-        metafunc.parametrize("estimator_class", estimator_classes_to_test)
+        metafunc.parametrize("estimator_class", [])
 
     # if estimator test, construct all instances for the test
     if "estimator_instance" in metafunc.fixturenames:


### PR DESCRIPTION
An attempt at diagnosing #1941: removes all tests in `test_all_estimators`.