### PR TITLE
[MNT] Remove `pytest-xdist` from CI-CD, un-skip `test_multiprocessing_idempotent`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
           cp .coveragerc testdir/
           cp setup.cfg testdir/
           cd testdir/
-          python -m pytest --showlocals --durations=10 --cov-report=xml -n 2 --cov=sktime -v --pyargs sktime
+          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime -v --pyargs sktime
       - name: Display coverage report
         run: ls -l ./testdir/
       - name: Publish code coverage

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -122,7 +122,7 @@ jobs:
           cp .coveragerc testdir/
           cp setup.cfg testdir/
           cd testdir/
-          python -m pytest --showlocals --durations=10 --cov-report=xml -n 2 --cov=sktime --pyargs sktime
+          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime --pyargs sktime
 
   upload_wheels:
     name: Upload wheels to PyPI

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: ## Run unit tests
 	mkdir -p ${TEST_DIR}
 	cp .coveragerc ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
-	cd ${TEST_DIR}; python -m pytest --cov-report html --cov=sktime --showlocals --durations=20 -n 2 --pyargs $(PACKAGE)
+	cd ${TEST_DIR}; python -m pytest --cov-report html --cov=sktime --showlocals --durations=20 --pyargs $(PACKAGE)
 
 tests: test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "pytest-xdist",
     "wheel",
 ]
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -664,8 +664,6 @@ def test_persistence_via_pickle(estimator_instance):
         )
 
 
-# todo: this needs to be diagnosed and fixed - temporary skip
-@pytest.mark.skip(reason="hangs on mac and unix remote tests")
 def test_multiprocessing_idempotent(estimator_class, scenario):
     """Test that single and multi-process run results are identical.
 


### PR DESCRIPTION
Update: upgrading this from a draft.

This PR removes `pytest-xdist` from CI-CD and adds back `test_multiprocessing_idempotent`.

This is based on the observation/conclusion that `pytest-xdist` is causing multiple strange interactions which lead to crashes and erroring out of our CI-CD under hard to specify conditions.

Implements https://github.com/alan-turing-institute/sktime/issues/2012 (also see there for further details)

---
Draft, attempt at diagnosing #1941 - removing `pytest-xdist`.

Also adds back `test_multiprocessing_idempotent` to see what happens.