### PR TITLE
[DOC] numpydoc compliance fix of simple forecasting extension template

### DIFF
--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -50,8 +50,8 @@ class MyForecaster(BaseForecaster):
 
     todo: describe your custom forecaster here
 
-    Hyper-parameters
-    ----------------
+    Parameters
+    ----------
     parama : int
         descriptive explanation of parama
     paramb : string, optional (default='default')


### PR DESCRIPTION
The simple forecasting extension template was not numpydoc compliant, since it was accidentally using a section "hyper-parameters". This has been fixed, and is now in line with the full forecasting extension template