### PR TITLE
[ENH] allow different import and package names in soft dependency check

### DIFF
--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -13,7 +13,13 @@ from sklearn import clone
 from sktime.alignment.base import BaseAligner
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("dtw", severity="warning", suppress_import_stdout=True)
+_check_soft_dependencies(
+    "dtw-python",
+    package_import_alias={"dtw-python": "dtw"},
+    severity="warning",
+    object="AlignerDTW or AlignerDTWfromDist",
+    suppress_import_stdout=True,
+)
 
 
 class AlignerDTW(BaseAligner):
@@ -66,8 +72,13 @@ class AlignerDTW(BaseAligner):
         variable_to_align=None,
     ):
         """Construct instance."""
-        _check_soft_dependencies("dtw", severity="error", object=self)
-
+        _check_soft_dependencies(
+            "dtw-python",
+            package_import_alias={"dtw-python": "dtw"},
+            severity="error",
+            object=self,
+            suppress_import_stdout=True,
+        )
         super(AlignerDTW, self).__init__()
 
         self.dist_method = dist_method
@@ -234,6 +245,13 @@ class AlignerDTWfromDist(BaseAligner):
         open_end=False,
     ):
         """Construct instance."""
+        _check_soft_dependencies(
+            "dtw-python",
+            package_import_alias={"dtw-python": "dtw"},
+            severity="error",
+            object=self,
+            suppress_import_stdout=True,
+        )
         super(AlignerDTWfromDist, self).__init__()
 
         self.dist_trafo = dist_trafo

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -5,6 +5,7 @@ import io
 import sys
 import warnings
 from importlib import import_module
+from inspect import isclass
 
 
 def _check_soft_dependencies(
@@ -27,8 +28,9 @@ def _check_soft_dependencies(
         should be provided if import name differs from package name
     severity : str, "error" (default) or "warning"
         whether the check should raise an error, or only a warning
-    object : python object or None, default=None
-        if self is passed here when _check_soft_dependencies is called within __init__
+    object : python class, object or None, default=None
+        if self is passed here when _check_soft_dependencies is called within __init__,
+        or a class is passed when it is called at the start of a single-class module,
         the error message is more informative and will refer to the class
     suppress_import_stdout : bool, optional. Default=False
         whether to suppress stdout printout upon import.
@@ -77,7 +79,9 @@ def _check_soft_dependencies(
                     f"sktime[all_extras]`"
                 )
             else:
-                class_name = type(object).__name__
+                if not isclass(object):
+                    class_ref = type(object)
+                class_name = class_ref.__name__
                 msg = (
                     f"{class_name} requires package '{package}' to be present "
                     f"in the python environment, but '{package}' was not found. "

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -28,10 +28,11 @@ def _check_soft_dependencies(
         should be provided if import name differs from package name
     severity : str, "error" (default) or "warning"
         whether the check should raise an error, or only a warning
-    object : python class, object or None, default=None
+    object : python class, object, str, or None, default=None
         if self is passed here when _check_soft_dependencies is called within __init__,
         or a class is passed when it is called at the start of a single-class module,
-        the error message is more informative and will refer to the class
+        the error message is more informative and will refer to the class/object;
+        if str is passed, will be used as name of the class/object or module
     suppress_import_stdout : bool, optional. Default=False
         whether to suppress stdout printout upon import.
 
@@ -81,7 +82,10 @@ def _check_soft_dependencies(
             else:
                 if not isclass(object):
                     class_ref = type(object)
-                class_name = class_ref.__name__
+                elif not isinstance(object, str):
+                    class_name = class_ref.__name__
+                else:
+                    class_name = object
                 msg = (
                     f"{class_name} requires package '{package}' to be present "
                     f"in the python environment, but '{package}' was not found. "

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -8,14 +8,23 @@ from importlib import import_module
 
 
 def _check_soft_dependencies(
-    *packages, severity="error", object=None, suppress_import_stdout=False
+    *packages,
+    package_import_alias=None,
+    severity="error",
+    object=None,
+    suppress_import_stdout=False,
 ):
     """Check if required soft dependencies are installed and raise error or warning.
 
     Parameters
     ----------
     packages : str or tuple of str
-        One or more package names to check
+        One or more package names to check. This needs to be the *package* name,
+        i.e., the name of the package on pypi, installed by pip install package
+    package_import_alias : dict with str keys and values, optional, default=empty
+        key-value pairs are package name, import name
+        import name is str used in python import, i.e., from import_name import ...
+        should be provided if import name differs from package name
     severity : str, "error" (default) or "warning"
         whether the check should raise an error, or only a warning
     object : python object or None, default=None
@@ -29,15 +38,35 @@ def _check_soft_dependencies(
     ModuleNotFoundError
         error with informative message, asking to install required soft dependencies
     """
+    if not all(isinstance(x, str) for x in packages):
+        raise TypeError("packages must be str or tuple of str")
+
+    if package_import_alias is None:
+        package_import_alias = dict()
+    msg = "package_import_alias must be a dict with str keys and values"
+    if not isinstance(package_import_alias, dict):
+        raise TypeError(msg)
+    if not all(isinstance(x, str) for x in package_import_alias.keys()):
+        raise TypeError(msg)
+    if not all(isinstance(x, str) for x in package_import_alias.values()):
+        raise TypeError(msg)
+
     for package in packages:
+        # determine the package import
+        if package in package_import_alias.keys():
+            package_import_name = package_import_alias[package]
+        else:
+            package_import_name = package
+        # attempt import - if not possible, we know we need to raise warning/exception
         try:
             if suppress_import_stdout:
                 # setup text trap, import, then restore
                 sys.stdout = io.StringIO()
-                import_module(package)
+                import_module(package_import_name)
                 sys.stdout = sys.__stdout__
             else:
-                import_module(package)
+                import_module(package_import_name)
+        # if package cannot be imported, make the user aware of installation requirement
         except ModuleNotFoundError as e:
             if object is None:
                 msg = (
@@ -50,8 +79,8 @@ def _check_soft_dependencies(
             else:
                 class_name = type(object).__name__
                 msg = (
-                    f"{class_name} requires package '{package}' in python "
-                    f"environment to be instantiated, but '{package}' was not found. "
+                    f"{class_name} requires package '{package}' to be present "
+                    f"in the python environment, but '{package}' was not found. "
                     f"'{package}' is a soft dependency and not included in the base "
                     f"sktime installation. Please run: `pip install {package}` to "
                     f"install the {package} package. "

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -81,11 +81,13 @@ def _check_soft_dependencies(
                 )
             else:
                 if not isclass(object):
-                    class_ref = type(object)
-                elif not isinstance(object, str):
-                    class_name = class_ref.__name__
-                else:
+                    class_name = type(object).__name__
+                elif isclass(object):
+                    class_name = object.__name__
+                elif isinstance(object, str):
                     class_name = object
+                else:
+                    raise TypeError("object must be a class, an object, a str, or None")
                 msg = (
                     f"{class_name} requires package '{package}' to be present "
                     f"in the python environment, but '{package}' was not found. "


### PR DESCRIPTION
This PR solves https://github.com/alan-turing-institute/sktime/issues/1906 by adding an option to specify a package name different from an import name directly in `_check_soft_dependencies`.

This is then used to address the issue with the `dtw-python` import (whose import name is `dtw`, but package name is `dtw-python`).

This PR also adds:
* a missing soft dependency check in the same module
* input checks to `_check_soft_dependencies`
* the option to pass a class or string to pass information on the object, class, or module requiring the import to the error message generation logic