### PR TITLE
[ENH] raise `pytest-timeout` time limit to 10min

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
           cp .coveragerc testdir/
           cp setup.cfg testdir/
           cd testdir/
-          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime --timeout=300 -v -n 2 --pyargs sktime
+          python -m pytest --showlocals --durations=10 --cov-report=xml --cov=sktime --timeout=600 -v -n 2 --pyargs sktime
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v2
@@ -115,7 +115,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: make PYTESTOPTIONS="--cov --cov-report=xml --timeout=300" test
+        run: make PYTESTOPTIONS="--cov --cov-report=xml --timeout=600" test
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v2
@@ -156,7 +156,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: make PYTESTOPTIONS="--cov --cov-report=xml --timeout=300" test
+        run: make PYTESTOPTIONS="--cov --cov-report=xml --timeout=600" test
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -122,7 +122,7 @@ jobs:
           cp .coveragerc testdir/
           cp setup.cfg testdir/
           cd testdir/
-          python -m pytest --showlocals --durations=10 --pyargs sktime --timeout=300
+          python -m pytest --showlocals --durations=10 --pyargs sktime --timeout=600
 
   upload_wheels:
     name: Upload wheels to PyPI

--- a/build_tools/azure/build_wheels.sh
+++ b/build_tools/azure/build_wheels.sh
@@ -34,5 +34,5 @@ done
 # Install built wheel and test
 for PYTHON in "${PYTHON_VERSIONS[@]}"; do
   # Run tests
-  "${PYTHON}/pytest" --showlocals --durations=20 --junitxml=junit/test-results.xml --cov=sktime --cov-report=xml --cov-report=html --pyargs sktime --timeout=300
+  "${PYTHON}/pytest" --showlocals --durations=20 --junitxml=junit/test-results.xml --cov=sktime --cov-report=xml --cov-report=html --pyargs sktime --timeout=600
 done


### PR DESCRIPTION
This raises the per-test time limit in `pytest-timout` from 5min to 10min.

Reason: some tests, depending on time of day and total number of CI jobs run, may exceed 5min.