### PR TITLE
[ENH] escape predict_proba in multiprocessing-idempotent test

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -997,6 +997,11 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
 
         if "n_jobs" in params:
             for method in NON_STATE_CHANGING_METHODS:
+                # equality check at bottom not defined for tfp Distribution
+                #   so skipping this check for now
+                # todo: once this test is fixed, find way to check equality here
+                if method == "predict_proba":
+                    continue
                 if _has_capability(estimator_instance, method):
                     # run on a single process
                     # -----------------------


### PR DESCRIPTION
This PR escapes `predict_proba` in the multiprocessing-idempotent test which is currently skipped.

The test currently breaks on `predict_proba` since the comparison utility at the end cannot deal with tfp distributions.

This leads to `check_estimator` reporting the test as broken, since there it is not skipped.