### PR TITLE
[ENH] Skipping basic motions in classifier tests

### DIFF
--- a/sktime/classification/compose/_column_ensemble.py
+++ b/sktime/classification/compose/_column_ensemble.py
@@ -223,9 +223,9 @@ class ColumnEnsembleClassifier(BaseColumnEnsembleClassifier):
     Examples
     --------
     >>> from sktime.classification.interval_based import DrCIF
-    >>> from sktime.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train")
-    >>> X_test, y_test = load_unit_test(split="test")
+    >>> from sktime.datasets import load_basic_motions
+    >>> X_train, y_train = load_basic_motions(split="train")
+    >>> X_test, y_test = load_basic_motions(split="test")
     >>> clf = DrCIF(n_estimators=3)
     >>> estimators = [("DrCIF", clf, [0, 1])]
     >>> col_ens = ColumnEnsembleClassifier(estimators=estimators)

--- a/sktime/classification/compose/_column_ensemble.py
+++ b/sktime/classification/compose/_column_ensemble.py
@@ -223,9 +223,9 @@ class ColumnEnsembleClassifier(BaseColumnEnsembleClassifier):
     Examples
     --------
     >>> from sktime.classification.interval_based import DrCIF
-    >>> from sktime.datasets import load_basic_motions
-    >>> X_train, y_train = load_basic_motions(split="train")
-    >>> X_test, y_test = load_basic_motions(split="test")
+    >>> from sktime.datasets import load_unit_test
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = DrCIF(n_estimators=3)
     >>> estimators = [("DrCIF", clf, [0, 1])]
     >>> col_ens = ColumnEnsembleClassifier(estimators=estimators)

--- a/sktime/classification/compose/tests/test_column_ensemble.py
+++ b/sktime/classification/compose/tests/test_column_ensemble.py
@@ -2,9 +2,8 @@
 """Column ensemble test code."""
 __author__ = ["TonyBagnall"]
 
-import pytest
-
 import numpy as np
+import pytest
 from numpy import testing
 
 from sktime.classification.compose import ColumnEnsembleClassifier

--- a/sktime/classification/compose/tests/test_column_ensemble.py
+++ b/sktime/classification/compose/tests/test_column_ensemble.py
@@ -2,6 +2,7 @@
 """Column ensemble test code."""
 __author__ = ["TonyBagnall"]
 
+import pytest
 
 import numpy as np
 from numpy import testing
@@ -12,6 +13,7 @@ from sktime.classification.interval_based import DrCIF
 from sktime.datasets import load_basic_motions, load_unit_test
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_col_ens_on_basic_motions():
     """Test of ColumnEnsembleClassifier on basic motions data."""
     # load basic motions data

--- a/sktime/classification/dictionary_based/tests/test_muse.py
+++ b/sktime/classification/dictionary_based/tests/test_muse.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """MUSE test code."""
 
-import pytest
-
 import numpy as np
+import pytest
 from numpy import testing
 
 from sktime.classification.dictionary_based import MUSE

--- a/sktime/classification/dictionary_based/tests/test_muse.py
+++ b/sktime/classification/dictionary_based/tests/test_muse.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """MUSE test code."""
 
+import pytest
+
 import numpy as np
 from numpy import testing
 
@@ -24,6 +26,7 @@ def test_muse_on_unit_test_data():
     testing.assert_array_almost_equal(probas, muse_unit_test_probas, decimal=2)
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_muse_on_basic_motions():
     """Test MUSE on basic motions data."""
     # load basic motions data

--- a/sktime/classification/dictionary_based/tests/test_tde.py
+++ b/sktime/classification/dictionary_based/tests/test_tde.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """TDE test code."""
+import pytest
+
 import numpy as np
 from numpy import testing
 from sklearn.metrics import accuracy_score
@@ -58,6 +60,7 @@ def test_contracted_tde_on_unit_test_data():
     assert len(tde.estimators_) > 1
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_tde_on_basic_motions():
     """Test of TDE on basic motions data."""
     # load basic motions data

