### PR TITLE
[BUG] bound scipy to <1.8.0 on windows to resolve `gfortran` `FileNotFoundError` in all CI/CD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           conda install -c anaconda "pystan==2.19.1.1"
           conda install -c conda-forge "prophet>=1.0"
-          conda install -c conda-forge scipy matplotlib
+          conda install -c conda-forge "scipy<1.8.0" matplotlib
 
       - name: Install sktime and dependencies
         run: python -m pip install .[all_extras,dev]


### PR DESCRIPTION
Attempts the fix for #2552 suggested by @lmmentel, of bounding `scipy<1.8.0` in windows.

This was previously attempted by @chrisholder #2554 but with a mistake: adding the bound in the "wrong" place, which is easy to do because of the problem highlighted in #2559, where some windows bounds need to go in a hard to find place.