### PR TITLE
[ENH] Update predict docstrings corrected

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -915,6 +915,7 @@ class BaseForecaster(BaseEstimator):
         -------
         y_pred : time series in sktime compatible data container format
             Point forecasts at fh, with same index as fh
+            if fh was relative, index is relative to cutoff after update with y
             y_pred has same type as the y that has been passed most recently:
                 Series, Panel, Hierarchical scitype, same format (see above)
         """

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -831,10 +831,19 @@ class BaseForecaster(BaseEstimator):
 
         Returns
         -------
-        y_pred : time series in sktime compatible data container format
-            Point forecasts at fh, with same index as fh
-            y_pred has same type as the y that has been passed most recently:
+        y_pred : object that tabulates point forecasts from multiple split batches
+            format depends on pairs (cutoff, absolute horizon) forecast overall
+            if collection of absolute horizon points is unique:
+                type is time series in sktime compatible data container format
+                cutoff is suppressed in output
+                has same type as the y that has been passed most recently:
                 Series, Panel, Hierarchical scitype, same format (see above)
+            if collection of absolute horizon points is not unique:
+                type is a pandas DataFrame, with row and col index being time stamps
+                row index corresponds to cutoffs that are predicted from
+                column index corresponds to absolut horizons that are predicted
+                entry is the point prediction of col index predicted from row index
+                entry is nan if no prediction is made at that (cutoff, horizon) pair
         """
         self.check_is_fitted()
 


### PR DESCRIPTION
The docstrings for `update_predict_single` and `update_predict` were not properly reflecting the actual output of those methods.

This was updated to ensure the docstrings corresponds to what is actually returned.