### PR TITLE
[ENH] Add MultiplexTransformer - reverted & restored to fix remaining CI/CD issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ sktime/datasets/local_data/
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
+pip-wheel-metadata/
 
 # Unit test / coverage reports
 htmlcov/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,6 +32,8 @@ sktime/transformations/series/difference.py @rnkuhns
 sktime/transformations/series/exponent.py @rnkuhns
 sktime/transformations/series/scaledlogit.py @ltsaprounis
 sktime/transformations/panel/augmenter.py @MrPr3ntice @iljamaurer
+sktime/transformations/multiplex.py @miraep8
+sktime/transformations/tests/test_multiplexer.py @miraep8
 
 sktime/forecasting/base/ @fkiraly @mloning @aiwalter
 sktime/forecasting/base/adapters/_statsforecast.py @FedericoGarza

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -407,3 +407,16 @@ MovingBlockBootstrapTransformer
     :template: class.rst
 
     MovingBlockBootstrapTransformer
+
+Transformer Selection
+---------------------
+MultiplexTransformer
+~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.transformations.multiplexer
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    MultiplexTransformer

--- a/sktime/transformations/multiplexer.py
+++ b/sktime/transformations/multiplexer.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3 -u
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Implements transformer for selecting among different model classes."""
+
+from sktime.base import _HeterogenousMetaEstimator
+from sktime.transformations._delegate import _DelegatedTransformer
+from sktime.transformations.base import BaseTransformer
+
+__author__ = ["miraep8"]
+__all__ = ["MultiplexTransformer"]
+
+
+class MultiplexTransformer(_DelegatedTransformer, _HeterogenousMetaEstimator):
+    """Facilitate an AutoML based selection of the best transformer.
+
+    When used in combination with either TransformedTargetForecaster or
+    ForecastingPipeline in combination with ForecastingGridSearchCV
+    MultiplexTransformer provides a framework for transformer selection.  Through
+    selection of the appropriate pipeline (ie TransformedTargetForecaster vs
+    ForecastingPipeline) the transformers in MultiplexTransformer will either be
+    applied to exogenous data, or to the target data.
+
+    MultiplexTransformer delegates all transforming tasks (ie, calls to fit, transform,
+    inverse_transform, and update) to a copy of the transformer in transformers
+    whose name matches selected_transformer.  All other transformers in transformers
+    will be ignored.
+
+    Parameters
+    ----------
+    transformers : list of sktime transformers, or
+        list of tuples (str, estimator) of named sktime transformers
+        MultiplexTransformer can switch ("multiplex") between these transformers.
+        Note - all the transformers passed in "transformers" should be thought of as
+        blueprints.  Calling transformation functions on MultiplexTransformer will not
+        change their state at all. - Rather a copy of each is created and this is what
+        is updated.
+    selected_transformer: str or None, optional, Default=None.
+        If str, must be one of the transformer names.
+            If passed in transformers were unnamed then selected_transformer must
+            coincide with auto-generated name strings.
+            To inspect auto-generated name strings, call get_params.
+        If None, selected_transformer defaults to the name of the first transformer
+           in transformers.
+        selected_transformer represents the name of the transformer MultiplexTransformer
+           should behave as (ie delegate all relevant transformation functionality to)
+
+    Attributes
+    ----------
+    transformer_ : sktime transformer
+        clone of the transformer named by selected_transformer to which all the
+        transformation functionality is delegated to.
+    _transformers : list of (name, est) tuples, where est are direct references to
+        the estimators passed in transformers passed. If transformers was passed
+        without names, those be auto-generated and put here.
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_shampoo_sales
+    >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> from sktime.transformations.multiplexer import MultiplexTransformer
+    >>> from sktime.transformations.series.impute import Imputer
+    >>> from sktime.forecasting.compose import TransformedTargetForecaster
+    >>> from sktime.forecasting.model_selection import (
+    ...     ForecastingGridSearchCV,
+    ...     ExpandingWindowSplitter)
+    >>> # create MultiplexTransformer:
+    >>> multiplexer = MultiplexTransformer(transformers=[
+    ...     ("impute_mean", Imputer(method="mean", missing_values = -1)),
+    ...     ("impute_near", Imputer(method="nearest", missing_values = -1)),
+    ...     ("impute_rand", Imputer(method="random", missing_values = -1))])
+    >>> cv = ExpandingWindowSplitter(
+    ...     initial_window=24,
+    ...     step_length=12,
+    ...     start_with_window=True,
+    ...     fh=[1,2,3])
+    >>> pipe = TransformedTargetForecaster(steps = [
+    ...     ("multiplex", multiplexer),
+    ...     ("forecaster", NaiveForecaster())
+    ...     ])
+    >>> gscv = ForecastingGridSearchCV(
+    ...     cv=cv,
+    ...     param_grid={"multiplex__selected_transformer":
+    ...     ["impute_mean", "impute_near", "impute_rand"]},
+    ...     forecaster=pipe,
+    ...     )
+    >>> y = load_shampoo_sales()
+    >>> # randomly make some of the values nans:
+    >>> y.loc[y.sample(frac=0.1).index] = -1
+    >>> gscv = gscv.fit(y)
+    """
+
+    # tags will largely be copied from selected_transformer
+    _tags = {
+        "fit_is_empty": False,
+        "univariate-only": False,
+    }
+
+    _delegate_name = "transformer_"
+
+    def __init__(
+        self,
+        transformers: list,
+        selected_transformer=None,
+    ):
+        super(MultiplexTransformer, self).__init__()
+        self.selected_transformer = selected_transformer
+
+        self.transformers = transformers
+        self._check_estimators(
+            transformers,
+            attr_name="transformers",
+            cls_type=BaseTransformer,
+            clone_ests=False,
+        )
+        self._set_transformer()
+        self.clone_tags(self.transformer_)
+        self.set_tags(**{"fit_is_empty": False})
+
+    @property
+    def _transformers(self):
+        """Forecasters turned into name/est tuples."""
+        return self._get_estimator_tuples(self.transformers, clone_ests=False)
+
+    @_transformers.setter
+    def _transformers(self, value):
+        self.transformers = value
+
+    def _check_selected_transformer(self):
+        component_names = self._get_estimator_names(
+            self._transformers, make_unique=True
+        )
+        selected = self.selected_transformer
+        if selected is not None and selected not in component_names:
+            raise Exception(
+                f"Invalid selected_transformer parameter value provided, "
+                f" found: {selected}. Must be one of these"
+                f" valid selected_transformer parameter values: {component_names}."
+            )
+
+    def _set_transformer(self):
+        self._check_selected_transformer()
+        # clone the selected transformer to self.transformer_
+        if self.selected_transformer is not None:
+            for name, transformer in self._get_estimator_tuples(self.transformers):
+                if self.selected_transformer == name:
+                    self.transformer_ = transformer.clone()
+        else:
+            # if None, simply clone the first transformer to self.transformer_
+            self.transformer_ = self._get_estimator_list(self.transformers)[0].clone()
+
+    def get_params(self, deep=True):
+        """Get parameters for this estimator.
+
+        Parameters
+        ----------
+        deep : boolean, optional
+            If True, will return the parameters for this estimator and
+            contained subobjects that are estimators.
+
+        Returns
+        -------
+        params : mapping of string to any
+            Parameter names mapped to their values.
+        """
+        return self._get_params("_transformers", deep=deep)
+
+    def set_params(self, **kwargs):
+        """Set the parameters of this estimator.
+
+        Valid parameter keys can be listed with ``get_params()``.
+
+        Returns
+        -------
+        self
+        """
+        self._set_params("_transformers", **kwargs)
+        return self
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict
+        """
+        from sktime.transformations.series.impute import Imputer
+
+        # test with 2 simple detrend transformations with selected_transformer
+        params1 = {
+            "transformers": [
+                ("imputer_mean", Imputer(method="mean")),
+                ("imputer_near", Imputer(method="nearest")),
+            ],
+            "selected_transformer": "imputer_near",
+        }
+        # test no selected_transformer
+        params2 = {
+            "transformers": [
+                Imputer(method="mean"),
+                Imputer(method="nearest"),
+            ],
+        }
+        return [params1, params2]

