### PR TITLE
[BUG] Fix type checking error due to pipeline type polymorphism when constructing nested pipelines 

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -24,7 +24,7 @@ class _Pipeline(
 
     def _get_pipeline_scitypes(self, estimators):
         """Get list of scityes (str) from names/estimator list."""
-        return [scitype(x[1], coerce_to_list=True) for x in estimators]
+        return [scitype(x[1]) for x in estimators]
 
     def _get_forecaster_index(self, estimators):
         """Get the index of the first forecaster in the list."""

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -24,6 +24,7 @@ class _Pipeline(
 
     def _get_pipeline_scitypes(self, estimators):
         """Get list of scityes (str) from names/estimator list."""
+
         def resolve_scitype(x):
             """Return forecaster, then transformer, then None, from scitype list."""
             if "forecaster" in x:
@@ -32,6 +33,7 @@ class _Pipeline(
                 return "transformer"
             else:
                 return None
+
         # first we get lists
         scitypes = [scitype(x[1], coerce_to_list=True) for x in estimators]
         # then we default to one scitype, forecaster if contained, else transformer

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -585,8 +585,9 @@ class TransformedTargetForecaster(_Pipeline):
     ----------
     steps : list of sktime transformers and forecasters, or
         list of tuples (str, estimator) of sktime transformers or forecasters
-            must contain exactly one transformer
-        these are "blueprint" transformers, states do not change when `fit` is called
+            the list must contain exactly one forecaster
+        these are "blueprint" transformers resp forecasters,
+            forecaster/transformer states do not change when `fit` is called
 
     Attributes
     ----------

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -12,7 +12,6 @@ from sklearn.base import clone
 from sktime.base import _HeterogenousMetaEstimator
 from sktime.forecasting.base._base import BaseForecaster
 from sktime.registry import scitype
-from sktime.transformations.base import _SeriesToSeriesTransformer
 from sktime.utils.validation.series import check_series
 
 

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -24,7 +24,20 @@ class _Pipeline(
 
     def _get_pipeline_scitypes(self, estimators):
         """Get list of scityes (str) from names/estimator list."""
-        return [scitype(x[1]) for x in estimators]
+        def resolve_scitype(x):
+            """Return forecaster, then transformer, then None, from scitype list."""
+            if "forecaster" in x:
+                return "forecaster"
+            elif "transformer" in x:
+                return "transformer"
+            else:
+                return None
+        # first we get lists
+        scitypes = [scitype(x[1], coerce_to_list=True) for x in estimators]
+        # then we default to one scitype, forecaster if contained, else transformer
+        scitypes = [resolve_scitype(x) for x in scitypes]
+
+        return scitypes
 
     def _get_forecaster_index(self, estimators):
         """Get the index of the first forecaster in the list."""

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -24,22 +24,7 @@ class _Pipeline(
 
     def _get_pipeline_scitypes(self, estimators):
         """Get list of scityes (str) from names/estimator list."""
-
-        def resolve_scitype(x):
-            """Return forecaster, then transformer, then None, from scitype list."""
-            if "forecaster" in x:
-                return "forecaster"
-            elif "transformer" in x:
-                return "transformer"
-            else:
-                return None
-
-        # first we get lists
-        scitypes = [scitype(x[1], coerce_to_list=True) for x in estimators]
-        # then we default to one scitype, forecaster if contained, else transformer
-        scitypes = [resolve_scitype(x) for x in scitypes]
-
-        return scitypes
+        return [scitype(x[1], coerce_to_list=True) for x in estimators]
 
     def _get_forecaster_index(self, estimators):
         """Get the index of the first forecaster in the list."""

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -536,7 +536,7 @@ class ForecastingPipeline(_Pipeline):
 #     return Zt
 
 
-class TransformedTargetForecaster(_Pipeline, _SeriesToSeriesTransformer):
+class TransformedTargetForecaster(_Pipeline):
     """Meta-estimator for forecasting transformed time series.
 
     Pipeline functionality to apply transformers to the target series. The

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -79,12 +79,16 @@ def test_skip_inverse_transform():
 
 def test_nesting_pipelines():
     """Test that nesting of pipelines works."""
-    from sktime.transformations.series.compose import OptionalPassthrough
-    from sktime.transformations.series.boxcox import LogTransformer
-    from sktime.transformations.series.detrend import Detrender
     from sktime.forecasting.ets import AutoETS
+    from sktime.transformations.series.boxcox import LogTransformer
+    from sktime.transformations.series.compose import OptionalPassthrough
+    from sktime.transformations.series.detrend import Detrender
 
-    ForecastingPipeline(steps=[
+    from sktime.utils._testing.scenarios_forecasting import (
+        ForecasterFitPredictUnivariateWithX
+    )
+
+    pipe = ForecastingPipeline(steps=[
             ("logX", OptionalPassthrough(LogTransformer())),
             ("detrenderX", OptionalPassthrough(Detrender(forecaster=AutoETS()))),
             ("prophetforecaster", TransformedTargetForecaster(
@@ -96,3 +100,7 @@ def test_nesting_pipelines():
             )
         ]
     )
+
+    scenario = ForecasterFitPredictUnivariateWithX()
+
+    scenario.run(pipe)

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -85,19 +85,22 @@ def test_nesting_pipelines():
     from sktime.transformations.series.detrend import Detrender
 
     from sktime.utils._testing.scenarios_forecasting import (
-        ForecasterFitPredictUnivariateWithX
+        ForecasterFitPredictUnivariateWithX,
     )
 
-    pipe = ForecastingPipeline(steps=[
+    pipe = ForecastingPipeline(
+        steps=[
             ("logX", OptionalPassthrough(LogTransformer())),
             ("detrenderX", OptionalPassthrough(Detrender(forecaster=AutoETS()))),
-            ("prophetforecaster", TransformedTargetForecaster(
-                steps=[
-                    ("log", OptionalPassthrough(LogTransformer())),
-                    ("autoETS", AutoETS()),
+            (
+                "etsforecaster",
+                TransformedTargetForecaster(
+                    steps=[
+                        ("log", OptionalPassthrough(LogTransformer())),
+                        ("autoETS", AutoETS()),
                     ]
-                )
-            )
+                ),
+            ),
         ]
     )
 

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -3,7 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Tests for forecasting pipelines."""
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning", "fkiraly"]
 __all__ = []
 
 import numpy as np
@@ -106,4 +106,4 @@ def test_nesting_pipelines():
 
     scenario = ForecasterFitPredictUnivariateWithX()
 
-    scenario.run(pipe)
+    scenario.run(pipe, method_sequence=["fit", "predict"])

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -83,7 +83,6 @@ def test_nesting_pipelines():
     from sktime.transformations.series.boxcox import LogTransformer
     from sktime.transformations.series.compose import OptionalPassthrough
     from sktime.transformations.series.detrend import Detrender
-
     from sktime.utils._testing.scenarios_forecasting import (
         ForecasterFitPredictUnivariateWithX,
     )

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -8,18 +8,22 @@ from inspect import isclass
 from sktime.registry._base_classes import BASE_CLASS_REGISTER
 
 
-def scitype(obj):
+def scitype(obj, coerce_to_list=False):
     """Determine scitype string of obj.
 
     Parameters
     ----------
     obj : class or object inheriting from sktime BaseObject
+    coerce_to_list : bool, optional, default = False
+        whether return should be coerced to list, even if only one scitype is identified
 
     Returns
     -------
     scitype : str, or list of str of sktime scitype strings from BASE_CLASS_REGISTER
         str, sktime scitype string, if exactly one scitype can be determined for obj
-        list of str, of scitype strings, if more than one scityp are determined
+            and if coerce_to_list is False
+        list of str, of scitype strings, if more than one scitype are determined
+            or if coerce_to_list is True
         obj has scitype if it inherits from class in same row of BASE_CLASS_REGISTER
 
     Raises
@@ -31,8 +35,10 @@ def scitype(obj):
     else:
         scitypes = [sci[0] for sci in BASE_CLASS_REGISTER if isinstance(obj, sci[1])]
 
-    if len(scitypes) == 1:
+    if len(scitypes) == 1 and not coerce_to_list:
         return scitypes[0]
 
     if len(scitypes) == 0:
         raise TypeError("Error, no scitype could be determined for obj")
+
+    return scitypes

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -8,12 +8,16 @@ from inspect import isclass
 from sktime.registry._base_classes import BASE_CLASS_REGISTER
 
 
-def scitype(obj, coerce_to_list=False):
+def scitype(obj, force_single_scitype=True, coerce_to_list=False):
     """Determine scitype string of obj.
 
     Parameters
     ----------
     obj : class or object inheriting from sktime BaseObject
+    force_single_scitype : bool, optional, default = True
+        whether only a single scitype is returned
+        if True, only the *first* scitype found will be returned
+        order is determined by the order in BASE_CLASS_REGISTER
     coerce_to_list : bool, optional, default = False
         whether return should be coerced to list, even if only one scitype is identified
 
@@ -35,10 +39,13 @@ def scitype(obj, coerce_to_list=False):
     else:
         scitypes = [sci[0] for sci in BASE_CLASS_REGISTER if isinstance(obj, sci[1])]
 
-    if len(scitypes) == 1 and not coerce_to_list:
-        return scitypes[0]
-
     if len(scitypes) == 0:
         raise TypeError("Error, no scitype could be determined for obj")
+
+    if force_single_scitype:
+        scitypes = [scitypes[0]]
+
+    if len(scitypes) == 1 and not coerce_to_list:
+        return scitypes[0]
 
     return scitypes

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -25,8 +25,8 @@ def scitype(obj, force_single_scitype=True, coerce_to_list=False):
     -------
     scitype : str, or list of str of sktime scitype strings from BASE_CLASS_REGISTER
         str, sktime scitype string, if exactly one scitype can be determined for obj
-            and if coerce_to_list is False
-        list of str, of scitype strings, if more than one scitype are determined
+            or force_single_scitype is True, and if coerce_to_list is False
+        list of str, of scitype strings, if more than one scitype are determined,
             or if coerce_to_list is True
         obj has scitype if it inherits from class in same row of BASE_CLASS_REGISTER
 

--- a/sktime/utils/_testing/estimator_checks.py
+++ b/sktime/utils/_testing/estimator_checks.py
@@ -355,4 +355,7 @@ def _has_capability(est, method: str) -> bool:
         if method == "predict_proba" and isinstance(est, ALWAYS_HAVE_PREDICT_PROBA):
             return True
         return get_tag(est, "capability:pred_int", False)
+    # skip transform for forecasters that have it - pipelines
+    if method == "transform" and isinstance(est, BaseForecaster):
+        return False
     return True


### PR DESCRIPTION
This PR fixes three interacting bugs, causing #2455:

* an error in the `scitype` utility where None would be returned instead of a list of scitype in a case where the passed estimator was type polymorphic (had multiple scitypes). This is fixed.
* an error in the forecasting pipelines constructor check that would consider another forecasting pipeline as type-less and hence raise an error, because forecasting pipelines were expected to be constructed with transformers or forecasters. This is fixed by changing the default behaviour of `scitype` to what was assumed (just one type is returned).
* Since the `scitype` would come back empty for the `TransformedTargetForecaster`, no scenarios would be found in testing, because retrieval was based on the `scitype` utility. Now, with the change, scenarios are retrieved, and more tests are run, which (without fix) would fail, since tests for transformers are also run due to the polymorphism. This is remedied by removing transformer inheritance from `TransformedTargetForecaster` for now.

This PR also adds:
* a test for constructing a nested pipeline to ensure the functionality/ability of nesting pipelines does not get broken in the future.
* functionality to the `scitypes` function that forces it to return only a single scitype. Ties are resolved by the order in which the scitypes appear in the register, which prefers forecasters above transformers. This is enabled by default, as it was assumed by all references.