### PR TITLE
[ENH] sklearn typing util

### DIFF
--- a/sktime/utils/sklearn.py
+++ b/sktime/utils/sklearn.py
@@ -65,6 +65,6 @@ def sklearn_scitype(obj, var_name="obj"):
     if issubclass(obj, sklearn_mixins):
         for mx in sklearn_mixins:
             if issubclass(obj, mx):
-                return mixin_to_scitype(mx)
+                return mixin_to_scitype[mx]
     else:
         return "estimator"

--- a/sktime/utils/sklearn.py
+++ b/sktime/utils/sklearn.py
@@ -21,8 +21,8 @@ def is_sklearn_estimator(obj):
     -------
     is_sklearn_est : bool, whether obj is an sklearn estimator
     """
-    is_in_sklearn = isinstance(obj, SklearnBaseEstimator)
-    is_in_sktime = not isinstance(obj, BaseObject)
+    is_in_sklearn = issubclass(obj, SklearnBaseEstimator)
+    is_in_sktime = not issubclass(obj, BaseObject)
 
     is_sklearn_est = is_in_sklearn and not is_in_sktime
     return is_sklearn_est
@@ -62,9 +62,9 @@ def sklearn_scitype(obj, var_name="obj"):
 
     sklearn_mixins = tuple(mixin_to_scitype.keys())
 
-    if isinstance(obj, sklearn_mixins):
+    if issubclass(obj, sklearn_mixins):
         for mx in sklearn_mixins:
-            if isinstance(obj, mx):
+            if issubclass(obj, mx):
                 return mixin_to_scitype(mx)
     else:
         return "estimator"

--- a/sktime/utils/sklearn.py
+++ b/sktime/utils/sklearn.py
@@ -4,8 +4,8 @@
 
 from sklearn.base import BaseEstimator as SklearnBaseEstimator
 from sklearn.base import ClassifierMixin, ClusterMixin, RegressorMixin, TransformerMixin
-from sktime.base import BaseObject
 
+from sktime.base import BaseObject
 
 __author__ = ["fkiraly"]
 

--- a/sktime/utils/sklearn.py
+++ b/sktime/utils/sklearn.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""Sklearn related typing and inheritance checking utility."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+from sklearn.base import BaseEstimator as SklearnBaseEstimator
+from sklearn.base import ClassifierMixin, ClusterMixin, RegressorMixin, TransformerMixin
+from sktime.base import BaseObject
+
+
+__author__ = ["fkiraly"]
+
+
+def is_sklearn_estimator(obj):
+    """Check whether obj is an sklearn estimator.
+
+    Parameters
+    ----------
+    obj : any object
+
+    Returns
+    -------
+    is_sklearn_est : bool, whether obj is an sklearn estimator
+    """
+    is_in_sklearn = isinstance(obj, SklearnBaseEstimator)
+    is_in_sktime = not isinstance(obj, BaseObject)
+
+    is_sklearn_est = is_in_sklearn and not is_in_sktime
+    return is_sklearn_est
+
+
+mixin_to_scitype = {
+    ClassifierMixin: "classifier",
+    ClusterMixin: "clusterer",
+    RegressorMixin: "regressor",
+    TransformerMixin: "transformer",
+}
+
+
+def sklearn_scitype(obj, var_name="obj"):
+    """Return sklearn scitype.
+
+    Parameters
+    ----------
+    obj : any object
+    var_name : str, optional, default = "obj"
+        name of variable (obj) to display in error message
+
+    Returns
+    -------
+    str, sklearn scitype inferred, one of
+        "classifier" - supervised classifier
+        "clusterer" - unsupervised clusterer
+        "regressor" - supervised regressor
+        "transformer" - transformer (pipeline element, feature extractor, unsupervised)
+
+    Raises
+    ------
+    TypeError if obj is not an sklearn estimator, according to is_sklearn_estimator
+    """
+    if not is_sklearn_estimator(obj):
+        raise TypeError(f"{var_name} is not an sklearn estimator, has type {type(obj)}")
+
+    sklearn_mixins = tuple(mixin_to_scitype.keys())
+
+    if isinstance(obj, sklearn_mixins):
+        for mx in sklearn_mixins:
+            if isinstance(obj, mx):
+                return mixin_to_scitype(mx)
+    else:
+        return "estimator"

--- a/sktime/utils/sklearn.py
+++ b/sktime/utils/sklearn.py
@@ -2,6 +2,7 @@
 """Sklearn related typing and inheritance checking utility."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
