### PR TITLE
[ENH] add int handling to prophet

### DIFF
--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -211,6 +211,7 @@ class _ProphetAdapter(BaseForecaster):
 
         if X is not None and X.index.dtype == "int64":
             X = X.copy()
+            X = X.loc[self.fh.to_absolute(self.cutoff).to_numpy()]
             X.index = fh
 
         # prepare the return DataFrame - empty with correct cols

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -26,7 +26,7 @@ class _ProphetAdapter(BaseForecaster):
     def _convert_int_to_date(self, y):
         """Convert int to date, for use by prophet."""
         y = y.copy()
-        idx_max = y.index[-1]
+        idx_max = y.index[-1] + 1
         int_idx = pd.date_range(start="2000-01-01", periods=idx_max, freq="D")
         int_idx = int_idx[y.index]
         y.index = int_idx

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -54,7 +54,7 @@ class _ProphetAdapter(BaseForecaster):
         if type(y.index) is pd.PeriodIndex:
             raise NotImplementedError(
                 "pd.PeriodIndex is not supported for y, use "
-                f"pd.DatetimeIndex or integer pd.Index instead."
+                "pd.DatetimeIndex or integer pd.Index instead."
             )
 
         # integer type indices are converted to datetime

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -51,6 +51,12 @@ class _ProphetAdapter(BaseForecaster):
         self._instantiate_model()
         self._check_changepoints()
 
+        if type(y.index) is pd.PeriodIndex:
+            raise NotImplementedError(
+                "pd.PeriodIndex is not supported for y, use "
+                f"pd.DatetimeIndex or integer pd.Index instead."
+            )
+
         # integer type indices are converted to datetime
         # since facebook prophet can only deal with dates
         if y.index.dtype == "int64":

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -145,6 +145,7 @@ class _ProphetAdapter(BaseForecaster):
 
         if X is not None and X.index.dtype == "int64":
             X = X.copy()
+            X = X.loc[self.fh.to_absolute(self.cutoff).to_numpy()]
             X.index = fh
 
         # Merge X with df (of created future DatetimeIndex values)

--- a/sktime/forecasting/fbprophet.py
+++ b/sktime/forecasting/fbprophet.py
@@ -17,6 +17,15 @@ _check_soft_dependencies("prophet", severity="warning")
 class Prophet(_ProphetAdapter):
     """Prophet forecaster by wrapping Facebook's prophet algorithm [1]_.
 
+    Direct interface to Facebook prophet, using the sktime interface.
+    All hyper-parameters are exposed via the constructor.
+
+    Data can be passed in one of the sktime compatible formats,
+    naming a column `ds` such as in the prophet package is not necessary.
+
+    Integer indices can also be passed, in which case internally a conversion
+    to days since Jan 1, 2000 is carried out before passing to prophet.
+
     Parameters
     ----------
     freq: str, default=None


### PR DESCRIPTION
Fixes #2564, i.e., ensures that `Prophet` works with integer index input.

This is done by translating integer indices to "days since Jan 1, 2000", internally, when fitting, and converting back to integer indices, after predicting.