### PR TITLE
[BUG] typo fix in tag deprecation message

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -655,7 +655,7 @@ class TagAliaserMixin:
             if tag_name in cls.alias_dict.keys():
                 version = cls.deprecate_dict[tag_name]
                 new_tag = cls.alias_dict[tag_name]
-                msg = f'tag "{tag_name}" is will be removed in sktime version {version}'
+                msg = f'tag "{tag_name}" will be removed in sktime version {version}'
                 if new_tag != "":
                     msg += (
                         f' and replaced by "{new_tag}", please use "{new_tag}" instead'


### PR DESCRIPTION
This PR fixes a minor typo in a tag deprecation message.