### PR TITLE
[MNT] remove pytest-xdist to diagnose #2066

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
           cp .coveragerc testdir/
           cp setup.cfg testdir/
           cd testdir/
-          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime -v -n 2 --pyargs sktime
+          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime -v --pyargs sktime
       - name: Display coverage report
         run: ls -l ./testdir/
       - name: Publish code coverage

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: ## Run unit tests
 	mkdir -p ${TEST_DIR}
 	cp .coveragerc ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
-	cd ${TEST_DIR}; python -m pytest --cov-report html --cov=sktime -v -n 2 --showlocals --durations=20 --pyargs $(PACKAGE)
+	cd ${TEST_DIR}; python -m pytest --cov-report html --cov=sktime -v --showlocals --durations=20 --pyargs $(PACKAGE)
 
 tests: test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "pytest-xdist",
     "wheel",
 ]
 


### PR DESCRIPTION
The bug in https://github.com/alan-turing-institute/sktime/issues/2066 may have become more frequent since `pytest-xdist` was added.

This PR checks the hypothesis by removing `pytest-xdist`.

Note to reviewers: `main` currently has #2144 which adds `xfails` to the problematic tests.
This is currently not merged to this PR, and merge will mask overall pass/fails below.