### PR TITLE
[BUG] Same cutoff typo-fix

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1500,6 +1500,15 @@
       "contributions": [
         "infra"
      ]
+    },
+    {
+      "login": "cdahlin",
+      "name": "Christopher Dahlin",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1567780?v=4",
+      "profile": "https://github.com/cdahlin",
+      "contributions": [
+        "code"
+     ]
     }
   ],
   "projectName": "sktime",

--- a/sktime/forecasting/tests/test_sktime_forecasters.py
+++ b/sktime/forecasting/tests/test_sktime_forecasters.py
@@ -50,7 +50,7 @@ y_train, y_test = temporal_train_test_split(y, train_size=0.75)
 # test _y setting
 @pytest.mark.parametrize("Forecaster", FORECASTERS)
 def test_oh_setting(Forecaster):
-    """Check cuttoff and _y."""
+    """Check cutoff and _y."""
     # check _y and cutoff is None after construction
     f = Forecaster.create_test_instance()
     n_columns_list = _get_n_columns(f.get_tag("scitype:y"))

--- a/sktime/utils/_testing/hierarchical.py
+++ b/sktime/utils/_testing/hierarchical.py
@@ -19,7 +19,7 @@ def _make_hierachical(
     hierarchy_levels: Tuple = (2, 4),
     max_timepoints: int = 12,
     min_timepoints: int = 12,
-    same_cuttoff: bool = True,
+    same_cutoff: bool = True,
     n_columns: int = 1,
     all_positive: bool = True,
     index_type: str = None,
@@ -36,7 +36,7 @@ def _make_hierachical(
         maximum time points a series can have, by default 12
     min_timepoints : int, optional
         minimum time points a seires can have, by default 12
-    same_cuttoff : bool, optional
+    same_cutoff : bool, optional
         If it's True all series will end at the same date, by default True
     n_columns : int, optional
         number of columns in the output dataframe, by default 1
@@ -71,7 +71,7 @@ def _make_hierachical(
         df_list = []
         for levels_tuple in product(*levels):
             n_timepoints = rng.randint(low=min_timepoints, high=max_timepoints)
-            if same_cuttoff:
+            if same_cutoff:
                 time_index = _make_index(max_timepoints, index_type)[-n_timepoints:]
             else:
                 time_index = _make_index(n_timepoints, index_type)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #2192.


#### What does this implement/fix? Explain your changes.
Renamed three occurrences of the typo `same_cuttoff` in `_make_hierachical`, and one in a docstring of `test_oh_setting`.

I could not find any other occurrences in the code base (`grep -rn '.' -e 'cuttoff'`).

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [x] I've added unit tests and made sure they pass locally.