### PR TITLE
[MNT] add skips to entirety of `test_plotting` until #2066 is resolved

### DIFF
--- a/sktime/utils/tests/test_plotting.py
+++ b/sktime/utils/tests/test_plotting.py
@@ -197,6 +197,8 @@ def test_univariate_plots_run_without_error(series_to_plot, plot_func):
     plt.close()
 
 
+# todo: remove xfail when issue #2066 has been fixed
+@pytest.mark.xfail(reason="sporadic failure on win CI/CD, see issue 2066")
 # Generically test whether plots only accepting univariate input
 # raise an error when invalid input type is found
 @pytest.mark.parametrize("series_to_plot", invalid_input_types)
@@ -218,6 +220,8 @@ def test_univariate_plots_invalid_input_type_raises_error(
             plot_func(series_to_plot)
 
 
+# todo: remove xfail when issue #2066 has been fixed
+@pytest.mark.xfail(reason="sporadic failure on win CI/CD, see issue 2066")
 # Generically test output of plots only accepting univariate input
 @pytest.mark.parametrize("series_to_plot", [y_airline])
 @pytest.mark.parametrize("plot_func", univariate_plots)

--- a/sktime/utils/tests/test_plotting.py
+++ b/sktime/utils/tests/test_plotting.py
@@ -49,6 +49,8 @@ def valid_data_types():
     return valid_data_types
 
 
+# todo: remove skip when issue #2066 has been fixed
+@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", series_to_test)
 def test_plot_series_runs_without_error(series_to_plot):
     """Test whether plot_series runs without error."""
@@ -68,6 +70,8 @@ def test_plot_series_runs_without_error(series_to_plot):
     plt.close()
 
 
+# todo: remove skip when issue #2066 has been fixed
+@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", invalid_input_types)
 def test_plot_series_invalid_input_type_raises_error(series_to_plot, valid_data_types):
     """Tests whether plot_series raises error for invalid input types."""
@@ -85,6 +89,8 @@ def test_plot_series_invalid_input_type_raises_error(series_to_plot, valid_data_
             _plot_series(series_to_plot)
 
 
+# todo: remove skip when issue #2066 has been fixed
+@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize(
     "series_to_plot", [(y_airline_true, y_airline_test.reset_index(drop=True))]
 )
@@ -97,6 +103,8 @@ def test_plot_series_with_unequal_index_type_raises_error(
         _plot_series(series_to_plot)
 
 
+# todo: remove skip when issue #2066 has been fixed
+@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", series_to_test)
 def test_plot_series_invalid_marker_kwarg_len_raises_error(series_to_plot):
     """Tests whether plot_series raises error for inconsistent series/markers."""
@@ -114,6 +122,8 @@ def test_plot_series_invalid_marker_kwarg_len_raises_error(series_to_plot):
         _plot_series(series_to_plot, markers=markers)
 
 
+# todo: remove skip when issue #2066 has been fixed
+@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", series_to_test)
 def test_plot_series_invalid_label_kwarg_len_raises_error(series_to_plot):
     """Tests whether plot_series raises error for inconsistent series/labels."""
@@ -131,7 +141,7 @@ def test_plot_series_invalid_label_kwarg_len_raises_error(series_to_plot):
         _plot_series(series_to_plot, labels=labels)
 
 
-# todo: remove xfail when issue #2066 has been fixed
+# todo: remove skip when issue #2066 has been fixed
 @pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", series_to_test)
 def test_plot_series_output_type(series_to_plot):
@@ -166,6 +176,8 @@ def test_plot_series_output_type(series_to_plot):
     )
 
 
+# todo: remove skip when issue #2066 has been fixed
+@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 def test_plot_series_uniform_treatment_of_int64_range_index_types():
     """Verify that plot_series treats Int64 and Range indices equally."""
     # We test that int64 and range indices are treated uniformly and do not raise an
@@ -182,7 +194,7 @@ def test_plot_series_uniform_treatment_of_int64_range_index_types():
     plt.close()
 
 
-# todo: remove xfail when issue #2066 has been fixed
+# todo: remove skip when issue #2066 has been fixed
 @pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 # Generically test whether plots only accepting univariate input run
 @pytest.mark.parametrize("series_to_plot", [y_airline])
@@ -197,7 +209,7 @@ def test_univariate_plots_run_without_error(series_to_plot, plot_func):
     plt.close()
 
 
-# todo: remove xfail when issue #2066 has been fixed
+# todo: remove skip when issue #2066 has been fixed
 @pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 # Generically test whether plots only accepting univariate input
 # raise an error when invalid input type is found
@@ -220,7 +232,7 @@ def test_univariate_plots_invalid_input_type_raises_error(
             plot_func(series_to_plot)
 
 
-# todo: remove xfail when issue #2066 has been fixed
+# todo: remove skip when issue #2066 has been fixed
 @pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 # Generically test output of plots only accepting univariate input
 @pytest.mark.parametrize("series_to_plot", [y_airline])
@@ -244,6 +256,8 @@ def test_univariate_plots_output_type(series_to_plot, plot_func):
     )
 
 
+# todo: remove skip when issue #2066 has been fixed
+@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 # For plots that only accept univariate input, from here onwards are
 # tests specific to a given plot. E.g. to test specific arguments or functionality.
 @pytest.mark.parametrize("series_to_plot", [y_airline])
@@ -259,7 +273,7 @@ def test_plot_lags_arguments(series_to_plot, lags, suptitle):
     plt.close()
 
 
-# todo: remove xfail when issue #2066 has been fixed
+# todo: remove skip when issue #2066 has been fixed
 @pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", [y_airline])
 @pytest.mark.parametrize("lags", [6, 12, 24, 36])

--- a/sktime/utils/tests/test_plotting.py
+++ b/sktime/utils/tests/test_plotting.py
@@ -132,7 +132,7 @@ def test_plot_series_invalid_label_kwarg_len_raises_error(series_to_plot):
 
 
 # todo: remove xfail when issue #2066 has been fixed
-@pytest.mark.xfail(reason="sporadic failure on win CI/CD, see issue 2066")
+@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", series_to_test)
 def test_plot_series_output_type(series_to_plot):
     """Tests whether plot_series returns plt.fig and plt.ax."""
@@ -183,7 +183,7 @@ def test_plot_series_uniform_treatment_of_int64_range_index_types():
 
 
 # todo: remove xfail when issue #2066 has been fixed
-@pytest.mark.xfail(reason="sporadic failure on win CI/CD, see issue 2066")
+@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 # Generically test whether plots only accepting univariate input run
 @pytest.mark.parametrize("series_to_plot", [y_airline])
 @pytest.mark.parametrize("plot_func", univariate_plots)
@@ -198,7 +198,7 @@ def test_univariate_plots_run_without_error(series_to_plot, plot_func):
 
 
 # todo: remove xfail when issue #2066 has been fixed
-@pytest.mark.xfail(reason="sporadic failure on win CI/CD, see issue 2066")
+@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 # Generically test whether plots only accepting univariate input
 # raise an error when invalid input type is found
 @pytest.mark.parametrize("series_to_plot", invalid_input_types)
@@ -221,7 +221,7 @@ def test_univariate_plots_invalid_input_type_raises_error(
 
 
 # todo: remove xfail when issue #2066 has been fixed
-@pytest.mark.xfail(reason="sporadic failure on win CI/CD, see issue 2066")
+@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 # Generically test output of plots only accepting univariate input
 @pytest.mark.parametrize("series_to_plot", [y_airline])
 @pytest.mark.parametrize("plot_func", univariate_plots)
@@ -260,7 +260,7 @@ def test_plot_lags_arguments(series_to_plot, lags, suptitle):
 
 
 # todo: remove xfail when issue #2066 has been fixed
-@pytest.mark.xfail(reason="sporadic failure on win CI/CD, see issue 2066")
+@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", [y_airline])
 @pytest.mark.parametrize("lags", [6, 12, 24, 36])
 @pytest.mark.parametrize("suptitle", ["Correlation Plot", None])

--- a/sktime/utils/tests/test_plotting.py
+++ b/sktime/utils/tests/test_plotting.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 from sktime.datasets import load_airline
-from sktime.utils.plotting import plot_series, plot_correlations, plot_lags
+from sktime.utils.plotting import plot_correlations, plot_lags, plot_series
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 from sktime.utils.validation.series import VALID_DATA_TYPES
 
@@ -131,6 +131,8 @@ def test_plot_series_invalid_label_kwarg_len_raises_error(series_to_plot):
         _plot_series(series_to_plot, labels=labels)
 
 
+# todo: remove xfail when issue #2066 has been fixed
+@pytest.mark.xfail(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", series_to_test)
 def test_plot_series_output_type(series_to_plot):
     """Tests whether plot_series returns plt.fig and plt.ax."""
@@ -180,6 +182,8 @@ def test_plot_series_uniform_treatment_of_int64_range_index_types():
     plt.close()
 
 
+# todo: remove xfail when issue #2066 has been fixed
+@pytest.mark.xfail(reason="sporadic failure on win CI/CD, see issue 2066")
 # Generically test whether plots only accepting univariate input run
 @pytest.mark.parametrize("series_to_plot", [y_airline])
 @pytest.mark.parametrize("plot_func", univariate_plots)
@@ -251,6 +255,8 @@ def test_plot_lags_arguments(series_to_plot, lags, suptitle):
     plt.close()
 
 
+# todo: remove xfail when issue #2066 has been fixed
+@pytest.mark.xfail(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", [y_airline])
 @pytest.mark.parametrize("lags", [6, 12, 24, 36])
 @pytest.mark.parametrize("suptitle", ["Correlation Plot", None])


### PR DESCRIPTION
This PR hence replaces adds `skip` to all tests in `test_plotting` - the #2066 issue seems to stochastically affect all tests in the file.

Temporary fix for #2066, follows #2144 and #2146.