### PR TITLE
[MNT] Faster docstring examples - `ForecastingGridSearchCV`, `MultiplexForecaster`

### DIFF
--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -64,14 +64,14 @@ class MultiplexForecaster(_HeterogenousEnsembleForecaster):
     ...     ForecastingGridSearchCV,
     ...     ExpandingWindowSplitter,
     ...     load_airline)
-    >>> y = load_airline()
+    >>> y = load_airline()[0:24]
     >>> forecaster = MultiplexForecaster(forecasters=[
     ...     ("ets", AutoETS()),
     ...     ("arima", AutoARIMA(suppress_warnings=True, seasonal=False)),
     ...     ("naive", NaiveForecaster())])
     >>> cv = ExpandingWindowSplitter(
     ...     start_with_window=True,
-    ...     step_length=24)
+    ...     step_length=12)
     >>> gscv = ForecastingGridSearchCV(
     ...     cv=cv,
     ...     param_grid={"selected_forecaster":["ets", "arima", "naive"]},

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -63,8 +63,8 @@ class MultiplexForecaster(_HeterogenousEnsembleForecaster):
     ...     NaiveForecaster,
     ...     ForecastingGridSearchCV,
     ...     ExpandingWindowSplitter,
-    ...     load_airline)
-    >>> y = load_airline()[0:24]
+    ...     load_shampoo_sales)
+    >>> y = load_shampoo_sales()
     >>> forecaster = MultiplexForecaster(forecasters=[
     ...     ("ets", AutoETS()),
     ...     ("arima", AutoARIMA(suppress_warnings=True, seasonal=False)),

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -375,7 +375,7 @@ class ForecastingGridSearchCV(BaseGridSearch):
     ...     ForecastingGridSearchCV,
     ...     ExpandingWindowSplitter)
     >>> from sktime.forecasting.naive import NaiveForecaster
-    >>> y = load_airline()
+    >>> y = load_airline()[0:36]
     >>> fh = [1,2,3]
     >>> cv = ExpandingWindowSplitter(
     ...     start_with_window=True,
@@ -400,12 +400,12 @@ class ForecastingGridSearchCV(BaseGridSearch):
     >>> from sktime.forecasting.compose import TransformedTargetForecaster
     >>> from sktime.forecasting.theta import ThetaForecaster
     >>> from sktime.transformations.series.impute import Imputer
-    >>> y = load_airline()
+    >>> y = load_airline()[0:36]
     >>> pipe = TransformedTargetForecaster(steps=[
     ...     ("imputer", Imputer()),
     ...     ("forecaster", NaiveForecaster())])
     >>> cv = ExpandingWindowSplitter(
-    ...     initial_window=48,
+    ...     initial_window=24,
     ...     step_length=12,
     ...     start_with_window=True,
     ...     fh=[1,2,3])

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -369,13 +369,13 @@ class ForecastingGridSearchCV(BaseGridSearch):
 
     Examples
     --------
-    >>> from sktime.datasets import load_airline
+    >>> from sktime.datasets import load_shampoo_sales
     >>> from sktime.forecasting.model_selection import (
     ...     ExpandingWindowSplitter,
     ...     ForecastingGridSearchCV,
     ...     ExpandingWindowSplitter)
     >>> from sktime.forecasting.naive import NaiveForecaster
-    >>> y = load_airline()[0:36]
+    >>> y = load_shampoo_sales()
     >>> fh = [1,2,3]
     >>> cv = ExpandingWindowSplitter(
     ...     start_with_window=True,
@@ -392,7 +392,7 @@ class ForecastingGridSearchCV(BaseGridSearch):
 
         Advanced model meta-tuning (model selection) with multiple forecasters
         together with hyper-parametertuning at same time using sklearn notation:
-    >>> from sktime.datasets import load_airline
+    >>> from sktime.datasets import load_shampoo_sales
     >>> from sktime.forecasting.exp_smoothing import ExponentialSmoothing
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.forecasting.model_selection import ExpandingWindowSplitter
@@ -400,7 +400,7 @@ class ForecastingGridSearchCV(BaseGridSearch):
     >>> from sktime.forecasting.compose import TransformedTargetForecaster
     >>> from sktime.forecasting.theta import ThetaForecaster
     >>> from sktime.transformations.series.impute import Imputer
-    >>> y = load_airline()[0:36]
+    >>> y = load_shampoo_sales()
     >>> pipe = TransformedTargetForecaster(steps=[
     ...     ("imputer", Imputer()),
     ...     ("forecaster", NaiveForecaster())])


### PR DESCRIPTION
This PR speeds up the two slowest docstring examples by reducing the size of data sets in those examples:
`ForecastingGridSearchCV` and `MultiplexForecaster`. This saves ca 60-90sec in testing (according to CI/CD and local timings).
