### PR TITLE
[ENH] treating empty y in forecaster update

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1783,6 +1783,22 @@ class BaseForecaster(BaseEstimator):
                     y_pred = (y_pred, y_pred_int)
                 y_preds.append(y_pred)
                 cutoffs.append(self.cutoff)
+
+                for i in range(len(y_preds)):
+                    if not return_pred_int:
+                        y_preds[i] = convert_to(
+                            y_preds[i],
+                            self._y_mtype_last_seen,
+                            store=self._converter_store_y,
+                            store_behaviour="freeze",
+                        )
+                    else:
+                        y_preds[i][0] = convert_to(
+                            y_preds[i][0],
+                            self._y_mtype_last_seen,
+                            store=self._converter_store_y,
+                            store_behaviour="freeze",
+                        )
         return _format_moving_cutoff_predictions(y_preds, cutoffs)
 
     # TODO: remove in v0.11.0
@@ -1839,9 +1855,12 @@ def _format_moving_cutoff_predictions(y_preds, cutoffs):
     ytype = type(y_preds[0])
     if isinstance(y_preds[0], pd.DataFrame):
         ycols = y_preds[0].columns
-    for y_pred in y_preds:
+    for i, y_pred in enumerate(y_preds):
         if not isinstance(y_pred, ytype):
-            raise ValueError("all elements of y_preds must be of the same type")
+            raise ValueError(
+                "all elements of y_preds must be of the same type, "
+                f"but y_pred[0] is {ytype} and y_pred[{i}] is {type(y_pred)}"
+            )
         if not len(y_pred) == ylen:
             raise ValueError("all elements of y_preds must be of the same length")
     if isinstance(y_preds[0], pd.DataFrame):

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -555,6 +555,10 @@ class BaseForecaster(BaseEstimator):
         """
         self.check_is_fitted()
 
+        if y is None or (hasattr(y, "__len__") and len(y) == 0):
+            warn("empty y passed to update, no update was carried out")
+            return self
+
         # input checks and minor coercions on X, y
         X_inner, y_inner = self._check_X_y(X=X, y=y)
 
@@ -679,11 +683,9 @@ class BaseForecaster(BaseEstimator):
             Point forecasts at fh, with same index as fh
             y_pred has same type as y
         """
-        self.check_is_fitted()
-        fh = self._check_fh(fh)
-
-        if y is None:
-            raise ValueError("y must be of Series type and cannot be None")
+        if y is None or (hasattr(y, "__len__") and len(y) == 0):
+            warn("empty y passed to update_predict, no update was carried out")
+            return self.predict(fh=fh, X=X)
 
         self.check_is_fitted()
         fh = self._check_fh(fh)


### PR DESCRIPTION
This PR allows empty and length 0 `y` to be passed to `update` and `update_predict_single`, in which case no updated is carried out.

This is in order to treat an edge case where a splitter object was passed to `update_predict` which resulted in an empty `y` being passed to `update`, in consequence causing potential issues with test failures in `update_predict_predicted_cutoff` or `test_update_predict_predicted_index`, due to the splitter in the test causing length 0 series to appear via `_predict_moving_cutoff`.

I think the entire update logic is a bit messy and needs to be cleaned up, but this should at least be a symptomatic fix until that happens.