### PR TITLE
[DOC] simplified extension templates for transformers and forecasters

### DIFF
--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """
 Extension template for forecasters.
 
@@ -30,9 +31,11 @@ Optional implements:
 
 Testing - implement if sktime forecaster (not needed locally):
     get default parameters for test instance(s) - get_test_params()
-
-copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """
+# todo: write an informative docstring for the file or module, remove the above
+# todo: add an appropriate copyright notice for your estimator
+#       estimators contributed to sktime should have the copyright notice at the top
+#       estimators of your own do not need to have permissive or BSD-3 copyright
 
 # todo: uncomment the following line, enter authors' GitHub IDs
 # __author__ = [authorGitHubID, anotherAuthorGitHubID]
@@ -48,8 +51,8 @@ class MyForecaster(BaseForecaster):
 
     todo: describe your custom forecaster here
 
-    Hyper-parameters
-    ----------------
+    Parameters
+    ----------
     parama : int
         descriptive explanation of parama
     paramb : string, optional (default='default')
@@ -57,9 +60,6 @@ class MyForecaster(BaseForecaster):
     paramc : boolean, optional (default= whether paramb is not the default)
         descriptive explanation of paramc
     and so on
-
-    Components
-    ----------
     est : sktime.estimator, BaseEstimator descendant
         descriptive explanation of est
     est2: another estimator

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""
+Extension template for forecasters, SIMPLE version.
+
+Contains only bare minimum of implementation requirements for a functional forecaster.
+Also assumes *no composition*, i.e., no forecaster or other estimator components.
+For advanced cases (probabilistic, composition, etc),
+    see full extension template in forecasting.py
+
+Purpose of this implementation template:
+    quick implementation of new estimators following the template
+    NOT a concrete class to import! This is NOT a base class or concrete class!
+    This is to be used as a "fill-in" coding template.
+
+How to use this implementation template to implement a new estimator:
+- make a copy of the template in a suitable location, give it a descriptive name.
+- work through all the "todo" comments below
+- fill in code for mandatory methods, and optionally for optional methods
+- you can add more private methods, but do not override BaseEstimator's private methods
+    an easy way to be safe is to prefix your methods with "_custom"
+- change docstrings for functions and the file
+- ensure interface compatibility by testing forecasting/tests/test_all_forecasters
+        and forecasting/tests/test_sktime_forecasters
+- once complete: use as a local library, or contribute to sktime via PR
+
+Mandatory implements:
+    fitting         - _fit(self, y, X=None, fh=None)
+    forecasting     - _predict(self, fh=None, X=None)
+
+Testing - implement if sktime forecaster (not needed locally):
+    get default parameters for test instance(s) - get_test_params()
+"""
+# todo: write an informative docstring for the file or module, remove the above
+# todo: add an appropriate copyright notice for your estimator
+#       estimators contributed to sktime should have the copyright notice at the top
+#       estimators of your own do not need to have permissive or BSD-3 copyright
+
+# todo: uncomment the following line, enter authors' GitHub IDs
+# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+
+
+from sktime.forecasting.base import BaseForecaster
+
+# todo: add any necessary imports here
+
+
+class MyForecaster(BaseForecaster):
+    """Custom forecaster. todo: write docstring.
+
+    todo: describe your custom forecaster here
+
+    Hyper-parameters
+    ----------------
+    parama : int
+        descriptive explanation of parama
+    paramb : string, optional (default='default')
+        descriptive explanation of paramb
+    paramc : boolean, optional (default= whether paramb is not the default)
+        descriptive explanation of paramc
+    and so on
+    """
+
+    # todo: fill out estimator tags here
+    #  tags are inherited from parent class if they are not set
+    # todo: define the forecaster scitype by setting the tags
+    #  the "forecaster scitype" is determined by the tags
+    #   scitype:y - the expected input scitype of y - univariate or multivariate or both
+    # tag values are "safe defaults" which can usually be left as-is
+    _tags = {
+        "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
+        "ignores-exogeneous-X": True,  # does estimator ignore the exogeneous X?
+        "handles-missing-data": False,  # can estimator handle missing data?
+        "y_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for y?
+        "X_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for X?
+        "requires-fh-in-fit": True,  # is forecasting horizon already required in fit?
+        "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
+        "enforce_index_type": None,  # index type that needs to be enforced in X/y
+        "capability:pred_int": False,  # does forecaster implement predict_quantiles?
+        # deprecated and will be renamed to capability:predict_quantiles in 0.11.0
+    }
+
+    # todo: add any hyper-parameters and components to constructor
+    def __init__(self, parama, paramb="default", paramc=None):
+
+        # todo: write any hyper-parameters to self
+        self.parama = parama
+        self.paramb = paramb
+        self.paramc = paramc
+        # important: no checking or other logic should happen here
+
+        # todo: change "MyForecaster" to the name of the class
+        super(MyForecaster, self).__init__()
+
+    # todo: implement this, mandatory
+    def _fit(self, y, X=None, fh=None):
+        """Fit forecaster to training data.
+
+        private _fit containing the core logic, called from fit
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+            Time series to which to fit the forecaster.
+            if self.get_tag("scitype:y")=="univariate":
+                guaranteed to have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+                guaranteed to have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions apply
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            Required (non-optional) here if self.get_tag("requires-fh-in-fit")==True
+            Otherwise, if not passed in _fit, guaranteed to be passed in _predict
+        X : optional (default=None)
+            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Exogeneous time series to fit to.
+
+        Returns
+        -------
+        self : reference to self
+        """
+
+        # implement here
+        # IMPORTANT: avoid side effects to y, X, fh
+        #
+        # any model parameters should be written to attributes ending in "_"
+        #  attributes set by the constructor must not be overwritten
+
+    # todo: implement this, mandatory
+    def _predict(self, fh, X=None):
+        """Forecast time series at future horizon.
+
+        private _predict containing the core logic, called from predict
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            If not passed in _fit, guaranteed to be passed here
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+
+        Returns
+        -------
+        y_pred : pd.Series
+            Point predictions
+        """
+
+        # implement here
+        # IMPORTANT: avoid side effects to X, fh
+
+    # todo: implement this if this is an estimator contributed to sktime
+    #   or to run local automated unit and integration testing of estimator
+    #   method should return default parameters, so that a test instance can be created
+    @classmethod
+    def get_test_params(cls):
+        """Return testing parameter settings for the estimator.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+
+        # todo: set the testing parameters for the estimators
+        # Testing parameters can be dictionary or list of dictionaries
+        #
+        # this can, if required, use:
+        #   class properties (e.g., inherited); parent class test case
+        #   imported objects such as estimators from sktime or sklearn
+        # important: all such imports should be *inside get_test_params*, not at the top
+        #            since imports are used only at testing time
+        #
+        # example 1: specify params as dictionary
+        # any number of params can be specified
+        # params = {"est": value0, "parama": value1, "paramb": value2}
+        #
+        # example 2: specify params as list of dictionary
+        # note: Only first dictionary will be used by create_test_instance
+        # params = [{"est": value1, "parama": value2},
+        #           {"est": value3, "parama": value4}]
+        #
+        # return params

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -31,6 +31,10 @@ Optional implements:
 Testing - implement if sktime transformer (not needed locally):
     get default parameters for test instance(s) - get_test_params()
 """
+# todo: write an informative docstring for the file or module, remove the above
+# todo: add an appropriate copyright notice for your estimator
+#       estimators contributed to sktime should have the copyright notice at the top
+#       estimators of your own do not need to have permissive or BSD-3 copyright
 
 # todo: uncomment the following line, enter authors' GitHub IDs
 # __author__ = [authorGitHubID, anotherAuthorGitHubID]

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""
+Extension template for transformers, MINIMAL version.
+
+Contains only bare minimum of implementation requirements for a functional transformer.
+Also assumes *no composition*, i.e., no transformer or other estimator components.
+For advanced cases (inverse transform, composition, etc),
+    see full extension template in forecasting.py
+
+Purpose of this implementation template:
+    quick implementation of new estimators following the template
+    NOT a concrete class to import! This is NOT a base class or concrete class!
+    This is to be used as a "fill-in" coding template.
+
+How to use this implementation template to implement a new estimator:
+- make a copy of the template in a suitable location, give it a descriptive name.
+- work through all the "todo" comments below
+- fill in code for mandatory methods, and optionally for optional methods
+- you can add more private methods, but do not override BaseEstimator's private methods
+    an easy way to be safe is to prefix your methods with "_custom"
+- change docstrings for functions and the file
+- ensure interface compatibility by testing transformations/tests/test_all_transformers
+        and tests/test_all_estimators
+- once complete: use as a local library, or contribute to sktime via PR
+
+Mandatory implements:
+    fitting         - _fit(self, X, y=None)
+    transformation  - _transform(self, X, y=None)
+
+Testing - implement if sktime transformer (not needed locally):
+    get default parameters for test instance(s) - get_test_params()
+"""
+# todo: write an informative docstring for the file or module, remove the above
+# todo: add an appropriate copyright notice for your estimator
+#       estimators contributed to sktime should have the copyright notice at the top
+#       estimators of your own do not need to have permissive or BSD-3 copyright
+
+# todo: uncomment the following line, enter authors' GitHub IDs
+# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+
+# todo: add any necessary sktime external imports here
+
+from sktime.transformations.base import BaseTransformer
+
+# todo: add any necessary sktime internal imports here
+
+
+class MyTransformer(BaseTransformer):
+    """Custom transformer. todo: write docstring.
+
+    todo: describe your custom transformer here
+        fill in sections appropriately
+        docstring must be numpydoc compliant
+
+    Parameters
+    ----------
+    parama : int
+        descriptive explanation of parama
+    paramb : string, optional (default='default')
+        descriptive explanation of paramb
+    paramc : boolean, optional (default= whether paramb is not the default)
+        descriptive explanation of paramc
+    and so on
+    """
+
+    # todo: fill out estimator tags here
+    #  tags are inherited from parent class if they are not set
+    #
+    # todo: define the transformer scitype by setting the tags
+    #   scitype:transform-input - the expected input scitype of X
+    #   scitype:transform-output - the output scitype that transform produces
+    #   scitype:transform-labels - whether y is used and if yes which scitype
+    #   scitype:instancewise - whether transform uses all samples or acts by instance
+    #
+    # todo: define internal types for X, y in _fit/_transform by setting the tags
+    #   X_inner_mtype - the internal mtype used for X in _fit and _transform
+    #   y_inner_mtype - if y is used, the internal mtype used for y; usually "None"
+    #   setting this guarantees that X, y passed to _fit, _transform are of above types
+    #   for possible mtypes see datatypes.MTYPE_REGISTER, or the datatypes tutorial
+    #
+    #  when scitype:transform-input is set to Panel:
+    #   X_inner_mtype must be changed to one or a list of sktime Panel mtypes
+    #  when scitype:transform-labels is set to Series or Panel:
+    #   y_inner_mtype must be changed to one or a list of compatible sktime mtypes
+    #  the other tags are "safe defaults" which can usually be left as-is
+    _tags = {
+        # todo: what is the scitype of X: Series, or Panel
+        "scitype:transform-input": "Series",
+        # todo: what scitype is returned: Primitives, Series, Panel
+        "scitype:transform-output": "Series",
+        # todo: what is the scitype of y: None (not needed), Primitives, Series, Panel
+        "scitype:transform-labels": "None",
+        "scitype:instancewise": True,  # is this an instance-wise transform?
+        "X_inner_mtype": "pd.DataFrame",  # which mtypes do _fit/_predict support for X?
+        # X_inner_mtype can be Panel mtype even if transform-input is Series, vectorized
+        "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
+        "capability:inverse_transform": True,  # does transformer have inverse transform
+        "skip-inverse-transform": False,  # is inverse-transform skipped when called?
+        "univariate-only": False,  # can the transformer handle multivariate X?
+        "handles-missing-data": False,  # can estimator handle missing data?
+        "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
+        "enforce_index_type": None,  # index type that needs to be enforced in X/y
+        "fit-in-transform": False,  # is fit empty and can be skipped? Yes = True
+        "transform-returns-same-time-index": False,
+        # does transform return have the same time index as input X
+    }
+
+    # todo: add any hyper-parameters and components to constructor
+    def __init__(self, parama, paramb="default", paramc=None):
+
+        # todo: write any hyper-parameters to self
+        self.parama = parama
+        self.paramb = paramb
+        self.paramc = paramc
+        # important: no checking or other logic should happen here
+
+        # todo: change "MyTransformer" to the name of the class
+        super(MyTransformer, self).__init__()
+
+    # todo: implement this, mandatory (except in special case below)
+    def _fit(self, X, y=None):
+        """Fit transformer to X and y.
+
+        private _fit containing the core logic, called from fit
+
+        Parameters
+        ----------
+        X : Series or Panel of mtype X_inner_mtype
+            if X_inner_mtype is list, _fit must support all types in it
+            Data to fit transform to
+        y : Series or Panel of mtype y_inner_mtype, default=None
+            Additional data, e.g., labels for transformation
+
+        Returns
+        -------
+        self: reference to self
+        """
+
+        # implement here
+        # X, y passed to this function are always of X_inner_mtype, y_inner_mtype
+        # IMPORTANT: avoid side effects to X, y
+        #
+        # any model parameters should be written to attributes ending in "_"
+        #  attributes set by the constructor must not be overwritten
+        #
+        # special case: if no fitting happens before transformation
+        #  then: delete _fit (don't implement)
+        #   set "fit-in-transform" tag to True
+
+    # todo: implement this, mandatory
+    def _transform(self, X, y=None):
+        """Transform X and return a transformed version.
+
+        private _transform containing core logic, called from transform
+
+        Parameters
+        ----------
+        X : Series or Panel of mtype X_inner_mtype
+            if X_inner_mtype is list, _transform must support all types in it
+            Data to be transformed
+        y : Series or Panel of mtype y_inner_mtype, default=None
+            Additional data, e.g., labels for transformation
+
+        Returns
+        -------
+        transformed version of X
+        """
+        # implement here
+        # X, y passed to this function are always of X_inner_mtype, y_inner_mtype
+        # IMPORTANT: avoid side effects to X, y
+        #
+        # if transform-output is "Primitives":
+        #  return should be pd.DataFrame, with as many rows as instances in input
+        #  if input is a single series, return should be single-row pd.DataFrame
+        # if transform-output is "Series":
+        #  return should be of same mtype as input, X_inner_mtype
+        #  if multiple X_inner_mtype are supported, ensure same input/output
+        # if transform-output is "Panel":
+        #  return a multi-indexed pd.DataFrame of Panel mtype pd_multiindex
+        #
+        # todo: add the return mtype/scitype to the docstring, e.g.,
+        #  Returns
+        #  -------
+        #  X_transformed : Series of mtype pd.DataFrame
+        #       transformed version of X
+
+    # todo: return default parameters, so that a test instance can be created
+    #   required for automated unit and integration testing of estimator
+    @classmethod
+    def get_test_params(cls):
+        """Return testing parameter settings for the estimator.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+
+        # todo: set the testing parameters for the estimators
+        # Testing parameters can be dictionary or list of dictionaries
+        #
+        # this can, if required, use:
+        #   class properties (e.g., inherited); parent class test case
+        #   imported objects such as estimators from sktime or sklearn
+        # important: all such imports should be *inside get_test_params*, not at the top
+        #            since imports are used only at testing time
+        #
+        # example 1: specify params as dictionary
+        # any number of params can be specified
+        # params = {"est": value0, "parama": value1, "paramb": value2}
+        #
+        # example 2: specify params as list of dictionary
+        # note: Only first dictionary will be used by create_test_instance
+        # params = [{"est": value1, "parama": value2},
+        #           {"est": value3, "parama": value4}]
+        #
+        # return params

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """
-Extension template for transformers, MINIMAL version.
+Extension template for transformers, SIMPLE version.
 
 Contains only bare minimum of implementation requirements for a functional transformer.
 Also assumes *no composition*, i.e., no transformer or other estimator components.


### PR DESCRIPTION
This PR adds two simplified extension templates for forecasters and transformers - these cover the minimal case for a functional forecaster and transformer, removing all optional features. This is meant to reduce cognitive load in the "most common case" for extenders.

Further changes in this PR:
* todos added for file docstring and copyright notice in the extension templates (main and simplified)
* todo for forecaster docstring is now numpydoc compliant
* formatting fixes