### PR TITLE
DRAFT for diagnosing CI/CD: removal of tests from `test_all_estimators`

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -503,30 +503,30 @@ def test_methods_do_not_change_state(estimator_instance):
             )
 
 
-def test_methods_have_no_side_effects(estimator_instance):
-    """Check that calling methods has no side effects on args."""
-    estimator = estimator_instance
+# def test_methods_have_no_side_effects(estimator_instance):
+#     """Check that calling methods has no side effects on args."""
+#     estimator = estimator_instance
 
-    set_random_state(estimator)
+#     set_random_state(estimator)
 
-    # Fit for the first time
-    fit_args = _make_args(estimator, "fit")
-    old_fit_args = deepcopy(fit_args)
-    estimator.fit(*fit_args)
+#     # Fit for the first time
+#     fit_args = _make_args(estimator, "fit")
+#     old_fit_args = deepcopy(fit_args)
+#     estimator.fit(*fit_args)
 
-    assert deep_equals(
-        old_fit_args, fit_args
-    ), f"Estimator: {estimator} has side effects on arguments of fit"
+#     assert deep_equals(
+#         old_fit_args, fit_args
+#     ), f"Estimator: {estimator} has side effects on arguments of fit"
 
-    for method in NON_STATE_CHANGING_METHODS:
-        if _has_capability(estimator, method):
-            new_args = _make_args(estimator, method)
-            old_args = deepcopy(new_args)
-            getattr(estimator, method)(*new_args)
+#     for method in NON_STATE_CHANGING_METHODS:
+#         if _has_capability(estimator, method):
+#             new_args = _make_args(estimator, method)
+#             old_args = deepcopy(new_args)
+#             getattr(estimator, method)(*new_args)
 
-            assert deep_equals(
-                old_args, new_args
-            ), f"Estimator: {estimator} has side effects on arguments of {method}"
+#             assert deep_equals(
+#                 old_args, new_args
+#             ), f"Estimator: {estimator} has side effects on arguments of {method}"
 
 
 def test_persistence_via_pickle(estimator_instance):
@@ -559,49 +559,49 @@ def test_persistence_via_pickle(estimator_instance):
         )
 
 
-def test_multiprocessing_idempotent(estimator_class):
-    """Test that single and multi-process run results are identical.
+# def test_multiprocessing_idempotent(estimator_class):
+#     """Test that single and multi-process run results are identical.
 
-    Check that running an estimator on a single process is no different to running
-    it on multiple processes. We also check that we can set n_jobs=-1 to make use
-    of all CPUs. The test is not really necessary though, as we rely on joblib for
-    parallelization and can trust that it works as expected.
-    """
-    estimator = estimator_class.create_test_instance()
-    params = estimator.get_params()
+#     Check that running an estimator on a single process is no different to running
+#     it on multiple processes. We also check that we can set n_jobs=-1 to make use
+#     of all CPUs. The test is not really necessary though, as we rely on joblib for
+#     parallelization and can trust that it works as expected.
+#     """
+#     estimator = estimator_class.create_test_instance()
+#     params = estimator.get_params()
 
-    if "n_jobs" in params:
-        results = {}
-        args = {}
+#     if "n_jobs" in params:
+#         results = {}
+#         args = {}
 
-        # run on a single process
-        estimator = estimator_class.create_test_instance()
-        estimator.set_params(n_jobs=1)
-        set_random_state(estimator)
-        args["fit"] = _make_args(estimator, "fit")
-        estimator.fit(*args["fit"])
+#         # run on a single process
+#         estimator = estimator_class.create_test_instance()
+#         estimator.set_params(n_jobs=1)
+#         set_random_state(estimator)
+#         args["fit"] = _make_args(estimator, "fit")
+#         estimator.fit(*args["fit"])
 
-        # compute and store results
-        for method in NON_STATE_CHANGING_METHODS:
-            if _has_capability(estimator, method):
-                args[method] = _make_args(estimator, method)
-                results[method] = getattr(estimator, method)(*args[method])
+#         # compute and store results
+#         for method in NON_STATE_CHANGING_METHODS:
+#             if _has_capability(estimator, method):
+#                 args[method] = _make_args(estimator, method)
+#                 results[method] = getattr(estimator, method)(*args[method])
 
-        # run on multiple processes, reusing the same input arguments
-        estimator = estimator_class.create_test_instance()
-        estimator.set_params(n_jobs=-1)
-        set_random_state(estimator)
-        estimator.fit(*args["fit"])
+#         # run on multiple processes, reusing the same input arguments
+#         estimator = estimator_class.create_test_instance()
+#         estimator.set_params(n_jobs=-1)
+#         set_random_state(estimator)
+#         estimator.fit(*args["fit"])
 
-        # compute and compare results
-        for method, value in results.items():
-            if hasattr(estimator, method):
-                result = getattr(estimator, method)(*args[method])
-                _assert_array_equal(
-                    value,
-                    result,
-                    err_msg="Results are not equal for n_jobs=1 and n_jobs=-1",
-                )
+#         # compute and compare results
+#         for method, value in results.items():
+#             if hasattr(estimator, method):
+#                 result = getattr(estimator, method)(*args[method])
+#                 _assert_array_equal(
+#                     value,
+#                     result,
+#                     err_msg="Results are not equal for n_jobs=1 and n_jobs=-1",
+#                 )
 
 
 def test_valid_estimator_class_tags(estimator_class):


### PR DESCRIPTION
An attempt at diagnosing #1941.

This PR removes individual tests from `test_all_estimators`:

* `test_multiprocessing_idempotent`, this could lead to freezes due to parallelization/virtualization issues
* `test_methods_have_no_side_effects`, this could lead to an infinite loop in `deep_equals` if an estimator contains an infinitely looping dict of dict where some pointer accident has happened