### PR TITLE
[BUG] fix conversion of nested to multiindex if series have names

### DIFF
--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -827,20 +827,12 @@ def from_nested_to_multi_index(X, instance_index=None, time_index=None):
     instances = []
     for instance_idx in instance_idxs:
         iidx = instance_idx
-        instance = [
-            pd.DataFrame(i[1], columns=[i[0]])
-            for i in X.loc[iidx, :].iteritems()  # noqa
-        ]
-        # instance = [
-        #     _val if isinstance(_val, (pd.Series) else pd.Series(_val, name=_lab)
-        #     for _lab, _val in X.loc[instance_idx, :].iteritems()  # noqa
-        # ]
-        # instance = [
-        #     X.loc[instance_idx, _label]
-        #     if isinstance(X.loc[instance_idx, _label], pd.Series)
-        #     else pd.Series(X.loc[instance_idx, _label], name=_label)
-        #     for _label in X.columns ]
+        series = [i[1] for i in X.loc[iidx, :].iteritems()]
+        colnames = [i[0] for i in X.loc[iidx, :].iteritems()]
+        for x in series:
+            x.name = None
 
+        instance = [pd.DataFrame(s, columns=[c]) for s, c in zip(series, colnames)]
         instance = pd.concat(instance, axis=1)
         # For primitive (non-nested column) assume the same
         # primitive value applies to every timepoint of the instance


### PR DESCRIPTION
This PR fixes a bug in the old function `from_nested_to_multi_index` that is wrapped by `convert`/`convert_to`.

The bug occurs if any of the series in the data frame have names.
In this case, the corresponding rows are empty, up to the entire resultant data frame becoming empty if all series had names.

The reason is a call to the `pd.DataFrame(series, columns=sth)` constructor, assuming that passing a `columns` argument always renames the columns. This assumption is false - if the argument `series` already has names, sub-setting is attempted, leading to an empty `pd.DataFrame` if a name is present, but the name is not identical with the name(s) in `sth`.