### PR TITLE
[ENH] unit tests for `deep_equals` utility

### DIFF
--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -15,8 +15,6 @@ __all__ = ["deep_equals"]
 import numpy as np
 import pandas as pd
 
-# from sktime.base import BaseObject
-
 
 def deep_equals(x, y, return_msg=False):
     """Test two objects for equality in value.

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -114,6 +114,8 @@ def deep_equals(x, y, return_msg=False):
         return ret(*_tuple_equals(x, y, return_msg=True))
     elif isinstance(x, dict):
         return ret(*_dict_equals(x, y, return_msg=True))
+    elif type(x).__name__ == "ForecastingHorizon":
+        return ret(*_fh_equals(x, y, return_msg=True))
     elif x != y:
         return ret(False, f" !=, {x} != {y}")
 
@@ -228,5 +230,47 @@ def _dict_equals(x, y, return_msg=False):
         is_equal, msg = deep_equals(xi, yi, return_msg=True)
         if not is_equal:
             return ret(False, f"[{key}]" + msg)
+
+    return ret(True, "")
+
+
+def _fh_equals(x, y, return_msg=False):
+    """Test two forecasting horizons for equality.
+
+    Correct if both x and y are ForecastingHorizon
+
+    Parameters
+    ----------
+    x: ForcastingHorizon
+    y: ForcastingHorizon
+    return_msg : bool, optional, default=False
+        whether to return informative message about what is not equal
+
+    Returns
+    -------
+    is_equal: bool - True if x and y are equal in value
+        x and y do not need to be equal in reference
+    msg : str, only returned if return_msg = True
+        indication of what is the reason for not being equal
+            concatenation of the following strings:
+            .is_relative - x is absolute and y is relative, or vice versa
+            .values - values of x and y are not equal
+    """
+
+    def ret(is_equal, msg):
+        if return_msg:
+            if is_equal:
+                msg = ""
+            return is_equal, msg
+        else:
+            return is_equal
+
+    if x.is_relative != y.is_relative:
+        return ret(False, ".is_relative")
+
+    # recurse through values of x, y
+    is_equal, msg = deep_equals(x._values, y._values, return_msg=True)
+    if not is_equal:
+        return ret(False, ".values" + msg)
 
     return ret(True, "")

--- a/sktime/utils/_testing/tests/test_deep_equals.py
+++ b/sktime/utils/_testing/tests/test_deep_equals.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Tests for deep_equals utility."""
+import pytest
+
+import pandas as pd
+import numpy as np
+
+from copy import deepcopy
+
+from sktime.forecasting.base import ForecastingHorizon
+from sktime.utils._testing.deep_equals import deep_equals
+
+
+# examples used for comparison below
+EXAMPLES = [
+    42,
+    [],
+    ((((())))),
+    [([([([()])])])],
+    np.array([2, 3, 4]),
+    np.array([2, 4, 5]),
+    pd.DataFrame({"a": [4, 2]}),
+    pd.DataFrame({"a": [4, 3]}),
+    (np.array([1, 2, 4]), [pd.DataFrame({"a": [4, 2]})]),
+    ForecastingHorizon([1, 2, 3], is_relative=True),
+    ForecastingHorizon([1, 2, 3], is_relative=False),
+    {"foo": [42], "bar": pd.Series([1, 2])},
+    {"bar": [42], "foo": pd.Series([1, 2])},
+]
+
+
+@pytest.mark.parametrize("fixture", EXAMPLES)
+def test_deep_equals_positive(fixture):
+    """Tests that deep_equals correctly identifies equal objects as equal."""
+    x = deepcopy(fixture)
+    y = deepcopy(fixture)
+
+    msg = (
+        f"deep_copy incorrectly returned False for two copies of "
+        f"the following object: {x}"
+    )
+    assert deep_equals(x, y), msg
+
+
+@pytest.mark.parametrize("fixture1", EXAMPLES)
+@pytest.mark.parametrize("fixture2", EXAMPLES)
+def test_deep_equals_negative(fixture1, fixture2):
+    """Tests that deep_equals correctly identifies unequal objects as unequal."""
+    x = deepcopy(fixture1)
+    y = deepcopy(fixture2)
+
+    msg = (
+        f"deep_copy incorrectly returned True when comparing "
+        f"the following different objects: x={x}, y={y}"
+    )
+    assert not deep_equals(x, y), msg

--- a/sktime/utils/_testing/tests/test_deep_equals.py
+++ b/sktime/utils/_testing/tests/test_deep_equals.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 """Tests for deep_equals utility."""
-import pytest
-
-import pandas as pd
-import numpy as np
-
 from copy import deepcopy
+
+import numpy as np
+import pandas as pd
+import pytest
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.utils._testing.deep_equals import deep_equals
-
 
 # examples used for comparison below
 EXAMPLES = [

--- a/sktime/utils/_testing/tests/test_deep_equals.py
+++ b/sktime/utils/_testing/tests/test_deep_equals.py
@@ -36,7 +36,7 @@ def test_deep_equals_positive(fixture):
     y = deepcopy(fixture)
 
     msg = (
-        f"deep_copy incorrectly returned False for two copies of "
+        f"deep_copy incorrectly returned False for two identical copies of "
         f"the following object: {x}"
     )
     assert deep_equals(x, y), msg
@@ -51,6 +51,6 @@ def test_deep_equals_negative(fixture1, fixture2):
 
     msg = (
         f"deep_copy incorrectly returned True when comparing "
-        f"the following different objects: x={x}, y={y}"
+        f"the following, different objects: x={x}, y={y}"
     )
     assert not deep_equals(x, y), msg

--- a/sktime/utils/_testing/tests/test_deep_equals.py
+++ b/sktime/utils/_testing/tests/test_deep_equals.py
@@ -42,8 +42,13 @@ def test_deep_equals_positive(fixture):
     assert deep_equals(x, y), msg
 
 
-@pytest.mark.parametrize("fixture1", EXAMPLES)
-@pytest.mark.parametrize("fixture2", EXAMPLES)
+n = len(EXAMPLES)
+DIFFERENT_PAIRS = [
+    (EXAMPLES[i], EXAMPLES[j]) for i in range(n) for j in range(n) if i != j
+]
+
+
+@pytest.mark.parametrize("fixture1,fixture2", DIFFERENT_PAIRS)
 def test_deep_equals_negative(fixture1, fixture2):
     """Tests that deep_equals correctly identifies unequal objects as unequal."""
     x = deepcopy(fixture1)


### PR DESCRIPTION
This PR adds unit tests for the `deep_equals` utility which were not present so far.
Includes #2555 (`ForecastingHorizon` compatibility).