### PR TITLE
0.10.0 deprecations and removals

### DIFF
--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -67,7 +67,7 @@ def _ret(valid, msg, metadata, return_metadata):
 @deprecated(
     version="v0.10.0",
     reason=(
-        "check_is has been deprecated and will be removed in v0.11.0."
+        "check_is is deprecated since v0.10.0 and will be removed in v0.11.0."
         "Please use check_is_mtype instead."
     ),
     category=FutureWarning,

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -565,6 +565,15 @@ class BaseForecaster(BaseEstimator):
                 "an issue on sktime."
             )
 
+        if return_pred_int:
+            warn(
+                "argument return_pred_int in update_predict() is deprecated "
+                "since version 0.10.0 and will be removed in version 0.11.0."
+                "please use update() then predict_interval() or predict_quantiles() "
+                "to generate predictive quantiles or prediction intervals.",
+                DeprecationWarning,
+            )
+
         # input checks and minor coercions on X, y
         X_inner, y_inner = self._check_X_y(X=X, y=y)
 
@@ -656,6 +665,15 @@ class BaseForecaster(BaseEstimator):
             warn(msg, category=DeprecationWarning)
         if y is None:
             raise ValueError("y must be of Series type and cannot be None")
+
+        if return_pred_int:
+            warn(
+                "argument return_pred_int in update_predict_single() is deprecated "
+                "since version 0.10.0 and will be removed in version 0.11.0."
+                "please use update() then predict_interval() or predict_quantiles() "
+                "to generate predictive quantiles or prediction intervals.",
+                DeprecationWarning,
+            )
 
         self.check_is_fitted()
         fh = self._check_fh(fh)

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -219,12 +219,12 @@ class BaseForecaster(BaseEstimator):
         # todo: deprecate in v 10
         else:
             warn(
-                "return_pred_int in predict() will be deprecated;"
+                "return_pred_int in predict() is deprecated since version 0.10.0 "
+                " and will be removed in version 0.11.0."
                 "please use predict_interval() instead to generate "
                 "prediction intervals.",
-                FutureWarning,
+                DeprecationWarning,
             )
