### PR TITLE
[BUG] fixing click/black incompatibility in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,10 @@ repos:
         name: isort
 
   - repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3
-        additional_dependencies: [click==8.0.4]
         # args: [--line-length 79]
 
   - repo: https://github.com/pycqa/flake8
@@ -46,7 +45,7 @@ repos:
     hooks:
       - id: nbqa-black
         args: [--nbqa-mutate, --nbqa-dont-skip-bad-cells]
-        additional_dependencies: [black==20.8b1, click==8.0.4]
+        additional_dependencies: [black==22.3.0]
       - id: nbqa-isort
         args: [--nbqa-mutate, --nbqa-dont-skip-bad-cells]
         additional_dependencies: [isort==5.6.4]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     hooks:
       - id: nbqa-black
         args: [--nbqa-mutate, --nbqa-dont-skip-bad-cells]
-        additional_dependencies: [black==20.8b1]
+        additional_dependencies: [black==20.8b1, click==8.0.4]
       - id: nbqa-isort
         args: [--nbqa-mutate, --nbqa-dont-skip-bad-cells]
         additional_dependencies: [isort==5.6.4]


### PR DESCRIPTION
`code-quality` checks in CI are failing due to an incompatibility ot `click` with the newest `black` version.
This bumps `black` to 22.3.0 for both code and notebook checks.
It also removes the pin on `click`, in an attempt to fix #2354.

This PR follows the fix suggested in
https://github.com/psf/black/issues/2964