### PR TITLE
[ENH] MockForecaster without logging, MockUnivariateForecaster clean-up

### DIFF
--- a/sktime/utils/estimators/__init__.py
+++ b/sktime/utils/estimators/__init__.py
@@ -3,7 +3,14 @@
 
 __author__ = ["ltsaprounis"]
 
-__all__ = ["MockUnivariateForecaster", "make_mock_estimator"]
+__all__ = [
+    "MockUnivariateForecaster",
+    "MockUnivariateForecasterLogger",
+    "make_mock_estimator",
+]
 
 from sktime.utils.estimators._base import make_mock_estimator
-from sktime.utils.estimators._forecasters import MockUnivariateForecaster
+from sktime.utils.estimators._forecasters import (
+    MockUnivariateForecaster,
+    MockUnivariateForecasterLogger,
+)

--- a/sktime/utils/estimators/__init__.py
+++ b/sktime/utils/estimators/__init__.py
@@ -4,13 +4,13 @@
 __author__ = ["ltsaprounis"]
 
 __all__ = [
-    "MockUnivariateForecaster",
+    "MockForecaster",
     "MockUnivariateForecasterLogger",
     "make_mock_estimator",
 ]
 
 from sktime.utils.estimators._base import make_mock_estimator
 from sktime.utils.estimators._forecasters import (
-    MockUnivariateForecaster,
+    MockForecaster,
     MockUnivariateForecasterLogger,
 )

--- a/sktime/utils/estimators/__init__.py
+++ b/sktime/utils/estimators/__init__.py
@@ -10,7 +10,4 @@ __all__ = [
 ]
 
 from sktime.utils.estimators._base import make_mock_estimator
-from sktime.utils.estimators._forecasters import (
-    MockForecaster,
-    MockForecasterLogger,
-)
+from sktime.utils.estimators._forecasters import MockForecaster, MockForecasterLogger

--- a/sktime/utils/estimators/__init__.py
+++ b/sktime/utils/estimators/__init__.py
@@ -10,4 +10,7 @@ __all__ = [
 ]
 
 from sktime.utils.estimators._base import make_mock_estimator
-from sktime.utils.estimators._forecasters import MockForecaster, MockForecasterLogger
+from sktime.utils.estimators._forecasters import (
+    MockForecaster,
+    MockForecasterLogger,
+)

--- a/sktime/utils/estimators/__init__.py
+++ b/sktime/utils/estimators/__init__.py
@@ -5,12 +5,12 @@ __author__ = ["ltsaprounis"]
 
 __all__ = [
     "MockForecaster",
-    "MockUnivariateForecasterLogger",
+    "MockForecasterLogger",
     "make_mock_estimator",
 ]
 
 from sktime.utils.estimators._base import make_mock_estimator
 from sktime.utils.estimators._forecasters import (
     MockForecaster,
-    MockUnivariateForecasterLogger,
+    MockForecasterLogger,
 )

--- a/sktime/utils/estimators/__init__.py
+++ b/sktime/utils/estimators/__init__.py
@@ -5,12 +5,12 @@ __author__ = ["ltsaprounis"]
 
 __all__ = [
     "MockForecaster",
-    "MockForecasterLogger",
+    "MockUnivariateForecasterLogger",
     "make_mock_estimator",
 ]
 
 from sktime.utils.estimators._base import make_mock_estimator
 from sktime.utils.estimators._forecasters import (
     MockForecaster,
-    MockForecasterLogger,
+    MockUnivariateForecasterLogger,
 )

--- a/sktime/utils/estimators/_base.py
+++ b/sktime/utils/estimators/_base.py
@@ -54,7 +54,7 @@ def _method_logger(method):
 def make_mock_estimator(
     estimator_class: BaseEstimator, method_regex: str = ".*"
 ) -> BaseEstimator:
-    r"""Transform any estimator class into a logged estimator class.
+    r"""Transform any estimator class into a mock estimator class.
 
     Parameters
     ----------

