### PR TITLE
[ENH] turn on tests for no state change in `transform`, `predict`

### DIFF
--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -55,8 +55,7 @@ class BasePairwiseTransformer(BaseEstimator):
     }
 
     def __init__(self):
-        super().__init__()
-        self.X_equals_X2 = False
+        super(BasePairwiseTransformer, self).__init__()
 
     def __call__(self, X, X2=None):
         """Compute distance/kernel matrix, call shorthand.
@@ -113,7 +112,6 @@ class BasePairwiseTransformer(BaseEstimator):
 
         if X2 is None:
             X2 = X
-            self.X_equals_X2 = True
         else:
             X2 = self._pairwise_table_x_check(X2, var_name="X2")
             # todo, possibly:
@@ -201,7 +199,6 @@ class BasePairwiseTransformerPanel(BaseEstimator):
 
     def __init__(self):
         super(BasePairwiseTransformerPanel, self).__init__()
-        self.X_equals_X2 = False
 
     def __call__(self, X, X2=None):
         """Compute distance/kernel matrix, call shorthand.
@@ -281,12 +278,8 @@ class BasePairwiseTransformerPanel(BaseEstimator):
 
         if X2 is None:
             X2 = X
-            self.X_equals_X2 = True
         else:
             X2 = self._pairwise_panel_x_check(X2, var_name="X2")
-            # todo, possibly:
-            # check X, X2 for equality, then set X_equals_X2
-            # could use deep_equals
 
         return self._transform(X=X, X2=X2)
 

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -76,11 +76,6 @@ class BasePairwiseTransformer(BaseEstimator):
         -------
         distmat: np.array of shape [n, m]
             (i,j)-th entry contains distance/kernel between X.iloc[i] and X2.iloc[j]
-
-        Writes to self
-        --------------
-        X_equals_X2: bool = True if X2 was not passed, False if X2 was passed
-            for use to make internal calculations efficient, e.g., in _transform
         """
         # no input checks or input logic here, these are done in transform
         # this just defines __call__ as an alias for transform
@@ -102,11 +97,6 @@ class BasePairwiseTransformer(BaseEstimator):
         -------
         distmat: np.array of shape [n, m]
             (i,j)-th entry contains distance/kernel between X.iloc[i] and X2.iloc[j]
-
-        Writes to self
-        --------------
-        X_equals_X2: bool = True if X2 was not passed, False if X2 was passed
-            for use to make internal calculations efficient, e.g., in _transform
         """
         X = self._pairwise_table_x_check(X)
 
@@ -114,9 +104,6 @@ class BasePairwiseTransformer(BaseEstimator):
             X2 = X
         else:
             X2 = self._pairwise_table_x_check(X2, var_name="X2")
-            # todo, possibly:
-            # check X, X2 for equality, then set X_equals_X2
-            # could use deep_equals
 
         return self._transform(X=X, X2=X2)
 
@@ -229,11 +216,6 @@ class BasePairwiseTransformerPanel(BaseEstimator):
         -------
         distmat: np.array of shape [n, m]
             (i,j)-th entry contains distance/kernel between X[i] and X2[j]
-
-        Writes to self
-        --------------
-        X_equals_X2: bool = True if X2 was not passed, False if X2 was passed
-            for use to make internal calculations efficient, e.g., in _transform
         """
         # no input checks or input logic here, these are done in transform
         # this just defines __call__ as an alias for transform
@@ -268,11 +250,6 @@ class BasePairwiseTransformerPanel(BaseEstimator):
         -------
         distmat: np.array of shape [n, m]
             (i,j)-th entry contains distance/kernel between X[i] and X2[j]
-
-        Writes to self
-        --------------
-        X_equals_X2: bool = True if X2 was not passed, False if X2 was passed
-            for use to make internal calculations efficient, e.g., in _transform
         """
         X = self._pairwise_panel_x_check(X)
 

