### PR TITLE
[ENH] make_mock_estimator passing constructor args for the mocked class

### DIFF
--- a/sktime/utils/estimators/_base.py
+++ b/sktime/utils/estimators/_base.py
@@ -56,6 +56,9 @@ def make_mock_estimator(
 ) -> BaseEstimator:
     r"""Transform any estimator class into a mock estimator class.
 
+    The returned class will accept the original arguments passed in estimator_class
+    __init__ as a dictionary of kwargs.
+
     Parameters
     ----------
     estimator_class : BaseEstimator
@@ -71,13 +74,28 @@ def make_mock_estimator(
     -------
     BaseEstimator
         input estimator class with logging feature enabled
+
+    Examples
+    --------
+    >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> from sktime.utils.estimators import make_mock_estimator
+    >>> from sktime.datasets import load_airline
+    >>> y = load_airline()
+    >>> mock_estimator_class = make_mock_estimator(NaiveForecaster)
+    >>> mock_estimator_instance = mock_estimator_class({"strategy": "last", "sp": 1})
+    >>> mock_estimator_instance.fit(y)
+    _MockEstimator(...)
+
     """
     dunder_methods_regex = r"^__\w+__$"
 
     class _MockEstimator(estimator_class, _MockEstimatorMixin):
-        def __init__(self, estimator_kwargs):
+        def __init__(self, estimator_kwargs=None):
             self.estimator_kwargs = estimator_kwargs
-            super().__init__(**estimator_kwargs)
+            if estimator_kwargs is not None:
+                super().__init__(**estimator_kwargs)
+            else:
+                super().__init__()
 
     for attr_name in dir(estimator_class):
         attr = getattr(_MockEstimator, attr_name)

--- a/sktime/utils/estimators/_base.py
+++ b/sktime/utils/estimators/_base.py
@@ -75,8 +75,9 @@ def make_mock_estimator(
     dunder_methods_regex = r"^__\w+__$"
 
     class _MockEstimator(estimator_class, _MockEstimatorMixin):
-        def __init__(self):
-            super().__init__()
+        def __init__(self, estimator_kwargs):
+            self.estimator_kwargs = estimator_kwargs
+            super().__init__(**estimator_kwargs)
 
     for attr_name in dir(estimator_class):
         attr = getattr(_MockEstimator, attr_name)

--- a/sktime/utils/estimators/tests/test_base.py
+++ b/sktime/utils/estimators/tests/test_base.py
@@ -4,6 +4,7 @@
 __author__ = ["ltsaprounis"]
 
 import pytest
+from pandas.testing import assert_series_equal
 
 from sktime.classification.base import BaseClassifier
 from sktime.clustering.base import BaseClusterer
@@ -159,3 +160,29 @@ def test_make_mock_estimator(estimator_class, method_regex, logged_methods):
     methods_called = [entry[0] for entry in estimator.log]
 
     assert set(methods_called) >= set(logged_methods)
+
+
+@pytest.mark.parametrize(
+    "estimator_class, estimator_kwargs",
+    [
+        (NaiveForecaster, {"strategy": "last", "sp": 2, "window_length": None}),
+        (NaiveForecaster, {"strategy": "mean", "sp": 1, "window_length": None}),
+    ],
+)
+def test_make_mock_estimator_with_kwargs(estimator_class, estimator_kwargs):
+    """Test that make_mock_estimator behaves like the passed estimator."""
+    mock_estimator = make_mock_estimator(estimator_class)
+    mock_estimator_instance = mock_estimator(estimator_kwargs)
+    estimator_instance = estimator_class(**estimator_kwargs)
+    mock_estimator_instance.fit(y_series)
+    estimator_instance.fit(y_series)
+
+    assert_series_equal(
+        estimator_instance.predict(fh=[1, 2, 3]),
+        mock_estimator_instance.predict(fh=[1, 2, 3]),
+    )
+    assert (
+        (mock_estimator_instance.strategy == estimator_kwargs["strategy"])
+        and (mock_estimator_instance.sp == estimator_kwargs["sp"])
+        and (mock_estimator_instance.window_length == estimator_kwargs["window_length"])
+    )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
fixes #2685 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
This deals with the problem of not being able to pass the relevant arguments in the __init__ of the returned mock estimator class (described in #2685) by allowing the user to pass a dictionary that contains the kwargs of the input estimator class.