--- a/sktime/utils/estimators/_base.py
+++ b/sktime/utils/estimators/_base.py
@@ -54,7 +54,7 @@ def _method_logger(method):
 def make_mock_estimator(
     estimator_class: BaseEstimator, method_regex: str = ".*"
 ) -> BaseEstimator:
-    r"""Transform any estimator class into a mock estimator class.
+    r"""Transform any estimator class into a logged estimator class.
 
     Parameters
     ----------

--- a/sktime/utils/estimators/_forecasters.py
+++ b/sktime/utils/estimators/_forecasters.py
@@ -1,12 +1,191 @@
 # -*- coding: utf-8 -*-
-"""Mock forecaster and logged version."""
 
 __author__ = ["ltsaprounis"]
 
 import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster
-from sktime.utils.estimators._base import make_mock_estimator
+from sktime.utils.estimators._base import _method_logger, _MockEstimatorMixin
+
+
+class MockUnivariateForecasterLogger(BaseForecaster, _MockEstimatorMixin):
+    """Mock univariate forecaster that logs the methods called and their parameters.
+
+    Parameters
+    ----------
+    prediction_constant : float, optional
+        The forecasted value for all steps in the horizon, by default 10
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.utils.estimators import MockUnivariateForecasterLogger
+    >>> y = load_airline()
+    >>> forecaster = MockUnivariateForecasterLogger()
+    >>> forecaster.fit(y)
+    MockUnivariateForecasterLogger(...)
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
+    >>> print(forecaster.log)
+    [('_fit', ...), ('_predict', ...)]
+    """
+
+    _tags = {
+        "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
+        "ignores-exogeneous-X": False,  # does estimator ignore the exogeneous X?
+        "handles-missing-data": False,  # can estimator handle missing data?
+        "y_inner_mtype": "pd.Series",  # which types do _fit, _predict, assume for y?
+        "X_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for X?
+        "requires-fh-in-fit": False,  # is forecasting horizon already required in fit?
+        "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
+        "enforce_index_type": None,  # index type that needs to be enforced in X/y
+        "capability:pred_int": True,  # does forecaster implement predict_quantiles?
+        # deprecated and likely to be removed in 0.12.0
+    }
+
+    def __init__(self, prediction_constant: float = 10):
+        self.prediction_constant = prediction_constant
+        super(MockUnivariateForecasterLogger, self).__init__()
+
+    @_method_logger
+    def _fit(self, y, X=None, fh=None):
+        """Fit forecaster to training data.
+
+        private _fit containing the core logic, called from fit
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+            Time series to which to fit the forecaster.
+            if self.get_tag("scitype:y")=="univariate":
+                guaranteed to have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+                guaranteed to have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions apply
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            Required (non-optional) here if self.get_tag("requires-fh-in-fit")==True
+            Otherwise, if not passed in _fit, guaranteed to be passed in _predict
+        X : optional (default=None)
+            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Exogeneous time series to fit to.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        return self
+
+    @_method_logger
+    def _predict(self, fh, X=None):
+        """Forecast time series at future horizon.
+
+        private _predict containing the core logic, called from predict
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            If not passed in _fit, guaranteed to be passed here
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+
+        Returns
+        -------
+        y_pred : pd.Series
+            Point predictions
+        """
+        index = fh.to_absolute(self.cutoff)
+        return pd.Series(self.prediction_constant, index=index)
+
+    @_method_logger
+    def _update(self, y, X=None, update_params=True):
+        """Update time series to incremental training data.
+
+        private _update containing the core logic, called from update
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Writes to self:
+            Sets fitted model attributes ending in "_", if update_params=True.
+            Does not write to self if update_params=False.
+
+        Parameters
+        ----------
+        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+            Time series with which to update the forecaster.
+            if self.get_tag("scitype:y")=="univariate":
+                guaranteed to have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+                guaranteed to have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions apply
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+        update_params : bool, optional (default=True)
+            whether model parameters should be updated
+
+        Returns
+        -------
+        self : reference to self
+        """
+        return self
+
+    @_method_logger
+    def _predict_quantiles(self, fh, X=None, alpha=None):
+        """Compute/return prediction quantiles for a forecast.
+
+        private _predict_quantiles containing the core logic,
+            called from predict_quantiles and possibly predict_interval
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : int, list, np.array or ForecastingHorizon
+            Forecasting horizon
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+        alpha : list of float (guaranteed not None and floats in [0,1] interval)
+            A list of probabilities at which quantile forecasts are computed.
+
+        Returns
+        -------
+        pred_quantiles : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+                second level being the quantile forecasts for each alpha.
+                Quantile forecasts are calculated for each a in alpha.
+            Row index is fh. Entries are quantile forecasts, for var in col index,
+                at quantile probability in second-level col index, for each row index.
+        """
+        fh_index = fh.to_absolute(self.cutoff)
+        col_index = pd.MultiIndex.from_product([["Quantiles"], alpha])
+        pred_quantiles = pd.DataFrame(columns=col_index, index=fh_index)
+
+        for a in alpha:
+            pred_quantiles[("Quantiles", a)] = pd.Series(
+                self.prediction_constant * 2 * a, index=fh_index
+            )
+
+        return pred_quantiles
 
 
 class MockForecaster(BaseForecaster):
@@ -20,11 +199,11 @@ class MockForecaster(BaseForecaster):
     Examples
     --------
     >>> from sktime.datasets import load_airline
-    >>> from sktime.utils.estimators import MockForecasterLogger
+    >>> from sktime.utils.estimators import MockUnivariateForecasterLogger
     >>> y = load_airline()
-    >>> forecaster = MockForecasterLogger()
+    >>> forecaster = MockUnivariateForecasterLogger()
     >>> forecaster.fit(y)
-    MockForecasterLogger(...)
+    MockUnivariateForecasterLogger(...)
     >>> y_pred = forecaster.predict(fh=[1,2,3])
     >>> print(forecaster.log)
     [('_fit', ...), ('_predict', ...)]
@@ -190,6 +369,3 @@ class MockForecaster(BaseForecaster):
             )
 
         return pred_quantiles
-
-
-MockForecasterLogger = make_mock_estimator(MockForecaster)

--- a/sktime/utils/estimators/_forecasters.py
+++ b/sktime/utils/estimators/_forecasters.py
@@ -360,13 +360,11 @@ class MockForecaster(BaseForecaster):
             cols = ["Quantiles"]
 
         col_index = pd.MultiIndex.from_product([cols, alpha])
-        pred_quantiles = pd.DataFrame(columns=index)
-
         fh_index = fh.to_absolute(self.cutoff)
         pred_quantiles = pd.DataFrame(index=fh_index, columns=col_index)
 
-        for col, a in zip(col_index, alpha):
-            pred_quantiles[(col, a)] = pd.Series(
+        for col, a in col_index:
+            pred_quantiles[col, a] = pd.Series(
                 self.prediction_constant * 2 * a, index=fh_index
             )
 

--- a/sktime/utils/estimators/_forecasters.py
+++ b/sktime/utils/estimators/_forecasters.py
@@ -8,7 +8,7 @@ from sktime.forecasting.base import BaseForecaster
 from sktime.utils.estimators._base import _method_logger, _MockEstimatorMixin
 
 
-class MockUnivariateForecaster(BaseForecaster, _MockEstimatorMixin):
+class MockUnivariateForecasterLogger(BaseForecaster, _MockEstimatorMixin):
     """Mock univariate forecaster that logs the methods called and their parameters.
 
     Parameters
