### PR TITLE
[BUG] fix soft dependency handling for `esig` imports

### DIFF
--- a/sktime/clustering/metrics/averaging/_averaging.py
+++ b/sktime/clustering/metrics/averaging/_averaging.py
@@ -5,10 +5,6 @@ from typing import Callable
 
 import numpy as np
 
-from sktime.utils.validation._dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("tslearn")
-
 
 def mean_average(X: np.ndarray) -> np.ndarray:
     """Compute the mean average of time series.

--- a/sktime/transformations/panel/signature_based/_rescaling.py
+++ b/sktime/transformations/panel/signature_based/_rescaling.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-"""
+"""Signature rescaling methods.
+
 rescaling.py
 =========================
-Signature rescaling methods. This implements the pre- and post- signature
+This implements the pre- and post- signature
 rescaling methods along with generic scaling methods along feature
 dimensions of 3D tensors.
 Code for `rescale_path` and `rescale_signature` written by Patrick Kidger.
@@ -11,13 +12,13 @@ import math
 import numpy as np
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("esig")
-import esig  # noqa: E402
+_check_soft_dependencies("esig", severity="warning")
 
 
 def _rescale_path(path, depth):
-    """Rescales the input path by depth! ** (1 / depth), so that the last
-    signature term should be roughly O(1).
+    """Rescale input path by depth! ** (1 / depth).
+
+    Ensures last signature term should be roughly O(1).
 
     Parameters
     ----------
@@ -36,8 +37,9 @@ def _rescale_path(path, depth):
 
 
 def _rescale_signature(signature, channels, depth):
-    """Rescales the output signature by multiplying the depth-d term by d!,
-    with the aim that every term become ~O(1).
+    """Rescals the output signature by multiplying the depth-d term by d!.
+
+    Ain is that every term become ~O(1).
 
     Parameters
     ----------
@@ -53,6 +55,8 @@ def _rescale_signature(signature, channels, depth):
     np.ndarray:
         The signature with factorial depth scaling.
     """
+    import esig
+
     # Needed for weird esig fails
     if depth == 1:
         sigdim = channels

--- a/sktime/transformations/panel/signature_based/tests/test_method.py
+++ b/sktime/transformations/panel/signature_based/tests/test_method.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
+"""Tests for signature method."""
+
+import esig
 import numpy as np
 import pytest
+
 from sktime.transformations.panel.signature_based import SignatureTransformer
 
 
-import esig
-
-
 def test_generalised_signature_method():
+    """Check that dimension and dim of output are correct."""
     # Build an array X, note that this is [n_sample, n_channels, length] shape.
     n_channels = 3
     depth = 4
@@ -34,6 +36,7 @@ def test_generalised_signature_method():
 
 
 def test_window_error():
+    """Test that wrong window parameters raise error."""
     X = np.random.randn(5, 2, 3)
 
     # Check dyadic gives a value error

--- a/sktime/transformations/panel/signature_based/tests/test_method.py
+++ b/sktime/transformations/panel/signature_based/tests/test_method.py
@@ -2,10 +2,9 @@
 import numpy as np
 import pytest
 from sktime.transformations.panel.signature_based import SignatureTransformer
-from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("esig")
-import esig  # noqa: E402
+
+import esig
 
 
 def test_generalised_signature_method():


### PR DESCRIPTION
This PR fixes too restrictive soft dependency handling for `esig` imports.

These have been moved into functions/classes so loading is possible without having `esig` installed.