+from inspect import isclass
 from sklearn.base import BaseEstimator as SklearnBaseEstimator
 from sklearn.base import ClassifierMixin, ClusterMixin, RegressorMixin, TransformerMixin
 
@@ -15,12 +16,15 @@ def is_sklearn_estimator(obj):
 
     Parameters
     ----------
-    obj : any object
+    obj : any class or object
 
     Returns
     -------
-    is_sklearn_est : bool, whether obj is an sklearn estimator
+    is_sklearn_est : bool, whether obj is an sklearn estimator (class or instance)
     """
+    if not isclass(obj):
+        obj = type(obj)
+
     is_in_sklearn = issubclass(obj, SklearnBaseEstimator)
     is_in_sktime = issubclass(obj, BaseObject)
 
@@ -41,13 +45,13 @@ def sklearn_scitype(obj, var_name="obj"):
 
     Parameters
     ----------
-    obj : any object
+    obj : any class or object
     var_name : str, optional, default = "obj"
         name of variable (obj) to display in error message
 
     Returns
     -------
-    str, sklearn scitype inferred, one of
+    str, the sklearn scitype of obj, inferred from inheritance tree, one of
         "classifier" - supervised classifier
         "clusterer" - unsupervised clusterer
         "regressor" - supervised regressor
@@ -57,6 +61,9 @@ def sklearn_scitype(obj, var_name="obj"):
     ------
     TypeError if obj is not an sklearn estimator, according to is_sklearn_estimator
     """
+    if not isclass(obj):
+        obj = type(obj)
+
     if not is_sklearn_estimator(obj):
         raise TypeError(f"{var_name} is not an sklearn estimator, has type {type(obj)}")
 

--- a/sktime/utils/sklearn.py
+++ b/sktime/utils/sklearn.py
@@ -68,3 +68,59 @@ def sklearn_scitype(obj, var_name="obj"):
                 return mixin_to_scitype[mx]
     else:
         return "estimator"
+
+
+def is_sklearn_transformer(obj):
+    """Check whether obj is an sklearn transformer.
+
+    Parameters
+    ----------
+    obj : any object
+
+    Returns
+    -------
+    bool, whether obj is an sklearn transformer
+    """
+    return is_sklearn_estimator(obj) and sklearn_scitype(obj) == "transformer"
+
+
+def is_sklearn_classifier(obj):
+    """Check whether obj is an sklearn classifier.
+
+    Parameters
+    ----------
+    obj : any object
+
+    Returns
+    -------
+    bool, whether obj is an sklearn classifier
+    """
+    return is_sklearn_estimator(obj) and sklearn_scitype(obj) == "classifier"
+
+
+def is_sklearn_regressor(obj):
+    """Check whether obj is an sklearn regressor.
+
+    Parameters
+    ----------
+    obj : any object
+
+    Returns
+    -------
+    bool, whether obj is an sklearn regressor
+    """
+    return is_sklearn_estimator(obj) and sklearn_scitype(obj) == "regressor"
+
+
+def is_sklearn_clusterer(obj):
+    """Check whether obj is an sklearn clusterer.
+
+    Parameters
+    ----------
+    obj : any object
+
+    Returns
+    -------
+    bool, whether obj is an sklearn clusterer
+    """
+    return is_sklearn_estimator(obj) and sklearn_scitype(obj) == "clusterer"

--- a/sktime/utils/sklearn.py
+++ b/sktime/utils/sklearn.py
@@ -3,6 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 from inspect import isclass
+
 from sklearn.base import BaseEstimator as SklearnBaseEstimator
 from sklearn.base import ClassifierMixin, ClusterMixin, RegressorMixin, TransformerMixin
 

