### PR TITLE
removed for loop, changed arguments of convert()

### DIFF
--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -120,7 +120,7 @@ def _check_equal_index(X):
 
 
 def from_3d_numpy_to_2d_array(X):
-    """Convert 2D NumPy Panel to 2D numpy Panel.
+    """Convert 3D NumPy Panel to 2D numpy Panel.
 
     Converts 3D numpy array (n_instances, n_columns, n_timepoints) to
     a 2D numpy array with shape (n_instances, n_columns*n_timepoints)

--- a/sktime/transformations/panel/dwt.py
+++ b/sktime/transformations/panel/dwt.py
@@ -23,12 +23,12 @@ class DWTTransformer(BaseTransformer):
     """
 
     _tags = {
-        "scitype:transform-input": "Series",
+        "scitype:transform-input": "Panel",
         # what is the scitype of X: Series, or Panel
         "scitype:transform-output": "Series",
         # what scitype is returned: Primitives, Series, Panel
-        "scitype:instancewise": False,  # is this an instance-wise transform?
-        "X_inner_mtype": "nested_univ",  # which mtypes do _fit/_predict support for X?
+        "scitype:instancewise": True,  # is this an instance-wise transform?
+        "X_inner_mtype": "pd-multiindex",  # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for X?
         "fit-in-transform": True,
     }
@@ -62,27 +62,27 @@ class DWTTransformer(BaseTransformer):
         col_names = X.columns
 
         Xt = pd.DataFrame()
-        for x in col_names:
-            # Convert one of the columns in the dataframe to numpy array
-            arr = convert(
-                pd.DataFrame(X[x]),
+        # for x in col_names:
+        # Convert one of the columns in the dataframe to numpy array
+        arr = convert(
+                pd.DataFrame(X),
                 from_type="nested_univ",
                 to_type="numpyflat",
-                as_scitype="Panel",
+                # as_scitype="Panel",
             )
 
-            transformedData = self._extract_wavelet_coefficients(arr)
+        transformedData = self._extract_wavelet_coefficients(arr)
 
-            # Convert to a numpy array
-            transformedData = np.asarray(transformedData)
+         # Convert to a numpy array
+        transformedData = np.asarray(transformedData)
 
-            # Add it to the dataframe
-            colToAdd = []
-            for i in range(len(transformedData)):
+          # Add it to the dataframe
+        colToAdd = []
+        for i in range(len(transformedData)):
                 inst = transformedData[i]
                 colToAdd.append(pd.Series(inst))
 
-            Xt[x] = colToAdd
+        Xt = colToAdd
 
         return Xt
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #1856 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
- Made changes to `_tags`, removed `for loop` to remove inefficient vectorization.
#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- [ ] running `pytest` on `test_dwt.py` gives tabularization errors. I'm not sure how to handle this. Out of 11 tests, 6 give the same error
```
================================================================== short test summary info ==================================================================
FAILED test_dwt.py::test_output_of_transformer - ValueError: Tabularization failed, it's possible that not all series were of equal length
FAILED test_dwt.py::test_no_levels_does_no_change - ValueError: Tabularization failed, it's possible that not all series were of equal length
FAILED test_dwt.py::test_output_dimensions[2-12] - ValueError: Tabularization failed, it's possible that not all series were of equal length
FAILED test_dwt.py::test_output_dimensions[3-11] - ValueError: Tabularization failed, it's possible that not all series were of equal length
FAILED test_dwt.py::test_output_dimensions[4-12] - ValueError: Tabularization failed, it's possible that not all series were of equal length
FAILED test_dwt.py::test_dwt_performs_correcly_along_each_dim - ValueError: Tabularization failed, it's possible that not all series were of equal length
```
- Will it be right to use [padder.py](https://github.com/alan-turing-institute/sktime/blob/main/sktime/transformations/panel/padder.py) to make all series of equal length? 
     
- [ ] I haven't moved the file to `series` folder yet, once the error is fixed, it can be moved along with the `test_dwt`.
#### Any other comments?
- I'm not sure if my approach is correct, please let me know if there's a better way to approach this. 
- Fixed a typo in `_convert.py`
- I have commented out code for my reference rather than deleting them, once the error is fixed I'll delete them.
- I haven't moved the file to `series` folder yet, once the error is fixed, it can be moved along with the `test_dwt`.
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->


