### PR TITLE
BUG] bugfix for default `_predict_var` implementation

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1917,7 +1917,7 @@ class BaseForecaster(BaseEstimator):
             pred_var = pd.DataFrame(vars_dict)
 
             # check whether column format was "nameless", set it to RangeIndex then
-            if pred_var.columns == "Coverage":
+            if len(pred_var.columns) == 1 and pred_var.columns == ["Coverage"]:
                 pred_var.columns = pd.RangeIndex(1)
 
         return pred_var


### PR DESCRIPTION
The default `_predict_var` implementation had an unreported bug where it compared column names in the multivariate case.

This is now fixed.