### PR TITLE
[ENH] require uniqueness from multiple alpha/coverage in interval/quantile forecasts

### DIFF
--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -292,6 +292,11 @@ class MyForecaster(BaseForecaster):
         #
         # Note: unlike in predict_quantiles where alpha can be float or list of float
         #   alpha in _predict_quantiles is guaranteed to be a list of float
+        #
+        # Note: the logic in this function should be able to deal with the case
+        #   where multiple copies of the same quantile value are passed.
+        #   If the model is stochastic, the _predict_quantiles function should return
+        #       conditionally independent samples for each copy of the quantile value.
 
     # implement one of _predict_interval or _predict_quantiles (above), or delete both
     #
@@ -338,6 +343,11 @@ class MyForecaster(BaseForecaster):
         #
         # Note: unlike in predict_interval where coverage can be float or list of float
         #   coverage in _predict_interval is guaranteed to be a list of float
+        #
+        # Note: the logic in this function should be able to deal with the case
+        #   where multiple copies of the same coverage values are passed.
+        #   If the model is stochastic, the _predict_interval function should return
+        #       conditionally independent samples for each copy of the coverage value.
 
     # todo: consider implementing _predict_var
     #

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -292,11 +292,6 @@ class MyForecaster(BaseForecaster):
         #
         # Note: unlike in predict_quantiles where alpha can be float or list of float
         #   alpha in _predict_quantiles is guaranteed to be a list of float
-        #
-        # Note: the logic in this function should be able to deal with the case
-        #   where multiple copies of the same quantile value are passed.
-        #   If the model is stochastic, the _predict_quantiles function should return
-        #       conditionally independent samples for each copy of the quantile value.
 
     # implement one of _predict_interval or _predict_quantiles (above), or delete both
     #
@@ -343,11 +338,6 @@ class MyForecaster(BaseForecaster):
         #
         # Note: unlike in predict_interval where coverage can be float or list of float
         #   coverage in _predict_interval is guaranteed to be a list of float
-        #
-        # Note: the logic in this function should be able to deal with the case
-        #   where multiple copies of the same coverage values are passed.
-        #   If the model is stochastic, the _predict_interval function should return
-        #       conditionally independent samples for each copy of the coverage value.
 
     # todo: consider implementing _predict_var
     #

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -311,6 +311,10 @@ class BaseForecaster(BaseEstimator):
             Exogenous time series
         alpha : float or list of float, optional (default=[0.05, 0.95])
             A probability or list of, at which quantile forecasts are computed.
+            Note: a list can contain multiple copies of the same alpha.
+                In such a case, multiple quantile forecasts will be produced.
+                These quantile forecasts are conditionally independent samples produced
+                    by the model, in case the model is stochastic, and may be different.
 
         Returns
         -------
@@ -368,7 +372,11 @@ class BaseForecaster(BaseEstimator):
         X : pd.DataFrame, optional (default=None)
             Exogenous time series
         coverage : float or list of float, optional (default=0.90)
-           nominal coverage(s) of predictive interval(s)
+            nominal coverage(s) of predictive interval(s)
+            Note: a list can contain multiple copies of the same coverage value.
+                In such a case, multiple interval forecasts will be produced.
+                These interval forecasts are conditionally independent samples produced
+                    by the model, in case the model is stochastic, and may be different.
 
         Returns
         -------

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -309,12 +309,8 @@ class BaseForecaster(BaseEstimator):
             Forecasting horizon, default = y.index (in-sample forecast)
         X : pd.DataFrame, optional (default=None)
             Exogenous time series
-        alpha : float or list of float, optional (default=[0.05, 0.95])
+        alpha : float or list of float of unique values, optional (default=[0.05, 0.95])
             A probability or list of, at which quantile forecasts are computed.
-            Note: a list can contain multiple copies of the same alpha.
-                In such a case, multiple quantile forecasts will be produced.
-                These quantile forecasts are conditionally independent samples produced
-                    by the model, in case the model is stochastic, and may be different.
 
         Returns
         -------
@@ -371,12 +367,8 @@ class BaseForecaster(BaseEstimator):
             Forecasting horizon, default = y.index (in-sample forecast)
         X : pd.DataFrame, optional (default=None)
             Exogenous time series
