### PR TITLE
[ENH] `NaiveVariance`: verbose arg and extended docstring

### DIFF
--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -510,7 +510,7 @@ class NaiveVariance(BaseForecaster):
         pred_var = self.predict_var(fh, X)
 
         z_scores = norm.ppf(alpha)
-        errors = [pred_var ** 0.5 * z for z in z_scores]
+        errors = [pred_var**0.5 * z for z in z_scores]
 
         index = pd.MultiIndex.from_product([["Quantiles"], alpha])
         pred_quantiles = pd.DataFrame(columns=index)

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -417,10 +417,17 @@ class NaiveVariance(BaseForecaster):
     - And for the covariance matrix prediction, the formula becomes
     :math:`Cov(y_k, y_l)=\frac{\sum_{i=1}^N \hat{r}_{k,k+i}*\hat{r}_{l,l+i}}{N}`.
 
+    The resulting forecaster will implement
+        `predict_interval`, `predict_quantiles`, `predict_var`, and `predict_proba`,
+        even if the wrapped forecaster `forecaster` did not have this capability;
+        for point forecasts (`predict`), behaves like the wrapped forecaster.
+
     Parameters
     ----------
     forecaster : estimator
-        Estimators to apply to the input series.
+        Estimator to which probabilistic forecasts are being added
+    verbose : bool, optional, default=False
+        whether to print warnings if windows with too few data points occur
 
     Examples
     --------
@@ -446,9 +453,10 @@ class NaiveVariance(BaseForecaster):
         # deprecated and likely to be removed in 0.12.0
     }
 
-    def __init__(self, forecaster):
+    def __init__(self, forecaster, verbose=False):
 
         self.forecaster = forecaster
+        self.verbose = verbose
         super(NaiveVariance, self).__init__()
 
         tags_to_clone = [
@@ -545,9 +553,11 @@ class NaiveVariance(BaseForecaster):
             try:
                 forecaster.fit(subset)
             except ValueError:
-                warn(
-                    f"Couldn't fit the model on time series of length {len(subset)}.\n"
-                )
+                if self.verbose:
+                    warn(
+                        f"Couldn't fit the model on "
+                        f"time series window length {len(subset)}.\n"
+                    )
                 continue
 
             y_true = self._y[id:]  # subset on which we predict


### PR DESCRIPTION
This small PR adds two things to `NaiveVariance`:

* a `verbose` arg which is by default `False`, suppressing the many warnings that are raised on toy data
* an explanation in the docstring which methods are added and how the wrapped estimator relates to the composite