### PR TITLE
[BUG] Addressing doc build issue due to failed soft dependency imports

### DIFF
--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -13,7 +13,7 @@ from sklearn import clone
 from sktime.alignment.base import BaseAligner
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("dtw")
+_check_soft_dependencies("dtw", severity="warning")
 
 
 class AlignerDTW(BaseAligner):
@@ -66,6 +66,8 @@ class AlignerDTW(BaseAligner):
         variable_to_align=None,
     ):
         """Construct instance."""
+        _check_soft_dependencies("dtw", severity="error")
+
         super(AlignerDTW, self).__init__()
 
         self.dist_method = dist_method

--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -66,7 +66,7 @@ class AlignerDTW(BaseAligner):
         variable_to_align=None,
     ):
         """Construct instance."""
-        _check_soft_dependencies("dtw", severity="error")
+        _check_soft_dependencies("dtw", severity="error", object=self)
 
         super(AlignerDTW, self).__init__()
 

--- a/sktime/clustering/k_shapes.py
+++ b/sktime/clustering/k_shapes.py
@@ -8,7 +8,7 @@ from numpy.random import RandomState
 from sktime.clustering.base import BaseClusterer, TimeSeriesInstances
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("tslearn")
+_check_soft_dependencies("tslearn", severity="warning")
 from tslearn.clustering import KShape  # noqa: E402
 
 
@@ -65,6 +65,8 @@ class TimeSeriesKShapes(BaseClusterer):
         verbose: bool = False,
         random_state: Union[int, RandomState] = None,
     ):
+        _check_soft_dependencies("tslearn", severity="error")
+
         self.init_algorithm = init_algorithm
         self.n_init = n_init
         self.max_iter = max_iter

--- a/sktime/clustering/k_shapes.py
+++ b/sktime/clustering/k_shapes.py
@@ -65,7 +65,7 @@ class TimeSeriesKShapes(BaseClusterer):
         verbose: bool = False,
         random_state: Union[int, RandomState] = None,
     ):
-        _check_soft_dependencies("tslearn", severity="error")
+        _check_soft_dependencies("tslearn", severity="error", object=self)
 
         self.init_algorithm = init_algorithm
         self.n_init = n_init

--- a/sktime/clustering/k_shapes.py
+++ b/sktime/clustering/k_shapes.py
@@ -9,7 +9,6 @@ from sktime.clustering.base import BaseClusterer, TimeSeriesInstances
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 _check_soft_dependencies("tslearn", severity="warning")
-from tslearn.clustering import KShape  # noqa: E402
 
 
 class TimeSeriesKShapes(BaseClusterer):
@@ -98,6 +97,8 @@ class TimeSeriesKShapes(BaseClusterer):
         self:
             Fitted estimator.
         """
+        from tslearn.clustering import KShape
+
         if self._tslearn_k_shapes is None:
             self._tslearn_k_shapes = KShape(
                 # n_clusters=self.n_clusters,

--- a/sktime/clustering/kernel_k_means.py
+++ b/sktime/clustering/kernel_k_means.py
@@ -84,7 +84,7 @@ class TimeSeriesKernelKMeans(BaseClusterer):
         n_jobs: Union[int, None] = None,
         random_state: Union[int, RandomState] = None,
     ):
-        _check_soft_dependencies("tslearn", severity="error")
+        _check_soft_dependencies("tslearn", severity="error", object=self)
 
         self.kernel = kernel
         self.n_init = n_init

--- a/sktime/clustering/kernel_k_means.py
+++ b/sktime/clustering/kernel_k_means.py
@@ -9,7 +9,6 @@ from sktime.clustering.base import BaseClusterer, TimeSeriesInstances
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 _check_soft_dependencies("tslearn", severity="warning")
-from tslearn.clustering import KernelKMeans as TsLearnKernelKMeans  # noqa: E402
 
 
 class TimeSeriesKernelKMeans(BaseClusterer):
@@ -119,6 +118,8 @@ class TimeSeriesKernelKMeans(BaseClusterer):
         self:
             Fitted estimator.
         """
