### PR TITLE
DRAFT for diagnosing CI/CD: Revert "[ENH] Generalize splitters to accept timedeltas (equally spaced)"

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1471,15 +1471,6 @@
       "contributions": [
         "ideas"
       ]
-    },
-    {
-      "login": "khrapovs",
-      "name": "Stanislav Khrapov",
-      "avatar_url": "https://avatars.githubusercontent.com/u/3774663?v=4",
-      "profile": "https://github.com/khrapovs",
-      "contributions": [
-        "code"
-      ]
     }
   ],
   "projectName": "sktime",

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -7,7 +7,6 @@ __author__ = ["mloning", "fkiraly", "eenticott-shell"]
 __all__ = ["ForecastingHorizon"]
 
 from functools import lru_cache
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -19,7 +18,6 @@ RELATIVE_TYPES = (pd.Int64Index, pd.RangeIndex)
 ABSOLUTE_TYPES = (pd.Int64Index, pd.RangeIndex, pd.DatetimeIndex, pd.PeriodIndex)
 assert set(RELATIVE_TYPES).issubset(VALID_INDEX_TYPES)
 assert set(ABSOLUTE_TYPES).issubset(VALID_INDEX_TYPES)
-VALID_FORECASTING_HORIZON_TYPES = (int, list, np.ndarray, pd.Index)
 
 DELEGATED_METHODS = (
     "__sub__",
@@ -61,7 +59,7 @@ def _delegator(method):
     return delegated
 
 
-def _check_values(values: Union[VALID_FORECASTING_HORIZON_TYPES]) -> pd.Index:
+def _check_values(values):
     """Validate forecasting horizon values.
 
     Validation checks validity and also converts forecasting horizon values
@@ -139,11 +137,7 @@ class ForecastingHorizon:
             absolute, if not relative and values of supported absolute index type
     """
 
-    def __new__(
-        cls,
-        values: Union[VALID_FORECASTING_HORIZON_TYPES] = None,
-        is_relative: bool = None,
-    ):
+    def __new__(cls, values=None, is_relative=None):
         """Create a new ForecastingHorizon object."""
         # We want the ForecastingHorizon class to be an extension of the
         # pandas index, but since subclassing pandas indices is not
@@ -155,11 +149,7 @@ class ForecastingHorizon:
             setattr(cls, method, _delegator(method))
         return object.__new__(cls)
 
-    def __init__(
-        self,
-        values: Union[VALID_FORECASTING_HORIZON_TYPES] = None,
-        is_relative: bool = True,
-    ):
+    def __init__(self, values=None, is_relative=True):
         if is_relative is not None and not isinstance(is_relative, bool):
             raise TypeError("`is_relative` must be a boolean or None")
         values = _check_values(values)
@@ -186,11 +176,7 @@ class ForecastingHorizon:
         self._values = values
         self._is_relative = is_relative
 
-    def _new(
-        self,
-        values: Union[VALID_FORECASTING_HORIZON_TYPES] = None,
-        is_relative: bool = None,
-    ):
+    def _new(self, values=None, is_relative=None):
         """Construct new ForecastingHorizon based on current object.
 
         Parameters
@@ -214,7 +200,7 @@ class ForecastingHorizon:
         return type(self)(values, is_relative)
 
     @property
-    def is_relative(self) -> bool:
+    def is_relative(self):
         """Whether forecasting horizon is relative to the end of the training series.
 
         Returns
@@ -223,7 +209,7 @@ class ForecastingHorizon:
         """
         return self._is_relative
 
-    def to_pandas(self) -> pd.Index:
+    def to_pandas(self):
         """Return forecasting horizon's underlying values as pd.Index.
 
         Returns
@@ -233,7 +219,7 @@ class ForecastingHorizon:
         """
         return self._values
 
-    def to_numpy(self, **kwargs) -> np.ndarray:
+    def to_numpy(self, **kwargs):
         """Return forecasting horizon's underlying values as np.array.
 
         Parameters

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -2,42 +2,38 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-"""Test reduce."""
-
 __author__ = ["Lovkush Agarwal", "Markus Löning", "Luis Zugasti", "Ayushmaan Seth"]
 
 import numpy as np
 import pandas as pd
 import pytest
-from sklearn.base import BaseEstimator, RegressorMixin
+from sklearn.base import BaseEstimator
+from sklearn.base import RegressorMixin
 from sklearn.dummy import DummyRegressor
 from sklearn.linear_model import LinearRegression
 from sklearn.pipeline import make_pipeline
-
 from sktime.datasets import load_airline
+
 from sktime.forecasting.base import ForecastingHorizon
-from sktime.forecasting.compose import (
-    DirectTabularRegressionForecaster,
-    DirectTimeSeriesRegressionForecaster,
-    DirRecTabularRegressionForecaster,
-    DirRecTimeSeriesRegressionForecaster,
-    MultioutputTabularRegressionForecaster,
-    MultioutputTimeSeriesRegressionForecaster,
-    RecursiveTabularRegressionForecaster,
-    RecursiveTimeSeriesRegressionForecaster,
-    make_reduction,
-)
+from sktime.forecasting.compose import DirectTabularRegressionForecaster
+from sktime.forecasting.compose import MultioutputTabularRegressionForecaster
+from sktime.forecasting.compose import MultioutputTimeSeriesRegressionForecaster
+from sktime.forecasting.compose import RecursiveTabularRegressionForecaster
+from sktime.forecasting.compose import make_reduction
 from sktime.forecasting.compose._reduce import _sliding_window_transform
-from sktime.forecasting.model_selection import (
-    SlidingWindowSplitter,
-    temporal_train_test_split,
-)
+from sktime.forecasting.model_selection import SlidingWindowSplitter
+from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.forecasting.model_selection.tests.test_split import _get_windows
-from sktime.forecasting.tests._config import TEST_OOS_FHS, TEST_WINDOW_LENGTHS_INT
-from sktime.performance_metrics.forecasting import mean_absolute_percentage_error
+from sktime.forecasting.tests._config import TEST_OOS_FHS
+from sktime.forecasting.tests._config import TEST_WINDOW_LENGTHS
 from sktime.regression.base import BaseRegressor
 from sktime.regression.interval_based import TimeSeriesForestRegressor
 from sktime.transformations.panel.reduce import Tabularizer
+from sktime.forecasting.compose import DirRecTabularRegressionForecaster
+from sktime.forecasting.compose import DirRecTimeSeriesRegressionForecaster
+from sktime.forecasting.compose import RecursiveTimeSeriesRegressionForecaster
+from sktime.forecasting.compose import DirectTimeSeriesRegressionForecaster
+from sktime.performance_metrics.forecasting import mean_absolute_percentage_error
 from sktime.utils._testing.forecasting import make_forecasting_problem
 from sktime.utils.validation.forecasting import check_fh
 
@@ -48,11 +44,10 @@ FH = ForecastingHorizon(1)
 
 
 @pytest.mark.parametrize("n_timepoints", N_TIMEPOINTS)
-@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
+@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 @pytest.mark.parametrize("scitype", ["tabular-regressor", "time-series-regressor"])
 def test_sliding_window_transform_against_cv(n_timepoints, window_length, fh, scitype):
-    """Test sliding window transform against cv."""
     fh = check_fh(fh)
     y = pd.Series(_make_y(0, n_timepoints))
     cv = SlidingWindowSplitter(fh=fh, window_length=window_length)
@@ -84,10 +79,9 @@ def _make_y_X(n_timepoints, n_variables):
 
 @pytest.mark.parametrize("n_timepoints", N_TIMEPOINTS)
 @pytest.mark.parametrize("n_variables", N_VARIABLES)
-@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
+@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
-def test_sliding_window_transform_tabular(n_timepoints, window_length, n_variables, fh):
-    """Test sliding window transform tabular."""
+def test_sliding_window_tranform_tabular(n_timepoints, window_length, n_variables, fh):
     y, X = _make_y_X(n_timepoints=n_timepoints, n_variables=n_variables)
     fh = check_fh(fh, enforce_relative=True)
     fh_max = fh[-1]
@@ -114,10 +108,9 @@ def test_sliding_window_transform_tabular(n_timepoints, window_length, n_variabl
 
 @pytest.mark.parametrize("n_timepoints", N_TIMEPOINTS)
 @pytest.mark.parametrize("n_variables", N_VARIABLES)
-@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
+@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
-def test_sliding_window_transform_panel(n_timepoints, window_length, n_variables, fh):
-    """Test sliding window transform panel."""
+def test_sliding_window_tranform_panel(n_timepoints, window_length, n_variables, fh):
     y, X = _make_y_X(n_timepoints=n_timepoints, n_variables=n_variables)
     fh = check_fh(fh, enforce_relative=True)
     fh_max = fh[-1]
@@ -142,8 +135,7 @@ def test_sliding_window_transform_panel(n_timepoints, window_length, n_variables
 
 
 def test_sliding_window_transform_explicit():
-    """Test sliding window transform explicit.
-
+    """
     testing with explicitly written down expected outputs
     intended to help future contributors understand the transformation
     """
@@ -194,7 +186,7 @@ def _make_y(start, end, method="linear-trend", slope=1):
 
 
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
-@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
+@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 @pytest.mark.parametrize("strategy", STRATEGIES)
 @pytest.mark.parametrize(
     "regressor, scitype",
@@ -214,7 +206,6 @@ def _make_y(start, end, method="linear-trend", slope=1):
 def test_linear_extrapolation_endogenous_only(
     fh, window_length, strategy, method, slope, regressor, scitype
 ):
-    """Test linear extrapolation endogenous only."""
     n_timepoints = 13
     y = _make_y(0, n_timepoints, method=method, slope=slope)
     y = pd.Series(y)
@@ -232,18 +223,15 @@ def test_linear_extrapolation_endogenous_only(
 
 
 @pytest.mark.parametrize("fh", [1, 3, 5])
-@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
+@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 @pytest.mark.parametrize("strategy", STRATEGIES)
 @pytest.mark.parametrize("scitype", ["time-series-regressor", "tabular-regressor"])
 def test_dummy_regressor_mean_prediction_endogenous_only(
     fh, window_length, strategy, scitype
 ):
-    """Test dummy regressor mean prediction endogenous_only.
-
-    The DummyRegressor ignores the input feature data X, hence we can use it for
-    testing reduction from forecasting to both tabular and time series regression.
-    The DummyRegressor also supports the 'multioutput' strategy.
-    """
+    # The DummyRegressor ignores the input feature data X, hence we can use it for
+    # testing reduction from forecasting to both tabular and time series regression.
+    # The DummyRegressor also supports the 'multioutput' strategy.
     y = make_forecasting_problem()
     fh = check_fh(fh)
     y_train, y_test = temporal_train_test_split(y, fh=fh)
@@ -307,16 +295,13 @@ class _TestTimeSeriesRegressor(_Recorder, BaseRegressor):
 @pytest.mark.parametrize(
     "estimator", [_TestTabularRegressor(), _TestTimeSeriesRegressor()]
 )
-@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
+@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 @pytest.mark.parametrize("strategy", ["recursive", "direct", "multioutput"])
 def test_consistent_data_passing_to_component_estimators_in_fit_and_predict(
     estimator, window_length, strategy
 ):
-    """Test consistent data passing to component estimators in fit and predict.
-
-    We generate data that represents time points in its values, i.e. an array of
-    values that increase in unit steps for each time point.
-    """
+    # We generate data that represents time points in its values, i.e. an array of
+    # values that increase in unit steps for each time point.
     n_variables = 3
     n_timepoints = 10
     y, X = _make_y_X(n_timepoints, n_variables)
@@ -357,9 +342,8 @@ def test_consistent_data_passing_to_component_estimators_in_fit_and_predict(
 
 
 @pytest.mark.parametrize("scitype, strategy, klass", _REGISTRY)
-@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
+@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 def test_make_reduction_construct_instance(scitype, strategy, klass, window_length):
-    """Test make_reduction."""
     estimator = DummyRegressor()
     forecaster = make_reduction(
         estimator, window_length=window_length, scitype=scitype, strategy=strategy
@@ -376,17 +360,13 @@ def test_make_reduction_construct_instance(scitype, strategy, klass, window_leng
     ],
 )
 def test_make_reduction_infer_scitype(estimator, scitype):
-    """Test make_reduction."""
     forecaster = make_reduction(estimator, scitype="infer")
     assert forecaster._estimator_scitype == scitype
 
 
 def test_make_reduction_infer_scitype_raises_error():
-    """Test make_reduction.
-
-    The scitype of pipeline cannot be inferred here, as it may be used together
-    with a tabular or time series regressor.
-    """
+    # The scitype of pipeline cannot be inferred here, as it may be used together
+    # with a tabular or time series regressor.
     estimator = make_pipeline(Tabularizer(), LinearRegression())
     with pytest.raises(ValueError):
         make_reduction(estimator, scitype="infer")
@@ -394,10 +374,8 @@ def test_make_reduction_infer_scitype_raises_error():
 
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 def test_multioutput_direct_equivalence_tabular_linear_regression(fh):
-    """Test multioutput and direct strategies with linear regression.
-
-    Regressor should produce same predictions
-    """
+    # multioutput and direct strategies with linear regression
+    # regressor should produce same predictions
     y, X = make_forecasting_problem(make_X=True)
     y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, fh=fh)
 
@@ -510,11 +488,9 @@ EXPECTED_AIRLINE_LINEAR_DIRECT = [
     ],
 )
 def test_reductions_airline_data(forecaster, expected):
-    """Test reduction forecasters.
-
-    Test reduction forecasters by making prediction
-    on airline dataset using linear estimators.
-    Predictions compared with values calculated by Lovkush
+    """
+    test reduction forecasters by making prediction on airline dataset
+    using linear estimators. predictions compared with values calculated by Lovkush
     Agarwal on their local machine in Mar 2021
     """
     y = load_airline()
@@ -527,10 +503,8 @@ def test_reductions_airline_data(forecaster, expected):
 
 
 def test_dirrec_against_recursive_accumulated_error():
-    """Test recursive and dirrec regressor strategies.
-
-    dirrec regressor should produce lower error due to less cumulative error
-    """
+    # recursive and dirrec regressor strategies
+    # dirrec regressor should produce lower error due to less cumulative error
     y = load_airline()
     y_train, y_test = temporal_train_test_split(y, test_size=24)
     fh = ForecastingHorizon(y_test.index, is_relative=False)

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Tests for model evaluation module.
-
-In particular, function `evaluate`, that performs time series
-cross-validation, is tested with various configurations for correct output.
-"""
 
 __author__ = ["Martin Walter", "Markus Löning"]
 __all__ = [
@@ -18,16 +13,14 @@ import numpy as np
 import pandas as pd
 import pytest
 from sklearn.base import clone
-
 from sktime.datasets import load_longley
 from sktime.forecasting.arima import ARIMA
 from sktime.forecasting.model_evaluation import evaluate
-from sktime.forecasting.model_selection import (
-    ExpandingWindowSplitter,
-    SlidingWindowSplitter,
-)
+from sktime.forecasting.model_selection import ExpandingWindowSplitter
+from sktime.forecasting.model_selection import SlidingWindowSplitter
 from sktime.forecasting.naive import NaiveForecaster
-from sktime.forecasting.tests._config import TEST_FHS, TEST_STEP_LENGTHS_INT
+from sktime.forecasting.tests._config import TEST_FHS
+from sktime.forecasting.tests._config import TEST_STEP_LENGTHS
 from sktime.performance_metrics.forecasting import (
     MeanAbsolutePercentageError,
     MeanAbsoluteScaledError,
@@ -83,7 +76,7 @@ def _check_evaluate_output(out, cv, y, scoring):
 @pytest.mark.parametrize("CV", [SlidingWindowSplitter, ExpandingWindowSplitter])
 @pytest.mark.parametrize("fh", TEST_FHS)
 @pytest.mark.parametrize("window_length", [7, 10])
-@pytest.mark.parametrize("step_length", TEST_STEP_LENGTHS_INT)
+@pytest.mark.parametrize("step_length", TEST_STEP_LENGTHS)
 @pytest.mark.parametrize("strategy", ["refit", "update"])
 @pytest.mark.parametrize(
     "scoring",
@@ -93,7 +86,6 @@ def _check_evaluate_output(out, cv, y, scoring):
     ],
 )
 def test_evaluate_common_configs(CV, fh, window_length, step_length, strategy, scoring):
-    """Test evaluate common configs."""
     y = make_forecasting_problem(n_timepoints=30, index_type="int")
     forecaster = NaiveForecaster()
     cv = CV(fh, window_length, step_length=step_length)
@@ -117,7 +109,6 @@ def test_evaluate_common_configs(CV, fh, window_length, step_length, strategy, s
 
 
 def test_evaluate_initial_window():
-    """Test evaluate initial window."""
     initial_window = 20
     y = make_forecasting_problem(n_timepoints=30, index_type="int")
     forecaster = NaiveForecaster()
@@ -140,7 +131,7 @@ def test_evaluate_initial_window():
 
 
 def test_evaluate_no_exog_against_with_exog():
-    """Check that adding exogenous data produces different results."""
+    # Check that adding exogenous data produces different results
     y, X = load_longley()
     forecaster = ARIMA(suppress_warnings=True)
     cv = SlidingWindowSplitter()

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -2,39 +2,35 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-"""Test grid search CV."""
-
 __author__ = ["Markus Löning"]
 __all__ = ["test_gscv", "test_rscv"]
 
 import numpy as np
 import pytest
 from sklearn.base import clone
-from sklearn.model_selection import ParameterGrid, ParameterSampler
+from sklearn.model_selection import ParameterGrid
+from sklearn.model_selection import ParameterSampler
 
 from sktime.datasets import load_longley
 from sktime.forecasting.arima import ARIMA
 from sktime.forecasting.compose import TransformedTargetForecaster
 from sktime.forecasting.model_evaluation import evaluate
-from sktime.forecasting.model_selection import (
-    ForecastingGridSearchCV,
-    ForecastingRandomizedSearchCV,
-    SingleWindowSplitter,
-    SlidingWindowSplitter,
-)
+from sktime.forecasting.model_selection import ForecastingGridSearchCV
+from sktime.forecasting.model_selection import ForecastingRandomizedSearchCV
+from sktime.forecasting.model_selection import SingleWindowSplitter
+from sktime.forecasting.model_selection import SlidingWindowSplitter
 from sktime.forecasting.naive import NaiveForecaster
-from sktime.forecasting.tests._config import (
-    TEST_N_ITERS,
-    TEST_OOS_FHS,
-    TEST_RANDOM_SEEDS,
-    TEST_WINDOW_LENGTHS_INT,
-)
+from sktime.forecasting.tests._config import TEST_N_ITERS
+from sktime.forecasting.tests._config import TEST_OOS_FHS
+from sktime.forecasting.tests._config import TEST_RANDOM_SEEDS
+from sktime.forecasting.tests._config import TEST_WINDOW_LENGTHS
 from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.performance_metrics.forecasting import (
     MeanAbsolutePercentageError,
     MeanSquaredError,
 )
 from sktime.transformations.series.detrend import Detrender
+
 
 TEST_METRICS = [MeanAbsolutePercentageError(symmetric=True), MeanSquaredError()]
 
@@ -69,7 +65,7 @@ def _check_cv(forecaster, gscv, cv, param_grid, y, X, scoring):
 
 
 NAIVE = NaiveForecaster(strategy="mean")
-NAIVE_GRID = {"window_length": TEST_WINDOW_LENGTHS_INT}
+NAIVE_GRID = {"window_length": TEST_WINDOW_LENGTHS}
 PIPE = TransformedTargetForecaster(
     [
         ("transformer", Detrender(PolynomialTrendForecaster())),
@@ -92,7 +88,6 @@ CVs = [
 @pytest.mark.parametrize("scoring", TEST_METRICS)
 @pytest.mark.parametrize("cv", CVs)
 def test_gscv(forecaster, param_grid, cv, scoring):
-    """Test ForecastingGridSearchCV."""
     y, X = load_longley()
     gscv = ForecastingGridSearchCV(
         forecaster, param_grid=param_grid, cv=cv, scoring=scoring
@@ -111,9 +106,7 @@ def test_gscv(forecaster, param_grid, cv, scoring):
 @pytest.mark.parametrize("n_iter", TEST_N_ITERS)
 @pytest.mark.parametrize("random_state", TEST_RANDOM_SEEDS)
 def test_rscv(forecaster, param_grid, cv, scoring, n_iter, random_state):
-    """Test ForecastingRandomizedSearchCV.
-
-    Tests that ForecastingRandomizedSearchCV successfully searches the
+    """Tests that ForecastingRandomizedSearchCV successfully searches the
     parameter distributions to identify the best parameter set
     """
     y, X = load_longley()

--- a/sktime/forecasting/tests/_config.py
+++ b/sktime/forecasting/tests/_config.py
@@ -7,14 +7,10 @@ __all__ = [
     "TEST_SPS",
     "TEST_ALPHAS",
     "TEST_FHS",
-    "TEST_STEP_LENGTHS_INT",
     "TEST_STEP_LENGTHS",
     "TEST_INS_FHS",
     "TEST_OOS_FHS",
-    "TEST_WINDOW_LENGTHS_INT",
     "TEST_WINDOW_LENGTHS",
-    "TEST_INITIAL_WINDOW_INT",
-    "TEST_INITIAL_WINDOW",
     "VALID_INDEX_FH_COMBINATIONS",
     "INDEX_TYPE_LOOKUP",
     "TEST_RANDOM_SEEDS",
@@ -27,33 +23,8 @@ import pandas as pd
 from sktime.utils._testing.series import _make_series
 
 # We here define the parameter values for unit testing.
-TEST_WINDOW_LENGTHS_INT = [1, 5]
-TEST_WINDOW_LENGTHS_TIMEDELTA = [pd.Timedelta(1, unit="D"), pd.Timedelta(5, unit="D")]
-TEST_WINDOW_LENGTHS_DATEOFFSET = [pd.offsets.Day(1), pd.offsets.Day(5)]
-TEST_WINDOW_LENGTHS = [
-    *TEST_WINDOW_LENGTHS_INT,
-    *TEST_WINDOW_LENGTHS_TIMEDELTA,
-    *TEST_WINDOW_LENGTHS_DATEOFFSET,
-]
-
-TEST_INITIAL_WINDOW_INT = [7, 10]
-TEST_INITIAL_WINDOW_TIMEDELTA = [pd.Timedelta(7, unit="D"), pd.Timedelta(10, unit="D")]
-TEST_INITIAL_WINDOW_DATEOFFSET = [pd.offsets.Day(7), pd.offsets.Day(10)]
-TEST_INITIAL_WINDOW = [
-    *TEST_INITIAL_WINDOW_INT,
-    *TEST_INITIAL_WINDOW_TIMEDELTA,
-    *TEST_INITIAL_WINDOW_DATEOFFSET,
-]
-
-TEST_STEP_LENGTHS_INT = [1, 5]
-TEST_STEP_LENGTHS_TIMEDELTA = [pd.Timedelta(1, unit="D"), pd.Timedelta(5, unit="D")]
-TEST_STEP_LENGTHS_DATEOFFSET = [pd.offsets.Day(1), pd.offsets.Day(5)]
-TEST_STEP_LENGTHS = [
-    *TEST_STEP_LENGTHS_INT,
-    *TEST_STEP_LENGTHS_TIMEDELTA,
-    *TEST_STEP_LENGTHS_DATEOFFSET,
-]
-
+TEST_WINDOW_LENGTHS = [1, 5]
+TEST_STEP_LENGTHS = [1, 5]
 TEST_OOS_FHS = [1, np.array([2, 5])]  # out-of-sample
 TEST_INS_FHS = [
     -3,  # single in-sample
@@ -64,7 +35,9 @@ TEST_INS_FHS = [
 TEST_FHS = TEST_OOS_FHS + TEST_INS_FHS
 TEST_SPS = [3, 12]
 TEST_ALPHAS = [0.05, 0.1]
-TEST_YS = [_make_series(all_positive=True)]
+TEST_YS = [
+    _make_series(all_positive=True),
+]
 TEST_RANDOM_SEEDS = [1, 42]
 TEST_N_ITERS = [1, 4]
 

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -35,7 +35,7 @@ from sktime.forecasting.tests._config import (
     TEST_ALPHAS,
     TEST_FHS,
     TEST_OOS_FHS,
-    TEST_STEP_LENGTHS_INT,
+    TEST_STEP_LENGTHS,
     TEST_WINDOW_LENGTHS,
     VALID_INDEX_FH_COMBINATIONS,
 )
@@ -454,7 +454,7 @@ def _check_update_predict_predicted_index(
 @pytest.mark.parametrize("Forecaster", FORECASTERS)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
-@pytest.mark.parametrize("step_length", TEST_STEP_LENGTHS_INT)
+@pytest.mark.parametrize("step_length", TEST_STEP_LENGTHS)
 @pytest.mark.parametrize("update_params", [False])
 def test_update_predict_predicted_index(
     Forecaster, fh, window_length, step_length, update_params

--- a/sktime/forecasting/tests/test_naive.py
+++ b/sktime/forecasting/tests/test_naive.py
@@ -11,11 +11,9 @@ import pytest
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.naive import NaiveForecaster
-from sktime.forecasting.tests._config import (
-    TEST_OOS_FHS,
-    TEST_SPS,
-    TEST_WINDOW_LENGTHS_INT,
-)
+from sktime.forecasting.tests._config import TEST_OOS_FHS
+from sktime.forecasting.tests._config import TEST_SPS
+from sktime.forecasting.tests._config import TEST_WINDOW_LENGTHS
 from sktime.utils._testing.forecasting import _assert_correct_pred_time_index
 from sktime.utils.validation.forecasting import check_fh
 
@@ -37,7 +35,7 @@ def test_strategy_last(fh):
 
 
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
-@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
+@pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
 def test_strategy_mean(fh, window_length):
     """Test mean strategy."""
     f = NaiveForecaster(strategy="mean", window_length=window_length)
@@ -71,7 +69,7 @@ def test_strategy_last_seasonal(fh, sp):
 
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 @pytest.mark.parametrize("sp", TEST_SPS)
-@pytest.mark.parametrize("window_length", [*TEST_WINDOW_LENGTHS_INT, None])
+@pytest.mark.parametrize("window_length", [*TEST_WINDOW_LENGTHS, None])
 def test_strategy_mean_seasonal(fh, sp, window_length):
     """Test mean strategy on seasonal data."""
     if (window_length is not None and window_length > sp) or (window_length is None):
@@ -120,7 +118,7 @@ def test_strategy_mean_seasonal_simple(n_seasons, sp):
 
 
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
-@pytest.mark.parametrize("window_length", [*TEST_WINDOW_LENGTHS_INT, None])
+@pytest.mark.parametrize("window_length", [*TEST_WINDOW_LENGTHS, None])
 def test_strategy_drift_unit_slope(fh, window_length):
     """Test drift strategy for constant slope 1."""
     if window_length != 1:
@@ -139,7 +137,7 @@ def test_strategy_drift_unit_slope(fh, window_length):
 
 
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
-@pytest.mark.parametrize("window_length", [*TEST_WINDOW_LENGTHS_INT, None])
+@pytest.mark.parametrize("window_length", [*TEST_WINDOW_LENGTHS, None])
 def test_strategy_drift_flat_line(fh, window_length):
     """Test flat time series data."""
     if window_length != 1:
@@ -159,7 +157,7 @@ def test_strategy_drift_flat_line(fh, window_length):
 
 
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
-@pytest.mark.parametrize("window_length", [*TEST_WINDOW_LENGTHS_INT, None])
+@pytest.mark.parametrize("window_length", [*TEST_WINDOW_LENGTHS, None])
 def test_strategy_drift_window_length(fh, window_length):
     """Test whether window_length is properly working."""
     if window_length != 1:
@@ -182,7 +180,7 @@ def test_strategy_drift_window_length(fh, window_length):
 
 
 @pytest.mark.parametrize("n", [3, 5])
-@pytest.mark.parametrize("window_length", list({4, 5, *TEST_WINDOW_LENGTHS_INT}))
+@pytest.mark.parametrize("window_length", list({4, 5, *TEST_WINDOW_LENGTHS}))
 @pytest.mark.parametrize("sp", list({3, 4, 8, *TEST_SPS}))
 @pytest.mark.parametrize("strategy", ["last", "mean"])
 def test_strategy_mean_and_last_seasonal_additional_combinations(

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -28,9 +28,7 @@ def _coerce_duration_to_int(duration, freq=None):
     ret : int
         Duration in integer values for given unit
     """
-    if isinstance(duration, int):
-        return duration
-    elif isinstance(duration, pd.tseries.offsets.DateOffset):
+    if isinstance(duration, pd.tseries.offsets.DateOffset):
         return duration.n
     elif isinstance(duration, pd.Index) and isinstance(
         duration[0], pd.tseries.offsets.BaseOffset

--- a/sktime/utils/validation/__init__.py
+++ b/sktime/utils/validation/__init__.py
@@ -1,63 +1,24 @@
-#!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Validation functions."""
-
-__all__ = [
-    "is_int",
-    "is_float",
-    "is_timedelta",
-    "is_date_offset",
-    "is_timedelta_or_date_offset",
-    "check_n_jobs",
-    "check_window_length",
-]
-__author__ = ["Markus Löning", "Taiwo Owoseni", "khrapovs"]
+__all__ = ["is_int", "is_float", "check_n_jobs", "check_window_length"]
+__author__ = ["Markus Löning", "Taiwo Owoseni"]
 
 import os
-from datetime import timedelta
-from typing import Union
 
 import numpy as np
-import pandas as pd
-
-ACCEPTED_TIMEDELTA_TYPES = pd.Timedelta, timedelta, np.timedelta64
-ACCEPTED_DATEOFFSET_TYPES = pd.DateOffset
-ACCEPTED_WINDOW_LENGTH_TYPES = Union[
-    int, float, Union[ACCEPTED_TIMEDELTA_TYPES], Union[ACCEPTED_DATEOFFSET_TYPES]
-]
-NON_FLOAT_WINDOW_LENGTH_TYPES = Union[
-    int, Union[ACCEPTED_TIMEDELTA_TYPES], Union[ACCEPTED_DATEOFFSET_TYPES]
-]
 
 
-def is_int(x) -> bool:
-    """Check if x is of integer type, but not boolean."""
+def is_int(x):
+    """Check if x is of integer type, but not boolean"""
     # boolean are subclasses of integers in Python, so explicitly exclude them
     return isinstance(x, (int, np.integer)) and not isinstance(x, bool)
 
 
-def is_float(x) -> bool:
-    """Check if x is of float type."""
+def is_float(x):
+    """Check if x is of float type"""
     return isinstance(x, (float, np.floating))
 
 
-def is_timedelta(x) -> bool:
-    """Check if x is of timedelta type."""
-    return isinstance(x, ACCEPTED_TIMEDELTA_TYPES)
-
-
-def is_date_offset(x) -> bool:
-    """Check if x is of pd.DateOffset type."""
-    return isinstance(x, ACCEPTED_DATEOFFSET_TYPES)
-
-
-def is_timedelta_or_date_offset(x) -> bool:
-    """Check if x is of timedelta or pd.DateOffset type."""
-    return is_timedelta(x=x) or is_date_offset(x=x)
-
-
-def check_n_jobs(n_jobs: int) -> int:
+def check_n_jobs(n_jobs):
     """Check `n_jobs` parameter according to the scikit-learn convention.
 
     Parameters
@@ -82,22 +43,15 @@ def check_n_jobs(n_jobs: int) -> int:
         return n_jobs
 
 
-def check_window_length(
-    window_length: ACCEPTED_WINDOW_LENGTH_TYPES,
-    n_timepoints: int = None,
-    name: str = "window_length",
-) -> NON_FLOAT_WINDOW_LENGTH_TYPES:
-    """Validate window length.
-
+def check_window_length(window_length, n_timepoints=None, name="window_length"):
+    """Validate window length"""
+    """
     Parameters
     ----------
-    window_length: positive int, positive float in (0, 1), positive timedelta,
-        positive pd.DateOffset, or None
+    window_length: positive int, positive float in (0, 1), or None
         The window length:
         - If int, the total number of time points.
         - If float, the fraction of time points relative to `n_timepoints`.
-        - If timedelta, length in corresponding time units
-        - If pd.DateOffset, length in corresponding time units following calendar rules
     n_timepoints: positive int, optional (default=None)
         The number of time points to which to apply `window_length` when
         passed as a float (fraction). Will be ignored if `window_length` is
@@ -107,7 +61,7 @@ def check_window_length(
 
     Returns
     -------
-    window_length: int or timedelta or pd.DateOffset
+    window_length: int
     """
     if window_length is None:
         return window_length
@@ -125,14 +79,6 @@ def check_window_length(
 
         # Compute fraction relative to `n_timepoints`.
         return int(np.ceil(window_length * n_timepoints))
-
-    elif is_timedelta(window_length) and window_length > timedelta(0):
-        return window_length
-
-    elif is_date_offset(window_length) and pd.Timestamp(
-        0
-    ) + window_length > pd.Timestamp(0):
-        return window_length
 
     else:
         raise ValueError(

--- a/sktime/utils/validation/forecasting.py
+++ b/sktime/utils/validation/forecasting.py
@@ -17,16 +17,15 @@ __all__ = [
 ]
 __author__ = ["Markus Löning", "@big-o"]
 
-from datetime import timedelta
-from typing import Optional, Union
-
 import numpy as np
 import pandas as pd
+
 from sklearn.base import clone, is_regressor
 from sklearn.ensemble import GradientBoostingRegressor
 
-from sktime.utils.validation import is_date_offset, is_int, is_timedelta
-from sktime.utils.validation.series import check_equal_time_index, check_series
+from sktime.utils.validation import is_int
+from sktime.utils.validation.series import check_equal_time_index
+from sktime.utils.validation.series import check_series
 
 
 def check_y_X(
@@ -172,7 +171,7 @@ def check_cv(cv, enforce_start_with_window=False):
     return cv
 
 
-def check_step_length(step_length) -> Optional[int]:
+def check_step_length(step_length):
     """Validate window length.
 
     Parameters
@@ -189,40 +188,13 @@ def check_step_length(step_length) -> Optional[int]:
     ValueError
         if step_length is negative or not an integer or is None.
     """
-    if step_length is None:
-        return None
-
-    elif is_int(step_length):
-        if step_length < 1:
+    if step_length is not None:
+        if not is_int(step_length) or step_length < 1:
             raise ValueError(
-                f"`step_length` must be a integer >= 1, " f"but found: {step_length}"
-            )
-        else:
-            return step_length
-
-    elif is_timedelta(step_length):
-        if step_length <= timedelta(0):
-            raise ValueError(
-                f"`step_length` must be a positive timedelta, "
+                f"`step_length` must be a positive integer >= 1 or None, "
                 f"but found: {step_length}"
             )
-        else:
-            return step_length
-
-    elif is_date_offset(step_length):
-        if step_length + pd.Timestamp(0) <= pd.Timestamp(0):
-            raise ValueError(
-                f"`step_length` must be a positive pd.DateOffset, "
-                f"but found: {step_length}"
-            )
-        else:
-            return step_length
-
-    else:
-        raise ValueError(
-            f"`step_length` must be an integer, timedelta, pd.DateOffset, or None, "
-            f"but found: {type(step_length)}"
-        )
+    return step_length
 
 
 def check_sp(sp, enforce_list=False):
@@ -232,7 +204,7 @@ def check_sp(sp, enforce_list=False):
     ----------
     sp : int or [int/float]
         Seasonal periodicity
-    enforce_list : bool, optional (default=False)
+    emforce_list : bool, optional (default=False)
         If true, convert sp to list if not list.
 
     Returns
@@ -321,7 +293,7 @@ def check_alpha(alpha):
     return alpha
 
 
-def check_cutoffs(cutoffs: Union[np.ndarray, pd.Index]) -> np.ndarray:
+def check_cutoffs(cutoffs):
     """Validate the cutoff.
 
     Parameters
@@ -353,7 +325,7 @@ def check_cutoffs(cutoffs: Union[np.ndarray, pd.Index]) -> np.ndarray:
 
 def check_scoring(scoring, allow_y_pred_benchmark=False):
     """
-    Validate the performance scoring.
+    Validate the performace scoring.
 
     Parameters
     ----------

--- a/sktime/utils/validation/series.py
+++ b/sktime/utils/validation/series.py
@@ -10,9 +10,6 @@ __all__ = [
     "check_equal_time_index",
     "check_consistent_index_type",
 ]
-
-from typing import Union
-
 import numpy as np
 import pandas as pd
 
@@ -152,11 +149,8 @@ def check_series(
 
 
 def check_time_index(
-    index: Union[pd.Index, np.array],
-    allow_empty: bool = False,
-    enforce_index_type: bool = None,
-    var_name: str = "input",
-) -> pd.Index:
+    index, allow_empty=False, enforce_index_type=None, var_name="input"
+):
     """Check time index.
 
     Parameters


### PR DESCRIPTION
Reverts alan-turing-institute/sktime#1758, to diagnose whether it is causing the recent CI/CD congestion.

Note: the skips were introduced with #1758.