### PR TITLE
[ENH] SummaryTransformer multivariate output fix and tests for series-to-primitives transform output

### DIFF
--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -148,6 +148,7 @@ def check_is_mtype(
             "is_univariate": bool, True iff table has one variable
             "is_empty": bool, True iff table has no variables or no instances
             "has_nans": bool, True iff the panel contains NaN values
+            "n_instances": int, number of instances/rows in the table
         For scitype "Alignment":
             currently none
 

--- a/sktime/datatypes/_table/_check.py
+++ b/sktime/datatypes/_table/_check.py
@@ -95,6 +95,7 @@ def check_pdseries_table(obj, return_metadata=False, var_name="obj"):
     index = obj.index
     metadata["is_empty"] = len(index) < 1
     metadata["is_univariate"] = True
+    metadata["n_instances"] = len(index)
 
     # check that dtype is not object
     if "object" == obj.dtypes:
@@ -126,6 +127,7 @@ def check_numpy1d_table(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a 1D np.ndarray
     metadata["is_empty"] = len(obj) < 1
+    metadata["n_instances"] = len(obj)
     # 1D numpy arrays are considered univariate
     metadata["is_univariate"] = True
     # check whether there any nans; compute only if requested
@@ -153,6 +155,7 @@ def check_numpy2d_table(obj, return_metadata=False, var_name="obj"):
     # we now know obj is a 2D np.ndarray
     metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
     metadata["is_univariate"] = obj.shape[1] < 2
+    metadata["n_instances"] = obj.shape[0]
     # check whether there any nans; compute only if requested
     if return_metadata:
         metadata["has_nans"] = pd.isnull(obj).any()
@@ -201,6 +204,7 @@ def check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
             [pd.isnull(d[key]) for d in obj for key in d.keys()]
         )
         metadata["is_empty"] = len(obj) < 1 or np.all([len(x) < 1 for x in obj])
+        metadata["n_instances"] = len(obj)
 
     return _ret(True, None, metadata, return_metadata)
 

--- a/sktime/datatypes/_table/_check.py
+++ b/sktime/datatypes/_table/_check.py
@@ -30,6 +30,7 @@ metadata: dict - metadata about obj if valid, otherwise None
         "is_univariate": bool, True iff table has one variable
         "is_empty": bool, True iff table has no variables or no instances
         "has_nans": bool, True iff the panel contains NaN values
+        "n_instances": int, number of instances/rows in the table
 """
 
 __author__ = ["fkiraly"]
@@ -64,6 +65,7 @@ def check_pddataframe_table(obj, return_metadata=False, var_name="obj"):
     index = obj.index
     metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
     metadata["is_univariate"] = len(obj.columns) < 2
+    metadata["n_instances"] = len(index)
 
     # check whether there are any nans
     #   compute only if needed

--- a/sktime/datatypes/_table/_examples.py
+++ b/sktime/datatypes/_table/_examples.py
@@ -62,6 +62,7 @@ example_dict_metadata[("Table", 0)] = {
     "is_univariate": True,
     "is_empty": False,
     "has_nans": False,
+    "n_instances": 4,
 }
 
 ###
@@ -97,4 +98,5 @@ example_dict_metadata[("Table", 1)] = {
     "is_univariate": False,
     "is_empty": False,
     "has_nans": False,
+    "n_instances": 4,
 }

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -9,6 +9,7 @@ from sklearn import clone
 
 from sktime.base import _HeterogenousMetaEstimator
 from sktime.transformations.base import BaseTransformer
+from sktime.utils.multiindex import flatten_multiindex
 from sktime.utils.sklearn import is_sklearn_transformer
 
 __author__ = ["fkiraly", "mloning"]
@@ -448,7 +449,7 @@ class FeatureUnion(BaseTransformer, _HeterogenousMetaEstimator):
     flatten_transform_index : bool, optional (default=True)
         if True, columns of return DataFrame are flat, by "transformer__variablename"
         if False, columns are MultiIndex (transformer, variablename)
-        has no effect if return mtypes is one without column names
+        has no effect if return mtype is one without column names
     """
 
     _required_parameters = ["transformer_list"]
@@ -632,8 +633,7 @@ class FeatureUnion(BaseTransformer, _HeterogenousMetaEstimator):
         )
 
         if self.flatten_transform_index:
-            flat_index = pd.Index([self._underscore_join(x) for x in Xt.columns])
-            Xt.columns = flat_index
+            Xt.columns = flatten_multiindex(Xt.columns)
 
         return Xt
 
@@ -676,12 +676,6 @@ class FeatureUnion(BaseTransformer, _HeterogenousMetaEstimator):
         ]
 
         return {"transformer_list": TRANSFORMERS}
-
-    @staticmethod
-    def _underscore_join(iterable):
-        """Create flattened column names from multiindex tuple."""
-        iterable_as_str = [str(x) for x in iterable]
-        return "__".join(iterable_as_str)
 
 
 class FitInTransform(BaseTransformer):

--- a/sktime/transformations/series/tests/test_summarize.py
+++ b/sktime/transformations/series/tests/test_summarize.py
@@ -70,8 +70,8 @@ def test_summary_transformer_output_type(y, summary_arg, quantile_arg):
     expected_features = expected_sum_features + expected_q_features
 
     # for multivariate series, columns = no variables * no feature types
-    if isinstance(yt, pd.DataFrame):
-        expected_features = len(yt.columns) * expected_features
+    if isinstance(y, pd.DataFrame):
+        expected_features = len(y.columns) * expected_features
 
     assert yt.shape == (expected_instances, expected_features)
 

