### PR TITLE
[ENH] cleaning up `_panel._convert` module

### DIFF
--- a/examples/loading_data.ipynb
+++ b/examples/loading_data.ipynb
@@ -4,45 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Loading and working with data in sktime\n",
+    "# Loading data into sktime\n",
     "\n",
-    "Python provides a variety of useful ways to represent data, but NumPy arrays and pandas DataFrames are commonly used for data analysis. When using NumPy 2d-arrays or pandas DataFrames to analyze tabular data the rows are commony used to represent each instance (e.g. case or observation) of the data, while the columns are used to represent a given feature (e.g. variable or dimension) for an observation. Since timeseries data also has a time dimension for a given instance and feature, several alternative data formats could be used to represent this data, including nested pandas DataFrame structures, NumPy 3d-arrays, or multi-indexed pandas DataFrames. \n",
+    "This tutorial outlines time series related file formats and how to load data into sktime.\n",
     "\n",
-    "Sktime is designed to work with timeseries data stored as nested pandas DataFrame objects. Similar to working with pandas DataFrames with tabular data, this allows instances to be represented by rows and the feature data for each dimension of a problem (e.g. variables or features) to be stored in the DataFrame columns. To accomplish this the timepoints for each instance-feature combination are stored in a single cell in the input Pandas DataFrame ([see Sktime pandas DataFrame format](#sktime_df_format) for more details). \n",
+    "Users can load or convert data into sktime compatible formats in two main ways:\n",
     "\n",
-    "Users can load or convert data into sktime's format in a variety of ways. Data can be loaded directly from a bespoke sktime file format (.ts) ([see Representing data with .ts files](#ts_files)) or supported file formats provided by [other existing data sources](#other_file_types) (such as Weka ARFF and .tsv). Sktime also provides functions to convert data to and from sktime's nested pandas DataFrame format and several other common ways for representing timeseries data using NumPy arrays or pandas DataFrames. [see Converting between sktime and alternative timeseries formats](#convert).\n",
+    "* pathway 1: direct loading from time series formats. Data can be loaded directly from a bespoke time series storage format, for instance `.ts` ([see Representing data with .ts files](#ts_files)) or other supported file formats, such as Weka `ARFF` and `.tsv` (see [other existing data sources](#other_file_types)). \n",
+    "* pathway 2: loading in-memory, then conversion. sktime provides functions to convert between common in-memory representations, see `AA_datatypes_and_datasets` tutorial. Hence, data can be loaded via any loader utility (e.g., `pandas.read_csv`) first, then converted manually into one of the sktime compatible specifications, and then converted between specifications using the sktime `convert` or `convert_to` utility.\n",
     "\n",
-    "The rest of this sktime tutorial will provide a more detailed description of the sktime pandas DataFrame format, a brief description of the .ts file format, how to load data from other supported formats, and how to convert between other common ways of representing timeseries data in NumPy arrays or pandas DataFrames.\n",
-    "\n",
-    "<a id=\"sktime_df_format\"></a>\n",
-    "## Sktime pandas DataFrame format\n",
-    "\n",
-    "The core data structure for storing datasets in sktime is a _nested_ pandas DataFrame, where rows of the dataframe correspond to instances (cases or observations),  and columns correspond to dimensions of the problem (features or variables). The multiple timepoints and their corresponding values for each instance-feature pair are stored as pandas Series object _nested_ within the applicable DataFrame cell.\n",
-    "\n",
-    "For example, for a problem with n cases that each have data across c timeseries dimensions:\n",
-    "\n",
-    "    DataFrame:\n",
-    "    index |   dim_0   |   dim_1   |    ...    |  dim_c-1\n",
-    "       0  | pd.Series | pd.Series | pd.Series | pd.Series\n",
-    "       1  | pd.Series | pd.Series | pd.Series | pd.Series\n",
-    "      ... |    ...    |    ...    |    ...    |    ...\n",
-    "       n  | pd.Series | pd.Series | pd.Series | pd.Series\n",
-    "\n",
-    "Representing timeseries data in this way makes it easy to align the timeseries features for a given instance with non-timeseries information. For example, in  a classification problem, it is easy to align the timeseries features for an observation with its (index-aligned) target class label:\n",
-    "\n",
-    "    index | class_val\n",
-    "      0   |   int\n",
-    "      1   |   int\n",
-    "     ...  |   ...\n",
-    "      n   |   int\n",
-    "\n",
-    "\n",
-    "While sktime's format uses pandas Series objects in its nested DataFrame structure, other data structures like NumPy arrays could be used to hold the timeseries values in each cell. However, the use of pandas Series objects helps to facilitate simple storage of sparse data and make it easy to accomodate series with non-integer timestamps (such as dates). \n",
-    "\n",
+    "The rest of this tutorial provides descriptions of pathway 1, i.e., how to load data from supported file formats.\n",
     "\n",
     "<a id=\"ts_files\"></a>\n",
     "## The .ts file format\n",
-    "One common use case is to load locally stored data. To make this easy, the .ts file format has been created for representing problems in a standard format for use with sktime. \n",
+    "One common use case is to load locally stored data. To make this easy, the `.ts` file format has been created for representing problems in a standard format for use with sktime. \n",
     "\n",
     "### Representing data with .ts files\n",
     "A .ts file include two main parts:\n",
@@ -131,7 +106,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Train and test partitions of the ArrowHead problem have been loaded into nested dataframes with an associated array of class values. As an example, below are the first 5 rows from the train_x and train_y:"
+    "Train and test partitions of the ArrowHead problem have been loaded into nested dataframes (the `nested_univ` format for panel data) with an associated array of class values. As an example, below are the first 5 rows from the train_x and train_y:"
    ]
   },
   {
@@ -148,8 +123,81 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "                                               dim_0\n0  0     -1.963009\n1     -1.957825\n2     -1.95614...\n1  0     -1.774571\n1     -1.774036\n2     -1.77658...\n2  0     -1.866021\n1     -1.841991\n2     -1.83502...\n3  0     -2.073758\n1     -2.073301\n2     -2.04460...\n4  0     -1.746255\n1     -1.741263\n2     -1.72274...",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>dim_0</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0     -1.963009\n1     -1.957825\n2     -1.95614...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0     -1.774571\n1     -1.774036\n2     -1.77658...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0     -1.866021\n1     -1.841991\n2     -1.83502...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0     -2.073758\n1     -2.073301\n2     -2.04460...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0     -1.746255\n1     -1.741263\n2     -1.72274...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>dim_0</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0     -1.963009\n",
+       "1     -1.957825\n",
+       "2     -1.95614...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0     -1.774571\n",
+       "1     -1.774036\n",
+       "2     -1.77658...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0     -1.866021\n",
+       "1     -1.841991\n",
+       "2     -1.83502...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0     -2.073758\n",
+       "1     -2.073301\n",
+       "2     -2.04460...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0     -1.746255\n",
+       "1     -1.741263\n",
+       "2     -1.72274...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               dim_0\n",
+       "0  0     -1.963009\n",
+       "1     -1.957825\n",
+       "2     -1.95614...\n",
+       "1  0     -1.774571\n",
+       "1     -1.774036\n",
+       "2     -1.77658...\n",
+       "2  0     -1.866021\n",
+       "1     -1.841991\n",
+       "2     -1.83502...\n",
+       "3  0     -2.073758\n",
+       "1     -2.073301\n",
+       "2     -2.04460...\n",
+       "4  0     -1.746255\n",
+       "1     -1.741263\n",
+       "2     -1.72274..."
+      ]
      },
      "execution_count": 2,
      "metadata": {},
@@ -174,7 +222,9 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "array(['0', '1', '2', '0', '1'], dtype='<U1')"
+      "text/plain": [
+       "array(['0', '1', '2', '0', '1'], dtype='<U1')"
+      ]
      },
      "execution_count": 3,
      "metadata": {},
