### PR TITLE
[ENH] Compositor for forecasting of exogeneous data before using in exogeneous forecaster

### DIFF
--- a/sktime/forecasting/compose/__init__.py
+++ b/sktime/forecasting/compose/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "AutoEnsembleForecaster",
     "TransformedTargetForecaster",
     "ForecastingPipeline",
+    "ForecastX",
     "DirectTabularRegressionForecaster",
     "DirectTimeSeriesRegressionForecaster",
     "MultioutputTabularRegressionForecaster",
@@ -32,6 +33,7 @@ from sktime.forecasting.compose._ensemble import (
 from sktime.forecasting.compose._multiplexer import MultiplexForecaster
 from sktime.forecasting.compose._pipeline import (
     ForecastingPipeline,
+    ForecastX,
     TransformedTargetForecaster,
 )
 from sktime.forecasting.compose._reduce import (

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1052,14 +1052,17 @@ class ForecastX(BaseForecaster):
     ...     forecaster_X=VAR(),
     ...     forecaster_y=ARIMA(),
     ... )
-    >>> pipe.fit(y, X)
+    >>> pipe.fit(y, X=X, fh=fh)
     >>> # this works without X from the future of y
     >>> y_pred = pipe.predict(fh=fh)
     """
 
     _tags = {
         "X_inner_mtype": "pd.DataFrame",
+        "y_inner_mtype": "pd.DataFrame",
+        "X-y-must-have-same-index": False,
         "fit_is_empty": False,
+        "ignores-exogeneous-X": False,
     }
 
     def __init__(self, forecaster_X, forecaster_y, fh_X=None, behaviour="update"):

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1072,6 +1072,12 @@ class ForecastX(BaseForecaster):
 
         self.forecaster_y = forecaster_y
         self.forecaster_X = forecaster_X
+
+        # forecaster_X_c handles the "if forecaster_X is None, use forecaster_y"
+        if forecaster_X is None:
+            self.forecaster_X_c = forecaster_y
+        else:
+            self.forecaster_X_c = forecaster_X
         self.fh_X = fh_X
         self.behaviour = behaviour
         super(ForecastX, self).__init__()
@@ -1104,7 +1110,7 @@ class ForecastX(BaseForecaster):
         self.fh_X_ = fh_X
 
         if self.behaviour == "update":
-            self.forecaster_X_ = self.forecaster_X.clone()
+            self.forecaster_X_ = self.forecaster_X_c.clone()
             self.forecaster_X_.fit(y=X, fh=fh_X)
 
         self.forecaster_y_ = self.forecaster_y.clone()
@@ -1124,7 +1130,7 @@ class ForecastX(BaseForecaster):
         elif self.behaviour == "refit":
             if self.fh_X_ is not None:
                 fh = self.fh_X_
-            forecaster = self.forecaster_X.clone()
+            forecaster = self.forecaster_X_c.clone()
             forecaster.fit(y=self._X, fh=fh)
         return forecaster
 


### PR DESCRIPTION
This PR adds a compositor, `ForecastX`, that makes forecasts on exogeneous data before using that forecast to forecast endogeneous data.

The typical use case is exogeneous data which is available only up until current cutoff, but forecasts are made of exogeneous data to apply another forecaster to endogeneous data which requires exogeneous data at the forecasting horizon time stampe.