### PR TITLE
[BUG] fix `pd.Series` to `pd.DataFrame` mtype conversion in case series has a name

### DIFF
--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -56,14 +56,14 @@ def convert_UvS_to_MvS_as_Series(obj: pd.Series, store=None) -> pd.DataFrame:
     if not isinstance(obj, pd.Series):
         raise TypeError("input must be a pd.Series")
 
+    res = pd.DataFrame(obj)
+
     if (
         isinstance(store, dict)
         and "columns" in store.keys()
         and len(store["columns"]) == 1
     ):
-        res = pd.DataFrame(obj, columns=store["columns"])
-    else:
-        res = pd.DataFrame(obj)
+        res.columns = store["columns"]
 
     return res
 


### PR DESCRIPTION
Internal conversions could lead to unexpected results and breakage in a rare case where internal methods or pipeline components produced non-conformant `pd.Series`, i.e., `pandas.Series` with a name (as opposed to no name).

In that case, `convert_to` would produce an empty `pandas.DataFrame`, in line with actual (but highly unintuitive behaviour) of the `pandas` native constructor converter `pd.DataFrame(my_series, columns="col_name")`, which also produces an empty `pandas.DataFrame` if `my_series` is a `pandas.Series` with a name that is not `"col_name"`.

This PR is a bugfix for such cases, by catching this edge case properly. From now on, even if `pd.Series` with a name are provided, the column name is correctly assigned, and the content of the data frame is correctly retained.

Should fix #2604.