### PR TITLE
[ENH] `BaseObject.reset` to return `self`

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -102,6 +102,8 @@ class BaseObject(_BaseEstimator):
         # run init with a copy of parameters self had at the start
         self.__init__(**params)
 
+        return self
+
     @classmethod
     def get_class_tags(cls):
         """Get class tags from estimator class and all its parent classes.


### PR DESCRIPTION
Simple PR which adds a `return self` to `BaseObject` reset.

Prior to this, `reset` was returning `None`, which was an oversight.