### PR TITLE
[ENH] Replace deprecated argument `squeeze` with the method `.squeeze("columns")` in `pd.read_csv`

### DIFF
--- a/sktime/_contrib/datasets/_single_problem_loaders.py
+++ b/sktime/_contrib/datasets/_single_problem_loaders.py
@@ -593,7 +593,7 @@ def load_shampoo_sales():
     name = "ShampooSales"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: float})
+    y = pd.read_csv(path, index_col=0, dtype={1: float}).squeeze("columns")
     y.index = pd.PeriodIndex(y.index, freq="M", name="Period")
     y.name = "Number of shampoo sales"
     return y
@@ -694,7 +694,7 @@ def load_lynx():
     name = "Lynx"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: float})
+    y = pd.read_csv(path, index_col=0, dtype={1: float}).squeeze("columns")
     y.index = pd.PeriodIndex(y.index, freq="Y", name="Period")
     y.name = "Number of Lynx trappings"
     return y
@@ -731,7 +731,7 @@ def load_airline():
     name = "Airline"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: float})
+    y = pd.read_csv(path, index_col=0, dtype={1: float}).squeeze("columns")
 
     # make sure time index is properly formatted
     y.index = pd.PeriodIndex(y.index, freq="M", name="Period")
@@ -774,7 +774,7 @@ def load_uschange(y_name="Consumption"):
     name = "Uschange"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    data = pd.read_csv(path, index_col=0, squeeze=True)
+    data = pd.read_csv(path, index_col=0).squeeze("columns")
 
     # Sort by Quarter then set simple numeric index
     # TODO add support for period/datetime indexing
@@ -823,7 +823,7 @@ def load_gun_point_segmentation():
     change_points = np.int32([900])
 
     path = os.path.join(MODULE, DIRNAME, dir, fname)
-    ts = pd.read_csv(path, index_col=0, header=None, squeeze=True)
+    ts = pd.read_csv(path, index_col=0, header=None).squeeze("columns")
 
     return ts, period_length, change_points
 
@@ -861,7 +861,7 @@ def load_electric_devices_segmentation():
     change_points = np.int32([1090, 4436, 5712, 7923])
 
     path = os.path.join(MODULE, DIRNAME, dir, fname)
-    ts = pd.read_csv(path, index_col=0, header=None, squeeze=True)
+    ts = pd.read_csv(path, index_col=0, header=None).squeeze("columns")
 
     return ts, period_length, change_points
 
@@ -898,7 +898,7 @@ def load_PBS_dataset():
     name = "PBS_dataset"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: float})
+    y = pd.read_csv(path, index_col=0, dtype={1: float}).squeeze("columns")
 
     # make sure time index is properly formatted
     y.index = pd.PeriodIndex(y.index, freq="M", name="Period")

--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -584,7 +584,7 @@ def load_shampoo_sales():
     name = "ShampooSales"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: float})
+    y = pd.read_csv(path, index_col=0, dtype={1: float}).squeeze("columns")
     y.index = pd.PeriodIndex(y.index, freq="M", name="Period")
     y.name = "Number of shampoo sales"
     return y
@@ -693,7 +693,7 @@ def load_lynx():
     name = "Lynx"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: float})
+    y = pd.read_csv(path, index_col=0, dtype={1: float}).squeeze("columns")
     y.index = pd.PeriodIndex(y.index, freq="Y", name="Period")
     y.name = "Number of Lynx trappings"
     return y
@@ -734,7 +734,7 @@ def load_airline():
     name = "Airline"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: float})
+    y = pd.read_csv(path, index_col=0, dtype={1: float}).squeeze("columns")
 
     # make sure time index is properly formatted
     y.index = pd.PeriodIndex(y.index, freq="M", name="Period")
@@ -781,7 +781,7 @@ def load_uschange(y_name="Consumption"):
     name = "Uschange"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    data = pd.read_csv(path, index_col=0, squeeze=True)
+    data = pd.read_csv(path, index_col=0).squeeze("columns")
 
     # Sort by Quarter then set simple numeric index
     # TODO add support for period/datetime indexing
@@ -832,7 +832,7 @@ def load_gun_point_segmentation():
     change_points = np.int32([900])
 
     path = os.path.join(MODULE, DIRNAME, dir, fname)
-    ts = pd.read_csv(path, index_col=0, header=None, squeeze=True)
+    ts = pd.read_csv(path, index_col=0, header=None).squeeze("columns")
 
     return ts, period_length, change_points
 
@@ -872,7 +872,7 @@ def load_electric_devices_segmentation():
     change_points = np.int32([1090, 4436, 5712, 7923])
 
     path = os.path.join(MODULE, DIRNAME, dir, fname)
-    ts = pd.read_csv(path, index_col=0, header=None, squeeze=True)
+    ts = pd.read_csv(path, index_col=0, header=None).squeeze("columns")
 
     return ts, period_length, change_points
 
@@ -914,7 +914,7 @@ def load_PBS_dataset():
     name = "PBS_dataset"
     fname = name + ".csv"
     path = os.path.join(MODULE, DIRNAME, name, fname)
-    y = pd.read_csv(path, index_col=0, squeeze=True, dtype={1: float})
+    y = pd.read_csv(path, index_col=0, dtype={1: float}).squeeze("columns")
 
     # make sure time index is properly formatted
     y.index = pd.PeriodIndex(y.index, freq="M", name="Period")


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Replace deprecated argument `squeeze` with the method `.squeeze("columns")` in `pd.read_csv`. This argument is deprecated since version `1.4.0` of `pandas` (see https://pandas.pydata.org/docs/whatsnew/v1.4.0.html and https://github.com/pandas-dev/pandas/pull/43427).

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [X] I've added unit tests and made sure they pass locally.
- [X] The PR title starts with either [ENH], [DOC] or [BUG] indicating whether the PR topic is related to enhancement, documentation or bug