### PR TITLE
refactored ShapeletTransformClassifier, added method get_test_params

### DIFF
--- a/sktime/classification/shapelet_based/_stc.py
+++ b/sktime/classification/shapelet_based/_stc.py
@@ -312,3 +312,22 @@ class ShapeletTransformClassifier(BaseClassifier):
                 method="predict_proba",
                 n_jobs=self._threads_to_use,
             )
+
+    @classmethod
+    def get_test_params(cls):
+        """Return testing parameter settings for the estimator.
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params = {
+            "estimator": RotationForest(n_estimators=3),
+            "max_shapelets": 5,
+            "n_shapelet_samples": 50,
+            "batch_size": 20,
+        }
+        return params

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -40,7 +40,6 @@ from sktime.classification.interval_based import (
     SupervisedTimeSeriesForest,
 )
 from sktime.classification.interval_based import TimeSeriesForestClassifier as TSFC
-from sktime.classification.shapelet_based import ShapeletTransformClassifier
 from sktime.contrib.vector_classifiers._rotation_forest import RotationForest
 from sktime.forecasting.compose import (
     DirectTabularRegressionForecaster,
@@ -174,12 +173,6 @@ ESTIMATOR_TEST_PARAMS = {
     },
     ColumnTransformer: {
         "transformers": [(name, estimator, [0]) for name, estimator in TRANSFORMERS]
-    },
-    ShapeletTransformClassifier: {
-        "estimator": RotationForest(n_estimators=3),
-        "max_shapelets": 5,
-        "n_shapelet_samples": 50,
-        "batch_size": 20,
     },
     RandomShapeletTransform: {
         "max_shapelets": 5,


### PR DESCRIPTION
Reference Issue:
Estimator Test Parameters Refactor #1678

Refactored ShapeletTransformClassifier by creating get_test_params method as explained in issue and removed params from tests/_config.py

