### PR TITLE
[BUG] fixed ignores-exogeneous-X tag for forecasting reducers

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -138,6 +138,8 @@ def _sliding_window_transform(
 class _Reducer(_BaseWindowForecaster):
     """Base class for reducing forecasting to regression."""
 
+    _tags = {"ignores-exogeneous-X": False} # reduction uses X in non-trivial way
+
     _required_parameters = ["estimator"]
 
     def __init__(self, estimator, window_length=10):

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -138,7 +138,7 @@ def _sliding_window_transform(
 class _Reducer(_BaseWindowForecaster):
     """Base class for reducing forecasting to regression."""
 
-    _tags = {"ignores-exogeneous-X": False} # reduction uses X in non-trivial way
+    _tags = {"ignores-exogeneous-X": False}  # reduction uses X in non-trivial way
 
     _required_parameters = ["estimator"]
 


### PR DESCRIPTION
This PR fixes the `ignores-exogeneous-X` for reducers which seems to have been set incorrectly - it should be `False` since the `X` argument is being used in a non-trivial way, internally.

See https://github.com/alan-turing-institute/sktime/discussions/2184

FYI @ngupta23.