+        from tslearn.clustering import KernelKMeans as TsLearnKernelKMeans
+
         verbose = 0
         if self.verbose is True:
             verbose = 1

--- a/sktime/clustering/kernel_k_means.py
+++ b/sktime/clustering/kernel_k_means.py
@@ -8,7 +8,7 @@ from numpy.random import RandomState
 from sktime.clustering.base import BaseClusterer, TimeSeriesInstances
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("tslearn")
+_check_soft_dependencies("tslearn", severity="warning")
 from tslearn.clustering import KernelKMeans as TsLearnKernelKMeans  # noqa: E402
 
 
@@ -84,6 +84,8 @@ class TimeSeriesKernelKMeans(BaseClusterer):
         n_jobs: Union[int, None] = None,
         random_state: Union[int, RandomState] = None,
     ):
+        _check_soft_dependencies("tslearn", severity="error")
+
         self.kernel = kernel
         self.n_init = n_init
         self.max_iter = max_iter

--- a/sktime/clustering/metrics/averaging/_averaging.py
+++ b/sktime/clustering/metrics/averaging/_averaging.py
@@ -8,7 +8,6 @@ import numpy as np
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 _check_soft_dependencies("tslearn")
-from tslearn.barycenters import dtw_barycenter_averaging  # noqa: E402
 
 
 def mean_average(X: np.ndarray) -> np.ndarray:
@@ -42,6 +41,8 @@ def dba(X: np.ndarray) -> np.ndarray:
     np.ndarray (2d array of shape (n_dimensions, series_length)
         The time series that is the computed average series.
     """
+    from tslearn.barycenters import dtw_barycenter_averaging
+
     return dtw_barycenter_averaging(X)
 
 

--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -9,7 +9,6 @@ __all__ = ["AutoARIMA", "ARIMA"]
 from sktime.forecasting.base.adapters._pmdarima import _PmdArimaAdapter
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-
 _check_soft_dependencies("pmdarima", severity="warning")
 
 

--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -267,7 +267,7 @@ class AutoARIMA(_PmdArimaAdapter):
         **kwargs
     ):
 
-        _check_soft_dependencies("pmdarima", severity="error")
+        _check_soft_dependencies("pmdarima", severity="error", object=self)
 
         self.start_p = start_p
         self.d = d
@@ -575,7 +575,7 @@ class ARIMA(_PmdArimaAdapter):
         **sarimax_kwargs
     ):
 
-        _check_soft_dependencies("pmdarima", severity="error")
+        _check_soft_dependencies("pmdarima", severity="error", object=self)
 
         self.order = order
         self.seasonal_order = seasonal_order

--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -9,8 +9,6 @@ __all__ = ["AutoARIMA", "ARIMA"]
 from sktime.forecasting.base.adapters._pmdarima import _PmdArimaAdapter
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("pmdarima")
-
 
 class AutoARIMA(_PmdArimaAdapter):
     """Automatically discover the optimal order for an ARIMA model.
@@ -266,6 +264,8 @@ class AutoARIMA(_PmdArimaAdapter):
         with_intercept=True,
         **kwargs
     ):
+
+        _check_soft_dependencies("pmdarima")
 
         self.start_p = start_p
         self.d = d