--- a/sktime/transformations/tests/test_multiplexer.py
+++ b/sktime/transformations/tests/test_multiplexer.py
@@ -18,7 +18,7 @@ from sktime.forecasting.model_selection import (
 )
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.transformations.multiplexer import MultiplexTransformer
-from sktime.transformations.series.impute import Imputer
+from sktime.transformations.series.exponent import ExponentTransformer
 from sktime.utils.validation.forecasting import check_scoring
 
 
@@ -34,8 +34,8 @@ def test_multiplex_transformer_alone():
     y.loc[y.sample(frac=0.1).index] = pd.np.nan
     # Note - we select two forecasters which are deterministic.
     transformer_tuples = [
-        ("mean", Imputer(method="mean")),
-        ("nearest", Imputer(method="nearest")),
+        ("two", ExponentTransformer(2)),
+        ("three", ExponentTransformer(3)),
     ]
     transformer_names = [name for name, _ in transformer_tuples]
     transformers = [transformer for _, transformer in transformer_tuples]
@@ -81,8 +81,8 @@ def test_multiplex_transformer_in_grid():
     y.iloc[[5, 10, 15, 25, 32]] = -1
     # Note - we select two forecasters which are deterministic.
     transformer_tuples = [
-        ("mean", Imputer(method="mean", missing_values=-1)),
-        ("nearest", Imputer(method="nearest", missing_values=-1)),
+        ("two", ExponentTransformer(2)),
+        ("three", ExponentTransformer(3)),
     ]
     transformer_names = [name for name, _ in transformer_tuples]
     multiplex_transformer = MultiplexTransformer(transformers=transformer_tuples)

