### PR TITLE
[ENH] Address deprecated references in datatypes modules

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1491,6 +1491,16 @@
         "doc",
         "infra"
       ]
+    },
+    {
+      "login":"SadmanSyfe",
+      "name":"Sadman Sudad Syfe",
+      "avatar_url":"https://avatars.githubusercontent.com/u/99546467?v=4",
+      "profile":"https://github.com/SadmanSyfe",
+      "contributions":[
+        "code"
+      ]
+
     }
   ],
   "projectName": "sktime",

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -47,8 +47,8 @@ import pandas as pd
 
 from sktime.datatypes._series._check import check_pddataframe_series
 
-VALID_INDEX_TYPES = (pd.Int64Index, pd.RangeIndex, pd.PeriodIndex, pd.DatetimeIndex)
-VALID_MULTIINDEX_TYPES = (pd.Int64Index, pd.RangeIndex)
+VALID_INDEX_TYPES = (pd.Index, pd.RangeIndex, pd.PeriodIndex, pd.DatetimeIndex)
+VALID_MULTIINDEX_TYPES = (pd.Index, pd.RangeIndex)
 
 
 def _list_all_equal(obj):

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -45,8 +45,8 @@ import pandas as pd
 
 from sktime.datatypes._series._check import check_pddataframe_series
 
-VALID_INDEX_TYPES = (pd.Int64Index, pd.RangeIndex, pd.PeriodIndex, pd.DatetimeIndex)
-VALID_MULTIINDEX_TYPES = (pd.Int64Index, pd.RangeIndex)
+VALID_INDEX_TYPES = (pd.Index, pd.RangeIndex, pd.PeriodIndex, pd.DatetimeIndex)
+VALID_MULTIINDEX_TYPES = (pd.Index, pd.RangeIndex)
 
 
 def _list_all_equal(obj):

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -40,7 +40,7 @@ __all__ = ["check_dict"]
 import numpy as np
 import pandas as pd
 
-VALID_INDEX_TYPES = (pd.Int64Index, pd.RangeIndex, pd.PeriodIndex, pd.DatetimeIndex)
+VALID_INDEX_TYPES = (pd.Index, pd.RangeIndex, pd.PeriodIndex, pd.DatetimeIndex)
 
 # whether the checks insist on freq attribute is set
 FREQ_SET_CHECK = False


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->


#### Reference Issues/PRs
Fixes #2049 

Changes:
```pd.Int64Index```
To
```pd.Index```
Files:
>_panel/_check.py
>_series/_check.py
>_hierarchical/_check.py
#### What does this implement/fix? Explain your changes.

<!--
A clear and concise description of what you have implemented.
-->
Fixes future warnings in datatypes modules




#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.




<!--
Thanks for contributing!
-->
