### PR TITLE
[ENH] `get_test_params` refactor for `PyODAnnotator`

### DIFF
--- a/sktime/annotation/adapters/_pyod.py
+++ b/sktime/annotation/adapters/_pyod.py
@@ -99,3 +99,27 @@ class PyODAnnotator(BaseSeriesAnnotator):
             Y = pd.Series(Y_val_np[Y_loc], index=X.index[Y_loc])
 
         return Y
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for annotators.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        from pyod.models.knn import KNN
+
+        params = {"estimator": KNN()}
+        return params

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -4,10 +4,8 @@ __author__ = ["mloning"]
 __all__ = ["ESTIMATOR_TEST_PARAMS", "EXCLUDE_ESTIMATORS", "EXCLUDED_TESTS"]
 
 import numpy as np
-from pyod.models.knn import KNN
 from sklearn.preprocessing import FunctionTransformer, StandardScaler
 
-from sktime.annotation.adapters import PyODAnnotator
 from sktime.annotation.clasp import ClaSPSegmentation
 from sktime.base import BaseEstimator
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
@@ -105,7 +103,6 @@ TRANSFORMERS = [
         ),
     ),
 ]
-ANOMALY_DETECTOR = KNN()
 ESTIMATOR_TEST_PARAMS = {
     FittedParamExtractor: {
         "forecaster": ExponentialSmoothing(),
@@ -132,7 +129,6 @@ ESTIMATOR_TEST_PARAMS = {
     },
     ComposableTimeSeriesForestRegressor: {"n_estimators": 3},
     UnobservedComponents: {"level": "local level"},
-    PyODAnnotator: {"estimator": ANOMALY_DETECTOR},
     ClaSPSegmentation: {"period_length": 5, "n_cps": 1},
 }
 


### PR DESCRIPTION
Carries out refactor described in issue https://github.com/alan-turing-institute/sktime/issues/1678 for `PyODAnnotator`.

Pre-PR state blocks the pydata 2022 tutorial due to making `check_estimator` dependent on `pyod`, so needs to be done asap.

Slightly confused, I thought you did that, @NoaBenAmi? Why was https://github.com/alan-turing-institute/sktime/pull/2352 closed and not merged?