-
             if not self._has_predict_quantiles_been_refactored():
                 # this means the method is not refactored
                 y_pred = self._predict(
@@ -621,7 +621,7 @@ class BaseForecaster(BaseEstimator):
                 must have 2 or more columns
             if self.get_tag("scitype:y")=="both": no restrictions apply
         y_new : alias for y for downwards compatibility, pass only one of y, y_new
-            to be deprecated in version 0.10.0
+            deprecated since version 0.10.0 and will be removed in 0.11.0
         fh : int, list, np.array or ForecastingHorizon, optional (default=None)
             The forecasters horizon with the steps ahead to to predict.
         X : pd.DataFrame, or 2D np.array, optional (default=None)
@@ -642,13 +642,18 @@ class BaseForecaster(BaseEstimator):
         pred_ints : pd.DataFrame
             Prediction intervals
         """
-        # todo deprecate return_pred_int in v 0.10.1
+        # todo: remove return_pred_int in v0.11.0
         self.check_is_fitted()
         fh = self._check_fh(fh)
 
-        # handle input alias, deprecate in v 0.10.1
+        # handle input alias, remove in v 0.11.0
         if y is None:
             y = y_new
+            msg = (
+                "argument y_new in update_predict_single is deprecated since "
+                "version 0.10.0 and will be removed in version 0.11.0"
+            )
+            warn(msg, category=DeprecationWarning)
         if y is None:
             raise ValueError("y must be of Series type and cannot be None")
 
@@ -1459,7 +1464,7 @@ class BaseForecaster(BaseEstimator):
                 cutoffs.append(self.cutoff)
         return _format_moving_cutoff_predictions(y_preds, cutoffs)
 
-    # TODO: remove in v0.10.0
+    # TODO: remove in v0.11.0
     def _has_predict_quantiles_been_refactored(self):
         """Check if specific forecaster implements one of the proba methods."""
         implements_interval = self._has_implementation_of("_predict_interval")
@@ -1470,7 +1475,7 @@ class BaseForecaster(BaseEstimator):
 
         return refactored
 
-    # TODO: remove in v0.10.0
+    # TODO: remove in v0.11.0
     def _convert_new_to_old_pred_int(self, pred_int_new, alpha):
         name = pred_int_new.columns.get_level_values(0).unique()[0]
         alpha = check_alpha(alpha)

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -273,8 +273,8 @@ class ForecastingPipeline(_Pipeline):
         if self._X is not None:
             # transform X before doing prediction
             for _, _, transformer in self._iter_transformers():
-                # todo: deprecation in 0.10.0
-                # add kwarg X= after deprecation of old trafo interface
+                # todo: remove in 0.11.0
+                # add kwarg X= after removal of old trafo interface
                 X = transformer.transform(X)
 
         return forecaster.predict(fh, X, return_pred_int=return_pred_int, alpha=alpha)

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -155,7 +155,7 @@ class BaseTransformer(BaseEstimator):
         y : Series or Panel, default=None
             Additional data, e.g., labels for transformation
         Z : possible alias for X; should not be passed when X is passed
-            alias Z will be deprecated in version 0.10.0
+            alias Z is deprecated since version 0.10.0 and will be removed in 0.11.0
 
         Returns
         -------
@@ -262,7 +262,7 @@ class BaseTransformer(BaseEstimator):
         y : Series or Panel, default=None
             Additional data, e.g., labels for transformation
         Z : possible alias for X; should not be passed when X is passed
-            alias Z will be deprecated in version 0.10.0
+            alias Z is deprecated since version 0.10.0 and will be removed in 0.11.0
 
         Returns
         -------
@@ -404,7 +404,7 @@ class BaseTransformer(BaseEstimator):
         y : Series or Panel, default=None
             Additional data, e.g., labels for transformation
         Z : possible alias for X; should not be passed when X is passed
-            alias Z will be deprecated in version 0.10.0
+            alias Z is deprecated since version 0.10.0 and will be removed in 0.11.0
 
         Returns
         -------
@@ -466,7 +466,7 @@ class BaseTransformer(BaseEstimator):
         y : Series or Panel, default=None
             Additional data, e.g., labels for transformation
         Z : possible alias for X; should not be passed when X is passed
-            alias Z will be deprecated in version 0.10.0
+            alias Z is deprecated since version 0.10.0 and will be removed in 0.11.0
 
         Returns
         -------
@@ -588,7 +588,7 @@ class BaseTransformer(BaseEstimator):
         y : Series or Panel, default=None
             Additional data, e.g., labels for transformation
         Z : possible alias for X; should not be passed when X is passed
-            alias Z will be deprecated in version 0.10.0
+            alias Z is deprecated since version 0.10.0 and will be removed in 0.11.0
         update_params : bool, default=True
             whether the model is updated. Yes if true, if false, simply skips call.
             argument exists for compatibility with forecasting module.
@@ -958,10 +958,11 @@ def _handle_alias(X, Z):
     if Z is None:
         return X
     elif X is None:
-        warnings.warn(
-            "argument Z will be deprecated in transformers, sktime version 0.10.0",
-            category=DeprecationWarning,
+        msg = (
+            "argument Z will in transformers is deprecated since version 0.10.0 "
+            "and will be removed in version 0.11.0"
         )
+        warnings.warn(msg, category=DeprecationWarning)
         return Z
     else:
         raise ValueError("X and Z are aliases, at most one of them should be passed")

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -4,10 +4,9 @@
 """Implement transformers for summarizing a time series."""
 
 __author__ = ["mloning", "RNKuhns"]
-__all__ = ["SummaryTransformer", "MeanTransformer"]
+__all__ = ["SummaryTransformer"]
 
 import pandas as pd
-from deprecated.sphinx import deprecated
 
 from sktime.transformations.base import BaseTransformer
 
@@ -188,33 +187,3 @@ class SummaryTransformer(BaseTransformer):
             summary_value = pd.DataFrame(summary_value)
 
         return summary_value.T
-
-
-class MeanTransformer(SummaryTransformer):
-    """Calculate mean value of a time series.
-
-    See Also
-    --------
-    SummaryTransformer :
-        Calculate summary values of a time series.
-
-    Examples
-    --------
-    >>> from sktime.transformations.series.summarize import MeanTransformer
-    >>> from sktime.datasets import load_airline
-    >>> y = load_airline()
-    >>> transformer = MeanTransformer()
-    >>> y_mean = transformer.fit_transform(y)
-    """
-
-    @deprecated(
-        version="0.9.0",
-        reason=(
-            "MeanTransformer will be removed in release v0.10.0. Please use "
-            "`SummaryTransformer` from `sktime.transformation.series.summarize` "
-            "instead."
-        ),
-        category=FutureWarning,
-    )
-    def __init__(self):
-        super().__init__(summary_function="mean", quantiles=None)


### PR DESCRIPTION
This PR adds 0.10.0 deprecation warnings and removes deprecation subjects scheduled for removal in 0.10.0:

* `MeanTransformer`, deprecated since 0.8.0, is removed
* `check_is` is deprecated and scheduled for removal in 0.11.0
* `Z` arg of series transformers is deprecated and scheduled for removal in 0.11.0
* `return_pred_int` arg of `predict` and related functions is deprecated and scheduled for removal in 0.11.0