--- a/sktime/dists_kernels/compose_from_align.py
+++ b/sktime/dists_kernels/compose_from_align.py
@@ -51,8 +51,7 @@ class DistFromAligner(BasePairwiseTransformerPanel):
         distmat: np.array of shape [n, m]
             (i,j)-th entry contains distance/kernel between X.iloc[i] and X2.iloc[j]
         """
-        self.aligner_ = clone(self.aligner)
-        aligner = self.aligner_
+        aligner = clone(self.aligner)
 
         # find out whether we know that the resulting matrix is symmetric
         #   since aligner distances are always symmetric,

--- a/sktime/dists_kernels/compose_tab_to_panel.py
+++ b/sktime/dists_kernels/compose_tab_to_panel.py
@@ -12,6 +12,7 @@ __author__ = ["fkiraly"]
 import numpy as np
 
 from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+from sktime.utils._testing import deep_equals
 
 
 class AggrDist(BasePairwiseTransformerPanel):
@@ -75,7 +76,7 @@ class AggrDist(BasePairwiseTransformerPanel):
         n = len(X)
         m = len(X2)
 
-        X_equals_X2 = self.X_equals_X2
+        X_equals_X2 = deep_equals(X, X2)
 
         aggfunc = self.aggfunc
         aggfunc_is_symm = self.aggfunc_is_symm

--- a/sktime/dists_kernels/compose_tab_to_panel.py
+++ b/sktime/dists_kernels/compose_tab_to_panel.py
@@ -12,7 +12,7 @@ __author__ = ["fkiraly"]
 import numpy as np
 
 from sktime.dists_kernels._base import BasePairwiseTransformerPanel
-from sktime.utils._testing import deep_equals
+from sktime.utils._testing.deep_equals import deep_equals
 
 
 class AggrDist(BasePairwiseTransformerPanel):

--- a/sktime/dists_kernels/tests/test_all_dist_kernels.py
+++ b/sktime/dists_kernels/tests/test_all_dist_kernels.py
@@ -83,32 +83,12 @@ def _general_pairwise_transformer_tests(x, y, pairwise_transformer):
     transformer = pairwise_transformer.create_test_instance()
     transformation = transformer.transform(x, y)
 
-    assert transformer.X_equals_X2 is False, (
-        f"X_equals_X2 is set to wrong value for {pairwise_transformer} "
-        f"when both X1 and X2 passed"
-    )
     assert isinstance(
         transformation, np.ndarray
     ), f"Shape of matrix returned is wrong for {pairwise_transformer}"
     assert (
         transformation.shape == EXPECTED_SHAPE
     ), f"Shape of matrix returned is wrong for {pairwise_transformer}"
-    assert transformer.X_equals_X2 is False, (
-        f"X_equals_X2 is set to wrong value for {transformer} " f"when only X passed"
-    )
 
     transformer = pairwise_transformer.create_test_instance()
     transformation = transformer.transform(x)
-    _x_equals_x2_test(transformation, x, transformer)
-
-
-def _x_equals_x2_test(transformation, x, transformer):
-    # test X_equals_X2
-    for i in range(len(x)):
-        # Have to round or test breaks on github (even though works locally)
-        row = np.around((transformation[i, :]).T, decimals=5).astype(float)
-        column = np.around(transformation[:, i], decimals=5).astype(float)
-        assert np.array_equal(row, column)
-    assert transformer.X_equals_X2, (
-        f"X_equals_X2 is set to wrong value for {transformer} " f"when only X passed"
-    )

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -72,6 +72,12 @@ EXCLUDED_TESTS = {
         "test_persistence_via_pickle",
         "test_fit_does_not_overwrite_hyper_params",
     ],
+    # sth is not quite right with the RowTransformer-s changing state,
+    #   but these are anyway on their path to deprecation, see #2370
+    "SeriesToPrimitivesRowTransformer": ["test_methods_do_not_change_state"],
+    "SeriesToSeriesRowTransformer": ["test_methods_do_not_change_state"],
+    # ColumnTransformer still needs to be refactored, see #2537
+    "ColumnTransformer": ["test_methods_do_not_change_state"],
 }
 
 # We here configure estimators for basic unit testing, including setting of

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -896,20 +896,6 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
                 _ = scenario.run(estimator, method_sequence=[method])
                 dict_after = estimator.__dict__
 
-                if method == "transform" and estimator.get_class_tag("fit_is_empty"):
-                    # Some transformations fit during transform, as they apply
-                    # some transformation to each series passed to transform,
-                    # so transform will actually change the state of these estimator.
-                    continue
-
-                if method == "predict" and estimator.get_class_tag("fit_is_empty"):
-                    # Some annotators fit during predict, as they apply
-                    # some apply annotation to each series passed to predict,
-                    # so predict will actually change the state of these annotators.
-                    continue
-
-                # old logic uses equality without auto-msg, keep comment until refactor
-                # is_equal = dict_after == dict_before
                 is_equal, msg = deep_equals(dict_after, dict_before, return_msg=True)
                 assert is_equal, (
                     f"Estimator: {type(estimator).__name__} changes __dict__ "

--- a/sktime/transformations/series/clasp.py
+++ b/sktime/transformations/series/clasp.py
@@ -63,7 +63,7 @@ def _sliding_mean_std(X, m):
         The moving mean and moving std
     """
     s = np.insert(np.cumsum(X), 0, 0)
