### PR TITLE
[MNT] added pytest timeout of 5 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
           cp .coveragerc testdir/
           cp setup.cfg testdir/
           cd testdir/
-          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime -v -n 2 --pyargs sktime --timeout=300
+          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime --timeout=300 -v -n 2 --pyargs sktime
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v2
@@ -115,7 +115,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: make PYTESTOPTIONS="--cov --cov-report=xml" test --timeout=300
+        run: make PYTESTOPTIONS="--cov --cov-report=xml --timeout=300" test
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v2
@@ -156,7 +156,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: make PYTESTOPTIONS="--cov --cov-report=xml" test --timeout=300
+        run: make PYTESTOPTIONS="--cov --cov-report=xml --timeout=300" test
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
           cp .coveragerc testdir/
           cp setup.cfg testdir/
           cd testdir/
-          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime -v -n 2 --pyargs sktime
+          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime -v -n 2 --pyargs sktime --timeout=300
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v2
@@ -115,7 +115,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: make PYTESTOPTIONS="--cov --cov-report=xml" test
+        run: make PYTESTOPTIONS="--cov --cov-report=xml" test --timeout=300
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v2
@@ -156,7 +156,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: make PYTESTOPTIONS="--cov --cov-report=xml" test
+        run: make PYTESTOPTIONS="--cov --cov-report=xml" test --timeout=300
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -122,7 +122,7 @@ jobs:
           cp .coveragerc testdir/
           cp setup.cfg testdir/
           cd testdir/
-          python -m pytest --showlocals --durations=10 --pyargs sktime
+          python -m pytest --showlocals --durations=10 --pyargs sktime --timeout=300
 
   upload_wheels:
     name: Upload wheels to PyPI

--- a/build_tools/azure/build_wheels.sh
+++ b/build_tools/azure/build_wheels.sh
@@ -34,5 +34,5 @@ done
 # Install built wheel and test
 for PYTHON in "${PYTHON_VERSIONS[@]}"; do
   # Run tests
-  "${PYTHON}/pytest" --showlocals --durations=20 --junitxml=junit/test-results.xml --cov=sktime --cov-report=xml --cov-report=html --pyargs sktime
+  "${PYTHON}/pytest" --showlocals --durations=20 --junitxml=junit/test-results.xml --cov=sktime --cov-report=xml --cov-report=html --pyargs sktime --timeout=300
 done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "pytest-timeout",
     "pytest-xdist",
     "wheel",
 ]


### PR DESCRIPTION
This PR adds a dependency on `pytest-timeout` in the `dev` dependency set, and a timeout-fail of 5min on all individual tests.

This will address tests hanging for 6 hours such as in https://github.com/alan-turing-institute/sktime/issues/2448 (they will fail earlier, at the 5min bound)