### PR TITLE
[BUG] fix `ThetaForecaster.predict_quantiles` breaking on `pd.DataFrame` input

### DIFF
--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -149,6 +149,8 @@ class ThetaForecaster(ExponentialSmoothing):
             The forecasters horizon with the steps ahead to to predict.
             Default is
             one-step ahead forecast, i.e. np.array([1]).
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
 
         Returns
         -------
@@ -218,7 +220,7 @@ class ThetaForecaster(ExponentialSmoothing):
             self.fh.to_relative(self.cutoff) * self.initial_level_ ** 2 + 1
         )
 
-        y_pred = super(ThetaForecaster, self).predict(fh, X)
+        y_pred = super(ThetaForecaster, self)._predict(fh, X)
 
         # we assume normal additive noise with sem variance
         for a in alpha:

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -217,7 +217,7 @@ class ThetaForecaster(ExponentialSmoothing):
         pred_quantiles = pd.DataFrame(columns=index)
 
         sem = self.sigma_ * np.sqrt(
-            self.fh.to_relative(self.cutoff) * self.initial_level_ ** 2 + 1
+            self.fh.to_relative(self.cutoff) * self.initial_level_**2 + 1
         )
 
         y_pred = super(ThetaForecaster, self)._predict(fh, X)


### PR DESCRIPTION
This PR fixes #2524.

The bug is explained by `_predict_quantiles` calling `super.predict` and not `super._predict` - the latter always returns a `pd.Series` as expected, while the former is polymorphic and breaks the function in case something else is returned (e.g., when `y` is a data frame).