### PR TITLE
DRAFT for diagnosing CI/CD: smaller set of class tests test_all_estimators, instance tests all removed

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -84,7 +84,7 @@ def pytest_generate_tests(metafunc):
             est for est in ALL_ESTIMATORS if not is_excluded(est)
         ]
         # parameterize test with the list of classes
-        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:30])
+        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:15])
 
     # if estimator test, construct all instances for the test
     if "estimator_instance" in metafunc.fixturenames:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -102,11 +102,7 @@ def pytest_generate_tests(metafunc):
             estimator_instance_names += instance_names
 
         # parameterize test with the list of instances
-        metafunc.parametrize(
-            "estimator_instance",
-            estimator_instances_to_test,
-            ids=estimator_instance_names,
-        )
+        metafunc.parametrize("estimator_instance", [], [])
 
 
 def test_create_test_instance(estimator_class):

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -84,7 +84,7 @@ def pytest_generate_tests(metafunc):
             est for est in ALL_ESTIMATORS if not is_excluded(est)
         ]
         # parameterize test with the list of classes
-        metafunc.parametrize("estimator_class", estimator_classes_to_test)
+        metafunc.parametrize("estimator_class", [])
 
     # if estimator test, construct all instances for the test
     if "estimator_instance" in metafunc.fixturenames:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -84,7 +84,7 @@ def pytest_generate_tests(metafunc):
             est for est in ALL_ESTIMATORS if not is_excluded(est)
         ]
         # parameterize test with the list of classes
-        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:60])
+        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:1])
 
     # if estimator test, construct all instances for the test
     if "estimator_instance" in metafunc.fixturenames:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -84,7 +84,7 @@ def pytest_generate_tests(metafunc):
             est for est in ALL_ESTIMATORS if not is_excluded(est)
         ]
         # parameterize test with the list of classes
-        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:13])
+        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:9])
 
     # if estimator test, construct all instances for the test
     if "estimator_instance" in metafunc.fixturenames:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -84,7 +84,7 @@ def pytest_generate_tests(metafunc):
             est for est in ALL_ESTIMATORS if not is_excluded(est)
         ]
         # parameterize test with the list of classes
-        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:7])
+        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:11])
 
     # if estimator test, construct all instances for the test
     if "estimator_instance" in metafunc.fixturenames:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -84,7 +84,7 @@ def pytest_generate_tests(metafunc):
             est for est in ALL_ESTIMATORS if not is_excluded(est)
         ]
         # parameterize test with the list of classes
-        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:11])
+        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:13])
 
     # if estimator test, construct all instances for the test
     if "estimator_instance" in metafunc.fixturenames:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -84,7 +84,7 @@ def pytest_generate_tests(metafunc):
             est for est in ALL_ESTIMATORS if not is_excluded(est)
         ]
         # parameterize test with the list of classes
-        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:1])
+        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:7])
 
     # if estimator test, construct all instances for the test
     if "estimator_instance" in metafunc.fixturenames:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -84,7 +84,7 @@ def pytest_generate_tests(metafunc):
             est for est in ALL_ESTIMATORS if not is_excluded(est)
         ]
         # parameterize test with the list of classes
-        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:15])
+        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:60])
 
     # if estimator test, construct all instances for the test
     if "estimator_instance" in metafunc.fixturenames:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -84,7 +84,7 @@ def pytest_generate_tests(metafunc):
             est for est in ALL_ESTIMATORS if not is_excluded(est)
         ]
         # parameterize test with the list of classes
-        metafunc.parametrize("estimator_class", [])
+        metafunc.parametrize("estimator_class", estimator_classes_to_test[0:30])
 
     # if estimator test, construct all instances for the test
     if "estimator_instance" in metafunc.fixturenames:


### PR DESCRIPTION
An attempt at diagnosing #1941: after removing all tests in `test_all_estimators`, adds back classes individually.

Aim is to conduct a binary search to identify a precise failure condition. I'll determine the number `i` such that adding back `estimator_classes_to_test[0:i]` does not fail but `estimator_classes_to_test[0:i+1]` does

This must exist because the tests run for `estimator_classes_to_test[0:0]` (empty list, #1946) but fail for `estimator_classes_to_test` (situation on main, and #1946 in earlier stage where only instance tests were removed), for a total of 135 estimator classes in `sktime` currently.