### PR TITLE
[ENH] `make_pipeline` utility to create linear pipelines of any type

### DIFF
--- a/sktime/pipeline/__init__.py
+++ b/sktime/pipeline/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Pipeline maker utility."""
+
+__all__ = ["make_pipeline"]
+
+from sktime.pipeline._make_pipeline import make_pipeline

--- a/sktime/pipeline/_make_pipeline.py
+++ b/sktime/pipeline/_make_pipeline.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""Pipeline making utility."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
+
+__author__ = ["fkiraly"]
+
+
+def make_pipeline(*steps):
+    """Approximations of uniform order statistic medians.
+
+    Parameters
+    ----------
+    steps : tuple of sktime estimators
+        in same order as used for pipeline construction
+
+    Returns
+    -------
+    pipe : sktime pipeline containing steps, in order
+        always a descendant of BaseObject, precise object determined by scitype
+        equivalent to result of step[0] * step[1] * ... * step[-1]
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> y = load_airline()
+
+    Example 1: forecaster pipeline
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.arima import ARIMA
+    >>> from sktime.pipeline import make_pipeline
+    >>> from sktime.transformations.series.exponent import ExponentTransformer
+    >>> y = load_airline()
+    >>> pipe = make_pipeline(ExponentTransformer(), ARIMA())
+    >>> pipe
+    TransformedTargetForecaster(steps=[ExponentTransformer(), ARIMA()])
+
+    Example 2: classifier pipeline
+    >>> from sktime.classification.feature_based import Catch22Classifier
+    >>> from sktime.pipeline import make_pipeline
+    >>> from sktime.transformations.series.exponent import ExponentTransformer
+    >>> pipe = make_pipeline(ExponentTransformer(), Catch22Classifier())
+    >>> pipe
+    ClassifierPipeline(classifier=Catch22Classifier(),
+                       transformers=[ExponentTransformer()])
+
+    Example 3: transformer pipeline
+    >>> from sktime.pipeline import make_pipeline
+    >>> from sktime.transformations.series.exponent import ExponentTransformer
+    >>> pipe = make_pipeline(ExponentTransformer(), ExponentTransformer())
+    >>> pipe
+    TransformerPipeline(steps=[ExponentTransformer(), ExponentTransformer()])
+    """
+    pipe = steps[0]
+    for i in range(1, len(steps)):
+        pipe = pipe * steps[i]
+
+    return pipe


### PR DESCRIPTION
This PR adds a `make_pipeline` utility to create linear pipelines of any type, similar to the utility of the same name in `sklearn`.

Under the hood, it uses the `*` dunder for case dispatch.