### PR TITLE
[BUG] `ignores-exogeneous-X` tag correction for `UnobservedComponents`

### DIFF
--- a/sktime/forecasting/structural.py
+++ b/sktime/forecasting/structural.py
@@ -204,6 +204,7 @@ class UnobservedComponents(_StatsModelsAdapter):
     _tags = {
         "capability:pred_int": True,
         "handles-missing-data": False,
+        "ignores-exogeneous-X": False,
     }
 
     def __init__(


### PR DESCRIPTION
The `ignores-exogeneous-X` tag was set incorrectly for `UnobservedComponents`.

As can be seen in the methods, `X`, is used non-trivially, so the tag should be `False`.