### PR TITLE
[DOC] cleaning up forecasting API reference

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -267,18 +267,8 @@ Model selection and tuning
     :toctree: auto_generated/
     :template: class.rst
 
-    CutoffSplitter
-    SingleWindowSplitter
-    SlidingWindowSplitter
-    ExpandingWindowSplitter
     ForecastingGridSearchCV
     ForecastingRandomizedSearchCV
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: function.rst
-
-    temporal_train_test_split
 
 Model Evaluation (Backtesting)
 ------------------------------
@@ -290,3 +280,25 @@ Model Evaluation (Backtesting)
     :template: function.rst
 
     evaluate
+
+Time series splitters
+---------------------
+
+Time series splitters can be used in both evaluation and tuning.
+
+.. currentmodule:: sktime.forecasting.model_selection
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    CutoffSplitter
+    SingleWindowSplitter
+    SlidingWindowSplitter
+    ExpandingWindowSplitter
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: function.rst
+
+    temporal_train_test_split

--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -44,6 +44,7 @@ Pipelines can also be constructed using ``*``, ``+``, and ``|`` dunders.
     ForecastingPipeline
     ColumnEnsembleForecaster
     MultiplexForecaster
+    ForecastX
 
 Reduction
 ---------

--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -6,6 +6,8 @@ Forecasting
 
 The :mod:`sktime.forecasting` module contains algorithms and composition tools for forecasting.
 
+Use ``sktime.registry.all_estimators`` and ``sktime.registry.all_tags`` for dynamic search and tag-based listing of forecasters.
+
 Base
 ----
 

--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -250,16 +250,6 @@ Online and stream forecasting
     NormalHedgeEnsemble
     NNLSEnsemble
 
-.. currentmodule:: sktime.forecasting.online_learning
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    OnlineEnsembleForecaster
-    NormalHedgeEnsemble
-    NNLSEnsemble
-
 .. currentmodule:: sktime.forecasting.stream
 
 .. autosummary::

--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -15,10 +15,63 @@ Base
     :toctree: auto_generated/
     :template: class.rst
 
+    BaseForecaster
     ForecastingHorizon
 
-Naive
------
+Pipeline composition
+--------------------
+
+Compositors for building forecasting pipelines.
+Pipelines can also be constructed using ``*``, ``+``, and ``|`` dunders.
+
+.. currentmodule:: sktime.pipeline
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: function.rst
+
+    make_pipeline
+
+.. currentmodule:: sktime.forecasting.compose
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    TransformedTargetForecaster
+    ForecastingPipeline
+    ColumnEnsembleForecaster
+    MultiplexForecaster
+
+Reduction
+---------
+
+Reduction forecasters that use ``sklearn`` regressors or ``sktime`` time series regressors to make forecasts.
+Use ``make_reduction`` for easy specification.
+
+.. currentmodule:: sktime.forecasting.compose
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: function.rst
+
+    make_reduction
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    DirectTabularRegressionForecaster
+    DirectTimeSeriesRegressionForecaster
+    MultioutputTabularRegressionForecaster
+    MultioutputTimeSeriesRegressionForecaster
+    RecursiveTabularRegressionForecaster
+    RecursiveTimeSeriesRegressionForecaster
+    DirRecTabularRegressionForecaster
+    DirRecTimeSeriesRegressionForecaster
+
+Naive forecaster
+----------------
 
 .. currentmodule:: sktime.forecasting.naive
 
@@ -27,10 +80,30 @@ Naive
     :template: class.rst
 
     NaiveForecaster
+
+Prediction intervals
+--------------------
+
+Wrappers that add prediction intervals to any forecaster.
+
+.. currentmodule:: sktime.forecasting.naive
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
     NaiveVariance
 
-Trend
------
+.. currentmodule:: sktime.forecasting.conformal
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ConformalIntervals
+
+Trend forecasters
+-----------------
 
 .. currentmodule:: sktime.forecasting.trend
 
@@ -42,8 +115,8 @@ Trend
     PolynomialTrendForecaster
     STLForecaster
 
-Exponential Smoothing
----------------------
+Exponential smoothing based forecasters
+---------------------------------------
 
 .. currentmodule:: sktime.forecasting.exp_smoothing
 