--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -10,6 +10,9 @@ from sktime.forecasting.base.adapters._pmdarima import _PmdArimaAdapter
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
+_check_soft_dependencies("pmdarima", severity="warning")
+
+
 class AutoARIMA(_PmdArimaAdapter):
     """Automatically discover the optimal order for an ARIMA model.
 
@@ -265,7 +268,7 @@ class AutoARIMA(_PmdArimaAdapter):
         **kwargs
     ):
 
-        _check_soft_dependencies("pmdarima")
+        _check_soft_dependencies("pmdarima", severity="error")
 
         self.start_p = start_p
         self.d = d

--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -574,6 +574,9 @@ class ARIMA(_PmdArimaAdapter):
         with_intercept=True,
         **sarimax_kwargs
     ):
+
+        _check_soft_dependencies("pmdarima", severity="error")
+
         self.order = order
         self.seasonal_order = seasonal_order
         self.start_params = start_params

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -12,6 +12,7 @@ import pandas as pd
 from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.base._base import DEFAULT_ALPHA
 from sktime.utils.validation import check_n_jobs
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 from sktime.utils.validation.forecasting import check_sp
 
 
@@ -39,6 +40,7 @@ class _TbatsAdapter(BaseForecaster):
         multiprocessing_start_method="spawn",
         context=None,
     ):
+        _check_soft_dependencies("tbats", severity="error")
 
         self.use_box_cox = use_box_cox
         self.box_cox_bounds = box_cox_bounds

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -40,7 +40,7 @@ class _TbatsAdapter(BaseForecaster):
         multiprocessing_start_method="spawn",
         context=None,
     ):
-        _check_soft_dependencies("tbats", severity="error")
+        _check_soft_dependencies("tbats", severity="error", object=self)
 
         self.use_box_cox = use_box_cox
         self.box_cox_bounds = box_cox_bounds

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -58,6 +58,14 @@ class _TbatsAdapter(BaseForecaster):
 
         super(_TbatsAdapter, self).__init__()
 
+    def _create_model_class(self):
+        """Instantiate (T)BATS model.
+
+        This method should write a (T)BATS model to self._ModelClass,
+            and should be overridden by concrete classes.
+        """
+        raise NotImplementedError
+
     def _instantiate_model(self):
         n_jobs = check_n_jobs(self.n_jobs)
         sp = check_sp(self.sp, enforce_list=True)
@@ -91,6 +99,7 @@ class _TbatsAdapter(BaseForecaster):
         -------
         self : returns an instance of self.
         """
+        self._create_model_class()
         self._forecaster = self._instantiate_model()
         self._forecaster = self._forecaster.fit(y)
         self._yname = y.name

--- a/sktime/forecasting/bats.py
+++ b/sktime/forecasting/bats.py
@@ -15,7 +15,7 @@ __all__ = ["BATS"]
 from sktime.forecasting.base.adapters import _TbatsAdapter
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("tbats")
+_check_soft_dependencies("tbats", severity="warning")
 
 
 class BATS(_TbatsAdapter):

--- a/sktime/forecasting/bats.py
+++ b/sktime/forecasting/bats.py
@@ -120,7 +120,6 @@ class BATS(_TbatsAdapter):
         from tbats import BATS as _BATS
 
         self._ModelClass = _BATS
-        super(BATS, self).__init__()
 
     @classmethod
     def get_test_params(cls):

--- a/sktime/forecasting/bats.py
+++ b/sktime/forecasting/bats.py
@@ -113,11 +113,14 @@ class BATS(_TbatsAdapter):
 
     _fitted_param_names = "aic"
 
-    # both bats and tbats inherit the same interface from the base class and only
-    # instantiate a different model class internally
-    from tbats import BATS as _BATS
+    def _create_model_class(self):
+        """Create model class."""
+        # both bats and tbats inherit the same interface from the base class and only
+        # instantiate a different model class internally
+        from tbats import BATS as _BATS
 
-    _ModelClass = _BATS
+        self._ModelClass = _BATS
+        super(BATS, self).__init__()
 
     @classmethod
     def get_test_params(cls):

--- a/sktime/forecasting/fbprophet.py
+++ b/sktime/forecasting/fbprophet.py
@@ -11,7 +11,7 @@ from sktime.forecasting.base._base import DEFAULT_ALPHA
 from sktime.forecasting.base.adapters import _ProphetAdapter
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("prophet")
+_check_soft_dependencies("prophet", severity="warning")
 
 
 class Prophet(_ProphetAdapter):
@@ -143,6 +143,8 @@ class Prophet(_ProphetAdapter):
         verbose=0,
         interval_width=0,
     ):