@@ -218,8 +268,81 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "                                               dim_0\n0  0     -1.963009\n1     -1.957825\n2     -1.95614...\n1  0     -1.774571\n1     -1.774036\n2     -1.77658...\n2  0     -1.866021\n1     -1.841991\n2     -1.83502...\n3  0     -2.073758\n1     -2.073301\n2     -2.04460...\n4  0     -1.746255\n1     -1.741263\n2     -1.72274...",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>dim_0</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0     -1.963009\n1     -1.957825\n2     -1.95614...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0     -1.774571\n1     -1.774036\n2     -1.77658...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0     -1.866021\n1     -1.841991\n2     -1.83502...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0     -2.073758\n1     -2.073301\n2     -2.04460...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0     -1.746255\n1     -1.741263\n2     -1.72274...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>dim_0</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0     -1.963009\n",
+       "1     -1.957825\n",
+       "2     -1.95614...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0     -1.774571\n",
+       "1     -1.774036\n",
+       "2     -1.77658...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0     -1.866021\n",
+       "1     -1.841991\n",
+       "2     -1.83502...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0     -2.073758\n",
+       "1     -2.073301\n",
+       "2     -2.04460...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0     -1.746255\n",
+       "1     -1.741263\n",
+       "2     -1.72274...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               dim_0\n",
+       "0  0     -1.963009\n",
+       "1     -1.957825\n",
+       "2     -1.95614...\n",
+       "1  0     -1.774571\n",
+       "1     -1.774036\n",
+       "2     -1.77658...\n",
+       "2  0     -1.866021\n",
+       "1     -1.841991\n",
+       "2     -1.83502...\n",
+       "3  0     -2.073758\n",
+       "1     -2.073301\n",
+       "2     -2.04460...\n",
+       "4  0     -1.746255\n",
+       "1     -1.741263\n",
+       "2     -1.72274..."
+      ]
      },
      "execution_count": 4,
      "metadata": {},
