### PR TITLE
[ENH] automated init args write to self by `BaseObject`

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -70,7 +70,12 @@ class BaseObject(_BaseEstimator):
     """
 
     def __init__(self):
+        # initializing dynamic tag dictionary
         self._tags_dynamic = dict()
+        # this writes all __init__ args to self
+        for key in inspect.getfullargspec(self.__init__).args:
+            setattr(self, key, eval(key))
+
         super(BaseObject, self).__init__()
 
     def reset(self):

--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -204,37 +204,7 @@ class AutoETS(_StatsModelsAdapter):
         ignore_inf_ic=True,
         n_jobs=None,
         random_state=None,
-        **kwargs
     ):
-        # Model params
-        self.error = error
-        self.trend = trend
-        self.damped_trend = damped_trend
-        self.seasonal = seasonal
-        self.sp = sp
-        self.initialization_method = initialization_method
-        self.initial_level = initial_level
-        self.initial_trend = initial_trend
-        self.initial_seasonal = initial_seasonal
-        self.bounds = bounds
-        self.dates = dates
-        self.freq = freq
-        self.missing = missing
-
-        # Fit params
-        self.start_params = start_params
-        self.maxiter = maxiter
-        self.full_output = full_output
-        self.disp = disp
-        self.callback = callback
-        self.return_params = return_params
-        self.information_criterion = information_criterion
-        self.auto = auto
-        self.allow_multiplicative_trend = allow_multiplicative_trend
-        self.restrict = restrict
-        self.additive_only = additive_only
-        self.ignore_inf_ic = ignore_inf_ic
-        self.n_jobs = n_jobs
 
         super(AutoETS, self).__init__(random_state=random_state)
 


### PR DESCRIPTION
Trying to fix #2733, it is truly atrocious to write long blocks of `self.foo = foo` and then `self.bar = bar` and then `self.supercalifragilistic = supercalifragilistic`.

Should't all estimators just write all `__init__` args to self automatically?

This is now done by `BaseObject`, and writes of parameters to `self` are no longer necessary.

As a proof-of-concept, `AutoETS` is refactored by removing the self writes.