### PR TITLE
[BUG] remove `alpha` arg from `_boxcox`, remove private method dependencies, ensure scipy 1.8.0 compatibility

### DIFF
--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -10,10 +10,7 @@ import numpy as np
 from scipy import optimize, special, stats
 from scipy.special import boxcox, inv_boxcox
 from scipy.stats import boxcox_llf, distributions, variation
-from scipy.stats.morestats import (
-    _boxcox_conf_interval,
-    _calc_uniform_order_statistic_medians,
-)
+from scipy.stats.morestats import _calc_uniform_order_statistic_medians
 
 from sktime.transformations.base import BaseTransformer
 from sktime.utils.validation import is_int
@@ -382,7 +379,7 @@ def _guerrero(x, sp, bounds=None):
     return optimizer(_eval_guerrero, args=(x_std, x_mean))
 
 
-def _boxcox(x, lmbda=None, bounds=None, alpha=None):
+def _boxcox(x, lmbda=None, bounds=None):
     r"""Return a dataset transformed by a Box-Cox power transformation.
 
     Parameters
@@ -393,10 +390,6 @@ def _boxcox(x, lmbda=None, bounds=None, alpha=None):
         If `lmbda` is not None, do the transformation for that value.
         If `lmbda` is None, find the lambda that maximizes the log-likelihood
         function and return it as the second output argument.
-    alpha : {None, float}, optional
-        If ``alpha`` is not None, return the ``100 * (1-alpha)%`` confidence
-        interval for `lmbda` as the third output argument.
-        Must be between 0.0 and 1.0.
 
     Returns
     -------
@@ -405,10 +398,6 @@ def _boxcox(x, lmbda=None, bounds=None, alpha=None):
     maxlog : float, optional
         If the `lmbda` parameter is None, the second returned argument is
         the lambda that maximizes the log-likelihood function.
-    (min_ci, max_ci) : tuple of float, optional
-        If `lmbda` parameter is None and ``alpha`` is not None, this returned
-        tuple of floats represents the minimum and maximum confidence limits
-        given ``alpha``.
 
     See Also
     --------
@@ -457,9 +446,4 @@ def _boxcox(x, lmbda=None, bounds=None, alpha=None):
     lmax = _boxcox_normmax(x, bounds=bounds, method="mle")
     y = _boxcox(x, lmax)
 
-    if alpha is None:
-        return y, lmax
-    else:
-        # Find confidence interval
-        interval = _boxcox_conf_interval(x, lmax, alpha)
-        return y, lmax, interval
+    return y, lmax

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -34,42 +34,6 @@ def _calc_uniform_order_statistic_medians(n):
     ----------
     .. [1] James J. Filliben, "The Probability Plot Correlation Coefficient
            Test for Normality", Technometrics, Vol. 17, pp. 111-117, 1975.
-
-    Examples
-    --------
-    Order statistics of the uniform distribution on the unit interval
-    are marginally distributed according to beta distributions.
-    The expectations of these order statistic are evenly spaced across
-    the interval, but the distributions are skewed in a way that
-    pushes the medians slightly towards the endpoints of the unit interval:
-
-    >>> n = 4
-    >>> k = np.arange(1, n+1)
-    >>> from scipy.stats import beta
-    >>> a = k
-    >>> b = n-k+1
-    >>> beta.mean(a, b)
-    array([0.2, 0.4, 0.6, 0.8])
-    >>> beta.median(a, b)
-    array([0.15910358, 0.38572757, 0.61427243, 0.84089642])
-
-    The Filliben approximation uses the exact medians of the smallest
-    and greatest order statistics, and the remaining medians are approximated
-    by points spread evenly across a sub-interval of the unit interval:
-
-    >>> from scipy.morestats import _calc_uniform_order_statistic_medians
-    >>> _calc_uniform_order_statistic_medians(n)
-    array([0.15910358, 0.38545246, 0.61454754, 0.84089642])
-
-    This plot shows the skewed distributions of the order statistics
-    of a sample of size four from a uniform distribution on the unit interval:
-
-    >>> import matplotlib.pyplot as plt
-    >>> x = np.linspace(0.0, 1.0, num=50, endpoint=True)
-    >>> pdfs = [beta.pdf(x, a[i], b[i]) for i in range(n)]
-    >>> plt.figure()
-    >>> plt.plot(x, pdfs[0], x, pdfs[1], x, pdfs[2], x, pdfs[3])
-
     """
     v = np.empty(n, dtype=np.float64)
     v[-1] = 0.5 ** (1.0 / n)

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -72,7 +72,7 @@ def _calc_uniform_order_statistic_medians(n):
 
     """
     v = np.empty(n, dtype=np.float64)
-    v[-1] = 0.5**(1.0 / n)
+    v[-1] = 0.5 ** (1.0 / n)
     v[0] = 1 - v[-1]
     i = np.arange(2, n)
     v[1:-1] = (i - 0.3175) / (n + 0.365)


### PR DESCRIPTION
This PR fixes https://github.com/alan-turing-institute/sktime/issues/1994, what I think is the last issue that prevents sktime from being compatible with `scipy` 1.8.0.

The fix is to remove the otherwise unused `alpha` arg from `_boxcox`, which allows to remove the `_boxcox_conf_interval dependency` entirely