@@ -256,8 +379,306 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "                                               dim_0  \\\n0  0     0.079106\n1     0.079106\n2    -0.903497\n3...   \n1  0     0.377751\n1     0.377751\n2     2.952965\n3...   \n2  0    -0.813905\n1    -0.813905\n2    -0.424628\n3...   \n3  0     0.289855\n1     0.289855\n2    -0.669185\n3...   \n4  0    -0.123238\n1    -0.123238\n2    -0.249547\n3...   \n\n                                               dim_1  \\\n0  0     0.394032\n1     0.394032\n2    -3.666397\n3...   \n1  0    -0.610850\n1    -0.610850\n2     0.970717\n3...   \n2  0     0.825666\n1     0.825666\n2    -1.305033\n3...   \n3  0     0.284130\n1     0.284130\n2    -0.210466\n3...   \n4  0     0.379341\n1     0.379341\n2     0.541501\n3...   \n\n                                               dim_2  \\\n0  0     0.551444\n1     0.551444\n2    -0.282844\n3...   \n1  0    -0.147376\n1    -0.147376\n2    -5.962515\n3...   \n2  0     0.032712\n1     0.032712\n2     0.826170\n3...   \n3  0     0.213680\n1     0.213680\n2     0.252267\n3...   \n4  0    -0.286006\n1    -0.286006\n2     0.208420\n3...   \n\n                                               dim_3  \\\n0  0     0.351565\n1     0.351565\n2    -0.095881\n3...   \n1  0    -0.103872\n1    -0.103872\n2    -7.593275\n3...   \n2  0     0.021307\n1     0.021307\n2    -0.372872\n3...   \n3  0    -0.314278\n1    -0.314278\n2     0.018644\n3...   \n4  0    -0.098545\n1    -0.098545\n2    -0.023970\n3...   \n\n                                               dim_4  \\\n0  0     0.023970\n1     0.023970\n2    -0.319605\n3...   \n1  0    -0.109198\n1    -0.109198\n2    -0.697804\n3...   \n2  0     0.122515\n1     0.122515\n2    -0.045277\n3...   \n3  0     0.074574\n1     0.074574\n2     0.007990\n3...   \n4  0     0.058594\n1     0.058594\n2     0.175783\n3...   \n\n                                               dim_5  \n0  0     0.633883\n1     0.633883\n2     0.972131\n3...  \n1  0    -0.037287\n1    -0.037287\n2    -2.865789\n3...  \n2  0     0.775041\n1     0.775041\n2     0.383526\n3...  \n3  0    -0.079901\n1    -0.079901\n2     0.237040\n3...  \n4  0    -0.074574\n1    -0.074574\n2     0.114525\n3...  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>dim_0</th>\n      <th>dim_1</th>\n      <th>dim_2</th>\n      <th>dim_3</th>\n      <th>dim_4</th>\n      <th>dim_5</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0     0.079106\n1     0.079106\n2    -0.903497\n3...</td>\n      <td>0     0.394032\n1     0.394032\n2    -3.666397\n3...</td>\n      <td>0     0.551444\n1     0.551444\n2    -0.282844\n3...</td>\n      <td>0     0.351565\n1     0.351565\n2    -0.095881\n3...</td>\n      <td>0     0.023970\n1     0.023970\n2    -0.319605\n3...</td>\n      <td>0     0.633883\n1     0.633883\n2     0.972131\n3...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0     0.377751\n1     0.377751\n2     2.952965\n3...</td>\n      <td>0    -0.610850\n1    -0.610850\n2     0.970717\n3...</td>\n      <td>0    -0.147376\n1    -0.147376\n2    -5.962515\n3...</td>\n      <td>0    -0.103872\n1    -0.103872\n2    -7.593275\n3...</td>\n      <td>0    -0.109198\n1    -0.109198\n2    -0.697804\n3...</td>\n      <td>0    -0.037287\n1    -0.037287\n2    -2.865789\n3...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0    -0.813905\n1    -0.813905\n2    -0.424628\n3...</td>\n      <td>0     0.825666\n1     0.825666\n2    -1.305033\n3...</td>\n      <td>0     0.032712\n1     0.032712\n2     0.826170\n3...</td>\n      <td>0     0.021307\n1     0.021307\n2    -0.372872\n3...</td>\n      <td>0     0.122515\n1     0.122515\n2    -0.045277\n3...</td>\n      <td>0     0.775041\n1     0.775041\n2     0.383526\n3...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0     0.289855\n1     0.289855\n2    -0.669185\n3...</td>\n      <td>0     0.284130\n1     0.284130\n2    -0.210466\n3...</td>\n      <td>0     0.213680\n1     0.213680\n2     0.252267\n3...</td>\n      <td>0    -0.314278\n1    -0.314278\n2     0.018644\n3...</td>\n      <td>0     0.074574\n1     0.074574\n2     0.007990\n3...</td>\n      <td>0    -0.079901\n1    -0.079901\n2     0.237040\n3...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0    -0.123238\n1    -0.123238\n2    -0.249547\n3...</td>\n      <td>0     0.379341\n1     0.379341\n2     0.541501\n3...</td>\n      <td>0    -0.286006\n1    -0.286006\n2     0.208420\n3...</td>\n      <td>0    -0.098545\n1    -0.098545\n2    -0.023970\n3...</td>\n      <td>0     0.058594\n1     0.058594\n2     0.175783\n3...</td>\n      <td>0    -0.074574\n1    -0.074574\n2     0.114525\n3...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>dim_0</th>\n",
+       "      <th>dim_1</th>\n",
+       "      <th>dim_2</th>\n",
+       "      <th>dim_3</th>\n",
+       "      <th>dim_4</th>\n",
+       "      <th>dim_5</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0     0.079106\n",
+       "1     0.079106\n",
+       "2    -0.903497\n",
+       "3...</td>\n",
+       "      <td>0     0.394032\n",
+       "1     0.394032\n",
+       "2    -3.666397\n",
+       "3...</td>\n",
+       "      <td>0     0.551444\n",
+       "1     0.551444\n",
+       "2    -0.282844\n",
+       "3...</td>\n",
+       "      <td>0     0.351565\n",
+       "1     0.351565\n",
+       "2    -0.095881\n",
+       "3...</td>\n",
+       "      <td>0     0.023970\n",
+       "1     0.023970\n",
+       "2    -0.319605\n",
+       "3...</td>\n",
+       "      <td>0     0.633883\n",
+       "1     0.633883\n",
+       "2     0.972131\n",
+       "3...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0     0.377751\n",
+       "1     0.377751\n",
+       "2     2.952965\n",
+       "3...</td>\n",
+       "      <td>0    -0.610850\n",
+       "1    -0.610850\n",
+       "2     0.970717\n",
+       "3...</td>\n",
+       "      <td>0    -0.147376\n",
+       "1    -0.147376\n",
+       "2    -5.962515\n",
+       "3...</td>\n",
+       "      <td>0    -0.103872\n",
+       "1    -0.103872\n",
+       "2    -7.593275\n",
+       "3...</td>\n",
+       "      <td>0    -0.109198\n",
+       "1    -0.109198\n",
+       "2    -0.697804\n",
+       "3...</td>\n",
+       "      <td>0    -0.037287\n",
+       "1    -0.037287\n",
+       "2    -2.865789\n",
+       "3...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0    -0.813905\n",
+       "1    -0.813905\n",
+       "2    -0.424628\n",
+       "3...</td>\n",
+       "      <td>0     0.825666\n",
+       "1     0.825666\n",
+       "2    -1.305033\n",
+       "3...</td>\n",
+       "      <td>0     0.032712\n",
+       "1     0.032712\n",
+       "2     0.826170\n",
+       "3...</td>\n",
+       "      <td>0     0.021307\n",
+       "1     0.021307\n",
+       "2    -0.372872\n",
+       "3...</td>\n",
+       "      <td>0     0.122515\n",
+       "1     0.122515\n",
+       "2    -0.045277\n",
+       "3...</td>\n",
+       "      <td>0     0.775041\n",
+       "1     0.775041\n",
+       "2     0.383526\n",
+       "3...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0     0.289855\n",
+       "1     0.289855\n",
+       "2    -0.669185\n",
+       "3...</td>\n",
+       "      <td>0     0.284130\n",
+       "1     0.284130\n",
+       "2    -0.210466\n",
+       "3...</td>\n",
+       "      <td>0     0.213680\n",
+       "1     0.213680\n",
+       "2     0.252267\n",
+       "3...</td>\n",
+       "      <td>0    -0.314278\n",
+       "1    -0.314278\n",
+       "2     0.018644\n",
+       "3...</td>\n",
+       "      <td>0     0.074574\n",
+       "1     0.074574\n",
+       "2     0.007990\n",
+       "3...</td>\n",
+       "      <td>0    -0.079901\n",
+       "1    -0.079901\n",
+       "2     0.237040\n",
+       "3...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0    -0.123238\n",
+       "1    -0.123238\n",
+       "2    -0.249547\n",
+       "3...</td>\n",
+       "      <td>0     0.379341\n",
+       "1     0.379341\n",
+       "2     0.541501\n",
+       "3...</td>\n",
+       "      <td>0    -0.286006\n",
+       "1    -0.286006\n",
+       "2     0.208420\n",
+       "3...</td>\n",
+       "      <td>0    -0.098545\n",
+       "1    -0.098545\n",
+       "2    -0.023970\n",
+       "3...</td>\n",
+       "      <td>0     0.058594\n",
+       "1     0.058594\n",
+       "2     0.175783\n",
+       "3...</td>\n",
+       "      <td>0    -0.074574\n",
+       "1    -0.074574\n",
+       "2     0.114525\n",
+       "3...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               dim_0  \\\n",
+       "0  0     0.079106\n",
+       "1     0.079106\n",
+       "2    -0.903497\n",
+       "3...   \n",
+       "1  0     0.377751\n",
+       "1     0.377751\n",
+       "2     2.952965\n",
+       "3...   \n",
+       "2  0    -0.813905\n",
+       "1    -0.813905\n",
+       "2    -0.424628\n",
+       "3...   \n",
+       "3  0     0.289855\n",
+       "1     0.289855\n",
+       "2    -0.669185\n",
+       "3...   \n",
+       "4  0    -0.123238\n",
+       "1    -0.123238\n",
+       "2    -0.249547\n",
+       "3...   \n",
+       "\n",
+       "                                               dim_1  \\\n",
+       "0  0     0.394032\n",
+       "1     0.394032\n",
+       "2    -3.666397\n",
+       "3...   \n",
+       "1  0    -0.610850\n",
+       "1    -0.610850\n",
+       "2     0.970717\n",
+       "3...   \n",
+       "2  0     0.825666\n",
+       "1     0.825666\n",
+       "2    -1.305033\n",
+       "3...   \n",
+       "3  0     0.284130\n",
+       "1     0.284130\n",
+       "2    -0.210466\n",
+       "3...   \n",
+       "4  0     0.379341\n",
+       "1     0.379341\n",
+       "2     0.541501\n",
+       "3...   \n",
+       "\n",
+       "                                               dim_2  \\\n",
+       "0  0     0.551444\n",
+       "1     0.551444\n",
+       "2    -0.282844\n",
+       "3...   \n",
+       "1  0    -0.147376\n",
+       "1    -0.147376\n",
+       "2    -5.962515\n",
+       "3...   \n",
+       "2  0     0.032712\n",
+       "1     0.032712\n",
+       "2     0.826170\n",
+       "3...   \n",
+       "3  0     0.213680\n",
+       "1     0.213680\n",
+       "2     0.252267\n",
+       "3...   \n",
+       "4  0    -0.286006\n",
+       "1    -0.286006\n",
+       "2     0.208420\n",
+       "3...   \n",
+       "\n",
+       "                                               dim_3  \\\n",
+       "0  0     0.351565\n",
+       "1     0.351565\n",
+       "2    -0.095881\n",
+       "3...   \n",
+       "1  0    -0.103872\n",
+       "1    -0.103872\n",
+       "2    -7.593275\n",
+       "3...   \n",
+       "2  0     0.021307\n",
+       "1     0.021307\n",
+       "2    -0.372872\n",
+       "3...   \n",
+       "3  0    -0.314278\n",
+       "1    -0.314278\n",
+       "2     0.018644\n",
+       "3...   \n",
+       "4  0    -0.098545\n",
+       "1    -0.098545\n",
+       "2    -0.023970\n",
+       "3...   \n",
+       "\n",
+       "                                               dim_4  \\\n",
+       "0  0     0.023970\n",
+       "1     0.023970\n",
+       "2    -0.319605\n",
+       "3...   \n",
+       "1  0    -0.109198\n",
+       "1    -0.109198\n",
+       "2    -0.697804\n",
+       "3...   \n",
+       "2  0     0.122515\n",
+       "1     0.122515\n",
+       "2    -0.045277\n",
+       "3...   \n",
+       "3  0     0.074574\n",
+       "1     0.074574\n",
+       "2     0.007990\n",
+       "3...   \n",
+       "4  0     0.058594\n",
+       "1     0.058594\n",
+       "2     0.175783\n",
+       "3...   \n",
+       "\n",
+       "                                               dim_5  \n",
+       "0  0     0.633883\n",
+       "1     0.633883\n",
+       "2     0.972131\n",
+       "3...  \n",
+       "1  0    -0.037287\n",
+       "1    -0.037287\n",
+       "2    -2.865789\n",
+       "3...  \n",
+       "2  0     0.775041\n",
+       "1     0.775041\n",
+       "2     0.383526\n",
+       "3...  \n",
+       "3  0    -0.079901\n",
+       "1    -0.079901\n",
+       "2     0.237040\n",
+       "3...  \n",
+       "4  0    -0.074574\n",
+       "1    -0.074574\n",
+       "2     0.114525\n",
+       "3...  "
+      ]
      },
      "execution_count": 5,
      "metadata": {},