@@ -19,11 +19,11 @@ class MockUnivariateForecaster(BaseForecaster, _MockEstimatorMixin):
     Examples
     --------
     >>> from sktime.datasets import load_airline
-    >>> from sktime.utils.estimators import MockUnivariateForecaster
+    >>> from sktime.utils.estimators import MockUnivariateForecasterLogger
     >>> y = load_airline()
-    >>> forecaster = MockUnivariateForecaster()
+    >>> forecaster = MockUnivariateForecasterLogger()
     >>> forecaster.fit(y)
-    MockUnivariateForecaster(...)
+    MockUnivariateForecasterLogger(...)
     >>> y_pred = forecaster.predict(fh=[1,2,3])
     >>> print(forecaster.log)
     [('_fit', ...), ('_predict', ...)]
@@ -44,7 +44,7 @@ class MockUnivariateForecaster(BaseForecaster, _MockEstimatorMixin):
 
     def __init__(self, prediction_constant: float = 10):
         self.prediction_constant = prediction_constant
-        super(MockUnivariateForecaster, self).__init__()
+        super(MockUnivariateForecasterLogger, self).__init__()
 
     @_method_logger
     def _fit(self, y, X=None, fh=None):
@@ -176,11 +176,9 @@ class MockUnivariateForecaster(BaseForecaster, _MockEstimatorMixin):
             Row index is fh. Entries are quantile forecasts, for var in col index,
                 at quantile probability in second-level col index, for each row index.
         """
-        index = pd.MultiIndex.from_product([["Quantiles"], alpha])
-        pred_quantiles = pd.DataFrame(columns=index)
-
         fh_index = fh.to_absolute(self.cutoff)
-        pd.Series(self.prediction_constant, index=index)
+        col_index = pd.MultiIndex.from_product([["Quantiles"], alpha])
+        pred_quantiles = pd.DataFrame(columns=col_index, index=fh_index)
 
         for a in alpha:
             pred_quantiles[("Quantiles", a)] = pd.Series(
@@ -189,25 +187,187 @@ class MockUnivariateForecaster(BaseForecaster, _MockEstimatorMixin):
 
         return pred_quantiles
 
-    @classmethod
-    def get_test_params(cls, parameter_set="default"):
-        """Return testing parameter settings for the estimator.
+
+class MockForecaster(BaseForecaster):
+    """Mock forecaster, returns data frames filled with a constant.
+
+    Parameters
+    ----------
+    prediction_constant : float, optional
+        The forecasted value for all steps in the horizon, by default 10
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.utils.estimators import MockUnivariateForecasterLogger
+    >>> y = load_airline()
+    >>> forecaster = MockUnivariateForecasterLogger()
+    >>> forecaster.fit(y)
+    MockUnivariateForecasterLogger(...)
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
+    >>> print(forecaster.log)
+    [('_fit', ...), ('_predict', ...)]
+    """
+
+    _tags = {
+        "scitype:y": "both",  # which y are fine? univariate/multivariate/both
+        "ignores-exogeneous-X": False,  # does estimator ignore the exogeneous X?
+        "handles-missing-data": False,  # can estimator handle missing data?
+        "y_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for y?
+        "X_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for X?
+        "requires-fh-in-fit": False,  # is forecasting horizon already required in fit?
+        "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
+        "enforce_index_type": None,  # index type that needs to be enforced in X/y
+        "capability:pred_int": True,  # does forecaster implement predict_quantiles?
+        # deprecated and likely to be removed in 0.12.0
+    }
+
+    def __init__(self, prediction_constant: float = 10):
+        self.prediction_constant = prediction_constant
+        super(MockForecaster, self).__init__()
+
+    def _fit(self, y, X=None, fh=None):
+        """Fit forecaster to training data.
+
+        private _fit containing the core logic, called from fit
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
 
         Parameters
         ----------
-        parameter_set : str, default="default"
-            Name of the set of test parameters to return, for use in tests. If no
-            special parameters are defined for a value, will return `"default"` set.
-
+        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+            Time series to which to fit the forecaster.
+            if self.get_tag("scitype:y")=="univariate":
+                guaranteed to have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+                guaranteed to have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions apply
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            Required (non-optional) here if self.get_tag("requires-fh-in-fit")==True
+            Otherwise, if not passed in _fit, guaranteed to be passed in _predict
+        X : optional (default=None)
+            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Exogeneous time series to fit to.
 
         Returns
         -------
-        params : dict or list of dict, default = {}
-            Parameters to create testing instances of the class
-            Each dict are parameters to construct an "interesting" test instance, i.e.,
-            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
-            `create_test_instance` uses the first (or only) dictionary in `params`
+        self : reference to self
         """
