### PR TITLE
[DOC] updated utility API docs

### DIFF
--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -38,6 +38,8 @@ Data Format Checking and Conversion
 Estimator Search and Retrieval, Estimator Tags
 ----------------------------------------------
 
+:mod:`sktime.registry`
+
 .. automodule:: sktime.registry
     :no-members:
     :no-inherited-members:
@@ -55,7 +57,7 @@ Estimator Search and Retrieval, Estimator Tags
 Plotting
 --------
 
-``sktime.utils.plotting``
+:mod:`sktime.utils.plotting`
 
 .. automodule:: sktime.utils.plotting
     :no-members:
@@ -74,7 +76,7 @@ Plotting
 Estimator Validity Checking
 ---------------------------
 
-``sktime.utils.estimator_checks``
+:mod:`sktime.utils.estimator_checks`
 
 .. automodule:: sktime.utils.estimator_checks
     :no-members:

--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -9,20 +9,15 @@ Utility functions
 * :mod:`sktime.registry`, which contains utilities for estimator and tag search.
 * :mod:`sktime.utils`, which contains generic utility functions.
 
-.. automodule:: sktime.datatypes
-    :no-members:
-    :no-inherited-members:
-
-.. automodule:: sktime.registry
-    :no-members:
-    :no-inherited-members:
-
-.. automodule:: sktime.utils
-    :no-members:
-    :no-inherited-members:
 
 Data Format Checking and Conversion
 -----------------------------------
+
+:mod:`sktime.datatypes`
+
+.. automodule:: sktime.datatypes
+    :no-members:
+    :no-inherited-members:
 
 .. currentmodule:: sktime.datatypes
 
@@ -43,6 +38,10 @@ Data Format Checking and Conversion
 Estimator Search and Retrieval, Estimator Tags
 ----------------------------------------------
 
+.. automodule:: sktime.registry
+    :no-members:
+    :no-inherited-members:
+
 .. currentmodule:: sktime.registry
 
 .. autosummary::
@@ -56,6 +55,12 @@ Estimator Search and Retrieval, Estimator Tags
 Plotting
 --------
 
+``sktime.utils.plotting``
+
+.. automodule:: sktime.utils.plotting
+    :no-members:
+    :no-inherited-members:
+
 .. currentmodule:: sktime.utils.plotting
 
 .. autosummary::
@@ -68,6 +73,12 @@ Plotting
 
 Estimator Validity Checking
 ---------------------------
+
+``sktime.utils.estimator_checks``
+
+.. automodule:: sktime.utils.estimator_checks
+    :no-members:
+    :no-inherited-members:
 
 .. currentmodule:: sktime.utils.estimator_checks
 

--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -3,11 +3,55 @@
 Utility functions
 =================
 
-The :mod:`sktime.utils` module contains utility functions.
+``sktime`` has a number of modules dedicated to utilities:
+
+* :mod:`sktime.datatypes`, which contains utilities for data format checks and conversion.
+* :mod:`sktime.registry`, which contains utilities for estimator and tag search.
+* :mod:`sktime.utils`, which contains genneric utility functions.
+
+.. automodule:: sktime.datatypes
+    :no-members:
+    :no-inherited-members:
+
+.. automodule:: sktime.registry
+    :no-members:
+    :no-inherited-members:
 
 .. automodule:: sktime.utils
     :no-members:
     :no-inherited-members:
+
+Data Format Checking and Conversion
+-----------------------------------
+
+.. currentmodule:: sktime.datatypes
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: function.rst
+
+    convert_to
+    convert
+    check_raise
+    check_is_mtype
+    check_is_scitype
+    mtype
+    scitype
+    mtype_to_scitype
+    scitype_to_mtype
+
+Estimator Search and Retrieval, Estimator Tags
+----------------------------------------------
+
+.. currentmodule:: sktime.registry
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: function.rst
+
+    all_estimators
+    all_tags
+    check_tag_is_valid
 
 Plotting
 --------
@@ -22,25 +66,13 @@ Plotting
     plot_lags
     plot_correlations
 
-Data Processing
----------------
+Estimator Validity Checking
+---------------------------
 
-.. currentmodule:: sktime.datatypes._panel._convert
+.. currentmodule:: sktime.utils.estimator_checks
 
 .. autosummary::
     :toctree: auto_generated/
     :template: function.rst
 
-    are_columns_nested
-    is_nested_dataframe
-    from_nested_to_2d_array
-    from_2d_array_to_nested
-    from_3d_numpy_to_2d_array
-    from_3d_numpy_to_nested
-    from_nested_to_3d_numpy
-    from_multi_index_to_3d_numpy
-    from_3d_numpy_to_multi_index
-    from_multi_index_to_nested
-    from_nested_to_multi_index
-    from_nested_to_long
-    from_long_to_nested
+    check_estimator

--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -7,7 +7,7 @@ Utility functions
 
 * :mod:`sktime.datatypes`, which contains utilities for data format checks and conversion.
 * :mod:`sktime.registry`, which contains utilities for estimator and tag search.
-* :mod:`sktime.utils`, which contains genneric utility functions.
+* :mod:`sktime.utils`, which contains generic utility functions.
 
 .. automodule:: sktime.datatypes
     :no-members:


### PR DESCRIPTION
Fixes https://github.com/alan-turing-institute/sktime/issues/2528 by updating the utils API ref, removing listing of legacy functions in favour of current functionality.