### PR TITLE
[BUG] fixed bug with distance factory 1d arrays

### DIFF
--- a/sktime/distances/_numba_utils.py
+++ b/sktime/distances/_numba_utils.py
@@ -166,15 +166,19 @@ def to_numba_timeseries(x: np.ndarray) -> np.ndarray:
 
 @njit(cache=True)
 def _numba_to_timeseries(x: np.ndarray) -> np.ndarray:
-    _x = x.copy()
-    num_dims = _x.ndim
-    shape = _x.shape
-    if num_dims == 1:
-        _x = np.reshape(_x, (1, shape[0]))
-    elif num_dims > 2:
+    num_dims = x.ndim
+    shape = x.shape
+
+    if num_dims > 2:
         raise ValueError(
             "The matrix provided has more than 2 dimensions. This is not"
             "supported. Please provide a matrix with less than "
             "2 dimensions"
         )
+
+    if num_dims == 1:
+        _x = np.reshape(x, (1, shape[0]))
+    else:
+        _x = x
+
     return _x

--- a/sktime/distances/tests/test_numba_distances.py
+++ b/sktime/distances/tests/test_numba_distances.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal
 
-from sktime.distances._distance import _METRIC_INFOS, distance
+from sktime.distances._distance import _METRIC_INFOS, distance, distance_factory
 from sktime.distances.base import MetricInfo, NumbaDistance
 from sktime.distances.tests._expected_results import _expected_distance_results
 from sktime.distances.tests._shared_tests import (
@@ -200,3 +200,20 @@ def test_metric_parameters():
 def test_incorrect_parameters():
     """Ensure incorrect parameters raise errors."""
     _test_incorrect_parameters(distance)
+
+
+def test_distance_factory_1d():
+    """Test distance factory works with 1d and 2d."""
+    x = create_test_distance_numpy(100)
+    y = create_test_distance_numpy(100, random_state=2)
+    callable = distance_factory(x, y, metric="dtw")
+
+    first = callable(x, y)
+
+    x = create_test_distance_numpy(10, 100)
+    y = create_test_distance_numpy(10, 100, random_state=2)
+
+    second = callable(x, y)
+
+    assert first == 14.906015491572047
+    assert second == 422.81946268212846


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
This PR fixes a bug where the distance factory was incorrectly handling a 1d array being passed.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [x] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [DOC] or [BUG] indicating whether the PR topic is related to enhancement, documentation or bug

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
