### PR TITLE
[ENH] Conformal intervals additions

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1557,6 +1557,15 @@
       "contributions": [
         "code",
       ]
+    },
+    {
+      "login": "bethrice44",
+      "name": "bethrice44",
+      "avatar_url": "https://avatars.githubusercontent.com/u/11226988?v=4",
+      "profile": "https://github.com/bethrice44",
+      "contributions": [
+        "code",
+      ]
     }
   ],
   "projectName": "sktime",

--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -88,7 +88,7 @@ class ConformalIntervals(BaseForecaster):
         "conformal_bonferroni",
     ]
 
-    def __init__(self, forecaster, method="empirical", verbose=False):
+    def __init__(self, forecaster, method="empirical", sample_frac=None, verbose=False):
 
         if not isinstance(method, str):
             raise TypeError(f"method must be a str, one of {self.ALLOWED_METHODS}")
@@ -101,6 +101,7 @@ class ConformalIntervals(BaseForecaster):
         self.forecaster = forecaster
         self.method = method
         self.verbose = verbose
+        self.sample_frac = sample_frac
         super(ConformalIntervals, self).__init__()
 
         tags_to_clone = [
@@ -115,8 +116,15 @@ class ConformalIntervals(BaseForecaster):
         self.clone_tags(self.forecaster, tags_to_clone)
 
     def _fit(self, y, X=None, fh=None):
+        self.fh_early_ = fh is not None
         self.forecaster_ = clone(self.forecaster)
         self.forecaster_.fit(y=y, X=X, fh=fh)
+
+        if self.fh_early_:
+            self.residuals_matrix_ = self._compute_sliding_residuals(
+                y=y, X=X, forecaster=self.forecaster, initial_window=self.initial_window,
+                sample_frac=self.sample_frac
+            )
         return self
 
     def _predict(self, fh, X=None):
@@ -164,32 +172,19 @@ class ConformalIntervals(BaseForecaster):
                 Upper/lower interval end forecasts are equivalent to
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
-        y_index = self._y.index
         fh_relative = fh.to_relative(self.cutoff)
         fh_absolute = fh.to_absolute(self.cutoff)
 
-        residuals_matrix = pd.DataFrame(columns=y_index, index=y_index, dtype="float")
-        for id in y_index:
-            forecaster = clone(self.forecaster)
-            subset = self._y[:id]  # subset on which we fit
-            try:
-                forecaster.fit(subset)
-            except ValueError:
-                if self.verbose:
-                    warn(
-                        f"Couldn't fit the model on "
-                        f"time series window length {len(subset)}.\n"
-                    )
-                continue
-
-            y_true = self._y[id:]  # subset on which we predict
-            try:
-                residuals_matrix.loc[id] = forecaster.predict_residuals(y_true, self._X)
-            except IndexError:
-                warn(
-                    f"Couldn't predict after fitting on time series of length \
-                     {len(subset)}.\n"
-                )
+        if self.fh_early_:
+            residuals_matrix = self.residuals_matrix_
+        else:
+            residuals_matrix = self._compute_sliding_residuals(
+                y=self._y,
+                X=self._X,
+                forecaster=self.forecaster,
+                initial_window=self.initial_window,
+                sample_frac=self.sample_frac,
+            )
 
         ABS_RESIDUAL_BASED = ["conformal", "conformal_bonferroni", "empirical_residual"]
 
@@ -226,6 +221,60 @@ class ConformalIntervals(BaseForecaster):
             pred_int[col] = y_pred + sign * pred_int[col]
 
         return pred_int.convert_dtypes()
+
+    def _compute_sliding_residuals(self, y, X, forecaster, initial_window, sample_frac):
+        """Compute sliding residuals used in uncertainty estimates.
+        Parameters
+        ----------
+        y : pd.Series or pd.DataFrame
+            sktime compatible time series to use in computing residuals matrix
+        X : pd.DataFrame
+            sktime compatible exogeneous time series to use in forecasts
+        forecaster : sktime compatible forecaster
+            forecaster to use in computing the sliding residuals
+        initial_window : int
+            minimum length of initial window to use in fitting
+        Returns
+        -------
+        residuals_matrix : pd.DataFrame, row and column index = y.index[initial_window:]
+            [i,j]-th entry is signed residual of forecasting y.loc[j] from y.loc[:i],
+            using a clone of the forecaster passed through the forecaster arg
+        """
+        y_index = y.index[initial_window:]
+
+        residuals_matrix = pd.DataFrame(columns=y_index, index=y_index, dtype="float")
+
+        if sample_frac:
+            y_index = y_index.to_series().sample(frac=sample_frac)
+
+        for id in y_index:
+            forecaster = clone(forecaster)
+            y_train = y[:id]  # subset on which we fit
+            X_train = X[:id]
+            y_test = y[id:]   # subset on which we predict
+            X_test = X[id:]
+            # Check whether train and test are overlapping due to pandas slicing logic for timestamps
+            # Shift test forward in this case
+            if y_train.max() == y_test.min():
+                y_test = y_test[1:]
+                X_test = X_test[1:]
+            try:
+                forecaster.fit(y_train,  X=X_train, fh=y_test.index)
+            except ValueError:
+                warn(
+                    f"Couldn't fit the model on "
+                    f"time series window length {len(y_train)}.\n"
+                )
+                continue
+            try:
+                residuals_matrix.loc[id] = forecaster.predict_residuals(y_test, X_test).iloc[:, 0]
+            except IndexError:
+                warn(
+                    f"Couldn't predict after fitting on time series of length \
+                     {len(y_train)}.\n"
+                )
+
+        return residuals_matrix
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
#### Reference Issues/PRs
Building on #2542.

#### What does this implement/fix? Explain your changes.
1. Move `_compute_sliding_residuals` to it's own function like in `NaiveVariance`
2. Add early computation of residuals matrix like in `NaiveVariance`
3. Add option to pass a `sample_frac` argument at initialisation to speed up computing the residuals matrix
4. Found an issue where `forecaster.predict_residuals` doesn't always return a series, so assigning it to the residuals matrix can fail here:
```
residuals_matrix.loc[id] = forecaster.predict_residuals(y_test, X_test)
```

Fixed with:
```
residuals_matrix.loc[id] = forecaster.predict_residuals(y_test, X_test).iloc[:,0]
```
but this is up for discussion.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?
Numbers 3. and 4. are new and not yet implemented elsewhere.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [DOC] or [BUG] indicating whether the PR topic is related to enhancement, documentation or bug

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.

Will wait for review to complete the documentation on usage.