@@ -61,8 +134,27 @@ Exponential Smoothing
 
     AutoETS
 
-ARIMA
------
+.. currentmodule:: sktime.forecasting.theta
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ThetaForecaster
+
+.. currentmodule:: sktime.forecasting.croston
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    Croston
+
+AR/MA type forecasters
+----------------------
+
+Forecasters with AR or MA component.
+All "ARIMA" models below include VARIMAX capability.
 
 .. currentmodule:: sktime.forecasting.arima
 
@@ -73,9 +165,6 @@ ARIMA
     AutoARIMA
     ARIMA
 
-StatsForecast
--------------
-
 .. currentmodule:: sktime.forecasting.statsforecast
 
 .. autosummary::
@@ -84,19 +173,24 @@ StatsForecast
 
     StatsForecastAutoARIMA
 
-Theta
------
-
-.. currentmodule:: sktime.forecasting.theta
+.. currentmodule:: sktime.forecasting.sarimax
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    ThetaForecaster
+    SARIMAX
 
-BATS/TBATS
-----------
+.. currentmodule:: sktime.forecasting.var
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    VAR
+
+Structural time series models
+-----------------------------
 
 .. currentmodule:: sktime.forecasting.bats
 
@@ -114,20 +208,6 @@ BATS/TBATS
 
     TBATS
 
-Croston
--------
-
-.. currentmodule:: sktime.forecasting.croston
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    Croston
-
-Prophet
--------
-
 .. currentmodule:: sktime.forecasting.fbprophet
 
 .. autosummary::
@@ -135,9 +215,6 @@ Prophet
     :template: class.rst
 
     Prophet
-
-Unobserved Components
---------------------
 
 .. currentmodule:: sktime.forecasting.structural
 
@@ -147,8 +224,8 @@ Unobserved Components
 
     UnobservedComponents
 
-Composition
------------
+Ensembles and stacking
+----------------------
 
 .. currentmodule:: sktime.forecasting.compose
 
@@ -156,30 +233,12 @@ Composition
     :toctree: auto_generated/
     :template: class.rst
 
-    ColumnEnsembleForecaster
     EnsembleForecaster
     AutoEnsembleForecaster
     StackingForecaster
-    TransformedTargetForecaster
-    ForecastingPipeline
-    DirectTabularRegressionForecaster
-    DirectTimeSeriesRegressionForecaster
-    MultioutputTabularRegressionForecaster
-    MultioutputTimeSeriesRegressionForecaster
-    RecursiveTabularRegressionForecaster
-    RecursiveTimeSeriesRegressionForecaster
-    DirRecTabularRegressionForecaster
-    DirRecTimeSeriesRegressionForecaster
-    MultiplexForecaster
 
-.. autosummary::
-    :toctree: auto_generated/
-    :template: function.rst
-
-    make_reduction
-
-Online Forecasting
-------------------
+Online and stream forecasting
+-----------------------------
 
 .. currentmodule:: sktime.forecasting.online_learning
 
@@ -191,8 +250,26 @@ Online Forecasting
     NormalHedgeEnsemble
     NNLSEnsemble
 
-Model Selection
----------------
+.. currentmodule:: sktime.forecasting.online_learning
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    OnlineEnsembleForecaster
+    NormalHedgeEnsemble
+    NNLSEnsemble
+
+.. currentmodule:: sktime.forecasting.stream
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    UpdateRefitsEvery
+
+Model selection and tuning
+--------------------------
 
 .. currentmodule:: sktime.forecasting.model_selection
 
@@ -223,25 +300,3 @@ Model Evaluation (Backtesting)
     :template: function.rst
 
     evaluate
-
-VAR (Vector Autoregression)
----------------------------
-
-.. currentmodule:: sktime.forecasting.var
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    VAR
-
-SARIMAX
-----------
-
-.. currentmodule:: sktime.forecasting.sarimax
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    SARIMAX

--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -154,7 +154,7 @@ AR/MA type forecasters
 ----------------------
 
 Forecasters with AR or MA component.
-All "ARIMA" models below include VARIMAX capability.
+All "ARIMA" models below include SARIMAX capability.
 
 .. currentmodule:: sktime.forecasting.arima
 


### PR DESCRIPTION
This cleans up the forecasting API reference and adds some missing forecasters.