### PR TITLE
[BUG] pinning click due to incompatibility with newest black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     hooks:
       - id: black
         language_version: python3
+        additional_dependencies: [click==8.0.4]
         # args: [--line-length 79]
 
   - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
`code-quality` checks in CI are failing due to an incompatibility ot `click` with the newest `black` version.

This PR follows the fix suggested in
https://github.com/psf/black/issues/2964
to restore `code-quality` CI functionality temporarily, until the incompatibility is fixed.