### PR TITLE
[ENH] _predict_fixed_cutoff for Hierarchical Data 

### DIFF
--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -106,14 +106,17 @@ class _BaseWindowForecaster(BaseForecaster):
 
         Returns
         -------
-        y_pred = pd.Series
+        y_pred = pd.Series or pd.DataFrame
         """
         # assert all(fh > 0)
         y_pred = self._predict_last_window(
             fh, X, return_pred_int=return_pred_int, alpha=alpha
         )
-        index = fh.to_absolute(self.cutoff)
-        return pd.Series(y_pred, index=index)
+        if isinstance(y_pred, np.ndarray):
+            index = fh.to_absolute(self.cutoff)
+            return pd.Series(y_pred, index=index)
+        else:
+            return y_pred
 
     def _predict_in_sample(
         self, fh, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -110,11 +110,11 @@ class _BaseWindowForecaster(BaseForecaster):
         y_pred = self._predict_last_window(
             fh, X, return_pred_int=return_pred_int, alpha=alpha
         )
-        if isinstance(y_pred, np.ndarray):
+        if isinstance(y_pred, pd.Series) or isinstance(y_pred, pd.DataFrame):
+            return y_pred
+        else:
             index = fh.to_absolute(self.cutoff)
             return pd.Series(y_pred, index=index)
-        else:
-            return y_pred
 
     def _predict_in_sample(
         self, fh, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -9,10 +9,8 @@ __all__ = ["_BaseWindowForecaster"]
 import numpy as np
 import pandas as pd
 
-from sktime.forecasting.base._base import BaseForecaster
-from sktime.forecasting.base._base import DEFAULT_ALPHA
-from sktime.forecasting.model_selection import CutoffSplitter
-from sktime.forecasting.model_selection import SlidingWindowSplitter
+from sktime.forecasting.base._base import DEFAULT_ALPHA, BaseForecaster
+from sktime.forecasting.model_selection import CutoffSplitter, SlidingWindowSplitter
 from sktime.utils.datetime import _shift
 from sktime.utils.validation.forecasting import check_cv
 


### PR DESCRIPTION
Hierarchical data cannot be usefully returned as an np.ndarray without index information, since we will then lose the mapping of rows to individual instances of thed data. It is preferential to return data from a prediction function that already contains the correct multiindex featuring instances and  timepoints.

We will at a later timepoint include modification to the reduce class that will return multiindex information from prediction, see this prototoype.

You can see a working example here:

https://github.com/alan-turing-institute/sktime/pull/2074


#### Reference Issues/PRs
see above


#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

#### Any other comments?

#### PR checklist

##### For all contributions
- [x ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).

##### For new estimators
