### PR TITLE
[ENH] suppressing deprecation messages in `all_estimators` estimator retrieval, address `dtw` import message

### DIFF
--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -13,7 +13,7 @@ from sklearn import clone
 from sktime.alignment.base import BaseAligner
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("dtw", severity="warning")
+_check_soft_dependencies("dtw", severity="warning",suppress_import_stdout=True)
 
 
 class AlignerDTW(BaseAligner):

--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -13,7 +13,7 @@ from sklearn import clone
 from sktime.alignment.base import BaseAligner
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("dtw", severity="warning",suppress_import_stdout=True)
+_check_soft_dependencies("dtw", severity="warning", suppress_import_stdout=True)
 
 
 class AlignerDTW(BaseAligner):

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -134,7 +134,9 @@ def all_estimators(
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=FutureWarning)
         warnings.simplefilter("module", category=ImportWarning)
-        warnings.filterwarnings("ignore", category=UserWarning, message= ".*has been moved to.*")
+        warnings.filterwarnings(
+            "ignore", category=UserWarning, message= ".*has been moved to.*"
+        )
         for _, module_name, _ in pkgutil.walk_packages(path=[ROOT], prefix="sktime."):
 
             # Filter modules

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -134,6 +134,7 @@ def all_estimators(
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=FutureWarning)
         warnings.simplefilter("module", category=ImportWarning)
+        warnings.filterwarnings("ignore", category=UserWarning, message= ".*has been moved to.*")
         for _, module_name, _ in pkgutil.walk_packages(path=[ROOT], prefix="sktime."):
 
             # Filter modules

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -135,7 +135,7 @@ def all_estimators(
         warnings.simplefilter("ignore", category=FutureWarning)
         warnings.simplefilter("module", category=ImportWarning)
         warnings.filterwarnings(
-            "ignore", category=UserWarning, message= ".*has been moved to.*"
+            "ignore", category=UserWarning, message=".*has been moved to.*"
         )
         for _, module_name, _ in pkgutil.walk_packages(path=[ROOT], prefix="sktime."):
 

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 """Utility to check soft dependency imports, and raise warnings or errors."""
 
-import warnings
-from importlib import import_module
 import io
 import sys
+import warnings
+from importlib import import_module
 
-def _check_soft_dependencies(*packages, severity="error", object=None, suppress_import_stdout=False):
+def _check_soft_dependencies(
+    *packages, severity="error", object=None, suppress_import_stdout=False
+    ):
     """Check if required soft dependencies are installed and raise error or warning.
 
     Parameters
@@ -18,6 +20,8 @@ def _check_soft_dependencies(*packages, severity="error", object=None, suppress_
     object : python object or None, default=None
         if self is passed here when _check_soft_dependencies is called within __init__
         the error message is more informative and will refer to the class
+    suppress_import_stdout : bool, optional. Default=False
+        whether to suppress stdout printout upon import.
 
     Raises
     ------
@@ -27,7 +31,7 @@ def _check_soft_dependencies(*packages, severity="error", object=None, suppress_
     for package in packages:
         try:
             if suppress_import_stdout:
-                #setup text trap, import, then restore
+                # setup text trap, import, then restore
                 sys.stdout = io.StringIO()
                 import_module(package)
                 sys.stdout = sys.__stdout__

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -6,9 +6,10 @@ import sys
 import warnings
 from importlib import import_module
 
+
 def _check_soft_dependencies(
     *packages, severity="error", object=None, suppress_import_stdout=False
-    ):
+):
     """Check if required soft dependencies are installed and raise error or warning.
 
     Parameters

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -3,9 +3,10 @@
 
 import warnings
 from importlib import import_module
+import io
+import sys
 
-
-def _check_soft_dependencies(*packages, severity="error", object=None):
+def _check_soft_dependencies(*packages, severity="error", object=None, suppress_import_stdout=False):
     """Check if required soft dependencies are installed and raise error or warning.
 
     Parameters
@@ -25,7 +26,13 @@ def _check_soft_dependencies(*packages, severity="error", object=None):
     """
     for package in packages:
         try:
-            import_module(package)
+            if suppress_import_stdout:
+                #setup text trap, import, then restore
+                sys.stdout = io.StringIO()
+                import_module(package)
+                sys.stdout = sys.__stdout__
+            else:
+                import_module(package)
         except ModuleNotFoundError as e:
             if object is None:
                 msg = (


### PR DESCRIPTION
issue #2386: 

#### Reference Issues/PRs
registry.all_estimators shows deprecation warnings from module level in cases where estimators have been moved. These should by default not be raised, only a direct import of the deprecated location should raise these.

#### What does this implement/fix? Explain your changes.
sktime/registry/_lookup.py
ignores warnings in all_estimators() by filtering out UserWarning matching regex ".*has been moved to.*"

#### Does your contribution introduce a new dependency? If yes, which one?
no

issue #2385:
#### Reference Issues/PRs
Every time one imports the dtw-python module, even when attempting to do so silently and with warning suppressed, the following is printed...

#### What does this implement/fix? Explain your changes.
The print issue is here in dtw: https://github.com/DynamicTimeWarping/dtw-python/blob/master/dtw/__init__.py

sktime/utils/validation/_dependencies.py
_check_soft_dependencies imports with overwritten sys.stdout (setup text trap, imports, then restores)

sktime/alignment/dtw_python.py 
calls _check_soft_dependencies with suppress_import_stdout=True

#### Does your contribution introduce a new dependency? If yes, which one?
no?




