### PR TITLE
[BUG] remove MrSEQL notebook in docs

### DIFF
--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -63,6 +63,7 @@ Hybrid
     :template: class.rst
 
     HIVECOTEV1
+    HIVECOTEV2
 
 Interval-based
 --------------
@@ -74,10 +75,11 @@ Interval-based
     :template: class.rst
 
     TimeSeriesForestClassifier
-    RandomIntervalSpectralForest
     SupervisedTimeSeriesForest
     CanonicalIntervalForest
     DrCIF
+    RandomIntervalSpectralEnsemble
+
 
 Shapelet-based
 --------------
@@ -89,7 +91,6 @@ Shapelet-based
     :template: class.rst
 
     ShapeletTransformClassifier
-    MrSEQLClassifier
 
 Kernel-based
 ------------
@@ -116,3 +117,6 @@ Feature-based
     MatrixProfileClassifier
     TSFreshClassifier
     SignatureClassifier
+    FreshPRINCE
+    SummaryClassifier
+    RandomIntervalClassifier

--- a/docs/source/examples/02_classification_univariate.ipynb
+++ b/docs/source/examples/02_classification_univariate.ipynb
@@ -1,1 +1,0 @@
-../../../examples/02_classification_univariate.ipynb

--- a/docs/source/examples/03_classification_multivariate.ipynb
+++ b/docs/source/examples/03_classification_multivariate.ipynb
@@ -1,1 +1,0 @@
-../../../examples/03_classification_multivariate.ipynb

--- a/docs/source/examples/mrseql.ipynb
+++ b/docs/source/examples/mrseql.ipynb
@@ -1,1 +1,0 @@
-../../../examples/mrseql.ipynb


### PR DESCRIPTION
I did not realise there was a duplicate notebook in docs. MrSEQL has been deprecated with cython, hopefully it will come back at a later date, but this notebook should go