### PR TITLE
[ENH] Differencer NA handling - "fill zero" parameter

### DIFF
--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -135,7 +135,7 @@ class Differencer(BaseTransformer):
         # note: internally, we will use self._na_handling
         #   because we must never change input param saves for sklearn compatibility
         #   and because we need to "translate" the old "drop_na" arg
-        #   this could, in certain cases, overwrite the self. parameger
+        #   this could, in certain cases, overwrite the self. parameter
         #   and cause sklearn compatibility issues due to the point mentioned
 
         translate_arg = {True: "drop_na", False: "keep_na"}

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -60,14 +60,20 @@ def _inverse_diff(Z, lag):
     return Z
 
 
+# understand syntax
+# design - new parameters? for handling input part
+#   there is already drop_na, but there isn't a "fill" option
+#   padding, or fill (zeros?)
+# perhaps bonus: ensure this also works out of the box for hierarchical (using pandas?)
+
+
 class Differencer(BaseTransformer):
     """Apply iterative differences to a timeseries.
 
     The transformation works for univariate and multivariate timeseries. However,
     the multivariate case applies the same differencing to every series.
 
-    Difference transformations are applied at the specified lags in the order
-    provided.
+    Difference transformations are applied at the specified lags in the order provided.
 
     For example, given a timeseries with monthly periodicity, using lags=[1, 12]
     corresponds to applying a standard first difference to handle trend, and
@@ -87,15 +93,6 @@ class Differencer(BaseTransformer):
     drop_na : bool, default = True
         Whether the differencer should drop the initial observations that
         contain missing values as a result of the differencing operation(s).
-
-    Attributes
-    ----------
-    lags : int or array-like
-        Lags used to perform the differencing of the input series.
-
-    drop_na : bool
-        Stores whether the Differencer drops the initial observations that contain
-        missing values as a result of the differencing operation(s).
 
     Examples
     --------

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -143,7 +143,8 @@ class Differencer(BaseTransformer):
         if drop_na is not None:
             warn(
                 f"the drop_na parameter is deprecated and will be removed in 0.13.0, "
-                f'use na_handling="{translate_arg[drop_na]}" instead'
+                f'use na_handling="{translate_arg[drop_na]}" instead',
+                DeprecationWarning,
             )
             self._na_handling = translate_arg[drop_na]
         else:

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -142,7 +142,7 @@ class Differencer(BaseTransformer):
 
         if drop_na is not None:
             warn(
-                f"the drop_na parameter is deprecated and will be removed in 0.13.0"
+                f"the drop_na parameter is deprecated and will be removed in 0.13.0, "
                 f'use na_handling="{translate_arg[drop_na]}" instead'
             )
             self._na_handling = translate_arg[drop_na]

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -6,6 +6,7 @@ __author__ = ["RNKuhns"]
 __all__ = ["Differencer"]
 
 from typing import Union
+from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -67,6 +68,9 @@ def _inverse_diff(Z, lag):
 # perhaps bonus: ensure this also works out of the box for hierarchical (using pandas?)
 
 
+# todo: deprecation in 0.13.0
+#   remove the drop_na *argument* and its handling
+#   change the default behaviour form "drop_na" to "fill_zero"
 class Differencer(BaseTransformer):
     """Apply iterative differences to a timeseries.
 
@@ -91,8 +95,19 @@ class Differencer(BaseTransformer):
         If a single `int` value is
 
     drop_na : bool, default = True
+        deprecated from 0.12.0, to be removed in 0.13.0
         Whether the differencer should drop the initial observations that
         contain missing values as a result of the differencing operation(s).
+
+    na_handling : str, default = "drop_na"
+        default will change to "fill_zero" from 0.13.0
+        How to handle the NaNs that appear at the start of the series from differencing
+        Example: there are only 3 differences in a series of length 4,
+            differencing [a, b, c, d] gives [?, b-a, c-b, d-c]
+            so we need to determine what happens with the "?" (= unknown value)
+        "drop_na" - we drop the unknown value
+        "keep_na" - we fill with NaN
+        "fill_zero" - we fill zero
 
     Examples
     --------
@@ -118,15 +133,50 @@ class Differencer(BaseTransformer):
         "capability:inverse_transform": True,
     }
 
-    def __init__(self, lags=1, drop_na=True):
+    VALID_NA_HANDLING_STR = ["drop_na", "keep_na", "fill_zero"]
+
+    def __init__(self, lags=1, drop_na=None, na_handling="drop_na"):
         self.lags = lags
         self.drop_na = drop_na
