### PR TITLE
[BUG] Fixes the index name dependencies in WindowSummarizer

### DIFF
--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -343,7 +343,8 @@ class WindowSummarizer(BaseTransformer):
             bfill = False
         for cols in target_cols:
             if isinstance(X.index, pd.MultiIndex):
-                X_grouped = X.groupby("instances")[cols]
+                hier_levels = list(range(X.index.nlevels - 1))
+                X_grouped = X.groupby(level=hier_levels)[cols]
                 df = Parallel(n_jobs=self.n_jobs)(
                     delayed(_window_feature)(X_grouped, **kwargs, bfill=bfill)
                     for index, kwargs in func_dict.iterrows()

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -203,6 +203,7 @@ class WindowSummarizer(BaseTransformer):
         "X_inner_mtype": [
             "pd-multiindex",
             "pd.DataFrame",
+            "pd_multiindex_hier",
         ],  # which mtypes do _fit/_predict support for X?
         "skip-inverse-transform": True,  # is inverse-transform skipped when called?
         "univariate-only": False,  # can the transformer handle multivariate X?

--- a/sktime/transformations/series/tests/test_window_summarizer.py
+++ b/sktime/transformations/series/tests/test_window_summarizer.py
@@ -42,6 +42,20 @@ y_group2 = pd.DataFrame(y.values, index=mi, columns=["y"])
 
 y_grouped = pd.concat([y_group1, y_group2])
 
+mi = pd.MultiIndex.from_product([[0], [0], y.index], names=["h1", "h2", "time"])
+y_hier1 = pd.DataFrame(y.values, index=mi, columns=["y"])
+
+mi = pd.MultiIndex.from_product([[0], [1], y.index], names=["h1", "h2", "time"])
+y_hier2 = pd.DataFrame(y.values, index=mi, columns=["y"])
+
+mi = pd.MultiIndex.from_product([[1], [0], y.index], names=["h1", "h2", "time"])
+y_hier3 = pd.DataFrame(y.values, index=mi, columns=["y"])
+
+mi = pd.MultiIndex.from_product([[1], [1], y.index], names=["h1", "h2", "time"])
+y_hier4 = pd.DataFrame(y.values, index=mi, columns=["y"])
+
+y_hierarchical = pd.concat([y_hier1, y_hier2, y_hier3, y_hier4])
+
 y_ll, X_ll = load_longley()
 y_ll_train, _, X_ll_train, X_ll_test = temporal_train_test_split(y_ll, X_ll)
 
@@ -100,6 +114,13 @@ Xtmvar_none = ["GNPDEFL_lag_3", "GNPDEFL_lag_6", "GNP", "UNEMP", "ARMED", "POP"]
             None,
         ),
         (
+            kwargs,
+            ["y_lag_1", "y_mean_1_3", "y_mean_1_12", "y_std_1_4"],
+            y_hierarchical,
+            None,
+            None,
+        ),
+        (
             None,
             ["var_0_lag_1", "var_1"],
             y_multi,
@@ -135,6 +156,9 @@ def test_windowsummarizer(kwargs, column_names, y, target_cols, truncate):
             Xt_columns = Xt.name
     else:
         Xt_columns = None
+
+    # check that the index names are preserved
+    assert y.index.names == Xt.index.names
 
     check_eval(Xt_columns, column_names)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #2504 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Removed any dependency on level names. Only requires the agreed convention for `pd-multiindex` and `hierarchical` that the time dimension is the last level.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
Validate the quality of the hierarchical case unit tests

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added unit tests and made sure they pass locally.

<!--
Thanks for contributing!
-->
