### PR TITLE
DRAFT PR to diagnose gfortran FileNotFoundError

### DIFF
--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -175,7 +175,7 @@ class MultiplexForecaster(_HeterogenousEnsembleForecaster):
 
         Returns
         -------
-        params : dict or list of dict
+        params : dicct or list of dict
         """
         from sktime.forecasting.naive import NaiveForecaster
 


### PR DESCRIPTION
Some PR error out on windows CI with this, since recently:

`FileNotFoundError: Could not find module 'C:\Miniconda\envs\test\lib\site-packages\scipy\.libs\libbanded5x.TNNMG3IXHGJK7NIBT5J6YPEO5XWTOQAJ.gfortran-win_amd64.dll' (or one of its dependencies). Try using the full path with constructor syntax.`

PR for diagnostic runs of CI