### PR TITLE
[MNT] remove accidental codecov overwrite from nosoftdeps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,6 +181,3 @@ jobs:
 
       - name: Run tests
         run: make PYTESTOPTIONS="--cov --cov-report=xml --timeout=600" test_softdeps
-
-      - name: Publish code coverage
-        uses: codecov/codecov-action@v2


### PR DESCRIPTION
Accidentally, the new `nosoftdeps` worfklow was overwriting code coverage from the full tests.

This PR removes that accidental overwrite.