@@ -297,8 +718,81 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "                                               dim_0\n0  0     -1.963009\n1     -1.957825\n2     -1.95614...\n1  0     -1.774571\n1     -1.774036\n2     -1.77658...\n2  0     -1.866021\n1     -1.841991\n2     -1.83502...\n3  0     -2.073758\n1     -2.073301\n2     -2.04460...\n4  0     -1.746255\n1     -1.741263\n2     -1.72274...",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>dim_0</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0     -1.963009\n1     -1.957825\n2     -1.95614...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0     -1.774571\n1     -1.774036\n2     -1.77658...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0     -1.866021\n1     -1.841991\n2     -1.83502...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0     -2.073758\n1     -2.073301\n2     -2.04460...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0     -1.746255\n1     -1.741263\n2     -1.72274...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>dim_0</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0     -1.963009\n",
+       "1     -1.957825\n",
+       "2     -1.95614...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0     -1.774571\n",
+       "1     -1.774036\n",
+       "2     -1.77658...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0     -1.866021\n",
+       "1     -1.841991\n",
+       "2     -1.83502...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0     -2.073758\n",
+       "1     -2.073301\n",
+       "2     -2.04460...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0     -1.746255\n",
+       "1     -1.741263\n",
+       "2     -1.72274...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               dim_0\n",
+       "0  0     -1.963009\n",
+       "1     -1.957825\n",
+       "2     -1.95614...\n",
+       "1  0     -1.774571\n",
+       "1     -1.774036\n",
+       "2     -1.77658...\n",
+       "2  0     -1.866021\n",
+       "1     -1.841991\n",
+       "2     -1.83502...\n",
+       "3  0     -2.073758\n",
+       "1     -2.073301\n",
+       "2     -2.04460...\n",
+       "4  0     -1.746255\n",
+       "1     -1.741263\n",
+       "2     -1.72274..."
+      ]
      },
      "execution_count": 6,
      "metadata": {},
@@ -321,552 +815,8 @@
     "<a id=\"convert\"></a>\n",
     "## Converting between other NumPy and pandas formats\n",
     "\n",
