### PR TITLE
[MNT] CI/CD failure diagnostics: remove extra scipy/matplotlib install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,8 @@ jobs:
         run: |
           conda install -c anaconda "pystan==2.19.1.1"
           conda install -c conda-forge "prophet>=1.0"
-          conda install -c anaconda scipy matplotlib
+          conda install -c anaconda scipy
+          conda install -c conda-forge matplotlib
 
       - name: Install sktime and dependencies
         run: python -m pip install .[all_extras,dev]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,6 @@ jobs:
         run: |
           conda install -c anaconda "pystan==2.19.1.1"
           conda install -c conda-forge "prophet>=1.0"
-          conda install -c anaconda scipy
 
       - name: Install sktime and dependencies
         run: python -m pip install .[all_extras,dev]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,8 @@ jobs:
 
       - name: Install conda dependencies
         run: |
-          conda install -c anaconda "pystan==2.19.1.1"
-          conda install -c conda-forge "prophet>=1.0"
+          conda install -c anaconda -n test -y "pystan==2.19.1.1"
+          conda install -c conda-forge -n test -y "prophet>=1.0"
 
       - name: Install sktime and dependencies
         run: python -m pip install .[all_extras,dev]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,6 @@ jobs:
           conda install -c anaconda "pystan==2.19.1.1"
           conda install -c conda-forge "prophet>=1.0"
           conda install -c anaconda scipy
-          conda install -c conda-forge matplotlib
 
       - name: Install sktime and dependencies
         run: python -m pip install .[all_extras,dev]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,8 @@ jobs:
 
       - name: Install conda dependencies
         run: |
-          conda install -c anaconda -n test -y "pystan==2.19.1.1"
-          conda install -c conda-forge -n test -y "prophet>=1.0"
+          conda install -c anaconda "pystan==2.19.1.1"
+          conda install -c conda-forge "prophet>=1.0"
 
       - name: Install sktime and dependencies
         run: python -m pip install .[all_extras,dev]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -97,8 +97,8 @@ jobs:
 
       - name: Install conda dependencies
         run: |
-          conda install -c anaconda "pystan==2.19.1.1"
-          conda install -c conda-forge "prophet>=1.0"
+          conda install -c anaconda -n test -y "pystan==2.19.1.1"
+          conda install -c conda-forge -n test -y "prophet>=1.0"
 
       - name: Display downloaded artifacts
         run: ls -l wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Install conda dependencies
         run: |
           conda install -c anaconda -n test -y "pystan==2.19.1.1"
-          conda install -c conda-forge -n test -y "prophet>=1.0"
+          conda install -c conda-forge -n test -y "prophet>=1.0.0"
 
       - name: Display downloaded artifacts
         run: ls -l wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -100,7 +100,6 @@ jobs:
           conda install -c anaconda "pystan==2.19.1.1"
           conda install -c conda-forge "prophet>=1.0"
           conda install -c anaconda scipy
-          conda install -c conda-forge matplotlib
 
       - name: Display downloaded artifacts
         run: ls -l wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -99,7 +99,6 @@ jobs:
         run: |
           conda install -c anaconda "pystan==2.19.1.1"
           conda install -c conda-forge "prophet>=1.0"
-          conda install -c anaconda scipy
 
       - name: Display downloaded artifacts
         run: ls -l wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -97,9 +97,10 @@ jobs:
 
       - name: Install conda dependencies
         run: |
-          conda install -c anaconda -n test -y "pystan==2.19.1.1"
-          conda install -c conda-forge -n test -y "prophet>=1.0.0"
-          conda install -c conda-forge -n test -y scipy matplotlib
+          conda install -c anaconda "pystan==2.19.1.1"
+          conda install -c conda-forge "prophet>=1.0"
+          conda install -c anaconda scipy
+          conda install -c conda-forge matplotlib
 
       - name: Display downloaded artifacts
         run: ls -l wheelhouse


### PR DESCRIPTION
PR attempting to address #2584.

Removes the extra install of `scipy` and `matplotlib`, so it is directly installed as dependency of `sktime`.

That was probably causing the issue, as it installed a second time.