### PR TITLE
[ENH] unequal length classifier scenario

### DIFF
--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -3,7 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements base class for time series regression estimators in sktime."""
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = ["BaseRegressor"]
 
 from sktime.base import BaseEstimator
@@ -12,7 +12,11 @@ from sktime.base import BaseEstimator
 class BaseRegressor(BaseEstimator):
     """Base class for regressors, for identification."""
 
-    _tags = {"capability:multivariate": False}
+    _tags = {
+        "capability:multivariate": False,
+        "capability:unequal_length": False,
+        "capability:missing_values": False,
+    }
 
     def fit(self, X, y):
         """Fit regressor to training data.

--- a/sktime/utils/_testing/scenarios_classification.py
+++ b/sktime/utils/_testing/scenarios_classification.py
@@ -112,7 +112,7 @@ class ClassifierFitPredict(ClassifierTestScenario):
         "X_univariate": True,
         "X_unequal_length": False,
         "is_enabled": True,
-        "n_classes": 2
+        "n_classes": 2,
     }
 
     args = {
@@ -130,7 +130,7 @@ class ClassifierFitPredictMultivariate(ClassifierTestScenario):
         "X_univariate": False,
         "X_unequal_length": False,
         "is_enabled": True,
-        "n_classes": 2
+        "n_classes": 2,
     }
 
     args = {
@@ -156,7 +156,7 @@ class ClassifierFitPredictUnequalLength(ClassifierTestScenario):
         "X_univariate": True,
         "X_unequal_length": True,
         "is_enabled": True,
-        "n_classes": 2
+        "n_classes": 2,
     }
 
     args = {

--- a/sktime/utils/_testing/scenarios_classification.py
+++ b/sktime/utils/_testing/scenarios_classification.py
@@ -14,6 +14,7 @@ from inspect import isclass
 from sktime.base import BaseObject
 from sktime.classification.base import BaseClassifier
 from sktime.regression.base import BaseRegressor
+from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_classification_y, _make_panel_X
 from sktime.utils._testing.scenarios import TestScenario
 
@@ -81,8 +82,12 @@ class ClassifierTestScenario(TestScenario, BaseObject):
 
         # if X is multivariate, applicable only if can handle multivariate
         is_multivariate = not self.get_tag("X_univariate")
-
         if is_multivariate and not get_tag(obj, "capability:multivariate"):
+            return False
+
+        # if X is unequal length, applicable only if can handle unequal length
+        is_unequal_length = self.get_tag("X_unequal_length")
+        if is_unequal_length and not get_tag(obj, "capability:unequal_length"):
             return False
 
         return True
@@ -103,7 +108,12 @@ X_test_multivariate = _make_panel_X(
 class ClassifierFitPredict(ClassifierTestScenario):
     """Fit/predict with univariate panel X and labels y."""
 
-    _tags = {"X_univariate": True, "is_enabled": True, "n_classes": 2}
+    _tags = {
+        "X_univariate": True,
+        "X_unequal_length": False,
+        "is_enabled": True,
+        "n_classes": 2
+    }
 
     args = {
         "fit": {"y": y, "X": X},
@@ -116,7 +126,12 @@ class ClassifierFitPredict(ClassifierTestScenario):
 class ClassifierFitPredictMultivariate(ClassifierTestScenario):
     """Fit/predict with multivariate panel X and labels y."""
 
-    _tags = {"X_univariate": False, "is_enabled": True, "n_classes": 2}
+    _tags = {
+        "X_univariate": False,
+        "X_unequal_length": False,
+        "is_enabled": True,
+        "n_classes": 2
+    }
 
     args = {
         "fit": {"y": y, "X": X_multivariate},
@@ -126,13 +141,41 @@ class ClassifierFitPredictMultivariate(ClassifierTestScenario):
     default_arg_sequence = ["fit", "predict", "predict", "predict"]
 
 
+X_unequal_length = _make_hierarchical(
+    hierarchy_levels=(10,), min_timepoints=10, max_timepoints=15, random_state=RAND_SEED
+)
+X_unequal_length_test = _make_hierarchical(
+    hierarchy_levels=(5,), min_timepoints=10, max_timepoints=15, random_state=RAND_SEED
+)
+
+
+class ClassifierFitPredictUnequalLength(ClassifierTestScenario):
+    """Fit/predict with univariate panel X and labels y, unequal length series."""
+
+    _tags = {
+        "X_univariate": True,
+        "X_unequal_length": True,
+        "is_enabled": True,
+        "n_classes": 2
+    }
+
+    args = {
+        "fit": {"y": y, "X": X_unequal_length},
+        "predict": {"X": X_unequal_length_test},
+    }
+    default_method_sequence = ["fit", "predict", "predict_proba", "decision_function"]
+    default_arg_sequence = ["fit", "predict", "predict", "predict"]
+
+
 scenarios_classification = [
     ClassifierFitPredict,
     ClassifierFitPredictMultivariate,
+    ClassifierFitPredictUnequalLength,
 ]
 
 # we use the same scenarios for regression, as in the old test suite
 scenarios_regression = [
     ClassifierFitPredict,
     ClassifierFitPredictMultivariate,
+    ClassifierFitPredictUnequalLength,
 ]


### PR DESCRIPTION
This PR adds a scenario, `ClassifierFitPredictUnequalLength`, where the `X` used in `fit` and `predict` has unequal length, for testing of classifiers and regressors.

This scenario is used by the test suite whenever the classifier/regressor claims to be capable of handling unequal length series via the `capability:unequal_length` tag.

Introducing this scenario should prevent issues such as
https://github.com/alan-turing-institute/sktime/pull/2513
from happening again (in cases where the tags are correctly set).