-        params = [{}]
+        return self
 
-        return params
+    def _predict(self, fh, X=None):
+        """Forecast time series at future horizon.
+
+        private _predict containing the core logic, called from predict
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            If not passed in _fit, guaranteed to be passed here
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+
+        Returns
+        -------
+        y_pred : pd.Series
+            Point predictions
+        """
+        index = fh.to_absolute(self.cutoff)
+        return pd.DataFrame(
+            self.prediction_constant, index=index, columns=self._y.columns
+        )
+
+    def _update(self, y, X=None, update_params=True):
+        """Update time series to incremental training data.
+
+        private _update containing the core logic, called from update
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Writes to self:
+            Sets fitted model attributes ending in "_", if update_params=True.
+            Does not write to self if update_params=False.
+
+        Parameters
+        ----------
+        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+            Time series with which to update the forecaster.
+            if self.get_tag("scitype:y")=="univariate":
+                guaranteed to have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+                guaranteed to have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions apply
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+        update_params : bool, optional (default=True)
+            whether model parameters should be updated
+
+        Returns
+        -------
+        self : reference to self
+        """
+        return self
+
+    def _predict_quantiles(self, fh, X=None, alpha=None):
+        """Compute/return prediction quantiles for a forecast.
+
+        private _predict_quantiles containing the core logic,
+            called from predict_quantiles and possibly predict_interval
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : int, list, np.array or ForecastingHorizon
+            Forecasting horizon
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+        alpha : list of float (guaranteed not None and floats in [0,1] interval)
+            A list of probabilities at which quantile forecasts are computed.
+
+        Returns
+        -------
+        pred_quantiles : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+                second level being the quantile forecasts for each alpha.
+                Quantile forecasts are calculated for each a in alpha.
+            Row index is fh. Entries are quantile forecasts, for var in col index,
+                at quantile probability in second-level col index, for each row index.
+        """
+        cols = self._y.columns
+
+        if len(cols) == 1:
+            cols = ["Quantiles"]
+
+        col_index = pd.MultiIndex.from_product([cols, alpha])
+        pred_quantiles = pd.DataFrame(columns=index)
+
+        fh_index = fh.to_absolute(self.cutoff)
+        pred_quantiles = pd.DataFrame(index=fh_index, columns=col_index)
+
+        for col, a in zip(col_index, alpha):
+            pred_quantiles[(col, a)] = pd.Series(
+                self.prediction_constant * 2 * a, index=fh_index
+            )
+
+        return pred_quantiles

