### PR TITLE
[BUG] fixing `STLBootstrapTransformer` error message and docstrings

### DIFF
--- a/sktime/transformations/bootstrap/_mbb.py
+++ b/sktime/transformations/bootstrap/_mbb.py
@@ -248,9 +248,14 @@ class STLBootstrapTransformer(BaseTransformer):
         -------
         self: reference to self
         """
-        if self.sp <= 2:
+        if self.sp <= 1:
             raise NotImplementedError(
                 "STLBootstrapTransformer does not support non-seasonal data"
+            )
+
+        if not isinstance(self.sp, int):
+            raise ValueError(
+                "sp parameter of STLBootstrapTransformer must be an integer"
             )
 
         if len(X) <= self.sp:

--- a/sktime/transformations/bootstrap/_mbb.py
+++ b/sktime/transformations/bootstrap/_mbb.py
@@ -295,7 +295,7 @@ class STLBootstrapTransformer(BaseTransformer):
         if len(X) <= self.block_length_:
             raise ValueError(
                 "STLBootstrapTransformer requires that block_length is"
-                " greater than the length of X"
+                " strictly smaller than the length of X"
             )
 
         X_index = X.index

--- a/sktime/transformations/bootstrap/_mbb.py
+++ b/sktime/transformations/bootstrap/_mbb.py
@@ -240,11 +240,9 @@ class STLBootstrapTransformer(BaseTransformer):
 
         Parameters
         ----------
-        X : Series or Panel of mtype X_inner_mtype
-            if X_inner_mtype is list, _fit must support all types in it
-            Data to fit transform to
-        y : Series or Panel of mtype y_inner_mtype, default=None
-            Additional data, e.g., labels for transformation
+        X : pd.Series
+            Data to be transformed
+        y : ignored, for interface compatibility
 
         Returns
         -------
@@ -282,11 +280,9 @@ class STLBootstrapTransformer(BaseTransformer):
 
         Parameters
         ----------
-        X : Series or Panel of mtype X_inner_mtype
-            if X_inner_mtype is list, _transform must support all types in it
+        X : pd.Series
             Data to be transformed
-        y : Series or Panel of mtype y_inner_mtype, default=None
-            Additional data, e.g., labels for transformation
+        y : ignored, for interface compatibility
 
         Returns
         -------


### PR DESCRIPTION
This PR fixes an error message and docstrings in `STLBootstrapTransformer`.

@ltsaprounis, can you kindly check whether the error message regarding `sp` is correct now?