### PR TITLE
[BUG] fixed `ColumnEnsembleClassifier` handling of unequal lenght data

### DIFF
--- a/sktime/classification/compose/_column_ensemble.py
+++ b/sktime/classification/compose/_column_ensemble.py
@@ -4,7 +4,7 @@
 Builds classifiers on each dimension (column) independently.
 """
 
-__author__ = ["Aaron Bostrom"]
+__author__ = ["abostrom"]
 __all__ = ["ColumnEnsembleClassifier"]
 
 from itertools import chain
@@ -23,7 +23,7 @@ class BaseColumnEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
 
     _tags = {
         "capability:multivariate": True,
-        "X_inner_mtype": "pd-multiindex",
+        "X_inner_mtype": ["nested_univ", "pd-multiindex"],
     }
 
     def __init__(self, estimators, verbose=False):
@@ -165,7 +165,6 @@ class BaseColumnEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
             estimators_.append((name, estimator, column))
 
         self.estimators_ = estimators_
-        self._is_fitted = True
         return self
 
     def _collect_probas(self, X):
@@ -178,7 +177,6 @@ class BaseColumnEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
 
     def _predict_proba(self, X) -> np.ndarray:
         """Predict class probabilities for X using 'soft' voting."""
-        self.check_is_fitted()
         avg = np.average(self._collect_probas(X), axis=0)
         return avg
 

--- a/sktime/classification/compose/_column_ensemble.py
+++ b/sktime/classification/compose/_column_ensemble.py
@@ -23,6 +23,7 @@ class BaseColumnEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
 
     _tags = {
         "capability:multivariate": True,
+        "X_inner_mtype": "pd-multiindex",
     }
 
     def __init__(self, estimators, verbose=False):
@@ -30,6 +31,12 @@ class BaseColumnEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
         self.estimators = estimators
         self.remainder = "drop"
         super(BaseColumnEnsembleClassifier, self).__init__()
+        self._anytagis_then_set(
+            "capability:unequal_length", False, True, self._estimators
+        )
+        self._anytagis_then_set(
+            "capability:missing_values", False, True, self._estimators
+        )
 
     @property
     def _estimators(self):


### PR DESCRIPTION
This PR fixes two bugs in ColumnEnsembleClassifier` related to this report https://github.com/alan-turing-institute/sktime/issues/2312:

* tags were incorrectly set - `ColumnEnsembleClassifier` always thought it could not handle unequal length data, even if components supported that. This is now correctly inferred from the internal tags.
* the internal mtype was set to `numpy3D` which could handle only equal length data by definition of this data type. This was changed to the `pandas.DataFrame` based data types.