### PR TITLE
Katie

### DIFF
--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -13,7 +13,7 @@ from sklearn import clone
 from sktime.alignment.base import BaseAligner
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("dtw", severity="warning")
+_check_soft_dependencies("dtw", severity="warning",suppress_import_stdout=True)
 
 
 class AlignerDTW(BaseAligner):

--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -13,7 +13,7 @@ from sklearn import clone
 from sktime.alignment.base import BaseAligner
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("dtw", severity="warning",suppress_import_stdout=True)
+_check_soft_dependencies("dtw", severity="warning", suppress_import_stdout=True)
 
 
 class AlignerDTW(BaseAligner):

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -45,6 +45,7 @@ def all_estimators(
     exclude_estimators=None,
     return_names=True,
     as_dataframe=False,
+    suppress_import_stdout=False
 ):
     """Get a list of all estimators from sktime.
 
@@ -77,6 +78,8 @@ def all_estimators(
     as_dataframe: bool, optional (default=False)
                 if False, return is as described below;
                 if True, return is converted into a DataFrame for pretty display
+    suppress_import_stdout : bool, optional. Default=False
+        whether to suppress stdout printout upon import.
 
     Returns
     -------
@@ -95,6 +98,8 @@ def all_estimators(
     ----------
     Modified version from scikit-learn's `all_estimators()`.
     """
+    import io
+    import sys
     import warnings
 
     MODULES_TO_IGNORE = ("tests", "setup", "contrib", "benchmarking")
@@ -144,7 +149,13 @@ def all_estimators(
                 continue
 
             try:
-                module = import_module(module_name)
+                if suppress_import_stdout:
+                    # setup text trap, import, then restore
+                    sys.stdout = io.StringIO()
+                    module = import_module(module_name)
+                    sys.stdout = sys.__stdout__
+                else:
+                    module = import_module(module_name)
                 classes = inspect.getmembers(module, inspect.isclass)
 
                 # Filter classes

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -134,7 +134,9 @@ def all_estimators(
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=FutureWarning)
         warnings.simplefilter("module", category=ImportWarning)
-        warnings.filterwarnings("ignore", category=UserWarning, message= ".*has been moved to.*")
+        warnings.filterwarnings(
+            "ignore", category=UserWarning, message= ".*has been moved to.*"
+        )
         for _, module_name, _ in pkgutil.walk_packages(path=[ROOT], prefix="sktime."):
 
             # Filter modules

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -134,6 +134,7 @@ def all_estimators(
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=FutureWarning)
         warnings.simplefilter("module", category=ImportWarning)
+        warnings.filterwarnings("ignore", category=UserWarning, message= ".*has been moved to.*")
         for _, module_name, _ in pkgutil.walk_packages(path=[ROOT], prefix="sktime."):
 
             # Filter modules

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -135,7 +135,7 @@ def all_estimators(
         warnings.simplefilter("ignore", category=FutureWarning)
         warnings.simplefilter("module", category=ImportWarning)
         warnings.filterwarnings(
-            "ignore", category=UserWarning, message= ".*has been moved to.*"
+            "ignore", category=UserWarning, message=".*has been moved to.*"
         )
         for _, module_name, _ in pkgutil.walk_packages(path=[ROOT], prefix="sktime."):
 

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 """Utility to check soft dependency imports, and raise warnings or errors."""
 
-import warnings
-from importlib import import_module
 import io
 import sys
+import warnings
+from importlib import import_module
 
-def _check_soft_dependencies(*packages, severity="error", object=None, suppress_import_stdout=False):
+def _check_soft_dependencies(
+    *packages, severity="error", object=None, suppress_import_stdout=False
+    ):
     """Check if required soft dependencies are installed and raise error or warning.
 
     Parameters
@@ -18,6 +20,8 @@ def _check_soft_dependencies(*packages, severity="error", object=None, suppress_
     object : python object or None, default=None
         if self is passed here when _check_soft_dependencies is called within __init__
         the error message is more informative and will refer to the class
+    suppress_import_stdout : bool, optional. Default=False
+        whether to suppress stdout printout upon import.
 
     Raises
     ------
@@ -27,7 +31,7 @@ def _check_soft_dependencies(*packages, severity="error", object=None, suppress_
     for package in packages:
         try:
             if suppress_import_stdout:
-                #setup text trap, import, then restore
+                # setup text trap, import, then restore
                 sys.stdout = io.StringIO()
                 import_module(package)
                 sys.stdout = sys.__stdout__

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -6,9 +6,10 @@ import sys
 import warnings
 from importlib import import_module
 
+
 def _check_soft_dependencies(
     *packages, severity="error", object=None, suppress_import_stdout=False
-    ):
+):
     """Check if required soft dependencies are installed and raise error or warning.
 
     Parameters

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -3,9 +3,10 @@
 
 import warnings
 from importlib import import_module
+import io
+import sys
 
-
-def _check_soft_dependencies(*packages, severity="error", object=None):
+def _check_soft_dependencies(*packages, severity="error", object=None, suppress_import_stdout=False):
     """Check if required soft dependencies are installed and raise error or warning.
 
     Parameters
@@ -25,7 +26,13 @@ def _check_soft_dependencies(*packages, severity="error", object=None):
     """
     for package in packages:
         try:
-            import_module(package)
+            if suppress_import_stdout:
+                #setup text trap, import, then restore
+                sys.stdout = io.StringIO()
+                import_module(package)
+                sys.stdout = sys.__stdout__
+            else:
+                import_module(package)
         except ModuleNotFoundError as e:
             if object is None:
                 msg = (


### PR DESCRIPTION
#### Reference Issues/PRs
BUG] disable very aggressive citation message from dtw-python #2385

#### What does this implement/fix? Explain your changes.
Importing the dtw module has a forced print message. Everywhere that calls import_module:
  registry/_lookup.py *** fixing now
  utils/_maint/_show_versions.py (doesn't have dtw in deps list, not necessary to change)
  utils/validation/_dependencies.py (_check_soft_dependencies changed in previous commit d6fb526)


#### Does your contribution introduce a new dependency? If yes, which one?
no

#### What should a reviewer concentrate their feedback on?
I wasn't able to recreate the problem from the below, which I find a bit strange
from sktime.registry import all_estimators
all_estimators('forecaster')

However, testing this works with the changes
all_estimators('forecaster', suppress_import_stdout=True)

