### PR TITLE
[BUG] fixed state change caused by `ThetaForecaster.predict_quantiles`

### DIFF
--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -212,8 +212,8 @@ class ThetaForecaster(ExponentialSmoothing):
         # compute historical residual standard error
         n_timepoints = len(self._y)
 
-        self.sigma_ = np.sqrt(self._fitted_forecaster.sse / (n_timepoints - 1))
-        sem = self.sigma_ * np.sqrt(
+        sigma = np.sqrt(self._fitted_forecaster.sse / (n_timepoints - 1))
+        sem = sigma * np.sqrt(
             self.fh.to_relative(self.cutoff) * self.initial_level_ ** 2 + 1
         )
 


### PR DESCRIPTION
Contrary to specification `ThetaForecaster.predict_quantiles` changed object attributes - namely, an attribute `sigma_` was created in `self`. This was probably accidental.

The tests did not pick this up, since much of the generic test suite was deactivated for the new probabilistic forecasting methods.

This is being changed in https://github.com/alan-turing-institute/sktime/pull/2100, which picked up the issue.