### PR TITLE
[ENH] test generation error to raise and not return

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -121,6 +121,7 @@ class BaseFixtureGenerator:
             fixture_vars=fixture_vars,
             generator_dict=self.generator_dict(),
             fixture_sequence=fixture_sequence,
+            raise_exceptions=True,
         )
 
         metafunc.parametrize(fixture_param_str, fixture_prod, ids=fixture_names)

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -281,7 +281,7 @@ class QuickTester:
         Parameters
         ----------
         estimator : estimator class or estimator instance
-        return_exception : bool, optional, default=True
+        return_exceptions : bool, optional, default=True
             whether to return exceptions/failures, or raise them
                 if True: returns exceptions in results
                 if False: raises exceptions as they occur
@@ -382,6 +382,8 @@ class QuickTester:
             fixture_vars = getfullargspec(test_fun)[0][1:]
             fixture_vars = [var for var in fixture_sequence if var in fixture_vars]
 
+            raise_exceptions = not return_exceptions
+
             # this call retrieves the conditional fixtures
             #  for the test test_name, and the estimator
             _, fixture_prod, fixture_names = create_conditional_fixtures_and_names(
@@ -389,6 +391,7 @@ class QuickTester:
                 fixture_vars=fixture_vars,
                 generator_dict=temp_generator_dict,
                 fixture_sequence=fixture_sequence,
+                raise_exceptions=raise_exceptions,
             )
 
             # if function is decorated with mark.parameterize, add variable settings


### PR DESCRIPTION
This PR changes the `raise_exception` flag in test fixture generation to True, such that test generation errors are raised (and the test suite not run) if there is a fixture generation error in test collection.

This should take off testing compute load from tests where the collection already crashes, and produce informative errors and tracebacks in those cases.