### PR TITLE
[BUG] dealing with sklearn 1.2 deprecation warnings and solving the first part

### DIFF
--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -180,6 +180,7 @@ class SummaryTransformer(BaseTransformer):
         summary_value = Z.agg(summary_function)
         if quantiles is not None:
             quantile_value = Z.quantile(quantiles)
+            quantile_value.index = [str(s) for s in quantile_value.index]
             summary_value = pd.concat([summary_value, quantile_value])
 
         if isinstance(Z, pd.Series):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes the first part of #2143 : replacing float variable names by str in pandas.DataFrame passed.
 


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
I trace the warning and find out in summarize.py, quantiles are presented as "float" while other features are represented as "str", and that is the root of this warning. So I transform these float numbers to string.


#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
All unit tests in 'classification' directory have passed. And here is the output:
```
======================================== test session starts ========================================
platform linux -- Python 3.8.12, pytest-7.0.1, pluggy-1.0.0
rootdir: /root/sktime_dev/sktime, configfile: setup.cfg
plugins: cov-3.0.0, xdist-2.5.0, forked-1.4.0
collected 1 item                                                                                    

classification/feature_based/_summary_classifier.py .                                         [100%]

========================================= 1 passed in 4.14s ======================================                       


(sktime-dev) root@x86_64-conda-linux-gnu:sktime/sktime ‹main*›# 
(sktime-dev) root@x86_64-conda-linux-gnu:sktime/sktime ‹main*›# 
(sktime-dev) root@x86_64-conda-linux-gnu:sktime/sktime ‹main*›# pytest classification/feature_based/tests/test_summary_classifier.py
================================================== test session starts ===================================================
platform linux -- Python 3.8.12, pytest-7.0.1, pluggy-1.0.0
rootdir: /root/sktime_dev/sktime, configfile: setup.cfg
plugins: cov-3.0.0, xdist-2.5.0, forked-1.4.0
collected 2 items                                                                                                        

classification/feature_based/tests/test_summary_classifier.py ..                                                   [100%]

=================================================== 2 passed in 4.80s ====================================================
(sktime-dev) root@x86_64-conda-linux-gnu:sktime/sktime ‹main*›# pytest classification/tests/test_all_classifiers.py
================================================== test session starts ===================================================
platform linux -- Python 3.8.12, pytest-7.0.1, pluggy-1.0.0
rootdir: /root/sktime_dev/sktime, configfile: setup.cfg
plugins: cov-3.0.0, xdist-2.5.0, forked-1.4.0
collected 90 items                                                                                                       

classification/tests/test_all_classifiers.py ...........
.......................................................... [ 76%]
.....................                                                                                              [100%]

================================================== 90 passed in 44.68s ===================================================
```

