### PR TITLE
[DOC] reserved variables listed in extension templates

### DIFF
--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -11,8 +11,8 @@ How to use this implementation template to implement a new estimator:
 - make a copy of the template in a suitable location, give it a descriptive name.
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
-- do not write to reserved variables: _is_fitted, _X, _y, classes_, n_classes_,
-    fit_time_, _class_dictionary, _threads_to_use, _tags, _tags_dynamic
+- do not write to reserved variables: is_fitted, _is_fitted, _X, _y, classes_,
+    n_classes_, fit_time_, _class_dictionary, _threads_to_use, _tags, _tags_dynamic
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -12,7 +12,7 @@ How to use this implementation template to implement a new estimator:
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
 - do not write to reserved variables: _is_fitted, _X, _y, classes_, n_classes_,
-    fit_time_, _class_dictionary, _threads_to_use
+    fit_time_, _class_dictionary, _threads_to_use, _tags, _tags_dynamic
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -11,6 +11,8 @@ How to use this implementation template to implement a new estimator:
 - make a copy of the template in a suitable location, give it a descriptive name.
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
+- do not write to reserved variables: _is_fitted, _X, _y, classes_, n_classes_,
+    fit_time_, _class_dictionary, _threads_to_use
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -12,7 +12,7 @@ How to use this implementation template to implement a new estimator:
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
 - do not write to reserved variables: is_fitted, _is_fitted, fit_time_,
-        _class_dictionary, _threads_to_use, n_clusters
+        _class_dictionary, _threads_to_use, n_clusters, _tags, _tags_dynamic
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -11,6 +11,8 @@ How to use this implementation template to implement a new estimator:
 - make a copy of the template in a suitable location, give it a descriptive name.
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
+- do not write to reserved variables: is_fitted, _is_fitted, fit_time_,
+        _class_dictionary, _threads_to_use, n_clusters
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -7,7 +7,7 @@ How to use this:
 - do NOT import this file directly - it will break
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
-- do not write to reserved variables: is_fitted, _is_fitted
+- do not write to reserved variables: is_fitted, _is_fitted, _tags, _tags_dynamic
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -7,6 +7,7 @@ How to use this:
 - do NOT import this file directly - it will break
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
+- do not write to reserved variables: is_fitted, _is_fitted
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -7,7 +7,7 @@ How to use this:
 - do NOT import this file directly - it will break
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
-- do not write to reserved variables: is_fitted, _is_fitted
+- do not write to reserved variables: is_fitted, _is_fitted, _tags, _tags_dynamic
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -7,6 +7,7 @@ How to use this:
 - do NOT import this file directly - it will break
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
+- do not write to reserved variables: is_fitted, _is_fitted
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -12,6 +12,8 @@ How to use this implementation template to implement a new estimator:
 - make a copy of the template in a suitable location, give it a descriptive name.
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
+- do not write to reserved variables: is_fitted, _is_fitted, _X, _y, cutoff, _fh,
+    _cutoff, _converter_store_y, forecasters_
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -13,7 +13,7 @@ How to use this implementation template to implement a new estimator:
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
 - do not write to reserved variables: is_fitted, _is_fitted, _X, _y, cutoff, _fh,
-    _cutoff, _converter_store_y, forecasters_
+    _cutoff, _converter_store_y, forecasters_, _tags, _tags_dynamic
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -17,6 +17,8 @@ How to use this implementation template to implement a new estimator:
 - make a copy of the template in a suitable location, give it a descriptive name.
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
+- do not write to reserved variables: is_fitted, _is_fitted, _X, _y, cutoff, _fh,
+    _cutoff, _converter_store_y, forecasters_
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -18,7 +18,7 @@ How to use this implementation template to implement a new estimator:
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
 - do not write to reserved variables: is_fitted, _is_fitted, _X, _y, cutoff, _fh,
-    _cutoff, _converter_store_y, forecasters_
+    _cutoff, _converter_store_y, forecasters_, _tags, _tags_dynamic
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -12,6 +12,8 @@ How to use this implementation template to implement a new estimator:
 - make a copy of the template in a suitable location, give it a descriptive name.
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
+- do not write to reserved variables: is_fitted, _is_fitted, _X, _y,
+    _converter_store_X, transformers_
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -13,7 +13,7 @@ How to use this implementation template to implement a new estimator:
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
 - do not write to reserved variables: is_fitted, _is_fitted, _X, _y,
-    _converter_store_X, transformers_
+    _converter_store_X, transformers_, _tags, _tags_dynamic
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -17,6 +17,8 @@ How to use this implementation template to implement a new estimator:
 - make a copy of the template in a suitable location, give it a descriptive name.
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
+- do not write to reserved variables: is_fitted, _is_fitted, _X, _y,
+    _converter_store_X, transformers_
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -18,7 +18,7 @@ How to use this implementation template to implement a new estimator:
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
 - do not write to reserved variables: is_fitted, _is_fitted, _X, _y,
-    _converter_store_X, transformers_
+    _converter_store_X, transformers_, _tags, _tags_dynamic
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file


### PR DESCRIPTION
This adds a list of reserved variables to the instructions in the extension templates, to avoid accidental write to reserved variables by implementers of estimators.

FYI @miraep8 (#2738 was an example of this accident)