### PR TITLE
[ENH] Logger update - `__init__` removal, private `log` attribute

### DIFF
--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -129,7 +129,7 @@ def all_estimators(
     import sys
     import warnings
 
-    MODULES_TO_IGNORE = ("tests", "setup", "contrib", "benchmarking")
+    MODULES_TO_IGNORE = ("tests", "setup", "contrib", "benchmarking", "utils")
 
     all_estimators = []
     ROOT = str(Path(__file__).parent.parent)  # sktime package root directory

--- a/sktime/utils/estimators/_base.py
+++ b/sktime/utils/estimators/_base.py
@@ -13,13 +13,20 @@ from sktime.base import BaseEstimator
 class _MockEstimatorMixin:
     """Mixin class for constructing Mock estimators."""
 
-    def __init__(self):
-        self._log = []
-
     @property
     def log(self):
         """Log of the methods called and the parameters passed in each method."""
-        return self._log
+        if not hasattr(self, "_MockEstimatorMixin__log"):
+            return []
+        else:
+            return self._MockEstimatorMixin__log
+
+    @log.setter
+    def log(self, value):
+        if not hasattr(self, "_MockEstimatorMixin__log"):
+            self._MockEstimatorMixin__log = [value]
+        else:
+            self._MockEstimatorMixin__log = self._MockEstimatorMixin__log + [value]
 
 
 def _method_logger(method):
@@ -30,7 +37,7 @@ def _method_logger(method):
         if not isinstance(self, _MockEstimatorMixin):
             raise TypeError("method_logger requires a MockEstimator class")
         args_dict.pop("self")
-        self._log.append((method.__name__, deepcopy(args_dict)))
+        self.log = (method.__name__, deepcopy(args_dict))
         return method(self, *args, **kwargs)
 
     return wrapper

--- a/sktime/utils/estimators/_base.py
+++ b/sktime/utils/estimators/_base.py
@@ -21,8 +21,16 @@ class _MockEstimatorMixin:
         else:
             return self._MockEstimatorMixin__log
 
-    @log.setter
-    def log(self, value):
+    def add_log_item(self, value):
+        """Append an item to the log.
+
+        State change:
+        self.log - `value` is appended to the list self.log
+
+        Parameters
+        ----------
+        value : any object
+        """
         if not hasattr(self, "_MockEstimatorMixin__log"):
             self._MockEstimatorMixin__log = [value]
         else:
@@ -37,7 +45,7 @@ def _method_logger(method):
         if not isinstance(self, _MockEstimatorMixin):
             raise TypeError("method_logger requires a MockEstimator class")
         args_dict.pop("self")
-        self.log = (method.__name__, deepcopy(args_dict))
+        self.add_log_item((method.__name__, deepcopy(args_dict)))
         return method(self, *args, **kwargs)
 
     return wrapper

--- a/sktime/utils/estimators/tests/test_base.py
+++ b/sktime/utils/estimators/tests/test_base.py
@@ -42,7 +42,7 @@ def test_mixin(base):
 
     dummy_instance = _DummyClass()
     assert hasattr(dummy_instance, "log")
-    dummy_instance.log = 42
+    dummy_instance.add_log_item(42)
     assert hasattr(dummy_instance, "_MockEstimatorMixin__log")
 
 

--- a/sktime/utils/estimators/tests/test_base.py
+++ b/sktime/utils/estimators/tests/test_base.py
@@ -41,15 +41,9 @@ def test_mixin(base):
             pass
 
     dummy_instance = _DummyClass()
-    assert hasattr(dummy_instance, "_log") & hasattr(dummy_instance, "log")
-
-
-def test_log_is_property():
-    """Test _MockEstimatorMixin.log can't be overwritten."""
-    mixin = _MockEstimatorMixin()
-    with pytest.raises(AttributeError) as excinfo:
-        mixin.log = 1
-        assert "can't set attribute" in str(excinfo.value)
+    assert hasattr(dummy_instance, "log")
+    dummy_instance.log = 42
+    assert hasattr(dummy_instance, "_MockEstimatorMixin__log")
 
 
 def test_method_logger_exception():

--- a/sktime/utils/estimators/tests/test_base.py
+++ b/sktime/utils/estimators/tests/test_base.py
@@ -46,6 +46,15 @@ def test_mixin(base):
     assert hasattr(dummy_instance, "_MockEstimatorMixin__log")
 
 
+def test_log_is_property():
+    """Test _MockEstimatorMixin.log elements can't be overwritten."""
+    mixin = _MockEstimatorMixin()
+    mixin.log = 1
+    mixin.log = 2
+    assert mixin.log[0] == 1
+    assert mixin.log[1] == 2
+
+
 def test_method_logger_exception():
     """Test that _method_logger only works for _MockEstimatorMixin subclasses."""
 

--- a/sktime/utils/estimators/tests/test_base.py
+++ b/sktime/utils/estimators/tests/test_base.py
@@ -46,13 +46,21 @@ def test_mixin(base):
     assert hasattr(dummy_instance, "_MockEstimatorMixin__log")
 
 
-def test_log_is_property():
-    """Test _MockEstimatorMixin.log elements can't be overwritten."""
+def test_add_log_item():
+    """Test _MockEstimatorMixin.add_log_item behaviour."""
     mixin = _MockEstimatorMixin()
-    mixin.log = 1
-    mixin.log = 2
+    mixin.add_log_item(1)
+    mixin.add_log_item(2)
     assert mixin.log[0] == 1
     assert mixin.log[1] == 2
+
+
+def test_log_is_property():
+    """Test _MockEstimatorMixin.log can't be overwritten."""
+    mixin = _MockEstimatorMixin()
+    with pytest.raises(AttributeError) as excinfo:
+        mixin.log = 1
+        assert "can't set attribute" in str(excinfo.value)
 
 
 def test_method_logger_exception():


### PR DESCRIPTION
This PR makes the following changes to `_MockEstimatorMixin`:

* changes the name of the log attribute from `_log` to `__log`. That way, the attribute becomes hidden and cannot be affected directly.
* write logic is slightly changed, with `log` getting a setter that appends to the log (instead of overwritin it); `__init__` is removed entirely, first access creates the list and not the `__init__`.

Reason to make these changes:

* `__init__` clashes with linear inheritance structure of `sktime` estimators, in particular the pattern of passing args to `super` (which it blocks)
* clashes with `BaseObject` extension here: https://github.com/alan-turing-institute/sktime/pull/2531

Also adds the `utils` module to the ignore-list of the `all_estimators` retrieval utility, since (a) the test estimators are not actually ones a user will want to see, and (b) the combined mock/logger estimators change state in `predict` etc and fail some tests. But, for logger estimators a change of state in `predict` etc is actually intended (addition of the log).