--- a/sktime/transformations/tests/test_multiplexer.py
+++ b/sktime/transformations/tests/test_multiplexer.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3 -u
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for MultiplexTransformer and associated dunders."""
+
+__author__ = ["miraep8"]
+
+import pandas as pd
+from numpy.testing import assert_array_equal
+from sklearn.base import clone
+
+from sktime.datasets import load_shampoo_sales
+from sktime.forecasting.compose import TransformedTargetForecaster
+from sktime.forecasting.model_evaluation import evaluate
+from sktime.forecasting.model_selection import (
+    ExpandingWindowSplitter,
+    ForecastingGridSearchCV,
+)
+from sktime.forecasting.naive import NaiveForecaster
+from sktime.transformations.multiplexer import MultiplexTransformer
+from sktime.transformations.series.impute import Imputer
+from sktime.utils.validation.forecasting import check_scoring
+
+
+def test_multiplex_transformer_alone():
+    """Test behavior of MultiplexTransformer.
+
+    Because MultiplexTransformer is in many ways a wrapper for an underlying
+    transformer - we can confirm that if the selected_transformer is set that the
+    MultiplexTransformer delegates all its transformation responsibilities as expected.
+    """
+    y = load_shampoo_sales()
+    # randomly make some of the values nans:
+    y.loc[y.sample(frac=0.1).index] = pd.np.nan
+    # Note - we select two forecasters which are deterministic.
+    transformer_tuples = [
+        ("mean", Imputer(method="mean")),
+        ("nearest", Imputer(method="nearest")),
+    ]
+    transformer_names = [name for name, _ in transformer_tuples]
+    transformers = [transformer for _, transformer in transformer_tuples]
+    multiplex_transformer = MultiplexTransformer(transformers=transformer_tuples)
+    # for each of the forecasters - check that the wrapped forecaster predictions
+    # agree with the unwrapped forecaster predictions!
+    for ind, name in enumerate(transformer_names):
+        # make a copy to ensure we don't reference the same objectL
+        test_transformer = clone(transformers[ind])
+        y_transform_indiv = test_transformer.fit_transform(X=y)
+        multiplex_transformer.selected_transformer = name
+        # Note- MultiplexForecaster will make a copy of the forecaster before fitting.
+        y_transform_multi = multiplex_transformer.fit_transform(X=y)
+        assert_array_equal(y_transform_indiv, y_transform_multi)
+
+
+def _find_best_transformer(forecaster, transformers, cv, y):
+    """Evaluate all the forecasters on y and return the name of best."""
+    scoring = check_scoring(None)
+    scoring_name = f"test_{scoring.name}"
+    score = None
+    for name, transformer in transformers:
+        test_transformer = clone(transformer)
+        y_hat = test_transformer.fit_transform(y)
+        results = evaluate(clone(forecaster), cv, y_hat)
+        results = results.mean()
+        new_score = float(results[scoring_name])
+        if not score or new_score < score:
+            score = new_score
+            best_name = name
+    return best_name
+
+
+def test_multiplex_transformer_in_grid():
+    """Test behavior of MultiplexTransformer.
+
+    It often makes sense to use MultiplexTransformer in conjunction with
+    ForecastingGridSearchCV within a pipeline.  Here we check that when you do that
+    you get the expected result.
+    """
+    y = load_shampoo_sales()
+    # randomly make some of the values nans:
+    y.iloc[[5, 10, 15, 25, 32]] = -1
+    # Note - we select two forecasters which are deterministic.
+    transformer_tuples = [
+        ("mean", Imputer(method="mean", missing_values=-1)),
+        ("nearest", Imputer(method="nearest", missing_values=-1)),
+    ]
+    transformer_names = [name for name, _ in transformer_tuples]
+    multiplex_transformer = MultiplexTransformer(transformers=transformer_tuples)
+    cv = ExpandingWindowSplitter(
+        initial_window=24, step_length=12, start_with_window=True, fh=[1, 2, 3]
+    )
+    pipe = TransformedTargetForecaster(
+        steps=[
+            ("multiplex", multiplex_transformer),
+            ("forecaster", NaiveForecaster(strategy="mean")),
+        ]
+    )
+    gscv = ForecastingGridSearchCV(
+        cv=cv,
+        param_grid={"multiplex__selected_transformer": transformer_names},
+        forecaster=pipe,
+    )
+    gscv.fit(y)
+    best_steps = gscv.best_forecaster_.steps
+    for name, estimator in best_steps:
+        if "multiplex" == name:
+            gscv_best_name = estimator.selected_transformer
+    best_name = _find_best_transformer(
+        NaiveForecaster(strategy="mean"), transformer_tuples, cv, y
+    )
+    assert gscv_best_name == best_name


### PR DESCRIPTION
Restored #2738 to allow fixing remaining CI/CD failure.

The failure is fixed by aligning both sides of the comparison in the test `test_multiplex_transformer_in_grid`, by using a transformer without fit that is element-wise (`ExponentTransformer`). Previously, the sides would not necessarily agree, since in one side fit/transform is done on the entire batch, in the other sequentially/stream-wise.