### PR TITLE
[BUG] forecasting pipeline dunder fix

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -116,7 +116,7 @@ class _Pipeline(
         y : pd.Series, pd.DataFrame
             Inverse transformed y
         """
-        for _, transformer in transformers:
+        for _, transformer in reversed(transformers):
             # skip sktime transformers where inverse transform
             # is not wanted ur meaningful (e.g. Imputer, HampelFilter)
             skip_trafo = transformer.get_tag("skip-inverse-transform", False)

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -81,9 +81,7 @@ class _Pipeline(
         # Shallow copy
         return estimator_tuples
 
-    def _iter_transformers(self, reverse=False):
-
-        fc_idx = self._get_forecaster_index()
+    def _iter_transformers(self, reverse=False, fc_idx=-1):
 
         # exclude final forecaster
         steps = self.steps_[:fc_idx]
@@ -98,13 +96,14 @@ class _Pipeline(
         """Return the length of the Pipeline."""
         return len(self.steps)
 
-    def _get_inverse_transform(self, y, X=None, mode=None):
+    def _get_inverse_transform(self, transformers, y, X=None, mode=None):
         """Iterate over transformers.
 
         Inverse transform y (used for y_pred and pred_int)
 
         Parameters
         ----------
+        transformers : list of (str, transformer) to apply
         y : pd.Series, pd.DataFrame
             Target series
         X : pd.Series, pd.DataFrame
@@ -117,7 +116,7 @@ class _Pipeline(
         y : pd.Series, pd.DataFrame
             Inverse transformed y
         """
-        for _, _, transformer in self._iter_transformers(reverse=True):
+        for _, transformer in transformers:
             # skip sktime transformers where inverse transform
             # is not wanted ur meaningful (e.g. Imputer, HampelFilter)
             skip_trafo = transformer.get_tag("skip-inverse-transform", False)
@@ -837,7 +836,7 @@ class TransformedTargetForecaster(_Pipeline, _SeriesToSeriesTransformer):
         """
         y_pred = self.forecaster_.predict(fh=fh, X=X)
         # inverse transform y_pred
-        y_pred = self._get_inverse_transform(y_pred, X)
+        y_pred = self._get_inverse_transform(self.transformers_pre_, y_pred, X)
 
         # transform post
         for _, t in self.transformers_post_:
@@ -890,7 +889,7 @@ class TransformedTargetForecaster(_Pipeline, _SeriesToSeriesTransformer):
         """
         self.check_is_fitted()
         zt = check_series(Z)
-        for _, _, transformer in self._iter_transformers():
+        for _, transformer in self.transformers_pre_:
             zt = transformer.transform(zt, X)
         return zt
 
@@ -911,7 +910,7 @@ class TransformedTargetForecaster(_Pipeline, _SeriesToSeriesTransformer):
         """
         self.check_is_fitted()
         Z = check_series(Z)
-        return self._get_inverse_transform(Z, X)
+        return self._get_inverse_transform(self.transformers_pre_, Z, X)
 
     def _predict_quantiles(self, fh, X=None, alpha=None):
         """Compute/return prediction quantiles for a forecast.
@@ -946,7 +945,9 @@ class TransformedTargetForecaster(_Pipeline, _SeriesToSeriesTransformer):
                 at quantile probability in second-level col index, for each row index.
         """
         pred_int = self.forecaster_.predict_quantiles(fh=fh, X=X, alpha=alpha)
-        pred_int_transformed = self._get_inverse_transform(pred_int, mode="proba")
+        pred_int_transformed = self._get_inverse_transform(
+            self.transformers_pre_, pred_int, mode="proba"
+        )
         return pred_int_transformed
 
     def _predict_interval(self, fh, X=None, coverage=None):
@@ -986,5 +987,7 @@ class TransformedTargetForecaster(_Pipeline, _SeriesToSeriesTransformer):
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
         pred_int = self.forecaster_.predict_interval(fh=fh, X=X, coverage=coverage)
-        pred_int_transformed = self._get_inverse_transform(pred_int, mode="proba")
+        pred_int_transformed = self._get_inverse_transform(
+            self.transformers_pre_, pred_int, mode="proba"
+        )
         return pred_int_transformed

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -83,8 +83,10 @@ class _Pipeline(
 
     def _iter_transformers(self, reverse=False):
 
+        fc_idx = self._get_forecaster_index()
+
         # exclude final forecaster
-        steps = self.steps_[:-1]
+        steps = self.steps_[:fc_idx]
 
         if reverse:
             steps = reversed(steps)

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -159,6 +159,14 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
         TransformerPipeline object, concatenation of `self` (first) with `other` (last).
             not nested, contains only non-TransformerPipeline `sktime` transformers
         """
+        # need to escape if other is BaseForecaster
+        #   this is because forecsting Pipelines are *also* transformers
+        #   but they need to take precedence in parsing the expression
+        from sktime.forecasting.base import BaseForecaster
+
+        if isinstance(other, BaseForecaster):
+            return NotImplemented
+
         # we don't use names but _get_estimator_names to get the *original* names
         #   to avoid multiple "make unique" calls which may grow strings too much
         _, trafos = zip(*self.steps_)
@@ -200,6 +208,14 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
         TransformerPipeline object, concatenation of `other` (first) with `self` (last).
             not nested, contains only non-TransformerPipeline `sktime` steps
         """
+        # need to escape if other is BaseForecaster
+        #   this is because forecsting Pipelines are *also* transformers
+        #   but they need to take precedence in parsing the expression
+        from sktime.forecasting.base import BaseForecaster
+
+        if isinstance(other, BaseForecaster):
+            return NotImplemented
+
         _, trafos = zip(*self.steps_)
         names = tuple(self._get_estimator_names(self.steps))
         if isinstance(other, TransformerPipeline):


### PR DESCRIPTION
This fixes a semi-bug in the dunders for forecasting pipelines.

Since forecasting pipelines were both forecasters and transformers, the transformer chain logic would take precedence as parsing of the expressions was currently coded, resulting in a transformer and not a forecaster when chaining transformers and a forecaster. Strictly speaking that was not wrong, since forecasting pipelines can be used as transformers.

This PR changes precedence so that the forecaster type takes precedence over the transformer type, ensuring that multiplying transformers with forecaster results in forecasters.