### PR TITLE
[BUG] fixed `score_average` parameter of proba metrics, docstrings

### DIFF
--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -112,6 +112,10 @@ class _BaseProbaForecastingErrorMetric(_BaseForecastingErrorMetric):
         out_df = self._evaluate(y_true_inner, y_pred_inner, multioutput, **kwargs)
         if self.score_average:
             out_df = out_df.mean(axis=1)
+
+        # unwrap the case where resulting data frame has one entry
+        if self.score_average and multioutput in "uniform_average":
+            out_df = out_df.iloc[0]
         return out_df
 
     def _evaluate(self, y_true, y_pred, multioutput, **kwargs):

--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -45,7 +45,7 @@ class _BaseProbaForecastingErrorMetric(_BaseForecastingErrorMetric):
         func=None,
         name=None,
         multioutput="uniform_average",
-        score_average=False,
+        score_average=True,
     ):
         self.multioutput = multioutput
         self.score_average = score_average
@@ -304,14 +304,16 @@ class PinballLoss(_BaseProbaForecastingErrorMetric):
     def __init__(
         self,
         multioutput="uniform_average",
-        score_average=False,
+        score_average=True,
         alpha=None,
     ):
         name = "PinballLoss"
         self.score_average = score_average
         self.alpha = self._check_alpha(alpha)
         self.metric_args = {"alpha": alpha}
-        super().__init__(name=name, multioutput=multioutput)
+        super().__init__(
+            name=name, multioutput=multioutput, score_average=score_average
+        )
 
     def _evaluate(self, y_true, y_pred, multioutput, **kwargs):
         alpha = self.alpha

--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -45,7 +45,7 @@ class _BaseProbaForecastingErrorMetric(_BaseForecastingErrorMetric):
         func=None,
         name=None,
         multioutput="uniform_average",
-        score_average=True,
+        score_average=False,
     ):
         self.multioutput = multioutput
         self.score_average = score_average
@@ -65,16 +65,17 @@ class _BaseProbaForecastingErrorMetric(_BaseForecastingErrorMetric):
 
         Returns
         -------
-        loss : float or pd.DataFrame with calculated metric value(s)
-            if multioutput = "raw_values" 
+        loss : float or 1-column pd.DataFrame with calculated metric value(s)
+            metric is always averaged (arithmetic) over fh values
+            if multioutput = "raw_values",
+            if multioutput = "raw_values",
                 will have a column level corresponding to variables in y_true
             if multioutput = multioutput = "uniform_average" or or array-like
-                entries will be averaged over output variables
+                entries will be averaged over output variable column
             if score_average = False,
                 will have column levels corresponding to quantiles/intervals
-            if score_average = True and 
-                entries will be averaged over quantiles/intervals
-            if both averages are computed, output will be float
+            if score_average = True,
+                entries will be averaged over quantiles/interval column
         """
         return self.evaluate(y_true, y_pred, multioutput=self.multioutput, **kwargs)
 

--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -61,7 +61,7 @@ class _BaseProbaForecastingErrorMetric(_BaseForecastingErrorMetric):
             Ground truth (correct) target values.
 
         y_pred : return object of probabilistic predictition method scitype:y_pred
-            must be at fh and for variable equal to those in y_true
+            must be at fh and for variables equal to those in y_true
 
         Returns
         -------
@@ -89,7 +89,7 @@ class _BaseProbaForecastingErrorMetric(_BaseForecastingErrorMetric):
             Ground truth (correct) target values.
 
         y_pred : return object of probabilistic predictition method scitype:y_pred
-            must be at fh and for variable equal to those in y_true
+            must be at fh and for variables equal to those in y_true
 
         Returns
         -------
@@ -132,7 +132,7 @@ class _BaseProbaForecastingErrorMetric(_BaseForecastingErrorMetric):
             Ground truth (correct) target values.
 
         y_pred : return object of probabilistic predictition method scitype:y_pred
-            must be at fh and for variable equal to those in y_true
+            must be at fh and for variables equal to those in y_true
 
         Returns
         -------

--- a/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
@@ -23,34 +23,39 @@ QUANTILE_PRED = f.predict_quantiles(fh=fh, alpha=[0.5])
 INTERVAL_PRED = f.predict_interval(fh=fh, coverage=0.9)
 
 
+@pytest.mark.parametrize("score_average", [True, False])
 @pytest.mark.parametrize("Metric", list_of_metrics)
-def test_output(Metric):
+def test_output(Metric, score_average):
     """Test output is correct class."""
     y_true = y_test
-    Loss = Metric.create_test_instance()
-    eval_loss = Loss.evaluate(y_true, y_pred=QUANTILE_PRED)
-    index_loss = Loss.evaluate_by_index(y_true, y_pred=QUANTILE_PRED)
+    loss = Metric.create_test_instance()
+    loss.set_params("score_average", score_average)
+    eval_loss = loss.evaluate(y_true, y_pred=QUANTILE_PRED)
+    index_loss = loss.evaluate_by_index(y_true, y_pred=QUANTILE_PRED)
 
-    assert isinstance(eval_loss, pd.DataFrame)
+    if score_average:
+        assert isinstance(eval_loss, float)
+    else:
+        assert isinstance(eval_loss, pd.DataFrame)
     assert isinstance(index_loss, pd.DataFrame)
 
 
 @pytest.mark.parametrize("Metric", list_of_metrics)
 def test_evaluate_to_zero(Metric):
     """Tests whether metric returns 0 when y_true=y_pred."""
-    Loss = Metric.create_test_instance()
+    loss = Metric.create_test_instance()
     y_true = QUANTILE_PRED["Quantiles"][0.5]
-    eval_loss = Loss.evaluate(y_true, y_pred=QUANTILE_PRED)
+    eval_loss = loss.evaluate(y_true, y_pred=QUANTILE_PRED)
     assert np.isclose(0, eval_loss).all()
 
 
 @pytest.mark.parametrize("Metric", list_of_metrics)
 def test_evaluate_by_index_to_zero(Metric):
     """Tests whether metric returns 0 when y_true=y_pred by index."""
-    Loss = Metric.create_test_instance()
+    loss = Metric.create_test_instance()
     y_true = QUANTILE_PRED["Quantiles"][0.5]
-    index_loss = Loss.evaluate_by_index(y_true, y_pred=QUANTILE_PRED)
-    assert all([np.isclose(0, a) for a in index_loss.values[:, 0]])
+    index_loss = loss.evaluate_by_index(y_true, y_pred=QUANTILE_PRED)
+    assert all(np.isclose(0, a) for a in index_loss)
 
 
 @pytest.mark.parametrize("Metric", list_of_metrics)

--- a/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
@@ -29,15 +29,16 @@ def test_output(Metric, score_average):
     """Test output is correct class."""
     y_true = y_test
     loss = Metric.create_test_instance()
-    loss.set_params("score_average", score_average)
+    loss.set_params(score_average=score_average)
     eval_loss = loss.evaluate(y_true, y_pred=QUANTILE_PRED)
     index_loss = loss.evaluate_by_index(y_true, y_pred=QUANTILE_PRED)
 
     if score_average:
         assert isinstance(eval_loss, float)
+        assert isinstance(index_loss, pd.Series)
     else:
         assert isinstance(eval_loss, pd.DataFrame)
-    assert isinstance(index_loss, pd.DataFrame)
+        assert isinstance(index_loss, pd.DataFrame)
 
 
 @pytest.mark.parametrize("Metric", list_of_metrics)


### PR DESCRIPTION
This PR:
* fixes a bug in probabilistic metrics, `score_average` was not written to `self`, and not passed to super
* adds a proper "return" field to the docstrings