+        self.na_handling = self._check_na_handling(na_handling)
+        # note: internally, we will use self._na_handling
+        #   because we must never change input param saves for sklearn compatibility
+        #   and because we need to "translate" the old "drop_na" arg
+        #   this could, in certain cases, overwrite the self. parameger
+        #   and cause sklearn compatibility issues due to the point mentioned
+
+        translate_arg = {True: "drop_na", False: "keep_na"}
+
+        if drop_na is not None:
+            warn(
+                f'the drop_na is deprecated and will be removed in 0.13.0'
+                f'use na_handling="{translate_arg[drop_na]}" instead'
+            )
+            self._na_handling = translate_arg[drop_na]
+        else:
+            self._na_handling = na_handling
+
         self._Z = None
         self._lags = None
         self._cumulative_lags = None
         self._prior_cum_lags = None
         self._prior_lags = None
         super(Differencer, self).__init__()
+
+        # if the na_handling is "fill_zero" or "keep_na"
+        #   then the returned indices are same to the passed indices
+        if self._na_handling in ["fill_zero", "keep_na"]:
+            self.set_tags(**{"transform-returns-same-time-index": True})
+
+    def _check_na_handling(self, na_handling):
+        """Check na_handling parameter, should be a valid string as per docstring."""
+        if na_handling not in self.VALID_NA_HANDLING_STR:
+            raise ValueError(
+                "unreachable condition, invalid na_handling value encoutnered: "
+                f"{na_handling}"
+            )
+
+        return na_handling
 
     def _check_inverse_transform_index(self, Z):
         """Check fitted series contains indices needed in inverse_transform."""
@@ -149,7 +199,7 @@ class Differencer(BaseTransformer):
         elif first_idx > orig_last_idx:
             is_future = True
 
-        pad_z_inv = self.drop_na or is_future
+        pad_z_inv = self.na_handling == "drop_na" or is_future
 
         cutoff = Z.index[0] if pad_z_inv else Z.index[self._cumulative_lags[-1]]
         fh = ForecastingHorizon(np.arange(-1, -(self._cumulative_lags[-1] + 1), -1))
@@ -210,8 +260,19 @@ class Differencer(BaseTransformer):
             transformed version of X
         """
         Xt = _diff_transform(X, self._lags)
-        if self.drop_na:
+
+        na_handling = self._na_handling
+        if na_handling == "drop_na":
             Xt = Xt.iloc[self._cumulative_lags[-1] :]
+        elif na_handling == "fill_zero":
+            Xt.iloc[: self._cumulative_lags[-1]] = 0
+        elif na_handling == "keep_na":
+            pass
+        else:
+            raise RuntimeError(
+                "unreachable condition, invalid na_handling value encoutnered: "
+                f"{na_handling}"
+            )
         return Xt
 
     def _inverse_transform(self, X, y=None):
@@ -286,7 +347,11 @@ class Differencer(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+        params = [{"na_handling": x} for x in cls.VALID_NA_HANDLING_STR]
         # we're testing that inverse_transform is inverse to transform
         #   and that is only correct if the first observation is not dropped
-        params = {"drop_na": False}
+        # todo: ensure that we have proper tests or escapes for "incomplete inverses"
+        params = params[1:]
+        #   this removes "drop_na" setting where the inverse has problems
+        #   need to deal with this in a better way in testing
         return params

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -98,9 +98,9 @@ class Differencer(BaseTransformer):
         Example: there are only 3 differences in a series of length 4,
             differencing [a, b, c, d] gives [?, b-a, c-b, d-c]
             so we need to determine what happens with the "?" (= unknown value)
-        "drop_na" - we drop the unknown value
-        "keep_na" - we fill with NaN
-        "fill_zero" - we fill zero
+        "drop_na" - we drop the unknown value(s) and shorten the series
+        "keep_na" - we replace unknown value(s) with NaN
+        "fill_zero" - we replace unknown value(s) with zero
 
     Examples
     --------

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -165,8 +165,8 @@ class Differencer(BaseTransformer):
         """Check na_handling parameter, should be a valid string as per docstring."""
         if na_handling not in self.VALID_NA_HANDLING_STR:
             raise ValueError(
-                "unreachable condition, invalid na_handling value encoutnered: "
-                f"{na_handling}"
+                f'invalid na_handling parameter value encountered: "{na_handling}", '
+                f"na_handling must be one of: {self.VALID_NA_HANDLING_STR}"
             )
 
         return na_handling
@@ -263,7 +263,7 @@ class Differencer(BaseTransformer):
             pass
         else:
             raise RuntimeError(
-                "unreachable condition, invalid na_handling value encoutnered: "
+                "unreachable condition, invalid na_handling value encountered: "
                 f"{na_handling}"
             )
         return Xt

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -98,9 +98,9 @@ class Differencer(BaseTransformer):
         Example: there are only 3 differences in a series of length 4,
             differencing [a, b, c, d] gives [?, b-a, c-b, d-c]
             so we need to determine what happens with the "?" (= unknown value)
-        "drop_na" - we drop the unknown value(s) and shorten the series
-        "keep_na" - we replace unknown value(s) with NaN
-        "fill_zero" - we replace unknown value(s) with zero
+        "drop_na" - unknown value(s) are dropped, the series is shortened
+        "keep_na" - unknown value(s) is/are replaced by NaN
+        "fill_zero" - unknown value(s) is/are replaced by zero
 
     Examples
     --------

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -61,13 +61,6 @@ def _inverse_diff(Z, lag):
     return Z
 
 
-# understand syntax
-# design - new parameters? for handling input part
-#   there is already drop_na, but there isn't a "fill" option
-#   padding, or fill (zeros?)
-# perhaps bonus: ensure this also works out of the box for hierarchical (using pandas?)
-
-
 # todo: deprecation in 0.13.0
 #   remove the drop_na *argument* and its handling
 #   change the default behaviour form "drop_na" to "fill_zero"

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -142,7 +142,7 @@ class Differencer(BaseTransformer):
 
         if drop_na is not None:
             warn(
-                f'the drop_na is deprecated and will be removed in 0.13.0'
+                f"the drop_na parameter is deprecated and will be removed in 0.13.0"
                 f'use na_handling="{translate_arg[drop_na]}" instead'
             )
             self._na_handling = translate_arg[drop_na]

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -3,7 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Unit tests of Differencer functionality."""
 
