### PR TITLE
[ENH] upgrade `BasePairwiseTransformer` to use `datatypes` input conversions and checks

### DIFF
--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -165,7 +165,7 @@ class BasePairwiseTransformer(BaseEstimator):
         Returns
         -------
         X: Panel data container of a supported format in X_inner_mtype
-            usually df-list, list of pd.DataFrame, unless overridden
+            usually a 2D np.ndarray or a pd.DataFrame, unless overridden
         """
         X_valid = check_is_scitype(X, "Table", return_metadata=False, var_name=var_name)
 

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -175,7 +175,7 @@ class BasePairwiseTransformer(BaseEstimator):
             raise TypeError("X/X2 must be of Table scitype")
 
         X_inner_mtype = self.get_tag("X_inner_mtype")
-        X_coerced = convert_to(X, to_type=X_inner_mtype, as_scitype="Panel")
+        X_coerced = convert_to(X, to_type=X_inner_mtype, as_scitype="Table")
 
         return X_coerced
 

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -167,9 +167,7 @@ class BasePairwiseTransformer(BaseEstimator):
         X: Panel data container of a supported format in X_inner_mtype
             usually df-list, list of pd.DataFrame, unless overridden
         """
-        X_valid = check_is_scitype(
-            X, "Table", return_metadata=False, var_name=var_name
-        )
+        X_valid = check_is_scitype(X, "Table", return_metadata=False, var_name=var_name)
 
         if not X_valid:
             raise TypeError("X/X2 must be of Table scitype")

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -170,7 +170,12 @@ class BasePairwiseTransformer(BaseEstimator):
         X_valid = check_is_scitype(X, "Table", return_metadata=False, var_name=var_name)
 
         if not X_valid:
-            raise TypeError("X/X2 must be of Table scitype")
+            msg = (
+                "X and X2 must be in an sktime compatible format, of scitype Table, "
+                "for instance a pandas.DataFrame or a 2D numpy.ndarray. "
+                "See the data format tutorial examples/AA_datatypes_and_datasets.ipynb"
+            )
+            raise TypeError(msg)
 
         X_inner_mtype = self.get_tag("X_inner_mtype")
         X_coerced = convert_to(X, to_type=X_inner_mtype, as_scitype="Table")
@@ -343,7 +348,14 @@ class BasePairwiseTransformerPanel(BaseEstimator):
         X_scitype = metadata["scitype"]
 
         if not X_valid:
-            raise TypeError("X/X2 must be of Series or Panel scitype")
+            msg = (
+                "X and X2 must be in an sktime compatible format, "
+                "of scitype Series or Panel, "
+                "for instance a pandas.DataFrame with sktime compatible time indices, "
+                "or with MultiIndex and lowest level a sktime compatible time index. "
+                "See the data format tutorial examples/AA_datatypes_and_datasets.ipynb"
+            )
+            raise TypeError(msg)
 
         # if the input is a single series, convert it to a Panel
         if X_scitype == "Series":

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -33,13 +33,9 @@ Inspection methods:
 
 __author__ = ["fkiraly"]
 
-import numpy as np
-import pandas as pd
-
 from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_scitype, convert_to
 from sktime.datatypes._series_as_panel import convert_Series_to_Panel
-from sktime.utils.validation.series import check_series
 
 
 class BasePairwiseTransformer(BaseEstimator):
@@ -54,6 +50,7 @@ class BasePairwiseTransformer(BaseEstimator):
     # default tag values - these typically make the "safest" assumption
     _tags = {
         "symmetric": False,  # is the transformer symmetric, i.e., t(x,y)=t(y,x) always?
+        "X_inner_mtype": "numpy2D",  # which mtype is used internally in _transform?
         "fit_is_empty": True,  # is "fit" empty? Yes, for all pairwise transforms
     }
 
@@ -112,23 +109,16 @@ class BasePairwiseTransformer(BaseEstimator):
         X_equals_X2: bool = True if X2 was not passed, False if X2 was passed
             for use to make internal calculations efficient, e.g., in _transform
         """
-        X = check_series(X)
+        X = self._pairwise_table_x_check(X)
 
         if X2 is None:
             X2 = X
             self.X_equals_X2 = True
         else:
-            X2 = check_series(X2)
-
-            def input_as_numpy(val):
-                if isinstance(val, pd.DataFrame):
-                    return val.to_numpy(copy=True)
-                return val
-
-            temp_X = input_as_numpy(X)
-            temp_X2 = input_as_numpy(X2)
-            if np.array_equal(temp_X, temp_X2):
-                self.X_equals_X2 = True
+            X2 = self._pairwise_table_x_check(X2, var_name="X2")
+            # todo, possibly:
+            # check X, X2 for equality, then set X_equals_X2
+            # could use deep_equals
 
         return self._transform(X=X, X2=X2)
 
@@ -158,6 +148,36 @@ class BasePairwiseTransformer(BaseEstimator):
         # no fitting logic, but in case fit is called or expected
         self._is_fitted = True
         return self
+
+    def _pairwise_table_x_check(self, X, var_name="X"):
+        """Check and coerce input data.
+
+        Method used to check the input and convert Table input
+            to internally used format, as defined in X_inner_mtype tag
+
+        Parameters
+        ----------
+        X: pd.DataFrame, pd.Series, numpy 1D or 2D, list of dicts
+            sktime data container compliant with the Table scitype
+            The value to be checked and coerced
+        var_name: str, variable name to print in error messages
+
+        Returns
+        -------
+        X: Panel data container of a supported format in X_inner_mtype
+            usually df-list, list of pd.DataFrame, unless overridden
+        """
+        X_valid = check_is_scitype(
+            X, "Table", return_metadata=False, var_name=var_name
+        )
+
+        if not X_valid:
+            raise TypeError("X/X2 must be of Table scitype")
+
+        X_inner_mtype = self.get_tag("X_inner_mtype")
+        X_coerced = convert_to(X, to_type=X_inner_mtype, as_scitype="Panel")
+
+        return X_coerced
 
 
 class BasePairwiseTransformerPanel(BaseEstimator):
@@ -307,6 +327,7 @@ class BasePairwiseTransformerPanel(BaseEstimator):
         Parameters
         ----------
         X: List of dfs, Numpy of dfs, 3d numpy
+            sktime data container compliant with the Series or Panel scitype
             The value to be checked
         var_name: str, variable name to print in error messages
 


### PR DESCRIPTION
This PR upgrades `BasePairwiseTransformer` to use `datatypes` input conversions and checks.

For this, it uses the `Table` mtype to refactor the logic to parallel almost exactly that of `BasePairwiseTransformerPanel`.
Consequently, there is no longer a dependency on custom input checks or the legacy `check_series` utility.