### PR TITLE
[BUG] fixes duplication of Returns section in `_predict_var` docstring

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -429,14 +429,6 @@ class BaseForecaster(BaseEstimator):
             if True, computes covariance matrix forecast.
             if False, computes marginal variance forecasts.
 
-
-        Returns
-        -------
-        pred_var : pd.DataFrame
-            Column names are exactly those of `y` passed in `fit`/`update`.
-                For nameless formats, column index will be a RangeIndex.
-            Row index is fh. Entries are variance forecasts, for var in col index.
-
         Returns
         -------
         pred_var : pd.DataFrame, format dependent on `cov` variable


### PR DESCRIPTION
This PR fixes a merge accident that made it onto main.

There were two Returns sections in `_predict_var`, which is now corrected.

Emergency merge due to the problem being on main already.