### PR TITLE
[MNT] experimental removal of upper bound `holidays` to 0.13 in soft dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ all_extras = [
     "dtw-python",
     "esig==0.9.7",
     "prophet>=1.0",
-    "holidays<=0.13",
     "hcrystalball>=0.1.9",
     "matplotlib>=3.3.2",
     "pmdarima>=1.8.0,!=1.8.1",


### PR DESCRIPTION
Reverts alan-turing-institute/sktime#2749, to check whether facebook prophet have resolved their problem https://github.com/alan-turing-institute/sktime/issues/2748 with `holidays`, pre-0.12.0 release. Fixes #2748.

If it passes, we can merge to undo the upper bound temporary workaround.
