### PR TITLE
[BUG] attempted fix 2 to #2739 - removing `pd.Series` name as soon as seen

### DIFF
--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -70,6 +70,8 @@ def convert_UvS_to_MvS_as_Series(obj: pd.Series, store=None) -> pd.DataFrame:
     if not isinstance(obj, pd.Series):
         raise TypeError("input must be a pd.Series")
 
+    obj = obj.copy()
+    obj.name = None
     res = pd.DataFrame(obj)
 
     if (
@@ -96,10 +98,10 @@ def convert_MvS_to_UvS_as_Series(obj: pd.DataFrame, store=None) -> pd.Series:
     if isinstance(store, dict):
         store["columns"] = obj.columns[[0]]
 
-    y = obj[obj.columns[0]]
-    y.name = None
+    res = obj[obj.columns[0]]
+    res.name = None
 
-    return y
+    return res
 
 
 convert_dict[("pd.DataFrame", "pd.Series", "Series")] = convert_MvS_to_UvS_as_Series

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -51,6 +51,20 @@ for tp in ["pd.Series", "pd.DataFrame", "np.ndarray"]:
     convert_dict[(tp, tp, "Series")] = convert_identity
 
 
+def convert_UvS_to_UvS_strict_as_Series(obj: pd.Series, store=None) -> pd.Series:
+
+    if not isinstance(obj, pd.Series):
+        raise TypeError("input must be a pd.Series")
+
+    obj = obj.copy()
+    obj.name = None
+
+    return obj
+
+
+convert_dict[("pd.Series", "pd.Series", "Series")] = convert_UvS_to_UvS_strict_as_Series
+
+
 def convert_UvS_to_MvS_as_Series(obj: pd.Series, store=None) -> pd.DataFrame:
 
     if not isinstance(obj, pd.Series):

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -14,7 +14,9 @@ from sktime.datasets import load_airline
 from sktime.forecasting.compose import ForecastingPipeline, TransformedTargetForecaster
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.forecasting.naive import NaiveForecaster
+from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.transformations.series.adapt import TabularToSeriesAdaptor
+from sktime.transformations.series.detrend import Detrender
 from sktime.transformations.series.exponent import ExponentTransformer
 from sktime.transformations.series.impute import Imputer
 from sktime.transformations.series.outlier_detection import HampelFilter
@@ -106,3 +108,17 @@ def test_nesting_pipelines():
     scenario = ForecasterFitPredictUnivariateWithX()
 
     scenario.run(pipe, method_sequence=["fit", "predict"])
+
+
+def test_pipeline_with_detrender():
+    """Tests a specific pipeline that triggers multiple back/forth conversions."""
+    y = load_airline()
+
+    trans_fc = TransformedTargetForecaster(
+        [
+            ("detrender", Detrender(forecaster=PolynomialTrendForecaster(degree=1))),
+            ("forecaster", NaiveForecaster(strategy="last")),
+        ]
+    )
+    trans_fc.fit(y)
+    trans_fc.predict(1)


### PR DESCRIPTION
This is an attempted fix for #2739.

The fix is ensuring that, whenever seeing a `pd.Series`, its `name` is removed.

Includes #2790 to check that we've solved #2739.