--- a/sktime/utils/estimators/_forecasters.py
+++ b/sktime/utils/estimators/_forecasters.py
@@ -1,191 +1,12 @@
 # -*- coding: utf-8 -*-
+"""Mock forecaster and logged version."""
 
 __author__ = ["ltsaprounis"]
 
 import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster
-from sktime.utils.estimators._base import _method_logger, _MockEstimatorMixin
-
-
-class MockUnivariateForecasterLogger(BaseForecaster, _MockEstimatorMixin):
-    """Mock univariate forecaster that logs the methods called and their parameters.
-
-    Parameters
-    ----------
-    prediction_constant : float, optional
-        The forecasted value for all steps in the horizon, by default 10
-
-    Examples
-    --------
-    >>> from sktime.datasets import load_airline
-    >>> from sktime.utils.estimators import MockUnivariateForecasterLogger
-    >>> y = load_airline()
-    >>> forecaster = MockUnivariateForecasterLogger()
-    >>> forecaster.fit(y)
-    MockUnivariateForecasterLogger(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])
-    >>> print(forecaster.log)
-    [('_fit', ...), ('_predict', ...)]
-    """
-
-    _tags = {
-        "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
-        "ignores-exogeneous-X": False,  # does estimator ignore the exogeneous X?
-        "handles-missing-data": False,  # can estimator handle missing data?
-        "y_inner_mtype": "pd.Series",  # which types do _fit, _predict, assume for y?
-        "X_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for X?
-        "requires-fh-in-fit": False,  # is forecasting horizon already required in fit?
-        "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
-        "enforce_index_type": None,  # index type that needs to be enforced in X/y
-        "capability:pred_int": True,  # does forecaster implement predict_quantiles?
-        # deprecated and likely to be removed in 0.12.0
-    }
-
-    def __init__(self, prediction_constant: float = 10):
-        self.prediction_constant = prediction_constant
-        super(MockUnivariateForecasterLogger, self).__init__()
-
-    @_method_logger
-    def _fit(self, y, X=None, fh=None):
-        """Fit forecaster to training data.
-
-        private _fit containing the core logic, called from fit
-
-        Writes to self:
-            Sets fitted model attributes ending in "_".
-
-        Parameters
-        ----------
-        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
-            Time series to which to fit the forecaster.
-            if self.get_tag("scitype:y")=="univariate":
-                guaranteed to have a single column/variable
-            if self.get_tag("scitype:y")=="multivariate":
-                guaranteed to have 2 or more columns
-            if self.get_tag("scitype:y")=="both": no restrictions apply
-        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
-            The forecasting horizon with the steps ahead to to predict.
-            Required (non-optional) here if self.get_tag("requires-fh-in-fit")==True
-            Otherwise, if not passed in _fit, guaranteed to be passed in _predict
-        X : optional (default=None)
-            guaranteed to be of a type in self.get_tag("X_inner_mtype")
-            Exogeneous time series to fit to.
-
-        Returns
-        -------
-        self : reference to self
-        """
-        return self
-
-    @_method_logger
-    def _predict(self, fh, X=None):
-        """Forecast time series at future horizon.
-
-        private _predict containing the core logic, called from predict
-
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-            Fitted model attributes ending in "_"
-            self.cutoff
-
-        Parameters
-        ----------
-        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
-            The forecasting horizon with the steps ahead to to predict.
-            If not passed in _fit, guaranteed to be passed here
-        X : pd.DataFrame, optional (default=None)
-            Exogenous time series
-
-        Returns
-        -------
-        y_pred : pd.Series
-            Point predictions
-        """
-        index = fh.to_absolute(self.cutoff)
-        return pd.Series(self.prediction_constant, index=index)
-
-    @_method_logger
-    def _update(self, y, X=None, update_params=True):
-        """Update time series to incremental training data.
-
-        private _update containing the core logic, called from update
-
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-            Fitted model attributes ending in "_"
-            self.cutoff
-
-        Writes to self:
-            Sets fitted model attributes ending in "_", if update_params=True.
-            Does not write to self if update_params=False.
-
-        Parameters
-        ----------
-        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
-            Time series with which to update the forecaster.
-            if self.get_tag("scitype:y")=="univariate":
-                guaranteed to have a single column/variable
-            if self.get_tag("scitype:y")=="multivariate":
-                guaranteed to have 2 or more columns
-            if self.get_tag("scitype:y")=="both": no restrictions apply
-        X : pd.DataFrame, optional (default=None)
-            Exogenous time series
-        update_params : bool, optional (default=True)
-            whether model parameters should be updated
-
-        Returns
-        -------
-        self : reference to self
-        """
-        return self
-
-    @_method_logger
-    def _predict_quantiles(self, fh, X=None, alpha=None):
-        """Compute/return prediction quantiles for a forecast.
-
-        private _predict_quantiles containing the core logic,
-            called from predict_quantiles and possibly predict_interval
-
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-            Fitted model attributes ending in "_"
-            self.cutoff
-
-        Parameters
-        ----------
-        fh : int, list, np.array or ForecastingHorizon
-            Forecasting horizon
-        X : pd.DataFrame, optional (default=None)
-            Exogenous time series
-        alpha : list of float (guaranteed not None and floats in [0,1] interval)
-            A list of probabilities at which quantile forecasts are computed.
-
-        Returns
-        -------
-        pred_quantiles : pd.DataFrame
-            Column has multi-index: first level is variable name from y in fit,
-                second level being the quantile forecasts for each alpha.
-                Quantile forecasts are calculated for each a in alpha.
-            Row index is fh. Entries are quantile forecasts, for var in col index,
-                at quantile probability in second-level col index, for each row index.
-        """
-        fh_index = fh.to_absolute(self.cutoff)
-        col_index = pd.MultiIndex.from_product([["Quantiles"], alpha])
-        pred_quantiles = pd.DataFrame(columns=col_index, index=fh_index)
-
-        for a in alpha:
-            pred_quantiles[("Quantiles", a)] = pd.Series(
-                self.prediction_constant * 2 * a, index=fh_index
-            )
-
-        return pred_quantiles
+from sktime.utils.estimators._base import make_mock_estimator
 
 
 class MockForecaster(BaseForecaster):
