### PR TITLE
[BUG] fix for `update_predict` state handling bug, replace detached cutoff by deepcopy

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -799,7 +799,7 @@ class BaseForecaster(BaseEstimator):
             there are no restrictions on number of columns (unlike for y)
         update_params : bool, optional (default=True)
             whether model parameters should be updated in each update step
-        reset_forecaster : bool, optionel (default=True)
+        reset_forecaster : bool, optional (default=True)
             if True, will not change the state of the forecaster,
                 i.e., update/predict sequence is run with a copy,
                 and cutoff, model parameters, data memory of self do not change
@@ -2012,7 +2012,7 @@ class BaseForecaster(BaseEstimator):
             there are no restrictions on number of columns (unlike for y)
         update_params : bool, optional (default=True)
             whether model parameters should be updated in each update step
-        reset_forecaster : bool, optionel (default=True)
+        reset_forecaster : bool, optional (default=True)
             if True, will not change the state of the forecaster,
                 i.e., update/predict sequence is run with a copy,
                 and cutoff, model parameters, data memory of self do not change

--- a/sktime/forecasting/online_learning/tests/test_online_learning.py
+++ b/sktime/forecasting/online_learning/tests/test_online_learning.py
@@ -69,7 +69,7 @@ def test_weights_for_airline_normal_hedge():
     )
 
     forecaster.fit(y_train)
-    forecaster.update_predict(y=y_test, cv=cv)
+    forecaster.update_predict(y=y_test, cv=cv, reset_forecaster=False)
 
     expected = np.array([0.17077154, 0.48156709, 0.34766137])
     np.testing.assert_allclose(forecaster.weights, expected, atol=1e-8)
@@ -92,7 +92,7 @@ def test_weights_for_airline_nnls():
     )
 
     forecaster.fit(y_train)
-    forecaster.update_predict(y=y_test, cv=cv)
+    forecaster.update_predict(y=y_test, cv=cv, reset_forecaster=False)
 
     expected = np.array([0.04720766, 0, 1.03410876])
     np.testing.assert_allclose(forecaster.weights, expected, atol=1e-8)

--- a/sktime/forecasting/online_learning/tests/test_online_learning.py
+++ b/sktime/forecasting/online_learning/tests/test_online_learning.py
@@ -21,7 +21,6 @@ from sktime.forecasting.online_learning._prediction_weighted_ensembler import (
     NormalHedgeEnsemble,
 )
 
-
 cv = SlidingWindowSplitter(start_with_window=True, window_length=1, fh=1)
 
 

--- a/sktime/forecasting/online_learning/tests/test_online_learning.py
+++ b/sktime/forecasting/online_learning/tests/test_online_learning.py
@@ -6,19 +6,21 @@
 __author__ = ["magittan"]
 
 import numpy as np
-from sktime.datasets import load_airline
-from sktime.forecasting.model_selection import temporal_train_test_split
-from sktime.forecasting.online_learning._prediction_weighted_ensembler import (
-    NormalHedgeEnsemble,
-    NNLSEnsemble,
-)
-from sktime.forecasting.online_learning._online_ensemble import (
-    OnlineEnsembleForecaster,
-)
-from sktime.forecasting.model_selection import SlidingWindowSplitter
-from sktime.forecasting.exp_smoothing import ExponentialSmoothing
-from sktime.forecasting.naive import NaiveForecaster
 from sklearn.metrics import mean_squared_error
+
+from sktime.datasets import load_airline
+from sktime.forecasting.exp_smoothing import ExponentialSmoothing
+from sktime.forecasting.model_selection import (
+    SlidingWindowSplitter,
+    temporal_train_test_split,
+)
+from sktime.forecasting.naive import NaiveForecaster
+from sktime.forecasting.online_learning._online_ensemble import OnlineEnsembleForecaster
+from sktime.forecasting.online_learning._prediction_weighted_ensembler import (
+    NNLSEnsemble,
+    NormalHedgeEnsemble,
+)
+
 
 cv = SlidingWindowSplitter(start_with_window=True, window_length=1, fh=1)
 


### PR DESCRIPTION
This PR fixes #2556, the `update_predict` state handling bug, by replacing the `detached_cutoff` by a call of `deepcopy` and working with the deep copy.

This is a temporary fix which ensures correctness - long-term we should probably deprecate the `update_predict` behaviour that resets the `cutoff`.

One secondary problem was that some tests for the online forecaster were *assuming* the behaviour that was problematic in #2556, i.e,. that the inner state *does* get updated by `update_predict`.
This was accounted for by adding a `reset_forecaster` argument to `update_predict`, which can be used to switch between the two behaviours currently assumed in the code base, of `update_predict`.

Docstrings have also been added to clarify what `update_predict` actually does.