-        coverage : float or list of float, optional (default=0.90)
+        coverage : float or list of float of unique values, optional (default=0.90)
             nominal coverage(s) of predictive interval(s)
-            Note: a list can contain multiple copies of the same coverage value.
-                In such a case, multiple interval forecasts will be produced.
-                These interval forecasts are conditionally independent samples produced
-                    by the model, in case the model is stochastic, and may be different.
 
         Returns
         -------

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -328,12 +328,17 @@ class BaseForecaster(BaseEstimator):
                 "an issue on sktime."
             )
         self.check_is_fitted()
-        # input checks
-        if alpha is None:
-            alpha = [0.05, 0.95]
+
+        # input checks and conversions
+
+        # check fh and coerce to ForecastingHorizon
         fh = self._check_fh(fh)
 
-        alpha = check_alpha(alpha)
+        # default alpha
+        if alpha is None:
+            alpha = [0.05, 0.95]
+        # check alpha and coerce to list
+        alpha = check_alpha(alpha, name="alpha")
 
         # input check and conversion for X
         X_inner = self._check_X(X=X)
@@ -391,9 +396,13 @@ class BaseForecaster(BaseEstimator):
                 "an issue on sktime."
             )
         self.check_is_fitted()
-        # input checks
+
+        # input checks and conversions
+
+        # check fh and coerce to ForecastingHorizon
         fh = self._check_fh(fh)
-        coverage = check_alpha(coverage)
+        # check alpha and coerce to list
+        coverage = check_alpha(coverage, name="coverage")
 
         # check and convert X
         X_inner = self._check_X(X=X)
@@ -1836,7 +1845,7 @@ class BaseForecaster(BaseEstimator):
     # TODO: remove in v0.11.0
     def _convert_new_to_old_pred_int(self, pred_int_new, alpha):
         name = pred_int_new.columns.get_level_values(0).unique()[0]
-        alpha = check_alpha(alpha)
+        alpha = check_alpha(alpha, name="alpha")
         alphas = [alpha] if isinstance(alpha, (float, int)) else alpha
         pred_int_old_format = [
             pd.DataFrame(

--- a/sktime/utils/validation/forecasting.py
+++ b/sktime/utils/validation/forecasting.py
@@ -296,19 +296,28 @@ def check_fh(fh, enforce_relative=False):
     return fh
 
 
-def check_alpha(alpha):
-    """Check that a confidence level alpha (or list of alphas) is valid.
+def check_alpha(alpha, name="alpha"):
+    """Check that quantile or confidence level value, or list of values, is valid.
 
-    All alpha values must lie in the open interval (0, 1).
+    Checks:
+    alpha must be a float, or list of float, all in the open interval (0, 1).
+    values in alpha must be unique.
 
     Parameters
     ----------
     alpha : float, list of float
+    name : str, optional, default="alpha"
+        the name reference to alpha displayed in the error message
+
+    Returns
+    -------
+    alpha coerced to a list, i.e.: [alpha], if alpha was a float; alpha otherwise
 
     Raises
     ------
     ValueError
-        If alpha is outside the range (0, 1).
+        If alpha (float) or any value in alpha (list) is outside the range (0, 1).
+        If values in alpha (list) are non-unique.
     """
     # check type
     if isinstance(alpha, list):
@@ -324,8 +333,13 @@ def check_alpha(alpha):
     for a in alpha:
         if not 0 < a < 1:
             raise ValueError(
-                f"`alpha` must lie in the open interval (0, 1), " f"but found: {a}."
+                f"values in {name} must lie in the open interval (0, 1), "
+                f"but found value: {a}."
             )
+
+    # check uniqueness
+    if len(set(alpha)) < len(alpha):
+        raise ValueError(f"values in {name} must be unique, but found duplicates")
 
     return alpha
 


### PR DESCRIPTION
This PR adds an additional assumption to `predict_interval` and `predict_quantiles`: that values in potential lists `alpha` and `coverage` should be unique.

Related to discussion in https://github.com/alan-turing-institute/sktime/pull/2320.

Reason for adding these assumptions is that not all implemented methods may work if non-unique values are passed, e.g., if indexing of columns happens.

A check for uniqueness has been added to the utility `check_alpha`; docstrings, comments, and error messages have been improved.