-    "It is also possible to use data from sources other than .ts and .arff files by manually shaping the data into the format described above. \n",
-    "\n",
-    "Functions to convert from and to these types to sktime's nested DataFrame format are provided in `sktime.datatypes._panel._convert`\n",
-    "\n",
-    "### Using tabular data with sktime\n",
-    "\n",
-    "One approach to representing timeseries data is a tabular DataFrame. As usual, each row represents an instance. In the tabular setting each timepoint of the univariate timeseries being measured for each instance are treated as feature and stored as a primitive data type in the DataFrame's cells. \n",
-    "\n",
-    "In a univariate setting, where there are `n` instances of the series and each univariate timeseries has `t` timepoints, this would yield a pandas DataFrame with shape (n, t). In practice, this could be used to represent sensors measuring the same signal over time (features) on different machines (instances) or the same economic variable over time (features) for different countries (instances). \n",
-    "\n",
-    "The function `from_2d_array_to_nested` converts a (n, t) tabular DataFrame to nested DataFrame with shape (n, 1). To convert from a nested DataFrame to a tabular array the function `from_nested_to_2d_array` can be used.\n",
-    "\n",
-    "The example below uses 50 instances with 20 timepoints each. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The tabular data has the shape (50, 20)\n"
-     ]
-    }
-   ],
-   "source": [
-    "from numpy.random import default_rng\n",
-    "\n",
-    "from sktime.datatypes._panel._convert import (\n",
-    "    from_2d_array_to_nested,\n",
-    "    from_nested_to_2d_array,\n",
-    "    is_nested_dataframe,\n",
-    ")\n",
-    "\n",
-    "rng = default_rng()\n",
-    "X_2d = rng.standard_normal((50, 20))\n",
-    "print(f\"The tabular data has the shape {X_2d.shape}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The `from_2d_array_to_nested` function makes it easy to convert this to a nested DataFrame."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "X_nested is a nested DataFrame: True\n",
-      "The cell contains a <class 'pandas.core.series.Series'>.\n",
-      "The nested DataFrame has shape (50, 1)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "                                                   0\n0  0     2.471024\n1    -0.706527\n2     0.970234\n3...\n1  0    -3.602003\n1    -0.410588\n2    -0.187621\n3...\n2  0     0.347837\n1     0.806042\n2    -0.574513\n3...\n3  0     0.533445\n1    -0.197439\n2     1.579744\n3...\n4  0    -0.438283\n1    -0.084260\n2    -0.022976\n3...",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>0</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0     2.471024\n1    -0.706527\n2     0.970234\n3...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0    -3.602003\n1    -0.410588\n2    -0.187621\n3...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0     0.347837\n1     0.806042\n2    -0.574513\n3...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0     0.533445\n1    -0.197439\n2     1.579744\n3...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0    -0.438283\n1    -0.084260\n2    -0.022976\n3...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "X_nested = from_2d_array_to_nested(X_2d)\n",
-    "print(f\"X_nested is a nested DataFrame: {is_nested_dataframe(X_nested)}\")\n",
-    "print(f\"The cell contains a {type(X_nested.iloc[0,0])}.\")\n",
-    "print(f\"The nested DataFrame has shape {X_nested.shape}\")\n",
-    "X_nested.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This nested DataFrame can also be converted back to a tabular DataFrame using easily. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The tabular data has the shape (50, 20)\n"
-     ]
-    }
-   ],
-   "source": [
-    "X_2d = from_nested_to_2d_array(X_nested)\n",
-    "print(f\"The tabular data has the shape {X_2d.shape}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Using long-format data with sktime\n",
-    "\n",
-    "Timeseries data can also be represented in _long_ format where each row identifies the value for a single timepoint for a given dimension for a given instance. \n",
-    "\n",
-    "This format may be encountered in a database where each row stores a single value measurement identified by several identification columns. For example, where `case_id` is an id to identify a specific instance in the data, `dimension_id` is an integer between 0 and d-1 for d dimensions in the data, `reading_id` is the index of timepoints for the associated `case_id` and `dimension_id`, and `value` is the actual value of the observation. E.g.:\n",
-    "\n",
-    "          | case_id | dim_id | reading_id | value\n",
-    "     ------------------------------------------------\n",
-    "       0  |   int   |  int   |    int     | double\n",
-    "       1  |   int   |  int   |    int     | double\n",
-    "       2  |   int   |  int   |    int     | double\n",
-    "       3  |   int   |  int   |    int     | double\n",
-    "       \n",
-    "Sktime provides functions to convert to and from the long data format in `sktime.datatypes._panel._convert`. \n",
-    "\n",
-    "The `from_long_to_nested` function converts from a long format DataFrame to sktime's nested format (with assumptions made on how the data is initially formatted). Conversely, `from_nested_to_long` converts from a sktime nested DataFrame into a long format DataFrame. \n",
-    "\n",
-    "\n",
-    "To demonstrate this functionality the method below creates a dataset with a 50 instances (cases), 5 dimensions and 20 timepoints per dimension."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-12-19T14:32:13.998282Z",
-     "iopub.status.busy": "2020-12-19T14:32:13.997756Z",
-     "iopub.status.idle": "2020-12-19T14:32:14.000144Z",
-     "shell.execute_reply": "2020-12-19T14:32:14.000992Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "   case_id  dim_id  reading_id     value\n0        0       0           0  0.158472\n1        0       0           1  0.829247\n2        0       0           2  0.448986\n3        0       0           3  0.601427\n4        0       0           4  0.180356",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>case_id</th>\n      <th>dim_id</th>\n      <th>reading_id</th>\n      <th>value</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0.158472</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0</td>\n      <td>0</td>\n      <td>1</td>\n      <td>0.829247</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0</td>\n      <td>0</td>\n      <td>2</td>\n      <td>0.448986</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0</td>\n      <td>0</td>\n      <td>3</td>\n      <td>0.601427</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0</td>\n      <td>0</td>\n      <td>4</td>\n      <td>0.180356</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from sktime.datasets import generate_example_long_table\n",
-    "\n",
-    "X = generate_example_long_table(num_cases=50, series_len=20, num_dims=5)\n",
-    "\n",
-    "X.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "      case_id  dim_id  reading_id     value\n4995       49       4          15  0.810784\n4996       49       4          16  0.123684\n4997       49       4          17  0.747475\n4998       49       4          18  0.543235\n4999       49       4          19  0.942297",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>case_id</th>\n      <th>dim_id</th>\n      <th>reading_id</th>\n      <th>value</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>4995</th>\n      <td>49</td>\n      <td>4</td>\n      <td>15</td>\n      <td>0.810784</td>\n    </tr>\n    <tr>\n      <th>4996</th>\n      <td>49</td>\n      <td>4</td>\n      <td>16</td>\n      <td>0.123684</td>\n    </tr>\n    <tr>\n      <th>4997</th>\n      <td>49</td>\n      <td>4</td>\n      <td>17</td>\n      <td>0.747475</td>\n    </tr>\n    <tr>\n      <th>4998</th>\n      <td>49</td>\n      <td>4</td>\n      <td>18</td>\n      <td>0.543235</td>\n    </tr>\n    <tr>\n      <th>4999</th>\n      <td>49</td>\n      <td>4</td>\n      <td>19</td>\n      <td>0.942297</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "X.tail()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As shown below, applying the `from_long_to_nested` method returns a sktime-formatted dataset with individual dimensions represented by columns of the output dataframe."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-12-19T14:32:14.115195Z",
-     "iopub.status.busy": "2020-12-19T14:32:14.071800Z",
-     "iopub.status.idle": "2020-12-19T14:32:14.522026Z",
-     "shell.execute_reply": "2020-12-19T14:32:14.522679Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "                                               var_0  \\\n0  0     0.158472\n1     0.829247\n2     0.448986\n3...   \n1  0     0.928646\n1     0.847462\n2     0.619510\n3...   \n2  0     0.450786\n1     0.466746\n2     0.618851\n3...   \n3  0     0.533969\n1     0.050079\n2     0.206640\n3...   \n4  0     0.992040\n1     0.358423\n2     0.648216\n3...   \n\n                                               var_1  \\\n0  0     0.035773\n1     0.537928\n2     0.202437\n3...   \n1  0     0.587684\n1     0.027706\n2     0.852160\n3...   \n2  0     0.802627\n1     0.714242\n2     0.210690\n3...   \n3  0     0.141936\n1     0.749412\n2     0.402359\n3...   \n4  0     0.306376\n1     0.037136\n2     0.862202\n3...   \n\n                                               var_2  \\\n0  0     0.223865\n1     0.223151\n2     0.336629\n3...   \n1  0     0.200706\n1     0.775734\n2     0.771990\n3...   \n2  0     0.477587\n1     0.355327\n2     0.412145\n3...   \n3  0     0.105736\n1     0.639126\n2     0.874445\n3...   \n4  0     0.694042\n1     0.549120\n2     0.452202\n3...   \n\n                                               var_3  \\\n0  0     0.066188\n1     0.582615\n2     0.094436\n3...   \n1  0     0.923950\n1     0.317604\n2     0.627315\n3...   \n2  0     0.492878\n1     0.803969\n2     0.710368\n3...   \n3  0     0.340529\n1     0.104037\n2     0.966122\n3...   \n4  0     0.947300\n1     0.428502\n2     0.455309\n3...   \n\n                                               var_4  \n0  0     0.100623\n1     0.160963\n2     0.649942\n3...  \n1  0     0.651111\n1     0.265877\n2     0.249400\n3...  \n2  0     0.255306\n1     0.575683\n2     0.802154\n3...  \n3  0     0.055339\n1     0.981870\n2     0.681172\n3...  \n4  0     0.691163\n1     0.874449\n2     0.134566\n3...  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>var_0</th>\n      <th>var_1</th>\n      <th>var_2</th>\n      <th>var_3</th>\n      <th>var_4</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0     0.158472\n1     0.829247\n2     0.448986\n3...</td>\n      <td>0     0.035773\n1     0.537928\n2     0.202437\n3...</td>\n      <td>0     0.223865\n1     0.223151\n2     0.336629\n3...</td>\n      <td>0     0.066188\n1     0.582615\n2     0.094436\n3...</td>\n      <td>0     0.100623\n1     0.160963\n2     0.649942\n3...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0     0.928646\n1     0.847462\n2     0.619510\n3...</td>\n      <td>0     0.587684\n1     0.027706\n2     0.852160\n3...</td>\n      <td>0     0.200706\n1     0.775734\n2     0.771990\n3...</td>\n      <td>0     0.923950\n1     0.317604\n2     0.627315\n3...</td>\n      <td>0     0.651111\n1     0.265877\n2     0.249400\n3...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0     0.450786\n1     0.466746\n2     0.618851\n3...</td>\n      <td>0     0.802627\n1     0.714242\n2     0.210690\n3...</td>\n      <td>0     0.477587\n1     0.355327\n2     0.412145\n3...</td>\n      <td>0     0.492878\n1     0.803969\n2     0.710368\n3...</td>\n      <td>0     0.255306\n1     0.575683\n2     0.802154\n3...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0     0.533969\n1     0.050079\n2     0.206640\n3...</td>\n      <td>0     0.141936\n1     0.749412\n2     0.402359\n3...</td>\n      <td>0     0.105736\n1     0.639126\n2     0.874445\n3...</td>\n      <td>0     0.340529\n1     0.104037\n2     0.966122\n3...</td>\n      <td>0     0.055339\n1     0.981870\n2     0.681172\n3...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0     0.992040\n1     0.358423\n2     0.648216\n3...</td>\n      <td>0     0.306376\n1     0.037136\n2     0.862202\n3...</td>\n      <td>0     0.694042\n1     0.549120\n2     0.452202\n3...</td>\n      <td>0     0.947300\n1     0.428502\n2     0.455309\n3...</td>\n      <td>0     0.691163\n1     0.874449\n2     0.134566\n3...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from sktime.datatypes._panel._convert import from_long_to_nested, from_nested_to_long\n",
-    "\n",
-    "X_nested = from_long_to_nested(X)\n",
-    "X_nested.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As expected the result is a nested DataFrame and the cells include nested pandas Series objects. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-12-19T14:32:14.526778Z",
-     "iopub.status.busy": "2020-12-19T14:32:14.526253Z",
-     "iopub.status.idle": "2020-12-19T14:32:14.528291Z",
-     "shell.execute_reply": "2020-12-19T14:32:14.528788Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "X_nested is a nested DataFrame: True\n",
-      "The cell contains a <class 'pandas.core.series.Series'>.\n",
-      "The nested DataFrame has shape (50, 5)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "0    0.158472\n1    0.829247\n2    0.448986\n3    0.601427\n4    0.180356\nName: 0, dtype: float64"
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "print(f\"X_nested is a nested DataFrame: {is_nested_dataframe(X_nested)}\")\n",
-    "print(f\"The cell contains a {type(X_nested.iloc[0,0])}.\")\n",
-    "print(f\"The nested DataFrame has shape {X_nested.shape}\")\n",
-    "X_nested.iloc[0, 0].head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As shown below, the `from_nested_to_long` function can be used to convert the resulting nested DataFrame (or any nested DataFrame) to a long format DataFrame. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "Empty DataFrame\nColumns: [case_id, reading_id, dim_id, value]\nIndex: []",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>case_id</th>\n      <th>reading_id</th>\n      <th>dim_id</th>\n      <th>value</th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>"
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "X_long = from_nested_to_long(\n",
-    "    X_nested,\n",
-    "    instance_column_name=\"case_id\",\n",
-    "    time_column_name=\"reading_id\",\n",
-    "    dimension_column_name=\"dim_id\",\n",
-    ")\n",
-    "X_long.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "Empty DataFrame\nColumns: [case_id, reading_id, dim_id, value]\nIndex: []",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>case_id</th>\n      <th>reading_id</th>\n      <th>dim_id</th>\n      <th>value</th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>"
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "X_long.tail()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Using multi-indexed pandas DataFrames\n",
-    "\n",
-    "Pandas deprecated its Panel object in version 0.20.1. Since that time pandas has recommended representing 3-dimensional data using a multi-indexed DataFrame. \n",
-    "\n",
-    "Storing timeseries data in a Pandas multi-indexed DataFrame is a natural option since many timeseries problems include data over the instance, feature and time dimensions. \n",
-    "\n",
-    "Sktime provides the functions `from_multi_index_to_nested` and `from_nested_to_multi_index` in `sktime.datatypes._panel._convert` to easily convert between pandas multi-indexed DataFrames and sktime's nested DataFrame structure. \n",
-    "\n",
-    "The example below illustrates how these functions can be used to convert to and from the nested structure given data with 50 instances, 5 features (columns) and 20 timepoints per feature. In the multi-indexed DataFrame a row represents a unique combination of the instance and timepoint indices. Therefore, the resulting multi-indexed DataFrame should have the shape (1000, 5). "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The multi-indexed DataFrame has shape (1000, 5)\n",
-      "The multi-index names are ['case_id', 'reading_id']\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "                       var_0     var_1     var_2     var_3     var_4\ncase_id reading_id                                                  \n0       0           0.040227  0.141913  0.519128  0.499042  0.537793\n        1           0.985424  0.342231  0.489741  0.194902  0.710540\n        2           0.760047  0.791662  0.912142  0.030413  0.061576\n        3           0.331244  0.173313  0.938349  0.866284  0.314407\n        4           0.383535  0.210632  0.489057  0.791139  0.974697",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th></th>\n      <th>var_0</th>\n      <th>var_1</th>\n      <th>var_2</th>\n      <th>var_3</th>\n      <th>var_4</th>\n    </tr>\n    <tr>\n      <th>case_id</th>\n      <th>reading_id</th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th rowspan=\"5\" valign=\"top\">0</th>\n      <th>0</th>\n      <td>0.040227</td>\n      <td>0.141913</td>\n      <td>0.519128</td>\n      <td>0.499042</td>\n      <td>0.537793</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0.985424</td>\n      <td>0.342231</td>\n      <td>0.489741</td>\n      <td>0.194902</td>\n      <td>0.710540</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0.760047</td>\n      <td>0.791662</td>\n      <td>0.912142</td>\n      <td>0.030413</td>\n      <td>0.061576</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0.331244</td>\n      <td>0.173313</td>\n      <td>0.938349</td>\n      <td>0.866284</td>\n      <td>0.314407</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0.383535</td>\n      <td>0.210632</td>\n      <td>0.489057</td>\n      <td>0.791139</td>\n      <td>0.974697</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from sktime.datasets import make_multi_index_dataframe\n",
-    "from sktime.datatypes._panel._convert import (\n",
-    "    from_multi_index_to_nested,\n",
-    "    from_nested_to_multi_index,\n",
-    ")\n",
-    "\n",
-    "X_mi = make_multi_index_dataframe(n_instances=50, n_columns=5, n_timepoints=20)\n",
-    "\n",
-    "print(f\"The multi-indexed DataFrame has shape {X_mi.shape}\")\n",
-    "print(f\"The multi-index names are {X_mi.index.names}\")\n",
-    "\n",
-    "X_mi.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The multi-indexed DataFrame can be easily converted to a nested DataFrame with shape (50, 5). Note that the conversion to the nested DataFrame has preserved the column names (it has also preserved the values of the instance index and the pandas Series objects nested in each cell have preserved the time index). "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "X_nested is a nested DataFrame: True\n",
-      "The cell contains a <class 'pandas.core.series.Series'>.\n",
-      "The nested DataFrame has shape (50, 5)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "                                               var_0  \\\n0  0     0.040227\n1     0.985424\n2     0.760047\n3...   \n1  0     0.879083\n1     0.807789\n2     0.506862\n3...   \n2  0     0.732080\n1     0.276641\n2     0.976533\n3...   \n3  0     0.227164\n1     0.040144\n2     0.275620\n3...   \n4  0     0.201796\n1     0.690969\n2     0.001320\n3...   \n\n                                               var_1  \\\n0  0     0.141913\n1     0.342231\n2     0.791662\n3...   \n1  0     0.952675\n1     0.492735\n2     0.656166\n3...   \n2  0     0.627680\n1     0.571249\n2     0.888450\n3...   \n3  0     0.061936\n1     0.279238\n2     0.757245\n3...   \n4  0     0.288753\n1     0.684376\n2     0.200825\n3...   \n\n                                               var_2  \\\n0  0     0.519128\n1     0.489741\n2     0.912142\n3...   \n1  0     0.656355\n1     0.287666\n2     0.706245\n3...   \n2  0     0.699154\n1     0.945356\n2     0.385167\n3...   \n3  0     0.857088\n1     0.943210\n2     0.447408\n3...   \n4  0     0.279786\n1     0.113262\n2     0.308528\n3...   \n\n                                               var_3  \\\n0  0     0.499042\n1     0.194902\n2     0.030413\n3...   \n1  0     0.383427\n1     0.321653\n2     0.373711\n3...   \n2  0     0.268509\n1     0.908750\n2     0.080662\n3...   \n3  0     0.881512\n1     0.431819\n2     0.282606\n3...   \n4  0     0.577395\n1     0.867085\n2     0.991352\n3...   \n\n                                               var_4  \n0  0     0.537793\n1     0.710540\n2     0.061576\n3...  \n1  0     0.468713\n1     0.504228\n2     0.484827\n3...  \n2  0     0.483880\n1     0.670948\n2     0.941388\n3...  \n3  0     0.681319\n1     0.582301\n2     0.678950\n3...  \n4  0     0.614379\n1     0.533755\n2     0.958356\n3...  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>var_0</th>\n      <th>var_1</th>\n      <th>var_2</th>\n      <th>var_3</th>\n      <th>var_4</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0     0.040227\n1     0.985424\n2     0.760047\n3...</td>\n      <td>0     0.141913\n1     0.342231\n2     0.791662\n3...</td>\n      <td>0     0.519128\n1     0.489741\n2     0.912142\n3...</td>\n      <td>0     0.499042\n1     0.194902\n2     0.030413\n3...</td>\n      <td>0     0.537793\n1     0.710540\n2     0.061576\n3...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0     0.879083\n1     0.807789\n2     0.506862\n3...</td>\n      <td>0     0.952675\n1     0.492735\n2     0.656166\n3...</td>\n      <td>0     0.656355\n1     0.287666\n2     0.706245\n3...</td>\n      <td>0     0.383427\n1     0.321653\n2     0.373711\n3...</td>\n      <td>0     0.468713\n1     0.504228\n2     0.484827\n3...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0     0.732080\n1     0.276641\n2     0.976533\n3...</td>\n      <td>0     0.627680\n1     0.571249\n2     0.888450\n3...</td>\n      <td>0     0.699154\n1     0.945356\n2     0.385167\n3...</td>\n      <td>0     0.268509\n1     0.908750\n2     0.080662\n3...</td>\n      <td>0     0.483880\n1     0.670948\n2     0.941388\n3...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0     0.227164\n1     0.040144\n2     0.275620\n3...</td>\n      <td>0     0.061936\n1     0.279238\n2     0.757245\n3...</td>\n      <td>0     0.857088\n1     0.943210\n2     0.447408\n3...</td>\n      <td>0     0.881512\n1     0.431819\n2     0.282606\n3...</td>\n      <td>0     0.681319\n1     0.582301\n2     0.678950\n3...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0     0.201796\n1     0.690969\n2     0.001320\n3...</td>\n      <td>0     0.288753\n1     0.684376\n2     0.200825\n3...</td>\n      <td>0     0.279786\n1     0.113262\n2     0.308528\n3...</td>\n      <td>0     0.577395\n1     0.867085\n2     0.991352\n3...</td>\n      <td>0     0.614379\n1     0.533755\n2     0.958356\n3...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "X_nested = from_multi_index_to_nested(X_mi, instance_index=\"case_id\")\n",
-    "print(f\"X_nested is a nested DataFrame: {is_nested_dataframe(X_nested)}\")\n",
-    "print(f\"The cell contains a {type(X_nested.iloc[0,0])}.\")\n",
-    "print(f\"The nested DataFrame has shape {X_nested.shape}\")\n",
-    "X_nested.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Nested DataFrames can also be converted to a multi-indexed Pandas DataFrame"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "                       var_0     var_1     var_2     var_3     var_4\ncase_id reading_id                                                  \n0       0           0.040227  0.141913  0.519128  0.499042  0.537793\n        1           0.985424  0.342231  0.489741  0.194902  0.710540\n        2           0.760047  0.791662  0.912142  0.030413  0.061576\n        3           0.331244  0.173313  0.938349  0.866284  0.314407\n        4           0.383535  0.210632  0.489057  0.791139  0.974697",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th></th>\n      <th>var_0</th>\n      <th>var_1</th>\n      <th>var_2</th>\n      <th>var_3</th>\n      <th>var_4</th>\n    </tr>\n    <tr>\n      <th>case_id</th>\n      <th>reading_id</th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th rowspan=\"5\" valign=\"top\">0</th>\n      <th>0</th>\n      <td>0.040227</td>\n      <td>0.141913</td>\n      <td>0.519128</td>\n      <td>0.499042</td>\n      <td>0.537793</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0.985424</td>\n      <td>0.342231</td>\n      <td>0.489741</td>\n      <td>0.194902</td>\n      <td>0.710540</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0.760047</td>\n      <td>0.791662</td>\n      <td>0.912142</td>\n      <td>0.030413</td>\n      <td>0.061576</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0.331244</td>\n      <td>0.173313</td>\n      <td>0.938349</td>\n      <td>0.866284</td>\n      <td>0.314407</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0.383535</td>\n      <td>0.210632</td>\n      <td>0.489057</td>\n      <td>0.791139</td>\n      <td>0.974697</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "X_mi = from_nested_to_multi_index(\n",
-    "    X_nested, instance_index=\"case_id\", time_index=\"reading_id\"\n",
-    ")\n",
-    "X_mi.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Using NumPy 3d-arrays with sktime\n",
-    "\n",
-    "Another common approach for representing timeseries data is to use a 3-dimensional NumPy array with shape (n_instances, n_columns, n_timepoints). \n",
-    "\n",
-    "Sktime provides the functions `from_3d_numpy_to_nested` `from_nested_to_3d_numpy` in `sktime.datatypes._panel._convert` to let users easily convert between NumPy 3d-arrays and nested pandas DataFrames. \n",
-    "\n",
-    "This is demonstrated using a 3d-array with 50 instances, 5 features (columns) and 20 timepoints, resulting in a 3d-array with shape (50, 5, 20). "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The 3d-array has shape (50, 5, 20)\n"
-     ]
-    }
-   ],
-   "source": [
-    "from sktime.datatypes._panel._convert import (\n",
-    "    from_3d_numpy_to_nested,\n",
-    "    from_multi_index_to_3d_numpy,\n",
-    "    from_nested_to_3d_numpy,\n",
-    ")\n",
-    "\n",
-    "X_mi = make_multi_index_dataframe(n_instances=50, n_columns=5, n_timepoints=20)\n",
-    "X_3d = from_multi_index_to_3d_numpy(\n",
-    "    X_mi, instance_index=\"case_id\", time_index=\"reading_id\"\n",
-    ")\n",
-    "\n",
-    "print(f\"The 3d-array has shape {X_3d.shape}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The 3d-array can be easily converted to a nested DataFrame with shape (50, 5). Note that since NumPy array doesn't have indices, the instance index is the numerical range over the number of instances and the columns are automatically assigned. Users can optionally supply their own columns names via the columns_names parameter. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "X_nested is a nested DataFrame: True\n",
-      "The cell contains a <class 'pandas.core.series.Series'>.\n",
-      "The nested DataFrame has shape (50, 5)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "                                               var_0  \\\n0  0     0.753295\n1     0.000539\n2     0.879344\n3...   \n1  0     0.502694\n1     0.355529\n2     0.218012\n3...   \n2  0     0.772546\n1     0.655588\n2     0.943078\n3...   \n3  0     0.990557\n1     0.957716\n2     0.552375\n3...   \n4  0     0.330451\n1     0.759253\n2     0.716862\n3...   \n\n                                               var_1  \\\n0  0     0.115777\n1     0.486410\n2     0.514895\n3...   \n1  0     0.544544\n1     0.946004\n2     0.170380\n3...   \n2  0     0.561212\n1     0.272997\n2     0.768190\n3...   \n3  0     0.150498\n1     0.080510\n2     0.629138\n3...   \n4  0     0.552557\n1     0.813014\n2     0.907988\n3...   \n\n                                               var_2  \\\n0  0     0.825747\n1     0.848788\n2     0.335723\n3...   \n1  0     0.947290\n1     0.407878\n2     0.961967\n3...   \n2  0     0.140657\n1     0.936812\n2     0.820572\n3...   \n3  0     0.778561\n1     0.622978\n2     0.287282\n3...   \n4  0     0.513855\n1     0.116692\n2     0.478687\n3...   \n\n                                               var_3  \\\n0  0     0.333530\n1     0.778000\n2     0.056513\n3...   \n1  0     0.877199\n1     0.430808\n2     0.757588\n3...   \n2  0     0.362522\n1     0.153958\n2     0.210893\n3...   \n3  0     0.154990\n1     0.451038\n2     0.459710\n3...   \n4  0     0.240938\n1     0.221341\n2     0.921510\n3...   \n\n                                               var_4  \n0  0     0.434085\n1     0.612324\n2     0.388068\n3...  \n1  0     0.822185\n1     0.342398\n2     0.173290\n3...  \n2  0     0.606273\n1     0.817007\n2     0.131479\n3...  \n3  0     0.963155\n1     0.003720\n2     0.605448\n3...  \n4  0     0.612310\n1     0.333530\n2     0.043293\n3...  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>var_0</th>\n      <th>var_1</th>\n      <th>var_2</th>\n      <th>var_3</th>\n      <th>var_4</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0     0.753295\n1     0.000539\n2     0.879344\n3...</td>\n      <td>0     0.115777\n1     0.486410\n2     0.514895\n3...</td>\n      <td>0     0.825747\n1     0.848788\n2     0.335723\n3...</td>\n      <td>0     0.333530\n1     0.778000\n2     0.056513\n3...</td>\n      <td>0     0.434085\n1     0.612324\n2     0.388068\n3...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0     0.502694\n1     0.355529\n2     0.218012\n3...</td>\n      <td>0     0.544544\n1     0.946004\n2     0.170380\n3...</td>\n      <td>0     0.947290\n1     0.407878\n2     0.961967\n3...</td>\n      <td>0     0.877199\n1     0.430808\n2     0.757588\n3...</td>\n      <td>0     0.822185\n1     0.342398\n2     0.173290\n3...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0     0.772546\n1     0.655588\n2     0.943078\n3...</td>\n      <td>0     0.561212\n1     0.272997\n2     0.768190\n3...</td>\n      <td>0     0.140657\n1     0.936812\n2     0.820572\n3...</td>\n      <td>0     0.362522\n1     0.153958\n2     0.210893\n3...</td>\n      <td>0     0.606273\n1     0.817007\n2     0.131479\n3...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0     0.990557\n1     0.957716\n2     0.552375\n3...</td>\n      <td>0     0.150498\n1     0.080510\n2     0.629138\n3...</td>\n      <td>0     0.778561\n1     0.622978\n2     0.287282\n3...</td>\n      <td>0     0.154990\n1     0.451038\n2     0.459710\n3...</td>\n      <td>0     0.963155\n1     0.003720\n2     0.605448\n3...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0     0.330451\n1     0.759253\n2     0.716862\n3...</td>\n      <td>0     0.552557\n1     0.813014\n2     0.907988\n3...</td>\n      <td>0     0.513855\n1     0.116692\n2     0.478687\n3...</td>\n      <td>0     0.240938\n1     0.221341\n2     0.921510\n3...</td>\n      <td>0     0.612310\n1     0.333530\n2     0.043293\n3...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "X_nested = from_3d_numpy_to_nested(X_3d)\n",
-    "print(f\"X_nested is a nested DataFrame: {is_nested_dataframe(X_nested)}\")\n",
-    "print(f\"The cell contains a {type(X_nested.iloc[0,0])}.\")\n",
-    "print(f\"The nested DataFrame has shape {X_nested.shape}\")\n",
-    "X_nested.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Nested DataFrames can also be converted to NumPy 3d-arrays. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The resulting object is a <class 'numpy.ndarray'>\n",
-      "The shape of the 3d-array is (50, 5, 20)\n"
-     ]
-    }
-   ],
-   "source": [
-    "X_3d = from_nested_to_3d_numpy(X_nested)\n",
-    "print(f\"The resulting object is a {type(X_3d)}\")\n",
-    "print(f\"The shape of the 3d-array is {X_3d.shape}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Converting between NumPy 3d-arrays and pandas multi-indexed DataFrame\n",
-    "\n",
-    "Although an example is not provided here, sktime lets users convert data between NumPy 3d-arrays and a multi-indexed pandas DataFrame formats using the functions `from_3d_numpy_to_multi_index` and `from_multi_index_to_3d_numpy` in `sktime.datatypes._panel._convert`. "
+    "To convert loaded formats to other sktime internal formats, use the `convert` or `convert_to` utilities in the `sktime.datatypes` module.\n",
+    "For more details, see the tutorial `AA_datatypes_and_datasets`."
    ]
   }
  ],

