### PR TITLE
[ENH] Imputer improved - correct docstrings, leakage free mean/median imputation

### DIFF
--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -420,7 +420,7 @@ class ForecastingGridSearchCV(BaseGridSearch):
     ...         "forecaster": [ThetaForecaster(sp=12)],
     ...     },
     ...     {
-    ...         "imputer__method": ["mean", "last"],
+    ...         "imputer__method": ["mean", "median"],
     ...         "forecaster": [ExponentialSmoothing(sp=12)],
     ...         "forecaster__trend": ["add", "mul"],
     ...     },

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -23,6 +23,13 @@ class Imputer(BaseTransformer):
     The Imputer transforms input series by replacing missing values according
     to an imputation strategy specified by `method`.
 
+    IMPORTANT NOTE: this transformer may lead to information leakage on the test set
+        for some choices of method when used for forecasting.
+        It is safe for time series classification, or in a panel setting where entire
+        series are either in the training or in the test set.
+        Leakage-free methods in all settings are:
+            "constant", "mean_fit", "median_fit"
+
     Parameters
     ----------
     method : str, default="drift"

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -93,11 +93,11 @@ class Imputer(BaseTransformer):
     }
 
     ALLOWED_METHODS = [
+        "mean",
         "drift",
         "linear",
         "nearest",
         "constant",
-        "mean",
         "mean_fit",
         "median",
         "median_fit",

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -219,7 +219,7 @@ class Imputer(BaseTransformer):
         elif method in ["nearest", "linear"]:
             Xt = X.interpolate(method=method)
         else:
-            raise ValueError(f"`method`: {method} not available.")
+            raise ValueError(f'`method`: "{method}" not available.')
         # fill first/last elements of series,
         # as some methods (e.g. "linear") cant impute those
         Xt = X.fillna(method="ffill").fillna(method="backfill")
@@ -229,7 +229,7 @@ class Imputer(BaseTransformer):
         method = self.method
 
         if method not in self.ALLOWED_METHODS:
-            raise ValueError(f"`method`: {method} not available.")
+            raise ValueError(f'`method`: "{method}" not available.')
         if (
             self.value is not None
             and method != "constant"

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -281,6 +281,7 @@ class Imputer(BaseTransformer):
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
         from sktime.forecasting.naive import NaiveForecaster
+
         methods_wo_param = set(cls.ALLOWED_METHODS).difference("constant", "forecaster")
         params = [{"method": x} for x in methods_wo_param]
         params += [{"method": "constant", "value": 42}]

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -282,7 +282,9 @@ class Imputer(BaseTransformer):
         """
         from sktime.forecasting.naive import NaiveForecaster
 
-        methods_wo_param = set(cls.ALLOWED_METHODS).difference("constant", "forecaster")
+        methods_wo_param = set(cls.ALLOWED_METHODS).difference(
+            ["constant", "forecaster"]
+        )
         params = [{"method": x} for x in methods_wo_param]
         params += [{"method": "constant", "value": 42}]
         params += [{"method": "forecaster", "forecaster": NaiveForecaster()}]

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -148,19 +148,20 @@ class Imputer(BaseTransformer):
         self: a fitted instance of the estimator
         """
         self._check_method()
+        method = self.method
 
-        if self.method not in self.METHODS_REQUIRE_FIT:
+        if method not in self.METHODS_REQUIRE_FIT:
             raise ValueError(
-                f"bug, unreachable code: {self.method} passed and _fit was called. "
+                f"bug, unreachable code: {method} passed and _fit was called. "
                 "_fit shouhld not be entered since the method does not require _fit."
             )
 
-        if self.method == "mean_fit":
+        if method == "mean_fit":
             self._fillconst = X.mean()
-        elif self.method == "median_fit":
+        elif method == "median_fit":
             self._fillconst = X.median()
         else:
-            raise ValueError(f"bug, unreachable code: {self.method} passed.")
+            raise ValueError(f"bug, unreachable code: {method} passed.")
 
         return self
 
@@ -181,6 +182,7 @@ class Imputer(BaseTransformer):
             transformed version of X
         """
         self._check_method()
+        method = self.method
 
         # replace missing_values with np.nan
         if self.missing_values:
@@ -189,7 +191,7 @@ class Imputer(BaseTransformer):
         if not _has_missing_values(X):
             return X
 
-        if self.method == "random":
+        if method == "random":
             if isinstance(X, pd.DataFrame):
                 Xt = X
                 for col in Xt:
@@ -198,38 +200,40 @@ class Imputer(BaseTransformer):
                     )
             else:
                 Xt = X.apply(lambda i: self._get_random(X) if np.isnan(i) else i)
-        elif self.method == "constant":
+        elif method == "constant":
             Xt = X.fillna(value=self.value)
-        elif self.method in ["backfill", "bfill", "pad", "ffill"]:
-            Xt = X.fillna(method=self.method)
-        elif self.method == "drift":
+        elif method in ["backfill", "bfill", "pad", "ffill"]:
+            Xt = X.fillna(method=method)
+        elif method == "drift":
             forecaster = PolynomialTrendForecaster(degree=1)
             Xt = _impute_with_forecaster(forecaster, X)
-        elif self.method == "forecaster":
+        elif method == "forecaster":
             forecaster = clone(self.forecaster)
             Xt = _impute_with_forecaster(forecaster, X)
-        elif self.method == "mean":
+        elif method == "mean":
             Xt = X.fillna(value=X.mean())
-        elif self.method == "median":
+        elif method == "median":
             Xt = X.fillna(value=X.median())
-        elif self.method in ["mean_fit", "median_fit"]:
+        elif method in ["mean_fit", "median_fit"]:
             Xt = X.fillna(value=self._fillconst)
-        elif self.method in ["nearest", "linear"]:
-            Xt = X.interpolate(method=self.method)
+        elif method in ["nearest", "linear"]:
+            Xt = X.interpolate(method=method)
         else:
-            raise ValueError(f"`method`: {self.method} not available.")
+            raise ValueError(f"`method`: {method} not available.")
         # fill first/last elements of series,
         # as some methods (e.g. "linear") cant impute those
         Xt = X.fillna(method="ffill").fillna(method="backfill")
         return Xt
 
     def _check_method(self):
-        if self.method not in self.ALLOWED_METHODS:
-            raise ValueError(f"`method`: {self.method} not available.")
+        method = self.method
+
+        if method not in self.ALLOWED_METHODS:
+            raise ValueError(f"`method`: {method} not available.")
         if (
             self.value is not None
-            and self.method != "constant"
-            or self.method == "constant"
+            and method != "constant"
+            or method == "constant"
             and self.value is None
         ):
             raise ValueError(
@@ -238,8 +242,8 @@ class Imputer(BaseTransformer):
             )
         elif (
             self.forecaster is not None
-            and self.method != "forecaster"
-            or self.method == "forecaster"
+            and method != "forecaster"
+            or method == "forecaster"
             and self.forecaster is None
         ):
             raise ValueError(

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -280,7 +280,11 @@ class Imputer(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        params = [{"method": x} for x in cls.ALLOWED_METHODS]
+        from sktime.forecasting.naive import NaiveForecaster
+        methods_wo_param = set(cls.ALLOWED_METHODS).difference("constant", "forecaster")
+        params = [{"method": x} for x in methods_wo_param]
+        params += [{"method": "constant", "value": 42}]
+        params += [{"method": "forecaster", "forecaster": NaiveForecaster()}]
 
         return params
 

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -223,8 +223,8 @@ class Imputer(BaseTransformer):
         Xt = X.fillna(method="ffill").fillna(method="backfill")
         return Xt
 
-    def _check_method(self, method):
-        if method not in self.ALLOWED_METHODS:
+    def _check_method(self):
+        if self.method not in self.ALLOWED_METHODS:
             raise ValueError(f"`method`: {self.method} not available.")
         if (
             self.value is not None


### PR DESCRIPTION
This PR addresses the concern raised in https://github.com/alan-turing-institute/sktime/discussions/2267 about information leakage on the test set when using the `Imputer` transformer in a forecasting pipeline.

Changes in this PR:
* improved docstrings, some corrections, and a highlight which methods are prone to information leakage
* adds two new methods, variants of `mean` and `median`, which use the mean/median from fit
* changes `get_test_params` so all admissible method strings are tested. This should be a "fast" estimator so no huge overhead in terms of compute (hopefully)
* replaced `Z` by `X` in `_transform` and named the output `Xt`, for better readability throughout

Also fixes a bug in the example in `ForecastingGridSearchCV` which used an unknown method `"last"` for the imputer. This never raised an error, since the data in the example did not have nan in it (and error handling was less stringent than in this PR).