### PR TITLE
[BUG] fixed `get_time_index` for most mtypes

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -23,7 +23,7 @@ def get_time_index(X):
     in one of the following sktime mtype specifications for Series, Panel, Hierarchical:
     pd.DataFrame, pd.Series, np.ndarray, pd-multiindex, nested_univ, pd_multiindex_hier
     assumes all time series have equal length and equal index set
-    will *not* work for numpy3D, list-of-df, pd-wide, pd-long
+    will *not* work for list-of-df, pd-wide, pd-long
 
     Returns
     -------
@@ -32,25 +32,20 @@ def get_time_index(X):
     """
     # assumes that all samples share the same the time index, only looks at
     # first row
-    if isinstance(X, pd.DataFrame):
+    if isinstance(X, (pd.DataFrame, pd.Series)):
+        # pd-multiindex or pd_multiindex_hier
         if isinstance(X.index, pd.MultiIndex):
-            return X.xs(
-                X.index.get_level_values("instances")[0], level="instances"
-            ).index
-        else:
+            first_inst = X.index.to_flat_index()[0][:-1]
+            return X.loc[first_inst].index
+        # nested_univ
+        elif isinstance(X, pd.DataFrame) and isinstance(X.iloc[0, 0], pd.DataFrame):
             return _get_index(X.iloc[0, 0])
-
-    elif isinstance(X, pd.Series):
-        if isinstance(X.index, pd.MultiIndex):
-            return X.xs(
-                X.index.get_level_values("instances")[0], level="instances"
-            ).index
+        # pd.Series or pd.DataFrame
         else:
-            return _get_index(X.iloc[0])
-
+            return X.index
+    # numpy3D and np.ndarray
     elif isinstance(X, np.ndarray):
         return _get_index(X)
-
     else:
         raise ValueError(
             f"X must be a pandas DataFrame or Series, but found: {type(X)}"


### PR DESCRIPTION
This PR fixes an unreported bug with `get_time_index`, as it would not work with most mtypes that it had claimed for in the docstring.
This should be fixed now.
I have not added tests, but that should be done soon.

Originally, in #2375, but factored it out due to the complexity of the issue with fixing the nested conversions.

FYI @danbartl 