### PR TITLE
[ENH] Proximity forest faster test param settings

### DIFF
--- a/sktime/classification/distance_based/_proximity_forest.py
+++ b/sktime/classification/distance_based/_proximity_forest.py
@@ -1251,7 +1251,7 @@ class ProximityTree(BaseClassifier):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
-        return {"max_depth": 2, "n_stump_evaluations": 1}
+        return {"max_depth": 1, "n_stump_evaluations": 1}
 
 
 class ProximityForest(BaseClassifier):
@@ -1570,9 +1570,9 @@ class ProximityForest(BaseClassifier):
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
         if parameter_set == "results_comparison":
-            return {"n_estimators": 3, "max_depth": 2, "n_stump_evaluations": 2}
+            return {"n_estimators": 3, "max_depth": 1, "n_stump_evaluations": 2}
         else:
-            return {"n_estimators": 2, "max_depth": 2, "n_stump_evaluations": 1}
+            return {"n_estimators": 2, "max_depth": 1, "n_stump_evaluations": 1}
 
 
 # start of util functions

--- a/sktime/classification/distance_based/_proximity_forest.py
+++ b/sktime/classification/distance_based/_proximity_forest.py
@@ -1570,7 +1570,7 @@ class ProximityForest(BaseClassifier):
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
         if parameter_set == "results_comparison":
-            return {"n_estimators": 3, "max_depth": 1, "n_stump_evaluations": 2}
+            return {"n_estimators": 3, "max_depth": 2, "n_stump_evaluations": 2}
         else:
             return {"n_estimators": 2, "max_depth": 1, "n_stump_evaluations": 1}
 


### PR DESCRIPTION
This PR changes test parameters of `ProximityForest` and `ProximityTree` to faster settings (reduced recursion depth), for lower runtime.
It leaves the special "unit test" parameters unchanged.