### PR TITLE
[ENH] Removed interval_width parameter of Prophet

### DIFF
--- a/sktime/forecasting/fbprophet.py
+++ b/sktime/forecasting/fbprophet.py
@@ -142,7 +142,6 @@ class Prophet(_ProphetAdapter):
         uncertainty_samples=1000,
         stan_backend=None,
         verbose=0,
-        interval_width=0,
     ):
         _check_soft_dependencies("prophet", severity="error", object=self)
 
@@ -167,7 +166,6 @@ class Prophet(_ProphetAdapter):
         self.uncertainty_samples = uncertainty_samples
         self.stan_backend = stan_backend
         self.verbose = verbose
-        self.interval_width = interval_width
 
         # import inside method to avoid hard dependency
         from prophet.forecaster import Prophet as _Prophet


### PR DESCRIPTION
Resolves: https://github.com/alan-turing-institute/sktime/issues/2626

To restate what is mentioned in the issue, the interval_width parameter of Prophet is not used and is later overwritten, and is not mentioned in the docstring. The initialization logic can be replaced by the default value if needed. So interval_width is removed as an __init__ argument and deleted where self.interval_width = interval_width.