### PR TITLE
Fix windows bug with index freq in VetorizedDF.__getitem__

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -4,7 +4,6 @@
 
 Contains VectorizedDF class.
 """
-
 import pandas as pd
 
 from sktime.datatypes._check import check_is_scitype, mtype
@@ -150,6 +149,7 @@ class VectorizedDF:
         X = self.X_multiindex
         ind = self.get_iter_indices()[i]
         item = X.loc[ind]
+        item = _enforce_index_freq(item)
         # pd-multiindex type (Panel case) expects these index names:
         if self.iterate_as == "Panel":
             item.index.set_names(["instances", "timepoints"], inplace=True)
@@ -208,3 +208,20 @@ class VectorizedDF:
             )
 
             return X_reconstructed_orig_format
+
+
+def _enforce_index_freq(item: pd.Series) -> pd.Series:
+    """Enforce the frequency of a Series index using pd.infer_freq.
+
+    Parameters
+    ----------
+    item : pd.Series
+    Returns
+    -------
+    pd.Series
+        Pandas series with the inferred frequency. If the frequency cannot be inferred
+        it will stay None
+    """
+    if hasattr(item.index, "freq") and item.index.freq is None:
+        item.index.freq = pd.infer_freq(item.index)
+    return item

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -4,15 +4,14 @@
 
 __author__ = ["fkiraly"]
 
-# from functools import reduce
-# from operator import mul
+from functools import reduce
+from operator import mul
 
 import pytest
 
-from sktime.datatypes import check_is_mtype, convert, get_examples
+from sktime.datatypes import check_is_mtype, convert
 from sktime.forecasting.arima import ARIMA
-
-# from sktime.utils._testing.hierarchical import _make_hierachical
+from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_panel_X
 
 PANEL_MTYPES = ["pd-multiindex", "nested_univ", "numpy3D"]
@@ -64,14 +63,11 @@ def test_vectorization_series_to_hier(mtype):
     This test passes Panel data to the ARIMA forecaster which internally has an
     implementation for Series only, so the BaseForecaster has to vectorize.
     """
-    # hierarchy_levels = (2, 4)
-    # n_instances = reduce(mul, hierarchy_levels)
+    hierarchy_levels = (2, 4)
+    n_instances = reduce(mul, hierarchy_levels)
 
-    # y = _make_hierachical(hierarchy_levels=hierarchy_levels, random_state=84)
-    # y = convert(y, from_type="pd_multiindex_hier", to_type=mtype)
-
-    y = get_examples(mtype, "Hierarchical")[1]
-    n_instances = 6
+    y = _make_hierarchical(hierarchy_levels=hierarchy_levels, random_state=84)
+    y = convert(y, from_type="pd_multiindex_hier", to_type=mtype)
 
     y_pred = ARIMA().fit(y).predict([1, 2, 3])
     valid, _, metadata = check_is_mtype(y_pred, mtype, return_metadata=True)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #2194 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
After a lot of debugging in #2224, I found that the tests are failing for Windows because the series obtained when looping through `VetorizedDF` have frequency `None` in Windows and `"D"` for both Linux and Mac. The fix is to  add a new function that uses `pd.infer_freq` to update the frequency of each series in `VetorizedDF.__getitem__`.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added unit tests and made sure they pass locally.

<!--
Thanks for contributing!
-->
