### PR TITLE
[BUG] fix random state overwrite in MiniRocketMultivariate

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -258,7 +258,7 @@
     },
     {
       "login": "angus924",
-      "name": "angus924",
+      "name": "Angus Dempster",
       "avatar_url": "https://avatars0.githubusercontent.com/u/55837131?v=4",
       "profile": "https://github.com/angus924",
       "contributions": [

--- a/sktime/transformations/panel/rocket/_minirocket.py
+++ b/sktime/transformations/panel/rocket/_minirocket.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-__author__ = "Angus Dempster"
+"""MiniRocket transformer."""
+
+__author__ = "angus924"
 __all__ = ["MiniRocket"]
 
 import multiprocessing

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate.py
@@ -66,9 +66,12 @@ class MiniRocketMultivariate(BaseTransformer):
         self.n_jobs = n_jobs
         self.random_state = random_state
 
-        if not isinstance(random_state, int):
-            raise ValueError("random_state in MiniRocketMultivariate must be int")
-        else:
+        if random_state is not None and not isinstance(random_state, int):
+            raise ValueError(
+                f"random_state in MiniRocketMultivariate must be int or None, "
+                f"but found {type(random_state)}"
+            )
+        if isinstance(random_state, int):
             self.random_state_ = np.int32(random_state)
 
         super(MiniRocketMultivariate, self).__init__()

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate.py
@@ -73,6 +73,8 @@ class MiniRocketMultivariate(BaseTransformer):
             )
         if isinstance(random_state, int):
             self.random_state_ = np.int32(random_state)
+        else:
+            self.random_state_ = random_state
 
         super(MiniRocketMultivariate, self).__init__()
 

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Multivariate MiniRocket transformer."""
 
-__authors__ = "angus924"
+__author__ = "angus924"
 __all__ = ["MiniRocketMultivariate"]
 
 import multiprocessing

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate.py
@@ -62,9 +62,12 @@ class MiniRocketMultivariate(BaseTransformer):
         self.max_dilations_per_kernel = max_dilations_per_kernel
 
         self.n_jobs = n_jobs
-        self.random_state = (
-            np.int32(random_state) if isinstance(random_state, int) else None
-        )
+        self.random_state = random_state
+
+        if not isinstance(random_state, int):
+            raise ValueError("random_state in MiniRocketMultivariate must be int")
+        else:
+            self.random_state_ = np.int32(random_state)
 
         super(MiniRocketMultivariate, self).__init__()
 
@@ -91,7 +94,7 @@ class MiniRocketMultivariate(BaseTransformer):
                 )
             )
         self.parameters = _fit_multi(
-            X, self.num_kernels, self.max_dilations_per_kernel, self.random_state
+            X, self.num_kernels, self.max_dilations_per_kernel, self.random_state_
         )
         return self
 

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Multivariate MiniRocket transformer."""
 
-__author__ = "angus924"
+__authors__ = "angus924"
 __all__ = ["MiniRocketMultivariate"]
 
 import multiprocessing

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-__author__ = "Angus Dempster"
+"""Multivariate MiniRocket transformer."""
+
+__author__ = "angus924"
 __all__ = ["MiniRocketMultivariate"]
 
 import multiprocessing


### PR DESCRIPTION
Correctly resetting estimators in https://github.com/alan-turing-institute/sktime/pull/2562 unmasked a hidden bug with `MiniRocketMultivariate`, which was overwriting its `random_state` variable in `__init__`. This has been fixed.