### PR TITLE
[BUG] fixing `StackingForecaster` for exogeneous data

### DIFF
--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -67,6 +67,7 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         "requires-fh-in-fit": True,
         "handles-missing-data": True,
         "scitype:y": "univariate",
+        "X-y-must-have-same-index": True,
     }
 
     def __init__(self, forecasters, regressor=None, random_state=None, n_jobs=None):
@@ -76,7 +77,6 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
 
         self._anytagis_then_set("ignores-exogeneous-X", False, True, forecasters)
         self._anytagis_then_set("handles-missing-data", False, True, forecasters)
-        self._anytagis_then_set("X-y-must-have-same-index", True, False, forecasters)
         self._anytagis_then_set("fit_is_empty", False, True, forecasters)
 
     def _fit(self, y, X=None, fh=None):

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -102,11 +102,11 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
 
         # split training series into training set to fit forecasters and
         # validation set to fit meta-learner
-        cv = SingleWindowSplitter(fh=fh.to_relative(self.cutoff))
+        inner_fh = fh.to_relative(self.cutoff)
+        cv = SingleWindowSplitter(fh=inner_fh)
         train_window, test_window = next(cv.split(y))
         y_train = y.iloc[train_window]
         y_test = y.iloc[test_window]
-        inner_fh = y_test.index
         if X is not None:
             X_test = X.iloc[test_window]
             X_train = X.iloc[train_window]

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -76,7 +76,6 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
 
         self._anytagis_then_set("ignores-exogeneous-X", False, True, forecasters)
         self._anytagis_then_set("handles-missing-data", False, True, forecasters)
-        self._anytagis_then_set("requires-fh-in-fit", True, False, forecasters)
         self._anytagis_then_set("X-y-must-have-same-index", True, False, forecasters)
         self._anytagis_then_set("fit_is_empty", False, True, forecasters)
 
@@ -112,6 +111,7 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
             X_train = X.iloc[train_window]
         else:
             X_meta = None
+            X_train = None
 
         # fit forecasters on training window
         self._fit_forecasters(forecasters, y_fcst, fh=fh, X=X_train)

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -107,15 +107,15 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         y_fcst = y.iloc[train_window]
         y_meta = y.iloc[test_window].values
         if X is not None:
-            X_meta = X.iloc[test_window]
+            X_test = X.iloc[test_window]
             X_train = X.iloc[train_window]
         else:
-            X_meta = None
+            X_test = None
             X_train = None
 
         # fit forecasters on training window
         self._fit_forecasters(forecasters, y_fcst, fh=fh, X=X_train)
-        X_meta = np.column_stack(self._predict_forecasters(fh=fh, X=X_meta))
+        X_meta = np.column_stack(self._predict_forecasters(fh=fh, X=X_test))
 
         # fit final regressor on on validation window
         self.regressor_.fit(X_meta, y_meta)


### PR DESCRIPTION
Fixes #2665 according to suggestions of @indinewton.

Also makes the following to `StackingForecaster`:

* changes the test parameter settings such that one of the forecasters actually uses `X`. This should enable the test suite to catch bugs like #2665.
* sets the capability tags correctly, dependent on the components. For the `"X-y-must-have-same-index"` tag, this should catch incompatible `X` indices at runtime and raise the standard error message.