-__author__ = ["Ryan Kuhns"]
+__author__ = ["RNKuhns"]
 __all__ = []
 
 import numpy as np
@@ -22,10 +22,29 @@ test_cases = [y_airline, y_airline_df]
 lags_to_test = [1, 12, (3), [5], np.array([7]), (8, 3), [1, 12], np.array([5, 7, 1])]
 
 
+y_simple = pd.DataFrame({"a": [1, 3, -1.5, -7]})
+y_simple_expected_diff = {
+    "drop_na": pd.DataFrame({"a": [2, -4.5, -5.5]}),
+    "keep_na": pd.DataFrame({"a": [np.nan, -4.5, -5.5]}),
+    "fill_zero": pd.DataFrame({"a": [0, -4.5, -5.5]}),
+}
+
+
+@pytest.mark.parametrize("na_handling", Differencer.VALID_NA_HANDLING_STR)
+def test_differencer_produces_expected_results(na_handling):
+    """Test that Differencer produces expected results on a simple DataFrame."""
+    transformer = Differencer(na_handling=na_handling)
+    y_transformed = transformer.fit_transform(y_simple)
+    y_expected = y_simple_expected_diff[na_handling]
+
+    _assert_array_almost_equal(y_transformed, y_expected)
+
+
 @pytest.mark.parametrize("y", test_cases)
 @pytest.mark.parametrize("lags", lags_to_test)
 def test_differencer_same_series(y, lags):
-    transformer = Differencer(lags=lags)
+    """Test transform against inverse_transform."""
+    transformer = Differencer(lags=lags, na_handling="drop_na")
     y_transform = transformer.fit_transform(y)
     y_reconstructed = transformer.inverse_transform(y_transform)
 
@@ -34,10 +53,12 @@ def test_differencer_same_series(y, lags):
     _assert_array_almost_equal(y.loc[y_reconstructed.index], y_reconstructed)
 
 
+@pytest.mark.parametrize("na_handling", ["keep_na", "fill_zero"])
 @pytest.mark.parametrize("y", test_cases)
 @pytest.mark.parametrize("lags", lags_to_test)
-def test_differencer_remove_missing_false(y, lags):
-    transformer = Differencer(lags=lags, drop_na=False)
+def test_differencer_remove_missing_false(y, lags, na_handling):
+    """Test transform against inverse_transform."""
+    transformer = Differencer(lags=lags, na_handling=na_handling)
     y_transform = transformer.fit_transform(y)
     y_reconstructed = transformer.inverse_transform(y_transform)
 
@@ -47,10 +68,11 @@ def test_differencer_remove_missing_false(y, lags):
 @pytest.mark.parametrize("y", test_cases)
 @pytest.mark.parametrize("lags", lags_to_test)
 def test_differencer_prediction(y, lags):
+    """Test transform against inverse_transform."""
     y_train = y.iloc[:-12].copy()
     y_true = y.iloc[-12:].copy()
 
-    transformer = Differencer(lags=[1, 12])
+    transformer = Differencer(lags=lags, na_handling="drop_na")
     y_transform = transformer.fit_transform(y)
 
     # Use the actual transformed values as predictions since we know we should


### PR DESCRIPTION
From a pair programming session with @lbventur (at the community meetup).

This PR solves #2478, it upgrades `Differencer` with NA handling parameter `na_handling`, which allows, besides the two current behaviours, a third behaviour `fill_zero` that fills zero.

This parameter replaces the boolean `drop_na` parameter, and adds deprecation with replacement at 0.13.0, and move to a `fill_zero` default.

Why is the `fill_zero` parameter a better default? It results in a "same index" and "no NA" condition at the end, which is the most compatible out of the alternatives when used in a pipeline. See also discussion (and user frustration) here: https://github.com/alan-turing-institute/sktime/issues/2452 and here: https://github.com/alan-turing-institute/sktime/issues/2451