### PR TITLE
[BUG] fix conversion interval->quantiles in `BaseForecaster`, and fix `ARIMA.predict_interval`

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1712,17 +1712,18 @@ class BaseForecaster(BaseEstimator):
 
         if implements_interval:
 
-            coverage = []
+            pred_int = pd.DataFrame()
             for a in alpha:
                 # compute quantiles corresponding to prediction interval coverage
                 #  this uses symmetric predictive intervals
                 if a < 0.5:
-                    coverage.extend([2 * a])
+                    coverage = 1 - 2 * a
                 else:
-                    coverage.extend([2 * (1 - a)])
+                    coverage = 2 * a - 1
 
-            # compute quantile forecasts corresponding to upper/lower
-            pred_int = self._predict_interval(fh=fh, X=X, coverage=coverage)
+                # compute quantile forecasts corresponding to upper/lower
+                pred_a = self._predict_interval(fh=fh, X=X, coverage=[coverage])
+                pred_int = pd.concat([pred_int, pred_a], axis=1)
 
             # now we need to subset to lower/upper depending
             #   on whether alpha was < 0.5 or >= 0.5

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1715,11 +1715,8 @@ class BaseForecaster(BaseEstimator):
             pred_int = pd.DataFrame()
             for a in alpha:
                 # compute quantiles corresponding to prediction interval coverage
-                #  this uses symmetric predictive intervals
-                if a < 0.5:
-                    coverage = 1 - 2 * a
-                else:
-                    coverage = 2 * a - 1
+                #  this uses symmetric predictive intervals:
+                coverage = abs(1 - 2 * a)
 
                 # compute quantile forecasts corresponding to upper/lower
                 pred_a = self._predict_interval(fh=fh, X=X, coverage=[coverage])

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -246,7 +246,8 @@ class _PmdArimaAdapter(BaseForecaster):
         int_idx = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
         pred_int = pd.DataFrame(columns=int_idx)
 
-        kwargs = {"X": X, "return_pred_int": True, "alpha": coverage}
+        alpha = [1 - x for x in coverage]
+        kwargs = {"X": X, "return_pred_int": True, "alpha": alpha}
         # all values are out-of-sample
         if fh_is_oosample:
             _, y_pred_int = self._predict_fixed_cutoff(fh_oos, **kwargs)


### PR DESCRIPTION
@ngupta, thank you for bringing this bug to our attention, this fixes https://github.com/alan-turing-institute/sktime/issues/2275.

There were three interacting bugs that are now fixed:

* `BaseForecaster`'s default conversion of `predict_interval` to `predict_quantiles` was mathematically incorrect. It should have said `coverage = abs(1 - 2 * a)` but it said sth completely different. Not sure how that happened.
* `BaseForecaster`'s default conversion of `predict_interval` to `predict_quantiles` could break on occasion when two (float/numerically) identical coverages were produced, due to non-unique indexing. This should be fixed now.
* `ARIMA.predict_interval` was passing `coverage` as `alpha`, where `alpha` in `ARIMA` is in fact `1-coverage`. This has been fixed.

So, all should now hopefully be consistent. The example in #2275 now seems to return consistent results.

Adding this to must haves for 0.11.0 since this seems quite critical (most `predict_quantiles` functions are broken, and `predict_interval` from `pmdarima`).