### PR TITLE
[ENH] replace deprecated `np.str` and `np.float`

### DIFF
--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -172,7 +172,7 @@ def _load_dataset(name, split, return_X_y, extract_path=None):
             result = load_from_tsfile_to_dataframe(abspath)
             X = pd.concat([X, pd.DataFrame(result[0])])
             y = pd.concat([y, pd.Series(result[1])])
-        y = pd.Series.to_numpy(y, dtype=np.str)
+        y = pd.Series.to_numpy(y, dtype=str)
     else:
         raise ValueError("Invalid `split` value =", split)
 

--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -512,7 +512,7 @@ def load_shampoo_sales():
     name = "ShampooSales"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: np.float})
+    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: float})
     y.index = pd.PeriodIndex(y.index, freq="M", name="Period")
     y.name = "Number of shampoo sales"
     return y
@@ -566,7 +566,7 @@ def load_longley(y_name="TOTEMP"):
     data = pd.read_csv(path, index_col=0)
     data = data.set_index("YEAR")
     data.index = pd.PeriodIndex(data.index, freq="Y", name="Period")
-    data = data.astype(np.float)
+    data = data.astype(float)
 
     # Get target series
     y = data.pop(y_name)
@@ -613,7 +613,7 @@ def load_lynx():
     name = "Lynx"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: np.float})
+    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: float})
     y.index = pd.PeriodIndex(y.index, freq="Y", name="Period")
     y.name = "Number of Lynx trappings"
     return y
@@ -650,7 +650,7 @@ def load_airline():
     name = "Airline"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: np.float})
+    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: float})
 
     # make sure time index is properly formatted
     y.index = pd.PeriodIndex(y.index, freq="M", name="Period")
@@ -817,7 +817,7 @@ def load_PBS_dataset():
     name = "PBS_dataset"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: np.float})
+    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: float})
 
     # make sure time index is properly formatted
     y.index = pd.PeriodIndex(y.index, freq="M", name="Period")

--- a/sktime/distances/_numba_utils.py
+++ b/sktime/distances/_numba_utils.py
@@ -132,7 +132,7 @@ def to_numba_pairwise_timeseries(x: np.ndarray) -> np.ndarray:
             f"distance computation a numpy arrays must be provided."
         )
 
-    _x = np.array(x, copy=True, dtype=np.float)
+    _x = np.array(x, copy=True, dtype=float)
     num_dims = _x.ndim
     if num_dims == 1:
         shape = _x.shape
@@ -177,7 +177,7 @@ def to_numba_timeseries(x: np.ndarray) -> np.ndarray:
             f"distance computation a numpy array must be provided."
         )
 
-    _x = np.array(x, copy=True, dtype=np.float)
+    _x = np.array(x, copy=True, dtype=float)
     num_dims = _x.ndim
     shape = _x.shape
     if num_dims == 1:

--- a/sktime/dists_kernels/tests/test_all_dist_kernels.py
+++ b/sktime/dists_kernels/tests/test_all_dist_kernels.py
@@ -106,8 +106,8 @@ def _x_equals_x2_test(transformation, x, transformer):
     # test X_equals_X2
     for i in range(len(x)):
         # Have to round or test breaks on github (even though works locally)
-        row = np.around((transformation[i, :]).T, decimals=5).astype(np.float)
-        column = np.around(transformation[:, i], decimals=5).astype(np.float)
+        row = np.around((transformation[i, :]).T, decimals=5).astype(float)
+        column = np.around(transformation[:, i], decimals=5).astype(float)
         assert np.array_equal(row, column)
     assert transformer.X_equals_X2, (
         f"X_equals_X2 is set to wrong value for {transformer} " f"when only X passed"

--- a/sktime/transformations/panel/catch22.py
+++ b/sktime/transformations/panel/catch22.py
@@ -162,7 +162,7 @@ class Catch22(_PanelToTabularTransformer):
         Numpy array containing a catch22 feature for each input series.
         """
         if isinstance(feature, (int, np.integer)) or isinstance(
-            feature, (float, np.float)
+            feature, (float, float)
         ):
             if feature > 21 or feature < 0:
                 raise ValueError("Invalid catch22 feature ID")

--- a/sktime/transformations/panel/padder.py
+++ b/sktime/transformations/panel/padder.py
@@ -56,7 +56,7 @@ class PaddingTransformer(_PanelToPanelTransformer):
         return self
 
     def _create_pad(self, series):
-        out = np.full(self.pad_length_, self.fill_value, np.float)
+        out = np.full(self.pad_length_, self.fill_value, float)
         out[: len(series)] = series.iloc[: len(series)]
         return out
 

--- a/sktime/transformations/panel/padder.py
+++ b/sktime/transformations/panel/padder.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
+"""Padding transformer."""
 import numpy as np
 import pandas as pd
+
 from sktime.transformations.base import _PanelToPanelTransformer
 from sktime.utils.validation.panel import check_X
 
 __all__ = ["PaddingTransformer"]
-__author__ = ["Aaron Bostrom"]
+__author__ = ["abostrom"]
 
 
 class PaddingTransformer(_PanelToPanelTransformer):
-    """PaddingTransformer docstring
+    """Padding transformer.
 
     Pads the input dataset to either a optional fixed length
     (longer than the longest series).


### PR DESCRIPTION
This PR replaces all deprecated `numpy.str` and `numpy.float` with `python` native `str` an `float`, respectively - as the deprecation message recommends.

This should turn off the annoying deprecation messages.

FYI @TonyBagnall, @chrisholder, @MatthewMiddlehurst, since this was all coming from the classification module.

Also adds/changes some docstrings in `PaddingTransformer` to be linting compliant.