--- a/sktime/classification/dictionary_based/tests/test_tde.py
+++ b/sktime/classification/dictionary_based/tests/test_tde.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """TDE test code."""
-import pytest
-
 import numpy as np
+import pytest
 from numpy import testing
 from sklearn.metrics import accuracy_score
 

--- a/sktime/classification/feature_based/tests/test_catch22_classifier.py
+++ b/sktime/classification/feature_based/tests/test_catch22_classifier.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Catch22Classifier test code."""
+import pytest
+
 import numpy as np
 from numpy import testing
 from sklearn.ensemble import RandomForestClassifier
@@ -30,6 +32,7 @@ def test_catch22_classifier_on_unit_test_data():
     )
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_catch22_classifier_on_basic_motions():
     """Test of Catch22Classifier on basic motions."""
     # load basic motions data

--- a/sktime/classification/feature_based/tests/test_catch22_classifier.py
+++ b/sktime/classification/feature_based/tests/test_catch22_classifier.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Catch22Classifier test code."""
-import pytest
-
 import numpy as np
+import pytest
 from numpy import testing
 from sklearn.ensemble import RandomForestClassifier
 

--- a/sktime/classification/feature_based/tests/test_random_interval_classifier.py
+++ b/sktime/classification/feature_based/tests/test_random_interval_classifier.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """RandomIntervalClassifier test code."""
+import pytest
+
 import numpy as np
 from numpy import testing
 from sklearn.ensemble import RandomForestClassifier
@@ -35,6 +37,7 @@ def test_random_interval_classifier_on_unit_test_data():
     )
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_random_interval_classifier_on_basic_motions():
     """Test of RandomIntervalClassifier on basic motions."""
     # load basic motions data

--- a/sktime/classification/feature_based/tests/test_random_interval_classifier.py
+++ b/sktime/classification/feature_based/tests/test_random_interval_classifier.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """RandomIntervalClassifier test code."""
-import pytest
-
 import numpy as np
+import pytest
 from numpy import testing
 from sklearn.ensemble import RandomForestClassifier
 

--- a/sktime/classification/feature_based/tests/test_signature_classifier.py
+++ b/sktime/classification/feature_based/tests/test_signature_classifier.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """SignatureClassifier test code."""
+import pytest
+
 import numpy as np
 from numpy import testing
 from sklearn.ensemble import RandomForestClassifier
@@ -28,6 +30,7 @@ def test_signatures_on_unit_test_data():
     )
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_signature_classifier_on_basic_motions():
     """Test of SignatureClassifier on basic motions."""
     # load basic motions data

--- a/sktime/classification/feature_based/tests/test_signature_classifier.py
+++ b/sktime/classification/feature_based/tests/test_signature_classifier.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """SignatureClassifier test code."""
-import pytest
-
 import numpy as np
+import pytest
 from numpy import testing
 from sklearn.ensemble import RandomForestClassifier
 

--- a/sktime/classification/feature_based/tests/test_summary_classifier.py
+++ b/sktime/classification/feature_based/tests/test_summary_classifier.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """SummaryClassifier test code."""
 import numpy as np
+import pytest
 from numpy import testing
 from sklearn.ensemble import RandomForestClassifier
 
@@ -28,6 +29,7 @@ def test_summary_classifier_on_unit_test_data():
     )
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_summary_classifier_on_basic_motions():
     """Test of SummaryClassifier on basic motions."""
     # load basic motions data

--- a/sktime/classification/feature_based/tests/test_tsfresh_classifier.py
+++ b/sktime/classification/feature_based/tests/test_tsfresh_classifier.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """TSFreshClassifier test code."""
 import numpy as np
+import pytest
 from sklearn.ensemble import RandomForestClassifier
 
 from sktime.classification.feature_based._tsfresh_classifier import TSFreshClassifier
