### PR TITLE
[BUG] fixing pmdarima interface index handling if `X` index set is strictly larger than `y` index set

### DIFF
--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -45,7 +45,8 @@ class _PmdArimaAdapter(BaseForecaster):
         -------
         self : returns an instance of self.
         """
-        X = X.loc[y.index]
+        if X is not None:
+            X = X.loc[y.index]
         self._forecaster = self._instantiate_model()
         self._forecaster.fit(y, X=X)
         return self

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -45,6 +45,7 @@ class _PmdArimaAdapter(BaseForecaster):
         -------
         self : returns an instance of self.
         """
+        X = X.loc[y.index]
         self._forecaster = self._instantiate_model()
         self._forecaster.fit(y, X=X)
         return self


### PR DESCRIPTION
This fixes an unreported bug where `ARIMA` and, more generally, `pmdarima` adapted estimators would break if `X` contained strictly more indices than `y`. The fix is simply subsetting `X` to the indinces of `y` before carrying out existing logic.