### PR TITLE
[BUG] fix import on clustering extension template

### DIFF
--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -31,7 +31,7 @@ copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """
 import numpy as np
 
-from sktime.clustering.base import BaseClusterer
+from sktime.clustering import BaseClusterer
 
 # todo: add any necessary imports here
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fix broken import. Module was rename from `base.py` to `_base.py`.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