--- a/examples/loading_data.ipynb
+++ b/examples/loading_data.ipynb
@@ -69,7 +69,7 @@
     "\n",
     "A dataset can be loaded from a .ts file using the following method in sktime.datasets:\n",
     "\n",
-    "    load_from_tsfile_to_dataframe(full_file_path_and_name, replace_missing_vals_with='NaN')\n",
+    "    load_from_tsfile(full_file_path_and_name, replace_missing_vals_with='NaN')\n",
     "\n",
     "This can be demonstrated using the Arrow Head problem that is included in sktime under sktime/datasets/data"
    ]
@@ -90,14 +90,14 @@
     "import os\n",
     "\n",
     "import sktime\n",
-    "from sktime.datasets import load_from_tsfile_to_dataframe\n",
+    "from sktime.datasets import load_from_tsfile\n",
     "\n",
     "DATA_PATH = os.path.join(os.path.dirname(sktime.__file__), \"datasets/data\")\n",
     "\n",
-    "train_x, train_y = load_from_tsfile_to_dataframe(\n",
+    "train_x, train_y = load_from_tsfile(\n",
     "    os.path.join(DATA_PATH, \"ArrowHead/ArrowHead_TRAIN.ts\")\n",
     ")\n",
-    "test_x, test_y = load_from_tsfile_to_dataframe(\n",
+    "test_x, test_y = load_from_tsfile(\n",
     "    os.path.join(DATA_PATH, \"ArrowHead/ArrowHead_TEST.ts\")\n",
     ")"
    ]
