### PR TITLE
[MNT] hotfix: scipy upper bound from 1.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "pandas>=1.1.0,<1.5.0",
     "scikit-learn>=0.24.0",
     "statsmodels>=0.12.1",
+    "scipy<1.8.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR introduces an upper bound `scipy<1.8.0` to keep our CI breaking due to #1994.

One that is resolved, the upper bound can be relaxed.