### PR TITLE
[ENH] remove error message on exogeneous X from DirRec reducer

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -662,13 +662,6 @@ class _DirRecReducer(_Reducer):
         self : Estimator
             An fitted instance of self.
         """
-        # Exogenous variables are not yet supported for the dirrec strategy.
-        if X is not None:
-            raise NotImplementedError(
-                f"{self.__class__.__name__} does not yet support exogenous "
-                f"variables `X`."
-            )
-
         if len(self.fh.to_in_sample(self.cutoff)) > 0:
             raise NotImplementedError("In-sample predictions are not implemented")
 
@@ -704,8 +697,6 @@ class _DirRecReducer(_Reducer):
 
             estimator.fit(X_fit, yt[:, i])
             self.estimators_.append(estimator)
-
-        self._is_fitted = True
         return self
 
     def _predict_last_window(

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -708,11 +708,9 @@ class _DirRecReducer(_Reducer):
         self, fh, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA
     ):
         # Exogenous variables are not yet support for the dirrec strategy.
+        # todo: implement this. For now, we escape.
         if X is not None:
-            raise NotImplementedError(
-                f"{self.__class__.__name__} does not yet support exogenous "
-                f"variables `X`."
-            )
+            X = None
 
         # Get last window of available data.
         y_last, X_last = self._get_last_window()

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -631,6 +631,7 @@ class _DirRecReducer(_Reducer):
     strategy = "dirrec"
     _tags = {
         "requires-fh-in-fit": True,  # is the forecasting horizon required in fit?
+        "ignores-exogeneous-X": True,
     }
 
     def _transform(self, y, X=None):
@@ -662,6 +663,10 @@ class _DirRecReducer(_Reducer):
         self : Estimator
             An fitted instance of self.
         """
+        # todo: logic for X below is broken. Escape X until fixed.
+        if X is not None:
+            X = None
+
         if len(self.fh.to_in_sample(self.cutoff)) > 0:
             raise NotImplementedError("In-sample predictions are not implemented")
 


### PR DESCRIPTION
The `_DirRecReducer` did not comply with the generic forecaster interface, where exogeneous `X` should not raise an error (in the worst case it should be ignored). The reducer did raise an error.

This PR does not add use of exogeneous `X`, it simply makes the reducer interface compliant, by ignoring `X` instead of raising an error.

Surfaced via widening tests here: https://github.com/alan-turing-institute/sktime/pull/2462