@@ -199,11 +20,11 @@ class MockForecaster(BaseForecaster):
     Examples
     --------
     >>> from sktime.datasets import load_airline
-    >>> from sktime.utils.estimators import MockUnivariateForecasterLogger
+    >>> from sktime.utils.estimators import MockForecasterLogger
     >>> y = load_airline()
-    >>> forecaster = MockUnivariateForecasterLogger()
+    >>> forecaster = MockForecasterLogger()
     >>> forecaster.fit(y)
-    MockUnivariateForecasterLogger(...)
+    MockForecasterLogger(...)
     >>> y_pred = forecaster.predict(fh=[1,2,3])
     >>> print(forecaster.log)
     [('_fit', ...), ('_predict', ...)]
@@ -369,3 +190,6 @@ class MockForecaster(BaseForecaster):
             )
 
         return pred_quantiles
+
+
+MockForecasterLogger = make_mock_estimator(MockForecaster)

--- a/sktime/utils/estimators/tests/test_forecasters.py
+++ b/sktime/utils/estimators/tests/test_forecasters.py
@@ -10,7 +10,7 @@ import pytest
 from sktime.datasets import load_airline
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.utils._testing.deep_equals import deep_equals
-from sktime.utils.estimators import MockUnivariateForecaster
+from sktime.utils.estimators import MockUnivariateForecasterLogger
 
 y_series = load_airline().iloc[:-5]
 y_frame = y_series.to_frame()
