### PR TITLE
[ENH] upgrade codecov uploader and cleanup coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,6 @@ show_missing = True
 
 [run]
 source = sktime
-include = */sktime/*
 omit =
     */setup.py
     */sktime/__init__.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,12 +88,9 @@ jobs:
           cp setup.cfg testdir/
           cd testdir/
           python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime -v -n 2 --pyargs sktime
-      - name: Display coverage report
-        run: ls -l ./testdir/
+
       - name: Publish code coverage
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./testdir/coverage.xml
+        uses: codecov/codecov-action@v2
 
   test-linux:
     needs: code-quality
@@ -118,14 +115,10 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: make tests
+        run: make PYTESTOPTIONS="--cov --cov-report=xml" test
 
-      - name: Display coverage report
-        run: ls -l ./testdir/
       - name: Publish code coverage
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./testdir/coverage.xml
+        uses: codecov/codecov-action@v2
 
   test-mac:
     needs: code-quality
@@ -163,11 +156,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: make tests
+        run: make PYTESTOPTIONS="--cov --cov-report=xml" test
 
-      - name: Display coverage report
-        run: ls -l ./testdir/
       - name: Publish code coverage
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./testdir/coverage.xml
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -122,7 +122,7 @@ jobs:
           cp .coveragerc testdir/
           cp setup.cfg testdir/
           cd testdir/
-          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime --pyargs sktime
+          python -m pytest --showlocals --durations=10 --pyargs sktime
 
   upload_wheels:
     name: Upload wheels to PyPI

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: ## Run unit tests
 	mkdir -p ${TEST_DIR}
 	cp .coveragerc ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
-	cd ${TEST_DIR}; python -m pytest --cov-report html --cov=sktime -v -n 2 --showlocals --durations=20 --pyargs $(PACKAGE)
+	cd ${TEST_DIR}; python -m pytest -v -n auto --showlocals --durations=20 $(PYTESTOPTIONS) --pyargs $(PACKAGE)
 
 tests: test
 
@@ -39,7 +39,6 @@ clean: ## Clean build dist and egg directories left after install
 	rm -rf ./htmlcov
 	rm -rf ./junit
 	rm -rf ./$(PACKAGE).egg-info
-	rm -rf ./cover
 	rm -rf coverage.xml
 	rm -f MANIFEST
 	rm -rf ./wheelhouse/*

--- a/sktime/utils/_testing/panel.py
+++ b/sktime/utils/_testing/panel.py
@@ -41,7 +41,7 @@ def _make_panel_X(
         X = X + (y * 100).reshape(-1, 1, 1)
 
     if all_positive:
-        X = X ** 2
+        X = X**2
 
     if return_numpy:
         return X


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
* addresses the deprecation of Codecov Bash Uploader: https://docs.codecov.com/docs/about-the-codecov-bash-uploader#deprecation-notice-and-schedule
* fixes the partial misconfiguration of codecov uploader https://github.com/alan-turing-institute/sktime/runs/5817665318?check_suite_focus=true#step:9:37
* fixes covergepy warnings: https://github.com/alan-turing-institute/sktime/runs/5807142605?check_suite_focus=true#step:7:12
* `make test` by default doesn't measure coverage but allows it via PYTESTOPTIONS variable
* uses `pytest -n auto`, which seems to work reliably. GHA MacOS runners have 3 core CPUs available, so that should speed up these builds


#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?
Check if code coverage got uploaded as it should. See if there are unwanted differences in the build or tests in general.
<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.
- [X] The PR title starts with either [ENH], [DOC] or [BUG] indicating wether the PR topic is related to enhancement, documentation or bug

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
