### PR TITLE
[MNT] bound sklearn to <1.1.0 as a temporary fix for #2631

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "numba>=0.53",
     "numpy>=1.21.0,<1.22",
     "pandas>=1.1.0,<1.5.0",
-    "scikit-learn>=0.24.0",
+    "scikit-learn>=0.24.0,<1.1.0",
     "statsmodels>=0.12.1",
     "scipy<1.9.0",
 ]


### PR DESCRIPTION
This PR bounds `sklearn` to <1.1.0 as a temporary fix for #2631.