### PR TITLE
[ENH] testing hierarchical input to transformers

### DIFF
--- a/sktime/transformations/tests/test_all_transformers.py
+++ b/sktime/transformations/tests/test_all_transformers.py
@@ -92,12 +92,6 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
             X_scitype, trafo_input, trafo_output
         )
 
-        # todo 0.11.0 or 0.12.0:
-        #   remove this once #2219 is merged, which adds Hierarchical support
-        #   until then, skip tests if expected scitype is Hierarchical
-        if Xt_expected_scitype == "Hierarchical":
-            return None
-
         valid_scitype, _, Xt_metadata = check_is_scitype(
             Xt, scitype=Xt_expected_scitype, return_metadata=True
         )


### PR DESCRIPTION
This removes the skip of tests for hierarchical input to transformations in `test_fit_transform_output`.

This should ensure that hierarchical input/output formats are also tested for transformers.