### PR TITLE
[ENH] Added tests for MultiplexForecaster

### DIFF
--- a/sktime/forecasting/compose/tests/test_multiplex.py
+++ b/sktime/forecasting/compose/tests/test_multiplex.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3 -u
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for MultiplexForecaster and associated dunders."""
+
+__author__ = ["aiwalter", "miraep8"]
+
+from sktime.datasets import load_shampoo_sales
+from sktime.forecasting.all import (
+    AutoETS,
+    ExpandingWindowSplitter,
+    ForecastingGridSearchCV,
+    MultiplexForecaster,
+    NaiveForecaster,
+)
+from sktime.forecasting.model_evaluation import evaluate
+from sktime.utils.validation.forecasting import check_scoring
+
+
+def _score_forecasters(forecasters, cv, y):
+    """Will evaluate all the forecasters on y and return the name of best."""
+    scoring = check_scoring(None)
+    scoring_name = f"test_{scoring.name}"
+    score = None
+    for name, forecaster in forecasters:
+        results = evaluate(forecaster, cv, y)
+        results = results.mean()
+        new_score = float(results[scoring_name])
+        if not score or new_score < score:
+            score = new_score
+            best_name = name
+    return best_name
+
+
+def test_multiplex():
+    """Test results of MultiplexForecaster.
+
+    Because MultiplexForecaster should essentially just be a framework for
+    comparing different models/selecting which model does best, we can check
+    that it performs as expected.
+    """
+    y = load_shampoo_sales()
+    forecasters = [
+        ("ets", AutoETS()),
+        ("naive", NaiveForecaster()),
+    ]
+    multiplex_forecaster = MultiplexForecaster(forecasters=forecasters)
+    forecaster_names = multiplex_forecaster.get_forecaster_names()
+    # check that get_forcaster_names performs as expected:
+    assert forecaster_names == [name for name, _ in forecasters]
+    cv = ExpandingWindowSplitter(start_with_window=True, step_length=12)
+    gscv = ForecastingGridSearchCV(
+        cv=cv,
+        param_grid={"selected_forecaster": forecaster_names},
+        forecaster=multiplex_forecaster,
+    )
+    gscv.fit(y)
+    gscv_best_name = gscv.best_forecaster_.selected_forecaster
+    best_name = _score_forecasters(forecasters, cv, y)
+    assert gscv_best_name == best_name

--- a/sktime/forecasting/compose/tests/test_multiplex.py
+++ b/sktime/forecasting/compose/tests/test_multiplex.py
@@ -45,9 +45,7 @@ def test_multiplex():
         ("naive", NaiveForecaster()),
     ]
     multiplex_forecaster = MultiplexForecaster(forecasters=forecasters)
-    forecaster_names = multiplex_forecaster.get_forecaster_names()
-    # check that get_forcaster_names performs as expected:
-    assert forecaster_names == [name for name, _ in forecasters]
+    forecaster_names = [name for name, _ in forecasters]
     cv = ExpandingWindowSplitter(start_with_window=True, step_length=12)
     gscv = ForecastingGridSearchCV(
         cv=cv,


### PR DESCRIPTION
#### Reference Issues/PRs

As mentioned in #2514 wrote some tests to see if `MultiplexForecaster` performs as expected.  

#### What does this implement/fix? Explain your changes.

Essentially - run `ForecastingGridSearchCV`  on `MultiplexForecaster` and verify that the best forecaster from the grid search is also the one we select if we simply evaluated all the forecasters separately. 

*Note - I use a very small data set and only compare have 2 forecasters in `MultiplexForecaster`.  I did this to not make the test too slow - but it is not the most thorough test.  Hopefully it would still help catch some obvious issues.*

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

Any other obvious tests that should be added? Should we add more forecasters?  Does this test make sense to you? 

#### Any other comments?

@aiwalter I went ahead and added you as an author to this file.  I figured since you had a hand in co-creating `MultiplexForecaster` in the first place and also weighed in on #2514 it seemed reasonable.  However - please let me know if you would prefer if I removed you. 

#### PR checklist
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [DOC] or [BUG] indicating whether the PR topic is related to enhancement, documentation or bug


<!--
Thanks for contributing!
-->
