### PR TITLE
[MNT] Remove `pytest-xdist` from mac&linux CI-CD, un-skip `test_multiprocessing_idempotent`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
           cp .coveragerc testdir/
           cp setup.cfg testdir/
           cd testdir/
-          python -m pytest --showlocals --durations=10 --cov-report=xml -n 2 --cov=sktime -v --pyargs sktime
+          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime -v --pyargs sktime
       - name: Display coverage report
         run: ls -l ./testdir/
       - name: Publish code coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,9 @@ jobs:
           conda install -c conda-forge scipy matplotlib
 
       - name: Install sktime and dependencies
-        run: python -m pip install .[all_extras,dev]
+        run: |
+          python -m pip install .[all_extras,dev]
+          python -m pip install pytest-xdist
 
       - name: Show dependecies
         run: python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
           cp .coveragerc testdir/
           cp setup.cfg testdir/
           cd testdir/
-          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime -v --pyargs sktime
+          python -m pytest --showlocals --durations=10 --cov-report=xml -n 2 --cov=sktime -v --pyargs sktime
       - name: Display coverage report
         run: ls -l ./testdir/
       - name: Publish code coverage
@@ -96,7 +96,7 @@ jobs:
           file: ./testdir/coverage.xml
 
   test-linux:
-    needs: code-quality
+    needs: test-windows
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -128,7 +128,7 @@ jobs:
           file: ./testdir/coverage.xml
 
   test-mac:
-    needs: code-quality
+    needs: test-windows
     runs-on: macOS-10.15
     strategy:
       matrix:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -122,7 +122,7 @@ jobs:
           cp .coveragerc testdir/
           cp setup.cfg testdir/
           cd testdir/
-          python -m pytest --showlocals --durations=10 --cov-report=xml -n 2 --cov=sktime --pyargs sktime
+          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime --pyargs sktime
 
   upload_wheels:
     name: Upload wheels to PyPI

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: ## Run unit tests
 	mkdir -p ${TEST_DIR}
 	cp .coveragerc ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
-	cd ${TEST_DIR}; python -m pytest --cov-report html --cov=sktime --showlocals --durations=20 -n 2 --pyargs $(PACKAGE)
+	cd ${TEST_DIR}; python -m pytest --cov-report html --cov=sktime --showlocals --durations=20 --pyargs $(PACKAGE)
 
 tests: test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "pytest-xdist",
     "wheel",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "pytest-xdist",
     "wheel",
 ]
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -664,8 +664,6 @@ def test_persistence_via_pickle(estimator_instance):
         )
 
 
-# todo: this needs to be diagnosed and fixed - temporary skip
-@pytest.mark.skip(reason="hangs on mac and unix remote tests")
 def test_multiprocessing_idempotent(estimator_class, scenario):
     """Test that single and multi-process run results are identical.
 


### PR DESCRIPTION
This PR:
* removes `pytest-xdist` from macos & linux CI/CD 
* makes macos & linux CI/CD conditional on windows CI/CD
* adds back `test_multiprocessing_idempotent`.

Alternative version of #2004 which ensures "fail fast" through windows CI/CD which still uses `pytest-xdist`.

Implements https://github.com/alan-turing-institute/sktime/issues/2012 (also see there for further details)