### PR TITLE
[ENH] fix side effects in `check_estimator` utility

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -344,7 +344,7 @@ class QuickTester:
             return [estimator_class], [estimator_class.__name__]
 
         def _generate_estimator_instance(test_name, **kwargs):
-            return [estimator], [estimator_class.__name__]
+            return [estimator.reset()], [estimator_class.__name__]
 
         def _generate_estimator_instance_cls(test_name, **kwargs):
             return estimator_class.create_test_instances_and_names()

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -344,7 +344,7 @@ class QuickTester:
             return [estimator_class], [estimator_class.__name__]
 
         def _generate_estimator_instance(test_name, **kwargs):
-            return [estimator.reset()], [estimator_class.__name__]
+            return [clone(estimator)], [estimator_class.__name__]
 
         def _generate_estimator_instance_cls(test_name, **kwargs):
             return estimator_class.create_test_instances_and_names()


### PR DESCRIPTION
The `check_estimator` utility can test estimator instances, which is useful to test specific hyper-parameter settings.

Unfortunately, this had side effects on the passed estimator - which was used in testing throughout - and would break if the estimator was already fitted.

This PR fixes that issue by passing a clone and not the reference to the testing framework, in `run_tests`.