### PR TITLE
[ENH] improved `deep_equals` return message if `dict`s are discrepant

### DIFF
--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -210,9 +210,16 @@ def _dict_equals(x, y, return_msg=False):
     ykeys = set(y.keys())
 
     if xkeys != ykeys:
-        return ret(False, f".keys, x.keys = {xkeys} != y.keys = {ykeys}")
+        xmy = xkeys.difference(ykeys)
+        ymx = ykeys.difference(xkeys)
+        diffmsg = ".keys,"
+        if len(xmy) > 0:
+            diffmsg += f" x.keys-y.keys = {xmy}."
+        if len(ymx) > 0:
+            diffmsg += f" y.keys-x.keys = {ymx}."
+        return ret(False, diffmsg)
 
-    # we now know all keys are the same
+    # we now know that xkeys == ykeys
     for key in xkeys:
         xi = x[key]
         yi = y[key]


### PR DESCRIPTION
This PR makes a minor change to improve the error reporting of `deep_equals`.

In case dictionary key sets are found discrepant, the error message is now more informative - instead of displaying the two key sets, it now displays the difference explicitly.