### PR TITLE
[BUG] switch scipy mirror to anaconda on windows to resolve `gfortran` `FileNotFoundError` in all CI/CD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           conda install -c anaconda "pystan==2.19.1.1"
           conda install -c conda-forge "prophet>=1.0"
-          conda install -c conda-forge scipy matplotlib
+          conda install -c anaconda scipy matplotlib
 
       - name: Install sktime and dependencies
         run: python -m pip install .[all_extras,dev]


### PR DESCRIPTION
Attempts a fix for #2552 suggested by @ciaran-g, changing the conda mirror for `scipy` (to anaconda)