@@ -32,6 +33,7 @@ def test_tsfresh_classifier_on_unit_test_data():
     # )
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_tsfresh_classifier_on_basic_motions():
     """Test of TSFreshClassifier on basic motions."""
     # load basic motions data

--- a/sktime/classification/hybrid/tests/test_hivecote_v2.py
+++ b/sktime/classification/hybrid/tests/test_hivecote_v2.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """HIVE-COTE v2 test code."""
 import numpy as np
+import pytest
 from numpy import testing
 from sklearn.ensemble import RandomForestClassifier
 
@@ -65,6 +66,7 @@ def test_contracted_hivecote_v2_on_unit_test_data():
     hc2.fit(X_train, y_train)
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_hivecote_v2_on_basic_motions():
     """Test of HIVEVOTEV2 on basic motions data."""
     # load basic motions data

--- a/sktime/classification/interval_based/tests/test_cif.py
+++ b/sktime/classification/interval_based/tests/test_cif.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """CanonicalIntervalForest test code."""
 import numpy as np
+import pytest
 from numpy import testing
 
 from sktime.classification.interval_based import CanonicalIntervalForest
@@ -37,6 +38,7 @@ def test_dtc_on_unit_test_data():
     cif.predict_proba(X_test.iloc[indices])
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_cif_on_basic_motions():
     """Test of CanonicalIntervalForest on basic motions data."""
     # load basic motions data

--- a/sktime/classification/interval_based/tests/test_drcif.py
+++ b/sktime/classification/interval_based/tests/test_drcif.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """DrCIF test code."""
 import numpy as np
+import pytest
 from numpy import testing
 from sklearn.metrics import accuracy_score
 
@@ -45,6 +46,7 @@ def test_contracted_drcif_on_unit_test_data():
     assert len(drcif.estimators_) > 1
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_drcif_on_basic_motions():
     """Test of DrCIF on basic motions data."""
     # load basic motions data

--- a/sktime/classification/kernel_based/tests/test_arsenal.py
+++ b/sktime/classification/kernel_based/tests/test_arsenal.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Arsenal test code."""
 import numpy as np
+import pytest
 from numpy import testing
 from sklearn.metrics import accuracy_score
 
@@ -48,6 +49,7 @@ def test_contracted_arsenal_on_unit_test_data():
     assert len(arsenal.estimators_) > 1
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_arsenal_on_basic_motions():
     """Test of Arsenal on basic motions data."""
     # load basic motions data

--- a/sktime/classification/kernel_based/tests/test_rocket_classifier.py
+++ b/sktime/classification/kernel_based/tests/test_rocket_classifier.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """RocketClassifier test code."""
 import numpy as np
+import pytest
 from numpy import testing
 
 from sktime.classification.kernel_based import RocketClassifier
@@ -23,6 +24,7 @@ def test_rocket_on_unit_test_data():
     testing.assert_array_almost_equal(probas, rocket_unit_test_probas, decimal=2)
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_rocket_on_basic_motions():
     """Test of RocketClassifier on basic motions."""
     # load basic motions data

--- a/sktime/classification/shapelet_based/tests/test_stc.py
+++ b/sktime/classification/shapelet_based/tests/test_stc.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """ShapeletTransformClassifier test code."""
 import numpy as np
+import pytest
 from numpy import testing
 from sklearn.metrics import accuracy_score
 
@@ -54,6 +55,7 @@ def test_contracted_stc_on_unit_test_data():
     stc.fit(X_train, y_train)
 
 
+@pytest.mark.skip(reason="skipped due to high runtime")
 def test_stc_on_basic_motions():
     """Test of ShapeletTransformClassifier on basic motions data."""
     # load basic motions data


### PR DESCRIPTION
This PR skips all tests of classifiers the "basic motions" dataset.
For validity checking, this is redundant with the "unit test" dataset, and incurs a large amount of compute due to the size of the "basic motions" dataset.