+        _check_soft_dependencies("prophet", severity="error")
+
         self.freq = freq
         self.add_seasonality = add_seasonality
         self.add_country_holidays = add_country_holidays

--- a/sktime/forecasting/fbprophet.py
+++ b/sktime/forecasting/fbprophet.py
@@ -143,7 +143,7 @@ class Prophet(_ProphetAdapter):
         verbose=0,
         interval_width=0,
     ):
-        _check_soft_dependencies("prophet", severity="error")
+        _check_soft_dependencies("prophet", severity="error", object=self)
 
         self.freq = freq
         self.add_seasonality = add_seasonality

--- a/sktime/forecasting/hcrystalball.py
+++ b/sktime/forecasting/hcrystalball.py
@@ -10,7 +10,7 @@ from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.base._base import DEFAULT_ALPHA
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("hcrystalball")
+_check_soft_dependencies("hcrystalball", severity="warning")
 
 
 def _check_fh(fh, cutoff):
@@ -113,6 +113,7 @@ class HCrystalBallForecaster(BaseForecaster):
     }
 
     def __init__(self, model):
+        _check_soft_dependencies("hcrystalball", severity="error")
         self.model = model
         super(HCrystalBallForecaster, self).__init__()
 

--- a/sktime/forecasting/hcrystalball.py
+++ b/sktime/forecasting/hcrystalball.py
@@ -113,7 +113,7 @@ class HCrystalBallForecaster(BaseForecaster):
     }
 
     def __init__(self, model):
-        _check_soft_dependencies("hcrystalball", severity="error")
+        _check_soft_dependencies("hcrystalball", severity="error", object=self)
         self.model = model
         super(HCrystalBallForecaster, self).__init__()
 

--- a/sktime/forecasting/tbats.py
+++ b/sktime/forecasting/tbats.py
@@ -115,11 +115,14 @@ class TBATS(_TbatsAdapter):
 
     _fitted_param_names = "aic"
 
-    # both bats and tbats inherit the same interface from the base class and only
-    # instantiate a different model class internally
-    from tbats import TBATS as _TBATS
+    def _create_model_class(self):
+        """Create model class."""
+        # both bats and tbats inherit the same interface from the base class and only
+        # instantiate a different model class internally
+        from tbats import TBATS as _TBATS
 
-    _ModelClass = _TBATS
+        self._ModelClass = _TBATS
+        super(TBATS, self).__init__()
 
     @classmethod
     def get_test_params(cls):

--- a/sktime/forecasting/tbats.py
+++ b/sktime/forecasting/tbats.py
@@ -122,7 +122,6 @@ class TBATS(_TbatsAdapter):
         from tbats import TBATS as _TBATS
 
         self._ModelClass = _TBATS
-        super(TBATS, self).__init__()
 
     @classmethod
     def get_test_params(cls):

--- a/sktime/forecasting/tbats.py
+++ b/sktime/forecasting/tbats.py
@@ -15,7 +15,7 @@ __all__ = ["TBATS"]
 from sktime.forecasting.base.adapters import _TbatsAdapter
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("tbats")
+_check_soft_dependencies("tbats", severity="warning")
 
 
 class TBATS(_TbatsAdapter):

--- a/sktime/transformations/panel/signature_based/_compute.py
+++ b/sktime/transformations/panel/signature_based/_compute.py
@@ -37,7 +37,7 @@ class _WindowSignatureTransform(_SeriesToPrimitivesTransformer):
         sig_depth=None,
         rescaling=None,
     ):
-        _check_soft_dependencies("esig", severity="error")
+        _check_soft_dependencies("esig", severity="error", object=self)
         super().__init__()
         self.window_name = window_name
         self.window_depth = window_depth

--- a/sktime/transformations/panel/signature_based/_compute.py
+++ b/sktime/transformations/panel/signature_based/_compute.py
@@ -10,7 +10,7 @@ from sktime.transformations.panel.signature_based._rescaling import (
 from sktime.transformations.panel.signature_based._window import _window_getter
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("esig")
+_check_soft_dependencies("esig", severity="warning")
 import esig  # noqa: E402
 
 
@@ -37,6 +37,7 @@ class _WindowSignatureTransform(_SeriesToPrimitivesTransformer):
         sig_depth=None,
         rescaling=None,
     ):
