### PR TITLE
[MNT] `check_estimators` to run without soft dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,9 @@ test_softdeps: ## Run unit tests
 	mkdir -p ${TEST_DIR}
 	cp .coveragerc ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
-	cd ${TEST_DIR}; python -m pytest -v -n auto --showlocals --durations=20 -k 'test_all_estimators' $(PYTESTOPTIONS) --pyargs sktime.registry
+	cd ${TEST_DIR}
+	python -m pytest -v -n auto --showlocals --durations=20 -k 'test_all_estimators' $(PYTESTOPTIONS) --pyargs sktime.registry
+	python -m pytest -v -n auto --showlocals --durations=20 -k 'test_check_estimator_does_not_raise' $(PYTESTOPTIONS) --pyargs sktime.utils
 
 tests: test
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -51,6 +51,7 @@ from sktime.utils._testing.estimator_checks import (
     _list_required_methods,
 )
 from sktime.utils._testing.scenarios_getter import retrieve_scenarios
+from sktime.utils.validation._dependencies import _check_dl_dependencies
 
 
 class BaseFixtureGenerator:
@@ -947,6 +948,12 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         set_random_state(estimator)
 
         for method in NON_STATE_CHANGING_METHODS:
+
+            # don't test predict_proba if tensorflow_probability is not installed
+            if method == "predict_proba" and isinstance(estimator, BaseForecaster):
+                if not _check_dl_dependencies(severity="none"):
+                    continue
+
             if _has_capability(estimator, method):
 
                 # dict_before = copy of dictionary of estimator before predict, post fit
@@ -982,6 +989,12 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         ), f"Estimator: {estimator} has side effects on arguments of fit"
 
         for method in NON_STATE_CHANGING_METHODS:
+
+            # don't test predict_proba if tensorflow_probability is not installed
+            if method == "predict_proba" and isinstance(estimator, BaseForecaster):
+                if not _check_dl_dependencies(severity="none"):
+                    continue
+
             if _has_capability(estimator, method):
                 # Fit the model, get args before and after
                 _, args_after = scenario.run(
@@ -1004,6 +1017,12 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         # Generate results before pickling
         results = {}
         for method in NON_STATE_CHANGING_METHODS:
+
+            # don't test predict_proba if tensorflow_probability is not installed
+            if method == "predict_proba" and isinstance(estimator, BaseForecaster):
+                if not _check_dl_dependencies(severity="none"):
+                    continue
+
             if _has_capability(estimator, method):
                 results[method] = scenario.run(estimator, method_sequence=[method])
 
@@ -1048,6 +1067,11 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
 
         if "n_jobs" in params:
             for method in NON_STATE_CHANGING_METHODS:
+                # don't test predict_proba if tensorflow_probability is not installed
+                estimator = estimator_instance
+                if method == "predict_proba" and isinstance(estimator, BaseForecaster):
+                    if not _check_dl_dependencies(severity="none"):
+                        continue
                 if _has_capability(estimator_instance, method):
                     # run on a single process
                     # -----------------------

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -869,7 +869,6 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         # NotFittedError
         for method in NON_STATE_CHANGING_METHODS:
             # don't test predict_proba if tensorflow_probability is not installed
-            
             if method == "predict_proba" and isinstance(estimator, BaseForecaster):
                 if not _check_dl_dependencies(severity="none"):
                     continue


### PR DESCRIPTION
This PR ensures that `check_estimator` can always run without soft dependencies, and adds a test for it.

It addresses a recent issue fixed by https://github.com/alan-turing-institute/sktime/pull/2755 where `check_estimator` could only be run with one specific soft dependency installed, and the problem that `check_estimator` runs for probabilistic forecasters only when `tensorflow-probability` is installed (for `predict_proba`).

This PR adds:
* a test for checking that `check_estimators` runs if no soft dependencies are installed, to the "no soft dependencies" CI checks.
* a `"none"` severity level for the dependency checker functions, which results in a return of True/False based on whether packages are installed or not
* a conditional escape from testing `predict_proba` in forecasters if `tensorflow-probability` is not installed