### PR TITLE
[ENH] new table mtypes: `pd.Series` based, `list` of `dict` (as used in bag of words transformers)

### DIFF
--- a/sktime/datatypes/_table/_check.py
+++ b/sktime/datatypes/_table/_check.py
@@ -36,7 +36,6 @@ __author__ = ["fkiraly"]
 
 __all__ = ["check_dict"]
 
-from multiprocessing.sharedctypes import Value
 import numpy as np
 import pandas as pd
 

--- a/sktime/datatypes/_table/_examples.py
+++ b/sktime/datatypes/_table/_examples.py
@@ -52,7 +52,7 @@ series = pd.Series([1, 4, 0.5, -3])
 example_dict[("pd_Series_Table", "Table", 0)] = series
 example_dict_lossy[("pd_Series_Table", "Table", 0)] = True
 
-list_of_dict = [{"a": 1.}, {"a": 4.}, {"a": 0.5}, {"a": -3.}]
+list_of_dict = [{"a": 1.0}, {"a": 4.0}, {"a": 0.5}, {"a": -3.0}]
 
 example_dict[("list_of_dict", "Table", 0)] = list_of_dict
 example_dict_lossy[("list_of_dict", "Table", 0)] = False
@@ -84,7 +84,10 @@ example_dict[("pd_Series_Table", "Table", 1)] = None
 example_dict_lossy[("pd_Series_Table", "Table", 1)] = None
 
 list_of_dict = [
-    {"a": 1., "b": 3.}, {"a": 4., "b": 7.}, {"a": 0.5, "b": 2.}, {"a": -3., "b": -3 / 7}
+    {"a": 1.0, "b": 3.0},
+    {"a": 4.0, "b": 7.0},
+    {"a": 0.5, "b": 2.0},
+    {"a": -3.0, "b": -3 / 7},
 ]
 
 example_dict[("list_of_dict", "Table", 1)] = list_of_dict

--- a/sktime/datatypes/_table/_examples.py
+++ b/sktime/datatypes/_table/_examples.py
@@ -47,6 +47,17 @@ arr = np.array([1, 4, 0.5, -3])
 example_dict[("numpy1D", "Table", 0)] = arr
 example_dict_lossy[("numpy1D", "Table", 0)] = True
 
+series = pd.Series([1, 4, 0.5, -3])
+
+example_dict[("pd_Series_Table", "Table", 0)] = series
+example_dict_lossy[("pd_Series_Table", "Table", 0)] = True
+
+list_of_dict = [{"a": 1.}, {"a": 4.}, {"a": 0.5}, {"a": -3.}]
+
+example_dict[("list_of_dict", "Table", 0)] = list_of_dict
+example_dict_lossy[("list_of_dict", "Table", 0)] = False
+
+
 example_dict_metadata[("Table", 0)] = {
     "is_univariate": True,
     "is_empty": False,
@@ -68,6 +79,16 @@ arr = np.array([[1, 3], [4, 7], [0.5, 2], [-3, -3 / 7]])
 
 example_dict[("numpy2D", "Table", 1)] = arr
 example_dict_lossy[("numpy2D", "Table", 1)] = True
+
+example_dict[("pd_Series_Table", "Table", 1)] = None
+example_dict_lossy[("pd_Series_Table", "Table", 1)] = None
+
+list_of_dict = [
+    {"a": 1., "b": 3.}, {"a": 4., "b": 7.}, {"a": 0.5, "b": 2.}, {"a": -3., "b": -3 / 7}
+]
+
+example_dict[("list_of_dict", "Table", 1)] = list_of_dict
+example_dict_lossy[("list_of_dict", "Table", 1)] = False
 
 example_dict_metadata[("Table", 1)] = {
     "is_univariate": False,

--- a/sktime/datatypes/_table/_registry.py
+++ b/sktime/datatypes/_table/_registry.py
@@ -12,6 +12,8 @@ MTYPE_REGISTER_TABLE = [
     ("pd_DataFrame_Table", "Table", "pd.DataFrame representation of a data table"),
     ("numpy1D", "Table", "1D np.narray representation of a univariate table"),
     ("numpy2D", "Table", "2D np.narray representation of a univariate table"),
+    ("pd_Series_Table", "Table", "pd.Series representation of a data table"),
+    ("list_of_dict", "Table", "list of dictionaries with primitive entries"),
 ]
 
 MTYPE_LIST_TABLE = pd.DataFrame(MTYPE_REGISTER_TABLE)[0].values


### PR DESCRIPTION
This PR introduces two new mtypes for the `Table` scitype:
* a `pandas.Series` based mtype, `pd_Series_Table`, which has less conditions on the type than for time series (e.g., no ordered indices needed). This is being used in various components of classifiers, where `y` is a `pandas.Series` but without ordered time index.
* `list_of_dict`, which is a `list` of `dict` with the condition that all entries are primitive (`str`, `int`, or `float`). This is currently returned by bag of words type transformers, see discussion in #2064. Introduction of this type would make those transformers interface compliant.

FYI @patrickzib, @MatthewMiddlehurst 