### PR TITLE
[BUG] Fixed bug with check_pdmultiindex_panel

### DIFF
--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -188,7 +188,7 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj"):
     check_res = [
         check_pddataframe_series(obj.loc[i], return_metadata=True) for i in inst_inds
     ]
-    bad_inds = [i for i in inst_inds if not check_res[i][0]]
+    bad_inds = [i for i in range(len(inst_inds)) if not check_res[i][0]]
 
     if len(bad_inds) > 0:
         msg = (


### PR DESCRIPTION
Bug can be seen in this code, that will pass with first group but fail with second.

```
# -*- coding: utf-8 -*-
import pandas as pd
from sktime.datasets import load_airline
from sktime.datatypes import get_examples
from sktime.forecasting.model_selection import temporal_train_test_split
from sktime.datatypes._panel._check import check_pdmultiindex_panel

# Load data that will be the basis of tests
y = load_airline()
y_pd = get_examples(mtype="pd.DataFrame", as_scitype="Series")[0]
y_series = get_examples(mtype="pd.Series", as_scitype="Series")[0]
y_multi = get_examples(mtype="pd-multiindex", as_scitype="Panel")[0]
# y Train will be univariate data set
y_train, y_test = temporal_train_test_split(y)

# Create Panel sample data
mi = pd.MultiIndex.from_product([[0], y.index], names=["instances", "timepoints"])
y_group1 = pd.DataFrame(y.values, index=mi, columns=["y"])

mi = pd.MultiIndex.from_product([[1], y.index], names=["instances", "timepoints"])
y_group2 = pd.DataFrame(y.values, index=mi, columns=["y"])

y_grouped = pd.concat([y_group1, y_group2])
check_pdmultiindex_panel(y_grouped)
y = load_airline()
y_pd = get_examples(mtype="pd.DataFrame", as_scitype="Series")[0]
y_series = get_examples(mtype="pd.Series", as_scitype="Series")[0]
y_multi = get_examples(mtype="pd-multiindex", as_scitype="Panel")[0]
# y Train will be univariate data set
y_train, y_test = temporal_train_test_split(y)

# Create Panel sample data
mi = pd.MultiIndex.from_product([[1], y.index], names=["instances", "timepoints"])
y_group1 = pd.DataFrame(y.values, index=mi, columns=["y"])

mi = pd.MultiIndex.from_product([[3], y.index], names=["instances", "timepoints"])
y_group2 = pd.DataFrame(y.values, index=mi, columns=["y"])

y_grouped = pd.concat([y_group1, y_group2])
check_pdmultiindex_panel(y_grouped)
```

The only change is from
```
mi = pd.MultiIndex.from_product([[0], y.index], names=["instances", "timepoints"])
mi = pd.MultiIndex.from_product([[1], y.index], names=["instances", "timepoints"])
```
to
```
mi = pd.MultiIndex.from_product([[1], y.index], names=["instances", "timepoints"])
mi = pd.MultiIndex.from_product([[3], y.index], names=["instances", "timepoints"])
```


#### What does this implement/fix? Explain your changes.

The erronerous check for bad indices assumes that instances are all monotonous and start with 0, e.g, 0,1,2,3,4 and will fail if not. This assumption, however ist too strict. As you can see from the datatypes example notebook, there should  be no such restriction, and e.g. 1,2,3,4,5 as instances or 1,3,5 should also work.
```
In the `"pd-multiindex"` mtype, time series panels are represented by an in-memory container `obj: pandas.DataFrame` as follows.
* structure convention: `obj.index` must be a pair multi-index of type `(RangeIndex, t)`, where `t` is one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex` and monotonous. `obj.index` must have name `("instances", "timepoints")`.
* instances: rows with the same `"instances"` index correspond to the same instance; rows with different `"instances"` index correspond to different instances.
* instance index: the first element of pairs in `obj.index` is interpreted as an instance index.
* variables: columns of `obj` correspond to different variables
* variable names: column names `obj.columns`
* time points: rows of `obj` with the same `"timepoints"` index correspond correspond to the same time point; rows of `obj` with different `"timepoints"` index correspond correspond to the different time points.
* time index: the second element of pairs in `obj.index` is interpreted as a time index.
* capabilities: can represent panels of multivariate series; can represent unequally spaced series; can represent panels of unequally supported series; cannot represent panels of series with different sets of variables.
```
#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
#### Any other comments?

#### PR checklist


##### For all contributions
- [x ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).

