### PR TITLE
[BUG] Sets "can handle missing value" tag in ARIMA and AutoARIMA

### DIFF
--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -224,6 +224,8 @@ class AutoARIMA(_PmdArimaAdapter):
     >>> y_pred = forecaster.predict(fh=[1,2,3])
     """  # noqa: E501
 
+    _tags = {"handles-missing-data": True}
+
     def __init__(
         self,
         start_p=2,
@@ -564,6 +566,8 @@ class ARIMA(_PmdArimaAdapter):
     ARIMA(...)
     >>> y_pred = forecaster.predict(fh=[1,2,3])
     """  # noqa: E501
+
+    _tags = {"handles-missing-data": True}
 
     def __init__(
         self,

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -19,7 +19,7 @@ class _PmdArimaAdapter(BaseForecaster):
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
         "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "handles-missing-data": True,
     }
 
     def __init__(self):


### PR DESCRIPTION
The "missing value" tag was incorrectly set in `ARIMA` and `AutoARIMA`, as reporte by @ngupta23 in https://github.com/alan-turing-institute/sktime/issues/2204

This has been confirmed and is now fixed.

Note to reviewers: I'm not setting the tag in the adapter class but in the concrete classes, to have the more conservative choice for any potential future model we interface from `pmdarima` by default.