### PR TITLE
[BUG] fixing pyproject and jinja2 CI failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ binder = [
 ]
 
 docs = [
+    "jinja2<3.0.3",
     "jupyter",
     "myst-parser",
     "nbsphinx>=0.8.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "sktime"
 version = "0.10.1"
 description = "A unified framework for machine learning with time series"
-license = "BSD-3-Clause"
+license = "LICENSE"
 authors = [
     {name = "Franz Király", email = "f.kiraly@ucl.ac.uk"},
     {name = "Tony Bagnall", email = "ajb@uea.ac.uk"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 name = "sktime"
 version = "0.10.1"
 description = "A unified framework for machine learning with time series"
-license = "LICENSE"
 authors = [
     {name = "Franz Király", email = "f.kiraly@ucl.ac.uk"},
     {name = "Tony Bagnall", email = "ajb@uea.ac.uk"},
@@ -108,6 +107,9 @@ homepage = "https://www.sktime.org"
 repository = "https://github.com/alan-turing-institute/sktime"
 documentation = "https://www.sktime.org"
 download = "https://pypi.org/project/sktime/#files"
+
+[project.license]
+file = "LICENSE"
 
 [build-system]
 requires = ["setuptools", "wheel", "toml", "build"]


### PR DESCRIPTION
This PR fixes two recent CI issues:
* `pyproject` license field flagged as erroneous, by replacing the license field by a table
* readthedocs CI failure in https://github.com/alan-turing-institute/sktime/issues/2297, by upper bounding `jinja2` with 3.0.3 in the docs dependency set