### PR TITLE
[ENH] add `ExpandingWindowSplitter` as default cv in `BaseForecaster.update_predict`

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -767,7 +767,7 @@ class BaseForecaster(BaseEstimator):
     def update_predict(
         self,
         y,
-        cv,
+        cv=None,
         X=None,
         update_params=True,
         reset_forecaster=True,
@@ -812,10 +812,13 @@ class BaseForecaster(BaseEstimator):
             For further details:
                 on usage, see forecasting tutorial examples/01_forecasting.ipynb
                 on specification of formats, examples/AA_datatypes_and_datasets.ipynb
-        cv : temporal cross-validation generator, e.g. a splitter like
-                SlidingWindowSplitter or ExpandingWindowSplitter
+        cv : temporal cross-validation generator inheriting from BaseSplitter, optional
+            for example, SlidingWindowSplitter or ExpandingWindowSplitter
+            default = ExpandingWindowSplitter with default parameters
+                = individual data points in y/X are added and forecast one-by-one,
+                `window_length = 10`, `step_length = 1` and `fh = 1`
         X : time series in sktime compatible format, optional (default=None)
-                Exogeneous time series for updating and forecasting
+            Exogeneous time series for updating and forecasting
             Should be of same scitype (Series, Panel, or Hierarchical) as y
             if self.get_tag("X-y-must-have-same-index"),
                 X.index must contain y.index and fh.index both
@@ -836,6 +839,11 @@ class BaseForecaster(BaseEstimator):
             y_pred has same type as the y that has been passed most recently:
                 Series, Panel, Hierarchical scitype, same format (see above)
         """
+        from sktime.forecasting.model_selection import ExpandingWindowSplitter
+
+        if cv is None:
+            cv = ExpandingWindowSplitter()
+
         self.check_is_fitted()
 
         # input checks and minor coercions on X, y

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -38,6 +38,7 @@ __author__ = ["mloning", "big-o", "fkiraly", "sveameyer13", "miraep8"]
 __all__ = ["BaseForecaster"]
 
 from copy import deepcopy
+from curses import window
 from warnings import warn
 
 import numpy as np
@@ -814,9 +815,9 @@ class BaseForecaster(BaseEstimator):
                 on specification of formats, examples/AA_datatypes_and_datasets.ipynb
         cv : temporal cross-validation generator inheriting from BaseSplitter, optional
             for example, SlidingWindowSplitter or ExpandingWindowSplitter
-            default = ExpandingWindowSplitter with default parameters
+            default = ExpandingWindowSplitter with `initial_window=1` and defaults
                 = individual data points in y/X are added and forecast one-by-one,
-                `window_length = 10`, `step_length = 1` and `fh = 1`
+                `initial_window = 1`, `step_length = 1` and `fh = 1`
         X : time series in sktime compatible format, optional (default=None)
             Exogeneous time series for updating and forecasting
             Should be of same scitype (Series, Panel, or Hierarchical) as y
@@ -842,7 +843,7 @@ class BaseForecaster(BaseEstimator):
         from sktime.forecasting.model_selection import ExpandingWindowSplitter
 
         if cv is None:
-            cv = ExpandingWindowSplitter()
+            cv = ExpandingWindowSplitter(initial_window=1)
 
         self.check_is_fitted()
 


### PR DESCRIPTION
This PR adds `ExpandingWindowSplitter`, with default parameters, as default cv in `BaseForecaster.update_predict`.

This results in `update_predict` updating and forecasting individual data points, successively, if no `cv` argument is specified.

This is, in my opinion, arguably the most sensible default, since other choices would be arbitrary.