### PR TITLE
[DOC] add scitype/mtype register pointers to docstrings in datatypes

### DIFF
--- a/sktime/datatypes/_convert.py
+++ b/sktime/datatypes/_convert.py
@@ -99,9 +99,12 @@ def convert(
     ----------
     obj : object to convert - any type, should comply with mtype spec for as_scitype
     from_type : str - the type to convert "obj" to, a valid mtype string
+        valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
     to_type : str - the type to convert "obj" to, a valid mtype string
+        valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
     as_scitype : str, optional - name of scitype the object "obj" is considered as
         default = inferred from from_type
+        valid scitype strings, with explanation, are in datatypes.SCITYPE_REGISTER
     store : optional, reference of storage for lossy conversions, default=None (no ref)
         is updated by side effect if not None and store_behaviour="reset" or "update"
     store_behaviour : str, optional, one of None (default), "reset", "freeze", "update"
@@ -183,9 +186,11 @@ def convert_to(
     ----------
     obj : object to convert - any type, should comply with mtype spec for as_scitype
     to_type : str - the type to convert "obj" to, a valid mtype string
-              or list - admissible types for conversion to
+            or list of str, this specifies admissible types for conversion to
+        valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
     as_scitype : str, optional - name of scitype the object "obj" is considered as
         pre-specifying the scitype reduces the number of checks done in type inference
+        valid scitype strings, with explanation, are in datatypes.SCITYPE_REGISTER
         default = inferred from mtype of obj, which is in turn inferred internally
     store : reference of storage for lossy conversions, default=None (no store)
         is updated by side effect if not None and store_behaviour="reset" or "update"
@@ -271,6 +276,7 @@ def _conversions_defined(scitype: str):
     Parameters
     ----------
     scitype: str - name of scitype for which conversions are queried
+        valid scitype strings, with explanation, are in datatypes.SCITYPE_REGISTER
 
     Returns
     -------

--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -14,6 +14,8 @@ the representation is considered "lossy" if the representation is incomplete
     e.g., metadata such as column names are missing
 """
 
+from sktime.datatypes._registry import mtype_to_scitype
+
 
 __author__ = ["fkiraly"]
 
@@ -66,7 +68,7 @@ example_dict_metadata.update(example_dict_metadata_Table)
 
 def get_examples(
     mtype: str,
-    as_scitype: str,
+    as_scitype: str = None,
     return_lossy: bool = False,
     return_metadata: bool = False,
 ):
@@ -74,8 +76,11 @@ def get_examples(
 
     Parameters
     ----------
-    mtype: str - name of the mtype for the example
-    as_scitype: str - name of scitype for the example
+    mtype: str - name of the mtype for the example, a valid mtype string
+        valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
+    as_scitype : str, optional - name of scitype of the example, a valid scitype string
+        valid scitype strings, with explanation, are in datatypes.SCITYPE_REGISTER
+        default = inferred from mtype of obj
     return_lossy: bool, optional, default=False
         whether to return second argument
     return_metadata: bool, optional, default=False
@@ -90,6 +95,10 @@ def get_examples(
         if return_metadata=True, elements are triples with fixture, lossy, and
             metadata: dict - metadata dict that would be returned by check_is_mtype
     """
+    # if as_scitype is None, infer from mtype
+    if as_scitype is None:
+        as_scitype = mtype_to_scitype(mtype)
+
     # retrieve all keys that match the query
     exkeys = example_dict.keys()
     keys = [k for k in exkeys if k[0] == mtype and k[1] == as_scitype]

--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -16,7 +16,6 @@ the representation is considered "lossy" if the representation is incomplete
 
 from sktime.datatypes._registry import mtype_to_scitype
 
-
 __author__ = ["fkiraly"]
 
 __all__ = [

--- a/sktime/datatypes/_registry.py
+++ b/sktime/datatypes/_registry.py
@@ -78,7 +78,8 @@ def mtype_to_scitype(mtype: str, return_unique=False, coerce_to_list=False):
     Parameters
     ----------
     mtype : str, or list of str, or nested list/str object, or None
-        mtype(s) to find scitype of
+        mtype(s) to find scitype of, a valid mtype string
+        valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
 
     Returns
     -------


### PR DESCRIPTION
This PR adds pointers to the scitype and mtype registers, which contain the list of valid scitype and mtype strings, to all docstrings in the `datatypes` module that have arguments which need to be valid scitype or mtype strings.

In addition, this PR makes the `scitype` argument of `get_examples` optional, inferring `scitype` from `mtype`.