### PR TITLE
[BUG] temp workaround for unnamed levels in hierarchical X passed to aggregator

### DIFF
--- a/sktime/transformations/hierarchical/aggregate.py
+++ b/sktime/transformations/hierarchical/aggregate.py
@@ -71,6 +71,11 @@ class Aggregator(BaseTransformer):
         -------
         df_out : multi-indexed pd.DataFrame of Panel mtype pd_multiindex
         """
+        X = X.copy()
+        X_orig_idx_names = X.index.names
+        new_idx_names = [str(x) for x in range(len(X_orig_idx_names))]
+        X.index.names = new_idx_names
+
         if X.index.nlevels == 1:
             warn(
                 "Aggregator is intended for use with X.index.nlevels > 1. "
@@ -146,6 +151,8 @@ class Aggregator(BaseTransformer):
                 )
 
             df_out.sort_index(inplace=True)
+
+            df_out.index.names = X_orig_idx_names
             return df_out
 
     @classmethod


### PR DESCRIPTION
The `Aggregator` incorrectly assumed that all levels of the hierarchy were named.

This made it near impossible to use it in certain relevant pipelines.

This PR introduces a workaround which names the levels at the start and reverts to the original names at the end.
It should eventually be replaced by sth less hacky, but will have to do for pydata...