### PR TITLE
[ENH] speed up Facebook Prophet tests

### DIFF
--- a/sktime/forecasting/fbprophet.py
+++ b/sktime/forecasting/fbprophet.py
@@ -217,7 +217,7 @@ class Prophet(_ProphetAdapter):
             "yearly_seasonality": False,
             "weekly_seasonality": False,
             "daily_seasonality": False,
-            "uncertainty_samples": 1000,
+            "uncertainty_samples": 10,
             "verbose": False,
         }
         return params


### PR DESCRIPTION
This PR tries to speed up Facebook `Prophet` tests.

Changes in the test settings:
* reduced number of "uncertainty samples" from 1000 to 10