### PR TITLE
[BUG] fixing constructor non-compliance with sklearn: `AutoETS`

### DIFF
--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -204,7 +204,6 @@ class AutoETS(_StatsModelsAdapter):
         ignore_inf_ic=True,
         n_jobs=None,
         random_state=None,
-        **kwargs
     ):
         # Model params
         self.error = error


### PR DESCRIPTION
Part of a fix for #2733, for `AutoETS`.