@@ -233,6 +233,66 @@
    ],
    "source": [
     "train_y[0:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The format of the loaded data can be controlled by the `return_data_type` argument.\n",
+    "\n",
+    "Allowed strings are identifier strings for sktime compatible `Panel` mtypes, as introduced in the \"datatypes and datasets\" tutorial (`AA_datatypes_and_datasets`).\n",
+    "\n",
+    "If provided, the loaded in-memory data container will comply with that type specification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_x, train_y = load_from_tsfile(\n",
+    "    os.path.join(DATA_PATH, \"ArrowHead/ArrowHead_TRAIN.ts\"), return_data_type=\"numpy3d\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[[-1.9630089, -1.9578249, -1.9561449, ..., -1.9053929,\n",
+       "         -1.9239049, -1.9091529]],\n",
+       "\n",
+       "       [[-1.7745713, -1.7740359, -1.7765863, ..., -1.7292269,\n",
+       "         -1.7756704, -1.7893245]],\n",
+       "\n",
+       "       [[-1.8660211, -1.8419912, -1.8350253, ..., -1.8625124,\n",
+       "         -1.8633682, -1.8464925]],\n",
+       "\n",
+       "       ...,\n",
+       "\n",
+       "       [[-2.1308119, -2.1044297, -2.0747549, ..., -2.0340977,\n",
+       "         -2.0800313, -2.103448 ]],\n",
+       "\n",
+       "       [[-1.8803376, -1.8626622, -1.8496866, ..., -1.8485336,\n",
+       "         -1.8640342, -1.8798851]],\n",
+       "\n",
+       "       [[-1.80105  , -1.7989155, -1.7783754, ..., -1.7965491,\n",
+       "         -1.7985443, -1.80105  ]]])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train_x"
    ]
   },
   {
@@ -836,7 +896,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -1,4 +1,31 @@
 # -*- coding: utf-8 -*-
+"""Machine type converters for Panel scitype.
+
+Exports conversion and mtype dictionary for Panel scitype:
+
+convert_dict: dict indexed by triples of str
+  1st element = convert from - str
+  2nd element = convert to - str
+  3rd element = considered as this scitype - str
+elements are conversion functions of machine type (1st) -> 2nd
+
+Function signature of all elements
+convert_dict[(from_type, to_type, as_scitype)]
+
+Parameters
+----------
+obj : from_type - object to convert
+store : dictionary - reference of storage for lossy conversions, default=None (no store)
+
+Returns
+-------
+converted_obj : to_type - object obj converted to to_type
+
+Raises
+------
+ValueError and TypeError, if requested conversion is not possible
+                            (depending on conversion logic)
+"""
 
 import numpy as np
 import pandas as pd
@@ -7,7 +34,6 @@ __all__ = [
     "convert_dict",
 ]
 
-from sktime.datatypes._panel._check import is_nested_dataframe
 from sktime.datatypes._panel._registry import MTYPE_LIST_PANEL
 
 # dictionary indexed by triples of types
@@ -519,53 +545,6 @@ def from_long_to_nested(
     else:
         X_nested.columns = column_names
 
-    # # get distinct dimension ids
-    # unique_dim_ids = long_dataframe.iloc[:, 1].unique()
-    # num_dims = len(unique_dim_ids)
-
-    # data_by_dim = []
-    # indices = []
-
-    # # get number of distinct cases (note: a case may have 1 or many dimensions)
-    # unique_case_ids = long_dataframe.iloc[:, 0].unique()
-    # # assume series are indexed from 0 to m-1 (can map to non-linear indices
-    # # later if needed)
-
-    # # init a list of size m for each d - to store the series data for m
-    # # cases over d dimensions
-    # # also, data may not be in order in long format so store index data for
-    # # aligning output later
-    # # (i.e. two stores required: one for reading id/timestamp and one for
-    # # value)
-    # for d in range(0, num_dims):
-    #     data_by_dim.append([])
-    #     indices.append([])
-    #     for _c in range(0, len(unique_case_ids)):
-    #         data_by_dim[d].append([])
-    #         indices[d].append([])
-
-    # # go through every row in the dataframe
-    # for i in range(0, len(long_dataframe)):
-    #     # extract the relevant data, catch cases where the dim id is not an
-    #     # int as it must be the class
-
-    #     row = long_dataframe.iloc[i]
-    #     case_id = int(row[0])
-    #     dim_id = int(row[1])
-    #     reading_id = int(row[2])
-    #     value = row[3]
-    #     data_by_dim[dim_id][case_id].append(value)
-    #     indices[dim_id][case_id].append(reading_id)
-
-    # x_data = {}
-    # for d in range(0, num_dims):
-    #     key = "dim_" + str(d)
-    #     dim_list = []
-    #     for i in range(0, len(unique_case_ids)):
-    #         temp = pd.Series(data_by_dim[d][i], indices[d][i])
-    #         dim_list.append(temp)
-    #     x_data[key] = pd.Series(dim_list)
-
     return X_nested
 
 
@@ -794,9 +773,6 @@ def from_nested_to_multi_index(X, instance_index=None, time_index=None):
         The multi-indexed pandas DataFrame
 
     """
-    if not is_nested_dataframe(X):
-        raise ValueError("Input DataFrame is not a nested DataFrame")
-
     if time_index is None:
         time_index_name = "timepoints"
     else:
@@ -883,15 +859,6 @@ def from_nested_to_3d_numpy(X):
     X_3d : np.ndarrray
         3-dimensional NumPy array
     """
-    # n_instances, n_columns = X.shape
-    # n_timepoints = X.iloc[0, 0].shape[0]
-    # array = np.empty((n_instances, n_columns, n_timepoints))
-    # for column in range(n_columns):
-    #     array[:, column, :] = X.iloc[:, column].tolist()
-    # return array
-    if not is_nested_dataframe(X):
-        raise ValueError("Input DataFrame is not a nested DataFrame")
-
     # n_columns = X.shape[1]
     nested_col_mask = [*are_columns_nested(X)]
 


### PR DESCRIPTION
This PR does some minor cleaning in the `_panel._convert` module which had much copy-pasted legacy code:

* removal of commented out code
* removal of heavy input checks (this should be done by the `check` functions if needed)
* added module docstring

It also removes redundant and outdated parts in the `loading_data` tutorial, which was importing a lot of now private functionality of the `datatypes` module. This is replaced by references to the datatypes tutorial which explains the multiple data formats.