### PR TITLE
[DOC] update location of TimeSeriesForestClassifier from kernel_based to interval_based in get_started.rst

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -45,7 +45,7 @@
         "ideas",
         "test",
         "tutorial"
-	]
+      ]
     },
     {
       "login": "Tomiiwa",
@@ -170,7 +170,7 @@
       "contributions": [
         "code",
         "test"
-        ]
+      ]
     },
     {
       "login": "jesellier",
@@ -1519,7 +1519,7 @@
       "profile": "https://github.com/RishiKumarRay",
       "contributions": [
         "infra"
-     ]
+      ]
     },
     {
       "login": "cdahlin",
@@ -1528,7 +1528,7 @@
       "profile": "https://github.com/cdahlin",
       "contributions": [
         "code"
-     ]
+      ]
     },
     {
       "login": "iljamaurer",
@@ -1546,7 +1546,7 @@
       "profile": "https://github.com/FedericoGarza",
       "contributions": [
         "code",
-	"example"
+        "example"
       ]
     },
     {
@@ -1563,6 +1563,15 @@
       "name": "Aleksandr Grekov",
       "avatar_url": "https://avatars.githubusercontent.com/u/44262176?v=4",
       "profile": "https://github.com/keepersas",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "dougollerenshaw",
+      "name": "Doug Ollerenshaw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/19944442?v=4",
+      "profile": "https://github.com/dougollerenshaw",
       "contributions": [
         "doc"
       ]

--- a/docs/source/get_started.rst
+++ b/docs/source/get_started.rst
@@ -93,7 +93,7 @@ Time Series Classification
 
 .. code-block:: python
 
-    >>> from sktime.classification.kernel_based import TimeSeriesForestClassifier
+    >>> from sktime.classification.interval_based import TimeSeriesForestClassifier
     >>> from sktime.datasets import load_arrow_head
     >>> from sklearn.model_selection import train_test_split
     >>> from sklearn.metrics import accuracy_score


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes issue #2716

#### What does this implement/fix? Explain your changes.
Changes import location of `TimeSeriesForestClassifier` in the quickstart guide from `kernel_based` to `interval_based`

#### Does your contribution introduce a new dependency? If yes, which one?
No.


#### What should a reviewer concentrate their feedback on?
This is my first PR. Please let me know if I'm missing any important steps (I did review the guidelines)

#### Any other comments?
Hopefully a small enough fix that it's easy to review

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.
- [ ] The PR title starts with either [ENH], [DOC] or [BUG] indicating whether the PR topic is related to enhancement, documentation or bug

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
