### PR TITLE
[MNT] upper bound `holidays` to 0.13 in soft dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ all_extras = [
     "dtw-python",
     "esig==0.9.7",
     "prophet>=1.0",
+    "holidays<=0.13",
     "hcrystalball>=0.1.9",
     "matplotlib>=3.3.2",
     "pmdarima>=1.8.0,!=1.8.1",


### PR DESCRIPTION
Resolves https://github.com/alan-turing-institute/sktime/issues/2748 by upper bounding the `holidays` indirect soft dependency to 0.13.