### PR TITLE
[ENH] removing dead args and functions post `_predict_moving_cutoff` refactor

### DIFF
--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -442,13 +442,7 @@ class MyForecaster(BaseForecaster):
 
     # todo: consider implementing this, optional
     # if not implementing, delete the method
-    def _predict_moving_cutoff(
-        self,
-        y,
-        cv,
-        X=None,
-        update_params=True,
-    ):
+    def _predict_moving_cutoff(self, y, cv, X=None, update_params=True):
         """Make single-step or multi-step moving cutoff predictions.
 
         Parameters

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -2025,34 +2025,22 @@ class BaseForecaster(BaseEstimator):
 
                 # we use `update_predict_single` here
                 #  this updates the forecasting horizon
-                y_pred = self._update_predict_single(
+                y_pred = self.update_predict_single(
                     y_new,
                     fh,
                     X,
                     update_params=update_params,
                 )
-                if return_pred_int:
-                    y_pred_int = self.predict_interval(fh, X, alpha=alpha)
-                    y_pred_int = self._convert_new_to_old_pred_int(y_pred_int)
-                    y_pred = (y_pred, y_pred_int)
                 y_preds.append(y_pred)
                 cutoffs.append(self.cutoff)
 
                 for i in range(len(y_preds)):
-                    if not return_pred_int:
-                        y_preds[i] = convert_to(
-                            y_preds[i],
-                            self._y_mtype_last_seen,
-                            store=self._converter_store_y,
-                            store_behaviour="freeze",
-                        )
-                    else:
-                        y_preds[i][0] = convert_to(
-                            y_preds[i][0],
-                            self._y_mtype_last_seen,
-                            store=self._converter_store_y,
-                            store_behaviour="freeze",
-                        )
+                    y_preds[i] = convert_to(
+                        y_preds[i],
+                        self._y_mtype_last_seen,
+                        store=self._converter_store_y,
+                        store_behaviour="freeze",
+                    )
         return _format_moving_cutoff_predictions(y_preds, cutoffs)
 
     # TODO: remove in v0.11.0

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -2030,28 +2030,6 @@ class BaseForecaster(BaseEstimator):
                     )
         return _format_moving_cutoff_predictions(y_preds, cutoffs)
 
-    # TODO: remove in v0.11.0
-    def _convert_new_to_old_pred_int(self, pred_int_new, alpha):
-        name = pred_int_new.columns.get_level_values(0).unique()[0]
-        alpha = check_alpha(alpha, name="alpha")
-        alphas = [alpha] if isinstance(alpha, (float, int)) else alpha
-        pred_int_old_format = [
-            pd.DataFrame(
-                {
-                    "lower": pred_int_new[(name, a, "lower")],
-                    "upper": pred_int_new[(name, a, "upper")],
-                }
-            )
-            for a in alphas
-        ]
-
-        # for a single alpha, return single pd.DataFrame
-        if len(alphas) == 1:
-            return pred_int_old_format[0]
-
-        # otherwise return list of pd.DataFrames
-        return pred_int_old_format
-
 
 def _format_moving_cutoff_predictions(y_preds, cutoffs):
     """Format moving-cutoff predictions.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1984,15 +1984,7 @@ class BaseForecaster(BaseEstimator):
 
         return pred_dist
 
-    def _predict_moving_cutoff(
-        self,
-        y,
-        cv,
-        X=None,
-        update_params=True,
-        return_pred_int=False,
-        alpha=DEFAULT_ALPHA,
-    ):
+    def _predict_moving_cutoff(self, y, cv, X=None, update_params=True):
         """Make single-step or multi-step moving cutoff predictions.
 
         Parameters
@@ -2001,16 +1993,11 @@ class BaseForecaster(BaseEstimator):
         cv : temporal cross-validation generator
         X : pd.DataFrame
         update_params : bool
-        return_pred_int : bool
-        alpha : float or array-like
 
         Returns
         -------
         y_pred = pd.Series
         """
-        if return_pred_int:
-            raise NotImplementedError()
-
         fh = cv.get_fh()
         y_preds = []
         cutoffs = []
@@ -2026,9 +2013,9 @@ class BaseForecaster(BaseEstimator):
                 # we use `update_predict_single` here
                 #  this updates the forecasting horizon
                 y_pred = self.update_predict_single(
-                    y_new,
-                    fh,
-                    X,
+                    y=y_new,
+                    fh=fh,
+                    X=X,
                     update_params=update_params,
                 )
                 y_preds.append(y_pred)

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -51,12 +51,7 @@ class _BaseWindowForecaster(BaseForecaster):
                 window_length=self.window_length_,
                 start_with_window=False,
             )
-        return self._predict_moving_cutoff(
-            y,
-            cv,
-            X,
-            update_params=update_params,
-        )
+        return self._predict_moving_cutoff(y, cv, X, update_params=update_params)
 
     def _predict(self, fh, X=None):
         """Predict core logic."""
@@ -124,20 +119,16 @@ class _BaseWindowForecaster(BaseForecaster):
         -------
         y_pred : pd.DataFrame or pd.Series
         """
+        if return_pred_int:
+            raise NotImplementedError()
+
         y_train = self._y
 
         # generate cutoffs from forecasting horizon, note that cutoffs are
         # still based on integer indexes, so that they can be used with .iloc
         cutoffs = fh.to_relative(self.cutoff) + len(y_train) - 2
         cv = CutoffSplitter(cutoffs, fh=1, window_length=self.window_length_)
-        return self._predict_moving_cutoff(
-            y_train,
-            cv,
-            X,
-            update_params=False,
-            return_pred_int=return_pred_int,
-            alpha=alpha,
-        )
+        return self._predict_moving_cutoff(y_train, cv, X, update_params=False)
 
     def _predict_last_window(
         self, fh, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -187,21 +187,3 @@ class _BaseWindowForecaster(BaseForecaster):
         """
         self.update(y=y, X=X, update_params=update_params)
         return self._predict(fh=fh, X=X)
-
-
-def _format_moving_cutoff_predictions(y_preds, cutoffs):
-    """Format moving-cutoff predictions."""
-    if not isinstance(y_preds, list):
-        raise ValueError(f"`y_preds` must be a list, but found: {type(y_preds)}")
-
-    if len(y_preds[0]) == 1:
-        # return series for single step ahead predictions
-        return pd.concat(y_preds)
-
-    else:
-        # return data frame when we predict multiple steps ahead
-        y_pred = pd.DataFrame(y_preds).T
-        y_pred.columns = cutoffs
-        if y_pred.shape[1] == 1:
-            return y_pred.iloc[:, 0]
-        return y_pred


### PR DESCRIPTION
Post https://github.com/alan-turing-institute/sktime/pull/2466, there were dead args and functions, i.e., not called resp used by anything anymore. Both occurrences are in private locations, so can be removed without any adverse effect.

* `return_pred_int` args in `_predict_moving_cutoff` - would raise a `NotImplementedError`, which is moved upwards into the `_BaseWindowForecaster`
* `_format_moving_cutoff_prediction` in `_sktime.py` is an older version of the one in the base module, and not called anywhere.