-    sSq = np.insert(np.cumsum(X ** 2), 0, 0)
+    sSq = np.insert(np.cumsum(X**2), 0, 0)
     segSum = s[m:] - s[:-m]
     segSumSq = sSq[m:] - sSq[:-m]
     movmean = segSum / m

--- a/sktime/transformations/series/clasp.py
+++ b/sktime/transformations/series/clasp.py
@@ -424,10 +424,10 @@ class ClaSPTransformer(BaseTransformer):
             ClaSP of the single time series as output
             with length as (n-window_length+1)
         """
-        self._check_scoring_metric(self.scoring_metric)
+        scoring_metric_call = self._check_scoring_metric(self.scoring_metric)
 
         X = X.flatten()
-        Xt, self.knn_mask = clasp(X, self.window_length, score=self.scoring_metric_call)
+        Xt, self.knn_mask = clasp(X, self.window_length, score=scoring_metric_call)
 
         return Xt
 
@@ -438,6 +438,12 @@ class ClaSPTransformer(BaseTransformer):
         ----------
         scoring_metric : string
             Choose from "ROC_AUC" or "F1"
+
+        Returns
+        -------
+        scoring_metric_call : a callable, keyed by the `scoring_metric` input
+            _roc_auc_score, if scoring_metric = "ROC_AUC"
+            _binary_f1_score, if scoring_metric = "F1"
         """
         valid_scores = ("ROC_AUC", "F1")
 
@@ -445,9 +451,9 @@ class ClaSPTransformer(BaseTransformer):
             raise ValueError(f"invalid input, please use one of {valid_scores}")
 
         if scoring_metric == "ROC_AUC":
-            self.scoring_metric_call = _roc_auc_score
+            return _roc_auc_score
         elif scoring_metric == "F1":
-            self.scoring_metric_call = _binary_f1_score
+            return _binary_f1_score
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/transformations/series/clasp.py
+++ b/sktime/transformations/series/clasp.py
@@ -400,7 +400,6 @@ class ClaSPTransformer(BaseTransformer):
 
     def __init__(self, window_length=10, scoring_metric="ROC_AUC"):
         self.window_length = int(window_length)
-        self.knn_mask = None
         self.scoring_metric = scoring_metric
         super(ClaSPTransformer, self).__init__()
 
@@ -427,7 +426,7 @@ class ClaSPTransformer(BaseTransformer):
         scoring_metric_call = self._check_scoring_metric(self.scoring_metric)
 
         X = X.flatten()
-        Xt, self.knn_mask = clasp(X, self.window_length, score=scoring_metric_call)
+        Xt, _ = clasp(X, self.window_length, score=scoring_metric_call)
 
         return Xt
 


### PR DESCRIPTION
`transform`, `predict` should not change state - these tests were turned off in the test refactor since some estimators were non-compliant.

This PR turns those tests on again, and excepts non-compliant estimators until fixed.

Fixes or escapes the following estimators that are failing the test:
* escapes the row transformers, these will be deprecated, see #2370
* escapes the column transformer, this has a bug and also still needs to be refactored, see #2537
* removes the `self.X_equals_X2` write in `transform` of pairwise transformers entirely, replaces instances of use with a local `deep_equals` check. Internal docstrings are updated accordinly. Not a public attribute, so no deprecation necessary. FYI @chrisholder.
* removes the `self.scoring_metric_call` and `self.knn_mask` writes in `transform` of `ClaSPTransformer`, this was unnecessary as `scoring_metric_call` is read out directly after, so could be replaced by a function call. `knn_mask` is not read at all. FYI @patrickzib 
* removes the `self.aligner_` write in `DistFromAligner`, as that was not read from anywhere