### PR TITLE
[MNT] Removed redundant `todo` from `transformer_simple` extension template

### DIFF
--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -110,7 +110,6 @@ class MyTransformer(BaseTransformer):
         # is transform result always guaranteed to be equal length (and series)?
         #   not relevant for transformers that return Primitives in transform-output
         "handles-missing-data": False,  # can estimator handle missing data?
-        # todo: rename to capability:missing_values
         "capability:missing_values:removes": False,
         # is transform result always guaranteed to contain no missing values?
     }


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Removed redundant `todo: rename to capability:missing_values` from `tags` in the `transformer_simple` extension template.  
 https://github.com/alan-turing-institute/sktime/blob/main/extension_templates/transformer_simple.py#:~:text=%23%20todo%3A%20rename%20to%20capability%3Amissing_valueslink 
It seems to be a `todo` for package maintainers, not a `todo` for Estimator implementors.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