--- a/sktime/utils/sklearn.py
+++ b/sktime/utils/sklearn.py
@@ -22,7 +22,7 @@ def is_sklearn_estimator(obj):
     is_sklearn_est : bool, whether obj is an sklearn estimator
     """
     is_in_sklearn = issubclass(obj, SklearnBaseEstimator)
-    is_in_sktime = not issubclass(obj, BaseObject)
+    is_in_sktime = issubclass(obj, BaseObject)
 
     is_sklearn_est = is_in_sklearn and not is_in_sktime
     return is_sklearn_est

--- a/sktime/utils/tests/test_sklearn_typing.py
+++ b/sktime/utils/tests/test_sklearn_typing.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""Tests for sklearn typing utilities in utils.sktime."""
+
+__author__ = ["fkiraly"]
+
+
+import pytest
+
+from sklearn.cluster import KMeans
+from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+from sklearn.preprocessing import StandardScaler
+
+from sktime.classification.feature_based import SummaryClassifier
+from sktime.forecasting.naive import NaiveForecaster
+from sktime.utils.sklearn import is_sklearn_estimator, sklearn_scitype
+
+CORRECT_SCITYPES = {
+    KMeans: "clusterer",
+    KNeighborsClassifier: "classifier",
+    KNeighborsRegressor: "regressor",
+    StandardScaler: "transformer",
+}
+
+sklearn_estimators = list(CORRECT_SCITYPES.keys())
+sktime_estimators = [SummaryClassifier, NaiveForecaster]
+
+
+@pytest.mark.parametrize("estimator", sklearn_estimators)
+def test_is_sklearn_estimator_positive(estimator):
+    """Test that is_sklearn_estimator recognizes positive examples correctly."""
+    msg = (
+        f"is_sklearn_estimator incorrectly considers {estimator.__name__} "
+        f"as not an sklearn estimator (output False), but output should be True"
+    )
+    assert is_sklearn_estimator(estimator), msg
+
+
+@pytest.mark.parametrize("estimator", sktime_estimators)
+def test_is_sklearn_estimator_negative(estimator):
+    """Test that is_sklearn_estimator recognizes negative examples correctly."""
+    msg = (
+        f"is_sklearn_estimator incorrectly considers {estimator.__name__} "
+        f"as an sklearn estimator (output True), but output should be False"
+    )
+    assert is_sklearn_estimator(estimator), msg
+
+
+@pytest.mark.parametrize("estimator", sklearn_estimators)
+def test_sklearn_scitype(estimator):
+    """Test that sklearn_scitype returns the correct scitype string."""
+    scitype = sklearn_scitype(estimator)
+    expected_scitype = CORRECT_SCITYPES[estimator]
+    msg = (
+        f"is_sklearn_estimator returns the incorrect scitype string for "
+        f'"{estimator.__name__}". Should be {expected_scitype}, but '
+        f'{scitype}" was returned.'
+    )
+    assert scitype == expected_scitype, msg

--- a/sktime/utils/tests/test_sklearn_typing.py
+++ b/sktime/utils/tests/test_sklearn_typing.py
@@ -5,7 +5,6 @@ __author__ = ["fkiraly"]
 
 
 import pytest
-
 from sklearn.cluster import KMeans
 from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 from sklearn.preprocessing import StandardScaler

--- a/sktime/utils/tests/test_sklearn_typing.py
+++ b/sktime/utils/tests/test_sklearn_typing.py
@@ -41,7 +41,7 @@ def test_is_sklearn_estimator_negative(estimator):
         f"is_sklearn_estimator incorrectly considers {estimator.__name__} "
         f"as an sklearn estimator (output True), but output should be False"
     )
-    assert is_sklearn_estimator(estimator), msg
+    assert not is_sklearn_estimator(estimator), msg
 
 
 @pytest.mark.parametrize("estimator", sklearn_estimators)


### PR DESCRIPTION
This PR contains the following typing utilities related to sklearn:
* a function `is_sklearn_estimator` which returns True/False whether the argument is an `sklearn` estimator.
* a function `sklearn_scitype` which returns a string (`"classifier"`, `"regressor"` etc) denoting the scitype of the estimator.
* four shorthances `is_sklearn_classifier`, for `is_sklearn_estimator` logical-and `sklearn_scitype` equal to certain scitype.

This can be used in type checking, as `sklearn_scitype` is closer to the use of `type`, and avoids `sklearn` imports of mixin classes.

Note: the logic is intentionally different from `sklearn.base.is_classifier` etc, as that assumes certain attributes to be set. The functions above do *not* assume that the argument is an `sklearn` estimator, and they check sub-class membership only.