### PR TITLE
[ENH] Tabular transformer adaptor "fit in transform" parameter

### DIFF
--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -70,8 +70,8 @@ class TabularToSeriesAdaptor(BaseTransformer):
         Transformer that is fitted to data, clone of transformer.
     fit_in_transform: bool, optional, default=False
         whether transformer_ should be fitted in transform (True), or in fit (False)
-            recommended setting for forecasting (single series or hierarchical): False
-            recommended setting for ts classification, regression, clustering: True
+            recommended setting in forecasting (single series or hierarchical): False
+            recommended setting in ts classification, regression, clustering: True
 
     Examples
     --------

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -70,6 +70,8 @@ class TabularToSeriesAdaptor(BaseTransformer):
         Transformer that is fitted to data, clone of transformer.
     fit_in_transform: bool, optional, default=False
         whether transformer_ should be fitted in transform (True), or in fit (False)
+            recommended setting for forecasting (single series or hierarchical): False
+            recommended setting for ts classification, regression, clustering: True
 
     Examples
     --------

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -157,7 +157,7 @@ class TabularToSeriesAdaptor(BaseTransformer):
         """
         from sklearn.preprocessing import StandardScaler
 
-        params1 = {"transformer": StandardScaler()}
+        params1 = {"transformer": StandardScaler(), "fit_in_transform": False}
         params2 = {"transformer": StandardScaler(), "fit_in_transform": True}
 
         return [params1, params2]


### PR DESCRIPTION
This PR adds a boolean parameter `fit_in_transform` to `TabularToSeriesAdaptor`.
This lets a user choose whether `fit` is mapped on `fit`, or whether it is executed in `transform`.
The default setting defaults to `False`, which is the current behaviour, ensuring downwards compatibility.

The reason for that is as follows:
* when used in forecasting or on a single series, the most common use is usually `fit_in_transform=False`.
* when used in TSC or TSR, on a panel, the most common (intended) use is usually `fit_in_transform=True`, since the test indices/instances are usually considered distinct from the training indices/instances. Otherwise, the automatic vectorization from the base class will consider train and test indices identical, and refuse to `transform` if number or set of indices is different between train/test.

Minor changes:
* docstring for `TabularToSeriesAdaptor` has been extended with a more formal description to clarify behaviour.