For tests/test_all_estimators.py, here is the output:
```
==================================================== warnings summary ====================================================
sktime/tests/test_all_estimators.py: 14 warnings
  /root/miniconda/envs/sktime-dev/lib/python3.8/site-packages/scipy/stats/morestats.py:897: RuntimeWarning: invalid value encountered in log
    logdata = np.log(data)

sktime/tests/test_all_estimators.py: 14 warnings
  /root/miniconda/envs/sktime-dev/lib/python3.8/site-packages/scipy/stats/morestats.py:906: RuntimeWarning: invalid value encountered in power
    variance = np.var(data**lmb / lmb, axis=0)

sktime/tests/test_all_estimators.py: 64 warnings
  /root/sktime_dev/sktime/sktime/performance_metrics/forecasting/_functions.py:1543: FutureWarning: In the percentage error metric functions the default argument symmetric=True is changing to symmetric=False in v0.12.0.
    warn(

sktime/tests/test_all_estimators.py: 16 warnings
  /root/miniconda/envs/sktime-dev/lib/python3.8/site-packages/sklearn/decomposition/_pca.py:499: RuntimeWarning: invalid value encountered in true_divide
    explained_variance_ = (S ** 2) / (n_samples - 1)

sktime/tests/test_all_estimators.py::TestAllEstimators::test_fit_updates_state[Prophet-ForecasterFitPredictUnivariateNoX]
  /root/miniconda/envs/sktime-dev/lib/python3.8/site-packages/pyximport/pyximport.py:51: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

sktime/tests/test_all_estimators.py: 28 warnings
  /root/sktime_dev/sktime/sktime/transformations/series/boxcox.py:377: RuntimeWarning: invalid value encountered in power
    x_ratio = x_std / x_mean ** (1 - lmb)

sktime/tests/test_all_estimators.py::TestAllEstimators::test_fit_updates_state[TimeSeriesKMeans-ClustererFitPredict]
  /root/miniconda/envs/sktime-dev/lib/python3.8/site-packages/tslearn/utils/utils.py:156: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    def to_time_series_dataset(dataset, dtype=numpy.float):

sktime/tests/test_all_estimators.py::TestAllEstimators::test_fit_updates_state[TimeSeriesKMeans-ClustererFitPredict]
  /root/miniconda/envs/sktime-dev/lib/python3.8/site-packages/tslearn/utils/cast.py:15: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    def to_sklearn_dataset(dataset, dtype=numpy.float, return_dim=False):

sktime/tests/test_all_estimators.py::TestAllEstimators::test_fit_updates_state[TimeSeriesKMeans-ClustererFitPredict]
  /root/miniconda/envs/sktime-dev/lib/python3.8/site-packages/tslearn/metrics/utils.py:9: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    compute_diagonal=True, dtype=numpy.float, *args, **kwargs):

sktime/tests/test_all_estimators.py::TestAllEstimators::test_fit_updates_state[TimeSeriesKMeans-ClustererFitPredict]
  /root/miniconda/envs/sktime-dev/lib/python3.8/site-packages/tslearn/metrics/sax.py:2: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    from .cysax import cydist_sax

sktime/tests/test_all_estimators.py::TestAllEstimators::test_fit_updates_state[TimeSeriesKMeans-ClustererFitPredict]
  /root/miniconda/envs/sktime-dev/lib/python3.8/site-packages/tslearn/metrics/sax.py:2: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    from .cysax import cydist_sax

sktime/tests/test_all_estimators.py::TestAllEstimators::test_fit_updates_state[TimeSeriesKMeans-ClustererFitPredict]
  /root/miniconda/envs/sktime-dev/lib/python3.8/site-packages/tslearn/metrics/__init__.py:24: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    from .cycc import cdist_normalized_cc, y_shifted_sbd_vec

sktime/tests/test_all_estimators.py: 50137 warnings
  /root/miniconda/envs/sktime-dev/lib/python3.8/site-packages/tslearn/utils/utils.py:149: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    if ts_out.dtype != numpy.float:

sktime/tests/test_all_estimators.py::TestAllEstimators::test_fit_idempotent[LogTransformer-TransformerFitTransformPanelUnivariateWithClassY]
sktime/tests/test_all_estimators.py::TestAllEstimators::test_methods_do_not_change_state[LogTransformer-TransformerFitTransformPanelUnivariateWithClassY]
sktime/tests/test_all_estimators.py::TestAllEstimators::test_methods_have_no_side_effects[LogTransformer-TransformerFitTransformPanelUnivariateWithClassY]
sktime/tests/test_all_estimators.py::TestAllEstimators::test_persistence_via_pickle[LogTransformer-TransformerFitTransformPanelUnivariateWithClassY]
  /root/sktime_dev/sktime/sktime/transformations/series/boxcox.py:250: RuntimeWarning: invalid value encountered in log
    Xt = np.log(X)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================= 3679 passed, 243 skipped, 50284 warnings in 402.83s (0:06:42) ==============================
```
There is no warning about "FutureWarning: Feature names only support names that are all strings. Got feature names with dtypes: ['float', 'str']. An error will be raised in 1.2."

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
The above warnings need to be solved too.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
