### PR TITLE
[ENH] more testing parameters for `NaiveForecaster`

### DIFF
--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -379,7 +379,12 @@ class NaiveForecaster(BaseForecaster):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        params1 = {}
-        params2 = {"sp": 2}
+        params_list = [
+            {},
+            {"sp": 2},
+            {"strategy": "mean"},
+            {"strategy": "drift"},
+            {"strategy": "mean", "window_length": 5}
+        ]
 
-        return [params1, params2]
+        return params_list

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -366,3 +366,20 @@ class NaiveForecaster(BaseForecaster):
         self : reference to self
         """
         return self._forecaster.update(y=y, X=X, update_params=update_params)
+
+    @classmethod
+    def get_test_params(cls):
+        """Return testing parameter settings for the estimator.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params1 = {}
+        params2 = {"sp": 2}
+
+        return [params1, params2]

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -384,7 +384,7 @@ class NaiveForecaster(BaseForecaster):
             {"sp": 2},
             {"strategy": "mean"},
             {"strategy": "drift"},
-            {"strategy": "mean", "window_length": 5}
+            {"strategy": "mean", "window_length": 5},
         ]
 
         return params_list


### PR DESCRIPTION
This PR adds more testing parameters to `NaiveForecaster`, which now should cover all significant parameter cases.

This follows a report of @aiwalter that `NaiveForecaster` does not work with the parameter setting `sp=2`, with a failure in `_reshape_last_window_for_sp`.