+        _check_soft_dependencies("esig", severity="error")
         super().__init__()
         self.window_name = window_name
         self.window_depth = window_depth

--- a/sktime/transformations/panel/tsfresh.py
+++ b/sktime/transformations/panel/tsfresh.py
@@ -12,7 +12,7 @@ from sktime.transformations.base import BaseTransformer
 from sktime.utils.validation import check_n_jobs
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("tsfresh")
+_check_soft_dependencies("tsfresh", severity="warning")
 
 
 class _TSFreshFeatureExtractor(BaseTransformer):
@@ -43,6 +43,8 @@ class _TSFreshFeatureExtractor(BaseTransformer):
         profiling_sorting=None,
         distributor=None,
     ):
+        _check_soft_dependencies("tsfresh", severity="error")
+
         self.default_fc_parameters = default_fc_parameters
         self.kind_to_fc_parameters = kind_to_fc_parameters
         self.n_jobs = n_jobs

--- a/sktime/transformations/panel/tsfresh.py
+++ b/sktime/transformations/panel/tsfresh.py
@@ -43,7 +43,7 @@ class _TSFreshFeatureExtractor(BaseTransformer):
         profiling_sorting=None,
         distributor=None,
     ):
-        _check_soft_dependencies("tsfresh", severity="error")
+        _check_soft_dependencies("tsfresh", severity="error", object=self)
 
         self.default_fc_parameters = default_fc_parameters
         self.kind_to_fc_parameters = kind_to_fc_parameters

--- a/sktime/transformations/series/matrix_profile.py
+++ b/sktime/transformations/series/matrix_profile.py
@@ -9,9 +9,7 @@ __all__ = ["MatrixProfileTransformer"]
 from sktime.transformations.base import BaseTransformer
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("stumpy")
-
-import stumpy  # noqa: E402
+_check_soft_dependencies("stumpy", severity="warning")
 
 
 class MatrixProfileTransformer(BaseTransformer):
@@ -58,6 +56,7 @@ class MatrixProfileTransformer(BaseTransformer):
     }
 
     def __init__(self, window_length=3):
+        _check_soft_dependencies("stumpy", severity="error")
         self.window_length = window_length
         super(MatrixProfileTransformer, self).__init__()
 
@@ -80,6 +79,8 @@ class MatrixProfileTransformer(BaseTransformer):
             Matrix Profile of time series as output with length as
             (n_timepoints-window_length+1)
         """
+        import stumpy
+
         X = X.flatten()
         Xt = stumpy.stump(X, self.window_length)
         Xt = Xt[:, 0].astype("float")

--- a/sktime/transformations/series/matrix_profile.py
+++ b/sktime/transformations/series/matrix_profile.py
@@ -56,7 +56,7 @@ class MatrixProfileTransformer(BaseTransformer):
     }
 
     def __init__(self, window_length=3):
-        _check_soft_dependencies("stumpy", severity="error")
+        _check_soft_dependencies("stumpy", severity="error", object=self)
         self.window_length = window_length
         super(MatrixProfileTransformer, self).__init__()
 

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Utility to check soft dependency imports, and raise warnings or errors."""
+
 import warnings
 from importlib import import_module
 
 
