### PR TITLE
[ENH] option to exclude tests/fixtures in `check_estimator`

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -287,7 +287,13 @@ class QuickTester:
     """Mixin class which adds the run_tests method to run tests on one estimator."""
 
     def run_tests(
-        self, estimator, return_exceptions=True, tests_to_run=None, fixtures_to_run=None
+        self,
+        estimator,
+        return_exceptions=True,
+        tests_to_run=None,
+        fixtures_to_run=None,
+        tests_to_exclude=None,
+        fixtures_to_exclude=None,
     ):
         """Run all tests on one single estimator.
 
@@ -315,6 +321,11 @@ class QuickTester:
             If both tests_to_run and fixtures_to_run are provided, runs the *union*,
             i.e., all test-fixture combinations for tests in tests_to_run,
                 plus all test-fixture combinations in fixtures_to_run.
+        tests_to_exclude : str or list of str, names of tests to exclude. default = none
+            removes tests that should not be run, after subsetting via tests_to_run.
+        fixtures_to_exclude : str or list of str, fixtures to exclude. default = none
+            removes test-fixture combinations that should not be run.
+            This is done after subsetting via fixtures_to_run.
 
         Returns
         -------
@@ -347,6 +358,12 @@ class QuickTester:
         )
         fixtures_to_run = self._check_None_str_or_list_of_str(
             fixtures_to_run, var_name="fixtures_to_run"
+        )
+        tests_to_exclude = self._check_None_str_or_list_of_str(
+            tests_to_exclude, var_name="tests_to_exclude"
+        )
+        fixtures_to_exclude = self._check_None_str_or_list_of_str(
+            fixtures_to_exclude, var_name="fixtures_to_exclude"
         )
 
         # retrieve tests from self
@@ -391,6 +408,12 @@ class QuickTester:
                 tests_from_fixt = [fixt.split("[")[0] for fixt in fixtures_to_run]
                 test_names_subset += list(set(test_names).intersection(tests_from_fixt))
             test_names_subset = list(set(test_names_subset))
+
+        # sub-setting by removing all tests from tests_to_exclude
+        if tests_to_exclude is not None:
+            test_names_subset = list(
+                set(test_names_subset).difference(tests_to_exclude)
+            )
 
         # the below loops run all the tests and collect the results here:
         results = dict()
@@ -449,6 +472,8 @@ class QuickTester:
                 # we subset to test-fixtures to run by this, if given
                 #  key is identical to the pytest test-fixture string identifier
                 if fixtures_to_run is not None and key not in fixtures_to_run:
+                    continue
+                if fixtures_to_exclude is not None and key in fixtures_to_exclude:
                     continue
 
                 if return_exceptions:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -321,9 +321,9 @@ class QuickTester:
             If both tests_to_run and fixtures_to_run are provided, runs the *union*,
             i.e., all test-fixture combinations for tests in tests_to_run,
                 plus all test-fixture combinations in fixtures_to_run.
-        tests_to_exclude : str or list of str, names of tests to exclude. default = none
+        tests_to_exclude : str or list of str, names of tests to exclude. default = None
             removes tests that should not be run, after subsetting via tests_to_run.
-        fixtures_to_exclude : str or list of str, fixtures to exclude. default = none
+        fixtures_to_exclude : str or list of str, fixtures to exclude. default = None
             removes test-fixture combinations that should not be run.
             This is done after subsetting via fixtures_to_run.
 

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -39,9 +39,9 @@ def check_estimator(
             plus all test-fixture combinations in fixtures_to_run.
     verbose : str, optional, default=True.
         whether to print out informative summary of tests run.
-    tests_to_exclude : str or list of str, names of tests to exclude. default = none
+    tests_to_exclude : str or list of str, names of tests to exclude. default = None
         removes tests that should not be run, after subsetting via tests_to_run.
-    fixtures_to_exclude : str or list of str, fixtures to exclude. default = none
+    fixtures_to_exclude : str or list of str, fixtures to exclude. default = None
         removes test-fixture combinations that should not be run.
         This is done after subsetting via fixtures_to_run.
 

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -11,6 +11,8 @@ def check_estimator(
     tests_to_run=None,
     fixtures_to_run=None,
     verbose=True,
+    tests_to_exclude=None,
+    fixtures_to_exclude=None,
 ):
     """Run all tests on one single estimator.
 
