### PR TITLE
[BUG] ensure row index names are preserved in hierarchical forecasting when vectorizing

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -190,7 +190,9 @@ class VectorizedDF:
         X_mi_index = X_mi_reconstructed.index
         X_orig_index = self.X_multiindex.index
         if overwrite_index and len(X_mi_index.names) == len(X_orig_index.names):
-            X_mi_reconstructed.index.set_names(X_orig_index.names)
+            X_mi_reconstructed.index = X_mi_index.set_names(
+                X_orig_index.names
+            )
 
         if not convert_back:
             return X_mi_reconstructed

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1550,7 +1550,7 @@ class BaseForecaster(BaseEstimator):
             for i in range(n):
                 method = getattr(self.forecasters_.iloc[i, 0], methodname)
                 y_preds += [method(X=Xs[i], **kwargs)]
-            y_pred = self._yvec.reconstruct(y_preds, overwrite_index=False)
+            y_pred = self._yvec.reconstruct(y_preds, overwrite_index=True)
             return y_pred
 
     def _fit(self, y, X=None, fh=None):


### PR DESCRIPTION
Fixes https://github.com/alan-turing-institute/sktime/issues/2434.

There were two reasons for the issue:

* row index name overwrite was turned off in the `BaseForecaster` class, although this was available as an option in `reconstruct`
* `reconstruct` did not overwrite the index when asked to do so, since it did not assign the result of a (non-inplace) `set_names` to the index