--- a/sktime/transformations/series/tests/test_summarize.py
+++ b/sktime/transformations/series/tests/test_summarize.py
@@ -52,7 +52,14 @@ def test_summary_transformer_output_type(y, summary_arg, quantile_arg):
     yt = transformer.transform(y)
 
     output_is_dataframe = isinstance(yt, pd.DataFrame)
-    expected_instances = 1 if isinstance(y, pd.Series) else y.shape[1]
+    assert output_is_dataframe
+
+    # compute number of expected rows and columns
+
+    # all test cases are single series, so single row
+    expected_instances = 1
+
+    # expected number of feature types = quantiles plus summaries
     expected_sum_features = 1 if isinstance(summary_arg, str) else len(summary_arg)
     if quantile_arg is None:
         expected_q_features = 0
@@ -62,7 +69,11 @@ def test_summary_transformer_output_type(y, summary_arg, quantile_arg):
         expected_q_features = len(quantile_arg)
     expected_features = expected_sum_features + expected_q_features
 
-    assert output_is_dataframe and yt.shape == (expected_instances, expected_features)
+    # for multivariate series, columns = no variables * no feature types
+    if isinstance(yt, pd.DataFrame):
+        expected_features = len(yt.columns) * expected_features
+
+    assert yt.shape == (expected_instances, expected_features)
 
 
 @pytest.mark.parametrize("summary_arg", incorrect_sum_funcs_to_test)

--- a/sktime/transformations/tests/test_all_transformers.py
+++ b/sktime/transformations/tests/test_all_transformers.py
@@ -120,6 +120,8 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
             return None
 
         # if we vectorize, number of instances before/after transform should be same
+
+        # series-to-series transformers
         if trafo_input == "Series" and trafo_output == "Series":
             if X_scitype == "Series" and Xt_scitype == "Series":
                 if estimator_instance.get_tag("transform-returns-same-time-index"):
@@ -128,9 +130,18 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
                 assert X_metadata["n_instances"] == Xt_metadata["n_instances"]
             if X_scitype == "Hierarchical" and Xt_scitype == "Hierarchical":
                 assert X_metadata["n_instances"] == Xt_metadata["n_instances"]
+
+        # panel-to-panel transformers
         if trafo_input == "Panel" and trafo_output == "Panel":
             if X_scitype == "Hierarchical" and Xt_scitype == "Hierarchical":
                 assert X_metadata["n_panels"] == Xt_metadata["n_panels"]
+
+        # series-to-primitives transformers
+        if trafo_input == "Series" and trafo_output == "Primitives":
+            if X_scitype == "Series":
+                assert Xt_metadata["n_instances"] == 1
+            if X_scitype == "Panel":
+                assert X_metadata["n_instances"] == Xt_metadata["n_instances"]
 
         # todo: also test the expected mtype
 

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -153,7 +153,11 @@ def test_sklearn_after_primitives():
 
     assert deep_equals(X_out.index, X_summary.index)
     assert deep_equals(X_out.columns, X_summary.columns)
+    # var_0 is the same for all three instances
+    # so summary statistics are all the same, thus StandardScaler transforms to 0
     assert X_out.iloc[0, 0] > -0.01
     assert X_out.iloc[0, 0] < 0.01
+    # var_1 has some variation between three instances
+    # fix this to one value to tie the output to current behaviour
     assert X_out.iloc[0, 10] > -1.37
     assert X_out.iloc[0, 10] < -1.36

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -153,5 +153,7 @@ def test_sklearn_after_primitives():
 
     assert deep_equals(X_out.index, X_summary.index)
     assert deep_equals(X_out.columns, X_summary.columns)
-    assert X_out.iloc[0, 0] > -0.79
-    assert X_out.iloc[0, 0] < -0.78
+    assert X_out.iloc[0, 0] > -0.01
+    assert X_out.iloc[0, 0] < 0.01
+    assert X_out.iloc[0, 10] > -1.37
+    assert X_out.iloc[0, 10] < -1.36

--- a/sktime/utils/multiindex.py
+++ b/sktime/utils/multiindex.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3 -u
+# -*- coding: utf-8 -*-
+"""Multiindex formatting related utilities."""
+
+__author__ = ["fkiraly"]
+__all__ = []
+
+import pandas as pd
+
+
+def underscore_join(iterable):
+    """Create flattened column names from multiindex tuple.
+
+    Parameters
+    ----------
+    iterable : an iterable
+
+    Returns
+    -------
+    str, for an iterable (x1, x2, ..., xn), returns the string
+        str(x1) + "__" + str(x2) + "__" + str(x3) + ... + "__" + str(xn)
+    """
+    iterable_as_str = [str(x) for x in iterable]
+    return "__".join(iterable_as_str)
+
+
+def flatten_multiindex(idx):
+    """Flatten a multiindex.
+
+    Parameters
+    ----------
+    idx: pandas.MultiIndex
+
+    Returns
+    -------
+    pandas.Index with str elements
+        i-th element of return is underscore_join of i-th element of `idx`
+    """
+    return pd.Index([underscore_join(x) for x in idx])


### PR DESCRIPTION
This PR adds tests for series-to-primitives output in `test_fit_transform_output`, and ensures the `SummaryTransformer` is compliant with that output.
This fixes #2717.

Further changes:
* functionality of flattening hierarchical column indices, which is now used in two estimators, is moved to the `sktime.utils` module. This hence affects `FeatureUnion` through refactoring of the common functionality.
* the type check for `Table` is modified to return a `n_instances` (number of rows/instances) metadata field, for all `Table` mtypes. This is used in the return type check, e.g., to check that `SummaryTransformer.fit_transform` returns the correct number of rows for multivariate input.