### PR TITLE
[DOC] typo fix contsructor -> constructor in extension templates

### DIFF
--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -133,7 +133,7 @@ class MyTimeSeriesClassifier(BaseClassifier):
         # Note: when interfacing a model that has fit, with parameters
         #   that are not data (X, y) or data-like,
         #   but model parameters, *don't* add as arguments to fit, but treat as follows:
-        #   1. pass to constructor,  2. write to self in contsructor,
+        #   1. pass to constructor,  2. write to self in constructor,
         #   3. read from self in _fit,  4. pass to interfaced_model.fit in _fit
 
     # todo: implement this, mandatory

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -164,7 +164,7 @@ class MyForecaster(BaseForecaster):
         # Note: when interfacing a model that has fit, with parameters
         #   that are not data (y, X) or forecasting-horizon-like,
         #   but model parameters, *don't* add as arguments to fit, but treat as follows:
-        #   1. pass to constructor,  2. write to self in contsructor,
+        #   1. pass to constructor,  2. write to self in constructor,
         #   3. read from self in _fit,  4. pass to interfaced_model.fit in _fit
 
     # todo: implement this, mandatory

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -132,7 +132,7 @@ class MyForecaster(BaseForecaster):
         # Note: when interfacing a model that has fit, with parameters
         #   that are not data (y, X) or forecasting-horizon-like,
         #   but model parameters, *don't* add as arguments to fit, but treat as follows:
-        #   1. pass to constructor,  2. write to self in contsructor,
+        #   1. pass to constructor,  2. write to self in constructor,
         #   3. read from self in _fit,  4. pass to interfaced_model.fit in _fit
 
     # todo: implement this, mandatory

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -180,7 +180,7 @@ class MyTransformer(BaseTransformer):
         # Note: when interfacing a model that has fit, with parameters
         #   that are not data (X, y) or data-like,
         #   but model parameters, *don't* add as arguments to fit, but treat as follows:
-        #   1. pass to constructor,  2. write to self in contsructor,
+        #   1. pass to constructor,  2. write to self in constructor,
         #   3. read from self in _fit,  4. pass to interfaced_model.fit in _fit
 
     # todo: implement this, mandatory

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -151,7 +151,7 @@ class MyTransformer(BaseTransformer):
         # Note: when interfacing a model that has fit, with parameters
         #   that are not data (X, y) or data-like
         #   but model parameters, *don't* add as arguments to fit, but treat as follows:
-        #   1. pass to constructor,  2. write to self in contsructor,
+        #   1. pass to constructor,  2. write to self in constructor,
         #   3. read from self in _fit,  4. pass to interfaced_model.fit in _fit
 
     # todo: implement this, mandatory


### PR DESCRIPTION
Fixes a systematic typo: contsructor -> constructor, in extension templates.

(accidental leftover of #2343 so I assume approval extends)