### PR TITLE
[ENH] tests for `check_estimator` tests passing

### DIFF
--- a/sktime/forecasting/model_selection/tests/test_split.py
+++ b/sktime/forecasting/model_selection/tests/test_split.py
@@ -451,10 +451,12 @@ def test_window_splitter_in_sample_fh_greater_than_window_length(CV):
 def test_split_by_fh(index_type, fh_type, is_relative, values):
     """Test temporal_train_test_split."""
     if fh_type == "timedelta":
-        pytest.skip(
-            "ForecastingHorizon with timedelta values "
-            "is currently experimental and not supported everywhere"
-        )
+        return None
+        # todo: ensure check_estimator works with pytest.skip like below
+        # pytest.skip(
+        #    "ForecastingHorizon with timedelta values "
+        #     "is currently experimental and not supported everywhere"
+        # )
     y = _make_series(20, index_type=index_type)
     cutoff = y.index[10]
     fh = _make_fh(cutoff, values, fh_type, is_relative)

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -208,8 +208,12 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         """Check that predicted time index matches forecasting horizon."""
         index_type, fh_type, is_relative = index_fh_comb
         if fh_type == "timedelta":
-            pytest.skip(pytest_skip_msg)
-
+            return None
+            # todo: ensure check_estimator works with pytest.skip like below
+            # pytest.skip(
+            #    "ForecastingHorizon with timedelta values "
+            #     "is currently experimental and not supported everywhere"
+            # )
         y_train = _make_series(
             n_columns=n_columns, index_type=index_type, n_timepoints=50
         )
@@ -233,8 +237,12 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         """Check that predict_residuals method works as expected."""
         index_type, fh_type, is_relative = index_fh_comb
         if fh_type == "timedelta":
-            pytest.skip(pytest_skip_msg)
-
+            return None
+            # todo: ensure check_estimator works with pytest.skip like below
+            # pytest.skip(
+            #    "ForecastingHorizon with timedelta values "
+            #     "is currently experimental and not supported everywhere"
+            # )
         y_train = _make_series(
             n_columns=n_columns, index_type=index_type, n_timepoints=50
         )
@@ -265,8 +273,12 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         """Check that predicted time index matches forecasting horizon."""
         index_type, fh_type, is_relative = index_fh_comb
         if fh_type == "timedelta":
-            pytest.skip(pytest_skip_msg)
-
+            return None
+            # todo: ensure check_estimator works with pytest.skip like below
+            # pytest.skip(
+            #    "ForecastingHorizon with timedelta values "
+            #     "is currently experimental and not supported everywhere"
+            # )
         z, X = make_forecasting_problem(index_type=index_type, make_X=True)
 
         # Some estimators may not support all time index types and fh types, hence we
@@ -293,8 +305,12 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         """Check that predicted time index equals fh for full in-sample predictions."""
         index_type, fh_type, is_relative = index_fh_comb
         if fh_type == "timedelta":
-            pytest.skip(pytest_skip_msg)
-
+            return None
+            # todo: ensure check_estimator works with pytest.skip like below
+            # pytest.skip(
+            #    "ForecastingHorizon with timedelta values "
+            #     "is currently experimental and not supported everywhere"
+            # )
         y_train = _make_series(n_columns=n_columns, index_type=index_type)
         cutoff = y_train.index[-1]
         steps = -np.arange(len(y_train))

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Tests for check_estimator."""
+
+__author__ = ["fkiraly"]
+
+import pytest
+
+from sktime.classification.feature_based import Catch22Classifier
+from sktime.forecasting.naive import NaiveForecaster
+from sktime.transformations.series.exponent import ExponentTransformer
+from sktime.utils.estimator_checks import check_estimator
+
+
+EXAMPLE_CLASSES = [Catch22Classifier, NaiveForecaster, ExponentTransformer]
+
+
+@pytest.mark.parametrize("estimator_class", EXAMPLE_CLASSES)
+def test_check_estimator_passed(estimator_class):
+    """Test that check_estimator returns only passed tests for examples."""
+    estimator_instance = estimator_class.create_test_instance()
+
+    result_class = check_estimator(estimator_class, verbose=False)
+    assert all(x == "PASSED" for x in result_class.values())
+
+    result_instance = check_estimator(estimator_instance, verbose=False)
+    assert all(x == "PASSED" for x in result_instance.values())
+
+
+@pytest.mark.parametrize("estimator_class", EXAMPLE_CLASSES)
+def test_check_estimator_does_not_raise(estimator_class):
+    """Test that check_estimator does raise when asked to raise exceptions."""
+    estimator_instance = estimator_class.create_test_instance()
+
+    check_estimator(estimator_class, return_exceptions=False, verbose=False)
+
+    check_estimator(estimator_instance, return_exceptions=False, verbose=False)

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -15,7 +15,7 @@ EXAMPLE_CLASSES = [Catch22Classifier, NaiveForecaster, ExponentTransformer]
 
 @pytest.mark.parametrize("estimator_class", EXAMPLE_CLASSES)
 def test_check_estimator_passed(estimator_class):
-    """Test that check_estimator returns only passed tests for examples."""
+    """Test that check_estimator returns only passed tests for examples we know pass."""
     estimator_instance = estimator_class.create_test_instance()
 
     result_class = check_estimator(estimator_class, verbose=False)
@@ -27,7 +27,7 @@ def test_check_estimator_passed(estimator_class):
 
 @pytest.mark.parametrize("estimator_class", EXAMPLE_CLASSES)
 def test_check_estimator_does_not_raise(estimator_class):
-    """Test that check_estimator does not raise when asked to raise exceptions."""
+    """Test that check_estimator does not raise exceptions on examples we know pass."""
     estimator_instance = estimator_class.create_test_instance()
 
     check_estimator(estimator_class, return_exceptions=False, verbose=False)

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -27,7 +27,7 @@ def test_check_estimator_passed(estimator_class):
 
 @pytest.mark.parametrize("estimator_class", EXAMPLE_CLASSES)
 def test_check_estimator_does_not_raise(estimator_class):
-    """Test that check_estimator does raise when asked to raise exceptions."""
+    """Test that check_estimator does not raise when asked to raise exceptions."""
     estimator_instance = estimator_class.create_test_instance()
 
     check_estimator(estimator_class, return_exceptions=False, verbose=False)

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -10,7 +10,6 @@ from sktime.forecasting.naive import NaiveForecaster
 from sktime.transformations.series.exponent import ExponentTransformer
 from sktime.utils.estimator_checks import check_estimator
 
-
 EXAMPLE_CLASSES = [Catch22Classifier, NaiveForecaster, ExponentTransformer]
 
 


### PR DESCRIPTION
This PR adds tests to test that tests conducted by the `check_estimator` utlity are passing, on three example estimators that are known to pass all tests in the full test suite.

This ensures that future tests catch unintentional side effects to changes in the test module that cause a `check_estimator` test to fail, such as the problem addressed recently in https://github.com/alan-turing-institute/sktime/pull/2405

Also turns some instances of `pytest.skip` inside tests into `return None`, as that currently breaks `check_estimator`. An issue to replace this workaroudn has been opened here: https://github.com/alan-turing-institute/sktime/issues/2419