### PR TITLE
[MNT] Revert "Revert "HC2 component bugfixes""

### DIFF
--- a/sktime/classification/dictionary_based/_tde.py
+++ b/sktime/classification/dictionary_based/_tde.py
@@ -479,6 +479,10 @@ class TemporalDictionaryEnsemble(BaseClassifier):
             indices = range(n_instances)
             for i, clf in enumerate(self.estimators_):
                 oob = [n for n in indices if n not in clf._subsample]
+
+                if len(oob) == 0:
+                    continue
+
                 preds = clf.predict(X[oob])
 
                 for n, pred in enumerate(preds):
@@ -913,11 +917,8 @@ class IndividualTDE(BaseClassifier):
                 fin_transformers.append(transformers[i])
 
         if len(dims) > self.max_dims:
-            idx = self.random_state.choice(
-                len(dims),
-                self.max_dims,
-                replace=False,
-            ).tolist()
+            rng = check_random_state(self.random_state)
+            idx = rng.choice(len(dims), self.max_dims, replace=False).tolist()
             dims = [dims[i] for i in idx]
             fin_transformers = [fin_transformers[i] for i in idx]
 

--- a/sktime/classification/interval_based/_drcif.py
+++ b/sktime/classification/interval_based/_drcif.py
@@ -572,6 +572,10 @@ class DrCIF(BaseClassifier):
         subsample = rng.choice(self.n_instances_, size=self.n_instances_)
         oob = [n for n in indices if n not in subsample]
 
+        results = np.zeros((self.n_instances_, self.n_classes_))
+        if len(oob) == 0:
+            return [results, oob]
+
         clf = _clone_estimator(self._base_estimator, rs)
         clf.fit(self.transformed_data_[idx][subsample], y[subsample])
         probas = clf.predict_proba(self.transformed_data_[idx][oob])
@@ -583,7 +587,6 @@ class DrCIF(BaseClassifier):
                 new_probas[:, cls_idx] = probas[:, i]
             probas = new_probas
 
-        results = np.zeros((self.n_instances_, self.n_classes_))
         for n, proba in enumerate(probas):
             results[oob[n]] += proba
 

--- a/sktime/classification/kernel_based/_arsenal.py
+++ b/sktime/classification/kernel_based/_arsenal.py
@@ -391,6 +391,10 @@ class Arsenal(BaseClassifier):
         subsample = rng.choice(self.n_instances_, size=self.n_instances_)
         oob = [n for n in indices if n not in subsample]
 
+        results = np.zeros((self.n_instances_, self.n_classes_))
+        if len(oob) == 0:
+            return results, 1, oob
+
         clf = make_pipeline(
             StandardScaler(with_mean=False),
             RidgeClassifierCV(alphas=np.logspace(-3, 3, 10)),
@@ -400,7 +404,6 @@ class Arsenal(BaseClassifier):
 
         weight = clf.steps[1][1].best_score_
 
-        results = np.zeros((self.n_instances_, self.n_classes_))
         for n, pred in enumerate(preds):
             results[oob[n]][self._class_dictionary[pred]] += weight
 

--- a/sktime/contrib/vector_classifiers/_rotation_forest.py
+++ b/sktime/contrib/vector_classifiers/_rotation_forest.py
@@ -461,6 +461,10 @@ class RotationForest(BaseEstimator):
         subsample = rng.choice(self.n_instances, size=self.n_instances)
         oob = [n for n in indices if n not in subsample]
 
+        results = np.zeros((self.n_instances, self.n_classes))
+        if len(oob) == 0:
+            return [results, oob]
+
         clf = _clone_estimator(self._base_estimator, rs)
         clf.fit(self.transformed_data[idx][subsample], y[subsample])
         probas = clf.predict_proba(self.transformed_data[idx][oob])
@@ -472,7 +476,6 @@ class RotationForest(BaseEstimator):
                 new_probas[:, cls_idx] = probas[:, i]
             probas = new_probas
 
-        results = np.zeros((self.n_instances, self.n_classes))
         for n, proba in enumerate(probas):
             results[oob[n]] += proba
 


### PR DESCRIPTION
Reverts the revert alan-turing-institute/sktime#2029

which is the same as adding #2020 back into the repository.

Checking whether the tests pass, with `test_multiprocessing_idempotent` removed.

FYI @MatthewMiddlehurst, @TonyBagnall 