@@ -33,14 +33,14 @@ fh_relative = ForecastingHorizon(values=[1, 2, 3], is_relative=True)
     ],
 )
 def test_mock_univariate_forecaster_log(y, X_train, X_pred, fh):
-    """Tests the log of the MockUnivariateForecaster.
+    """Tests the log of the MockUnivariateForecasterLogger.
 
     Tests the following:
     - log format and content
     - All the private methods that have logging enabled are in the log
     - the correct inner mtypes are preserved, according to the forecaster tags
     """
-    forecaster = MockUnivariateForecaster()
+    forecaster = MockUnivariateForecasterLogger()
     forecaster.fit(y, X_train, fh)
     forecaster.predict(fh, X_pred)
     forecaster.update(y, X_train, fh)

--- a/sktime/utils/estimators/tests/test_forecasters.py
+++ b/sktime/utils/estimators/tests/test_forecasters.py
@@ -10,7 +10,7 @@ import pytest
 from sktime.datasets import load_airline
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.utils._testing.deep_equals import deep_equals
-from sktime.utils.estimators import MockForecasterLogger
+from sktime.utils.estimators import MockUnivariateForecasterLogger
 
 y_series = load_airline().iloc[:-5]
 y_frame = y_series.to_frame()
@@ -33,14 +33,14 @@ fh_relative = ForecastingHorizon(values=[1, 2, 3], is_relative=True)
     ],
 )
 def test_mock_univariate_forecaster_log(y, X_train, X_pred, fh):
-    """Tests the log of the MockForecasterLogger.
+    """Tests the log of the MockUnivariateForecasterLogger.
 
     Tests the following:
     - log format and content
     - All the private methods that have logging enabled are in the log
     - the correct inner mtypes are preserved, according to the forecaster tags
     """
