### PR TITLE
[BUG] FeatureUnion output column names fixed

### DIFF
--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -587,7 +587,7 @@ class FeatureUnion(BaseTransformer, _HeterogenousMetaEstimator):
         )
 
         if self.flatten_transform_index:
-            flat_index = pd.Index("__".join([str(x) for x in Xt.columns]))
+            flat_index = pd.Index([self._underscore_join(x) for x in Xt.columns])
             Xt.columns = flat_index
 
         return Xt
@@ -631,3 +631,9 @@ class FeatureUnion(BaseTransformer, _HeterogenousMetaEstimator):
         ]
 
         return {"transformer_list": TRANSFORMERS}
+
+    @staticmethod
+    def _underscore_join(iterable):
+        """Create flattened column names from multiindex tuple."""
+        iterable_as_str = [str(x) for x in iterable]
+        return "__".join(iterable_as_str)

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -587,7 +587,7 @@ class FeatureUnion(BaseTransformer, _HeterogenousMetaEstimator):
         )
 
         if self.flatten_transform_index:
-            flat_index = pd.Index("__".join(str(x)) for x in Xt.columns)
+            flat_index = pd.Index("__".join([str(x) for x in Xt.columns]))
             Xt.columns = flat_index
 
         return Xt

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -105,12 +105,12 @@ def test_featureunion_transform_cols():
 
     expected_cols = pd.Index(
         [
-            "ExponentTransformer1_test1",
-            "ExponentTransformer1_test2",
-            "ExponentTransformer2_test1",
-            "ExponentTransformer2_test2",
-            "ExponentTransformer3_test1",
-            "ExponentTransformer3_test2",
+            "ExponentTransformer_1_test1",
+            "ExponentTransformer_1_test2",
+            "ExponentTransformer_2_test1",
+            "ExponentTransformer_2_test2",
+            "ExponentTransformer_3_test1",
+            "ExponentTransformer_3_test2",
         ]
     )
 

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -105,12 +105,12 @@ def test_featureunion_transform_cols():
 
     expected_cols = pd.Index(
         [
-            "ExponentTransformer_1_test1",
-            "ExponentTransformer_1_test2",
-            "ExponentTransformer_2_test1",
-            "ExponentTransformer_2_test2",
-            "ExponentTransformer_3_test1",
-            "ExponentTransformer_3_test2",
+            "ExponentTransformer_1__test1",
+            "ExponentTransformer_1__test2",
+            "ExponentTransformer_2__test1",
+            "ExponentTransformer_2__test2",
+            "ExponentTransformer_3__test1",
+            "ExponentTransformer_3__test2",
         ]
     )
 

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -10,6 +10,7 @@ from sklearn.preprocessing import StandardScaler
 
 from sktime.transformations.compose import FeatureUnion, TransformerPipeline
 from sktime.transformations.series.exponent import ExponentTransformer
+from sktime.utils._testing.deep_equals import deep_equals
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 
 
@@ -101,7 +102,8 @@ def test_featureunion_transform_cols():
     t123 = t1 + t2 + t3
 
     Xt = t123.fit_transform(X)
-    assert Xt.columns == pd.Index(
+
+    expected_cols = pd.Index(
         [
             "ExponentTransformer1_test1",
             "ExponentTransformer1_test2",
@@ -110,4 +112,11 @@ def test_featureunion_transform_cols():
             "ExponentTransformer3_test1",
             "ExponentTransformer3_test2",
         ]
-    ), "FeatureUnion creates incorrect column names for DataFrame output"
+    )
+
+    msg = (
+        f"FeatureUnion creates incorrect column names for DataFrame output. "
+        f"Expected: {expected_cols}, found: {Xt.columns}"
+    )
+
+    assert deep_equals(Xt.columns, expected_cols), msg

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -88,3 +88,26 @@ def test_mul_sklearn_autoadapt():
 
     _assert_array_almost_equal(t123.fit_transform(X), t123l.fit_transform(X))
     _assert_array_almost_equal(t123r.fit_transform(X), t123l.fit_transform(X))
+
+
+def test_featureunion_transform_cols():
+    """Test FeatureUnion name and number of columns."""
+    X = pd.DataFrame({"test1": [1, 2], "test2": [3, 4]})
+
+    t1 = ExponentTransformer(power=2)
+    t2 = ExponentTransformer(power=5)
+    t3 = ExponentTransformer(power=3)
+
+    t123 = t1 + t2 + t3
+
+    Xt = t123.fit_transform(X)
+    assert Xt.columns == pd.Index(
+        [
+            "ExponentTransformer1_test1",
+            "ExponentTransformer1_test2",
+            "ExponentTransformer2_test1",
+            "ExponentTransformer2_test2",
+            "ExponentTransformer3_test1",
+            "ExponentTransformer3_test2",
+        ]
+    ), "FeatureUnion creates incorrect column names for DataFrame output"


### PR DESCRIPTION
`FeatureUnion` was returning incorrect column labels due to a bad `str.join` command. This is now fixed.

The tests did not catch this since the format was correct, but not the number of columns.

This has been corrected, and a test has been added to ensure that `FeatureUnion` produces the right column names.