-def _check_soft_dependencies(*packages, severity="error"):
+def _check_soft_dependencies(*packages, severity="error", object=None):
     """Check if requred soft dependencies are installed and raise error or warning.
 
     Parameters
@@ -13,6 +14,9 @@ def _check_soft_dependencies(*packages, severity="error"):
         One or more package names to check
     severity : str, "error" (default) or "warning"
         whether the check should raise an error, or only a warning
+    object : python object or None, default=None
+        if self is passed here when _check_soft_dependencies is called within __init__
+        the error message is more informative and will refer to the class
 
     Raises
     ------
@@ -23,12 +27,25 @@ def _check_soft_dependencies(*packages, severity="error"):
         try:
             import_module(package)
         except ModuleNotFoundError as e:
-            msg = (
-                f"{e}. '{package}' is a soft dependency and not included in the "
-                f"sktime installation. Please run: `pip install {package}`. "
-                f"To install all soft dependencies, run: `pip install "
-                f"sktime[all_extras]`"
-            )
+            if object is None:
+                msg = (
+                    f"{e}. '{package}' is a soft dependency and not included in the "
+                    f"sktime installation. Please run: `pip install {package}` to "
+                    f"install the {package} package. "
+                    f"To install all soft dependencies, run: `pip install "
+                    f"sktime[all_extras]`"
+                )
+            else:
+                class_name = type(object).__name__
+                msg = (
+                    f"{class_name} requires package '{package}' in python "
+                    f"environment to be instantiated, but '{package}' was not found. "
+                    f"'{package}' is a soft dependency and not included in the base "
+                    f"sktime installation. Please run: `pip install {package}` to "
+                    f"install the {package} package. "
+                    f"To install all soft dependencies, run: `pip install "
+                    f"sktime[all_extras]`"
+                )
             if severity == "error":
                 raise ModuleNotFoundError(msg) from e
             elif severity == "warning":

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from importlib import import_module
+"""Utility to check soft dependency imports, and raise warnings or errors."""
 import warnings
+from importlib import import_module
 
 
 def _check_soft_dependencies(*packages, severity="error"):

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -1,22 +1,22 @@
 # -*- coding: utf-8 -*-
 from importlib import import_module
+import warnings
 
 
-def _check_soft_dependencies(*packages):
-    """
-    Check if all soft dependencies are installed and raise appropriate error message
-    when not.
+def _check_soft_dependencies(*packages, severity="error"):
+    """Check if requred soft dependencies are installed and raise error or warning.
 
     Parameters
     ----------
     packages : str
         One or more package names to check
+    severity : str, "error" (default) or "warning"
+        whether the check should raise an error, or only a warning
 
     Raises
     ------
     ModuleNotFoundError
-        User friendly error with suggested action to install all required soft
-        dependencies
+        error with informative message, asking to install required soft dependencies
     """
     for package in packages:
         try:
@@ -28,4 +28,12 @@ def _check_soft_dependencies(*packages):
                 f"To install all soft dependencies, run: `pip install "
                 f"sktime[all_extras]`"
             )
-            raise ModuleNotFoundError(msg) from e
+            if severity == "error":
+                raise ModuleNotFoundError(msg) from e
+            elif severity == "warning":
+                warnings.warn(msg)
+            else:
+                raise RuntimeError(
+                    "Error in calling _check_soft_dependencies, severity "
+                    f'argument must bee "error" or "warning", found "{severity}".'
+                )


### PR DESCRIPTION
This PR is an attempt to address the doc build fails that @aiwalter had reported, i.e., empty/missing pages for estimators with soft dependencies. This was also reported earlier as #2013.

The way this is done is via a minor change to `_check_soft_dependencies`, which gets an additional argument `severity` that controls whether a warning is raised, or an exception.
The extended utility is then used as follows:
* called on module import, but raises only a warning, so execution does not terminate
* called additionally on class construction, with an exception.

That way, users as well as the doc build process can import classes, read docstrings, and will get an error only when the class is constructed. The informative error message is still raised at the earliest possible point in time.

This PR addresses the issue for (hopefully) all instances of `_check_soft_dependencies` preventing doc build previously.
It also contains changes to make the error message more informative.

Changes still need to be made to dependent docs that outline how implementers/developer should deal with soft dependencies: the developer documentation, and the extension templates.

This PR also fixes the following bug:
* (T)BATS models behaving as a singleton, i.e., one call to `fit` overwrites all models in all instances, https://github.com/alan-turing-institute/sktime/issues/2174