-    forecaster = MockForecasterLogger()
+    forecaster = MockUnivariateForecasterLogger()
     forecaster.fit(y, X_train, fh)
     forecaster.predict(fh, X_pred)
     forecaster.update(y, X_train, fh)

--- a/sktime/utils/estimators/tests/test_forecasters.py
+++ b/sktime/utils/estimators/tests/test_forecasters.py
@@ -10,7 +10,7 @@ import pytest
 from sktime.datasets import load_airline
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.utils._testing.deep_equals import deep_equals
-from sktime.utils.estimators import MockUnivariateForecasterLogger
+from sktime.utils.estimators import MockForecasterLogger
 
 y_series = load_airline().iloc[:-5]
 y_frame = y_series.to_frame()
@@ -33,14 +33,14 @@ fh_relative = ForecastingHorizon(values=[1, 2, 3], is_relative=True)
     ],
 )
 def test_mock_univariate_forecaster_log(y, X_train, X_pred, fh):
-    """Tests the log of the MockUnivariateForecasterLogger.
+    """Tests the log of the MockForecasterLogger.
 
     Tests the following:
     - log format and content
     - All the private methods that have logging enabled are in the log
     - the correct inner mtypes are preserved, according to the forecaster tags
     """
-    forecaster = MockUnivariateForecasterLogger()
+    forecaster = MockForecasterLogger()
     forecaster.fit(y, X_train, fh)
     forecaster.predict(fh, X_pred)
     forecaster.update(y, X_train, fh)

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -6,11 +6,11 @@ __author__ = ["fkiraly"]
 import pytest
 
 from sktime.classification.feature_based import Catch22Classifier
-from sktime.forecasting.naive import NaiveForecaster
 from sktime.transformations.series.exponent import ExponentTransformer
 from sktime.utils.estimator_checks import check_estimator
+from sktime.utils.estimators import MockForecaster
 
-EXAMPLE_CLASSES = [Catch22Classifier, NaiveForecaster, ExponentTransformer]
+EXAMPLE_CLASSES = [Catch22Classifier, MockForecaster, ExponentTransformer]
 
 
 @pytest.mark.parametrize("estimator_class", EXAMPLE_CLASSES)


### PR DESCRIPTION
This PR introduces a `MockForecaster` without logging, for testing the test utilities.

It also cleans up the `MockUnivariateForecaster`, including a name change to `MockUnivariateForecasterLogger`, to distinguish mocks that log and mocks that do not log.
`MockUnivariateForecaster` methods are also cleaned up, it had some unnecessary and duplicative assignments.

Finally, the PR makes the following changes to speed up tests:

* replace `NaiveForecaster` in testing of `check_estimator` with `MockForecaster`, this reduces the `check_estimator` run from 2-5min to 20sec.

The PR relies on:
* https://github.com/alan-turing-institute/sktime/pull/2538 , a bug which the testing of `MockForecaster` uncovered.

FYI @ltsaprounis 