### PR TITLE
[BUG] `TransformedTargetForecaster` inverses were not working for univariate transformers and more than one quantile

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -121,7 +121,7 @@ class _Pipeline(
             skip_trafo = transformer.get_tag("skip-inverse-transform", False)
             if not skip_trafo:
                 if mode is None:
-                    yt = transformer.inverse_transform(y, X)
+                    y = transformer.inverse_transform(y, X)
                 # if proba, we slice by quantile/coverage combination
                 #   and collect the same quantile/coverage by variable
                 #   then inverse transform, then concatenate
@@ -132,6 +132,8 @@ class _Pipeline(
                     yt = dict()
                     for ix in idx_low:
                         levels = list(range(1, n))
+                        if len(levels) == 1:
+                            levels = levels[0]
                         yt[ix] = y.xs(ix, level=levels, axis=1)
                         # deal with the "Coverage" case, we need to get rid of this
                         #   i.d., special 1st level name of prediction objet
@@ -142,12 +144,12 @@ class _Pipeline(
                         yt[ix] = transformer.inverse_transform(yt[ix], X)
                         if len(yt[ix].columns) == 1:
                             yt[ix].columns = temp
-                    yt = pd.concat(yt, axis=1)
+                    y = pd.concat(yt, axis=1)
                     flipcols = [n - 1] + list(range(n - 1))
-                    yt.columns = yt.columns.reorder_levels(flipcols)
+                    y.columns = y.columns.reorder_levels(flipcols)
                 else:
                     raise ValueError('mode arg must be None or "proba"')
-        return yt
+        return y
 
     @property
     def named_steps(self):

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -7,7 +7,6 @@ __author__ = ["mloning", "aiwalter"]
 __all__ = ["TransformedTargetForecaster", "ForecastingPipeline"]
 
 import pandas as pd
-
 from sklearn.base import clone
 
 from sktime.base import _HeterogenousMetaEstimator

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -134,7 +134,15 @@ class _Pipeline(
                     for ix in idx_low:
                         levels = list(range(1, n))
                         yt[ix] = y.xs(ix, level=levels, axis=1)
+                        # deal with the "Coverage" case, we need to get rid of this
+                        #   i.d., special 1st level name of prediction objet
+                        #   in the case where there is only one variable
+                        if len(yt[ix].columns) == 1:
+                            temp = yt[ix].columns
+                            yt[ix].columns = self._y.columns
                         yt[ix] = transformer.inverse_transform(yt[ix], X)
+                        if len(yt[ix].columns) == 1:
+                            yt[ix].columns = temp
                     yt = pd.concat(yt, axis=1)
                     flipcols = [n - 1] + list(range(n - 1))
                     yt.columns = yt.columns.reorder_levels(flipcols)
@@ -219,7 +227,7 @@ class _Pipeline(
 
 
 # we ensure that internally we convert to pd.DataFrame for now
-SUPPORTED_MTYPES = ["pd.DataFrame", "pd.Series", "pd-multiindex", "pd_multiindex_hier"]
+SUPPORTED_MTYPES = ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"]
 
 
 class ForecastingPipeline(_Pipeline):

--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -158,7 +158,7 @@ class Detrender(BaseTransformer):
             if len(difference) != 0:
                 raise ValueError(
                     "X contains columns that have not been "
-                    "seen in fit: " + difference
+                    "seen in fit: " + str(difference)
                 )
             for colname in Xt.columns:
                 X_pred = self.forecaster_[colname].predict(fh=fh, X=y)
@@ -199,7 +199,7 @@ class Detrender(BaseTransformer):
             if len(difference) != 0:
                 raise ValueError(
                     "X contains columns that have not been "
-                    "seen in fit: " + difference
+                    "seen in fit: " + str(difference)
                 )
             for colname in X.columns:
                 X_pred = self.forecaster_[colname].predict(fh=fh, X=y)


### PR DESCRIPTION
In a case where `TransformedTargetForecaster` inverses were called, and more than one quantile was queried, the probabilistic predict methods would break.

The reason was that the `inverse_transform` of the transformers would be applied to a multivariate data frame (the output of the proba predict methods).

A workaround was using the `ColumnTransformer`, but that was not obvious to a user.

This has now been fixed by implementing column vectorization.

Going forward, we should consider implementing column vectorization out of the box, like we did with row instances.