### PR TITLE
[MNT] Remove jinja2 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ binder = [
 ]
 
 docs = [
-    "jinja2<3.0.3",
     "jupyter",
     "myst-parser",
     "nbsphinx>=0.8.6",


### PR DESCRIPTION
should be able to pass as soon as `jinja2` got a new release

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
#2297 #2299 