@@ -37,6 +39,11 @@ def check_estimator(
             plus all test-fixture combinations in fixtures_to_run.
     verbose : str, optional, default=True.
         whether to print out informative summary of tests run.
+    tests_to_exclude : str or list of str, names of tests to exclude. default = none
+        removes tests that should not be run, after subsetting via tests_to_run.
+    fixtures_to_exclude : str or list of str, fixtures to exclude. default = none
+        removes test-fixture combinations that should not be run.
+        This is done after subsetting via fixtures_to_run.
 
     Returns
     -------
@@ -82,6 +89,8 @@ def check_estimator(
         return_exceptions=return_exceptions,
         tests_to_run=tests_to_run,
         fixtures_to_run=fixtures_to_run,
+        tests_to_exclude=tests_to_exclude,
+        fixtures_to_exclude=fixtures_to_exclude,
     )
 
     try:

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -41,6 +41,8 @@ def test_check_estimator_subset_tests():
     tests_to_exclude = ["test_repr"]
 
     expected_tests = set(tests_to_run).difference(tests_to_exclude)
+    expected_tests = set(x.split("[")[0] for x in expected_tests)
+
     results = check_estimator(
         ExponentTransformer,
         verbose=False,

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -45,7 +45,7 @@ def test_check_estimator_subset_tests():
         ExponentTransformer,
         verbose=False,
         tests_to_run=tests_to_run,
-        tests_to_exclude=tests_to_exclude
+        tests_to_exclude=tests_to_exclude,
     )
 
     assert set(results.keys()) == expected_tests

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -33,3 +33,19 @@ def test_check_estimator_does_not_raise(estimator_class):
     check_estimator(estimator_class, return_exceptions=False, verbose=False)
 
     check_estimator(estimator_instance, return_exceptions=False, verbose=False)
+
+
+def test_check_estimator_subset_tests():
+    """Test that subsetting by tests_to_run and tests_to_exclude works as intended."""
+    tests_to_run = ["test_get_params", "test_set_params", "test_clone", "test_repr"]
+    tests_to_exclude = ["test_repr"]
+
+    expected_tests = set(tests_to_run).difference(tests_to_exclude)
+    results = check_estimator(
+        ExponentTransformer,
+        verbose=False,
+        tests_to_run=tests_to_run,
+        tests_to_exclude=tests_to_exclude
+    )
+
+    assert set(results.keys()) == expected_tests

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -41,7 +41,6 @@ def test_check_estimator_subset_tests():
     tests_to_exclude = ["test_repr"]
 
     expected_tests = set(tests_to_run).difference(tests_to_exclude)
-    expected_tests = set(x.split("[")[0] for x in expected_tests)
 
     results = check_estimator(
         ExponentTransformer,
@@ -49,5 +48,6 @@ def test_check_estimator_subset_tests():
         tests_to_run=tests_to_run,
         tests_to_exclude=tests_to_exclude,
     )
+    results_tests = set(x.split("[")[0] for x in results.keys())
 
-    assert set(results.keys()) == expected_tests
+    assert results_tests == expected_tests


### PR DESCRIPTION
This PR adds arguments to `check_estimator` and the underlying `run_tests` utility that allows to exclude tests and fixture/test combinations by name.

In-principle, this would already be possible by passing a positive list and removing the tests to exclude, but currently there is no easy way to get the positive list. Hence, the argument is an easier (non-redundant) way to do this.