### PR TITLE
[DOC] add missing TonyBagnall to contributors of 0.12.0 in changelog

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -288,6 +288,7 @@ Contributors
 :user:`miraep8`,
 :user:`NoaBenAmi`,
 :user:`Ris-Bali`,
+:user:`TonyBagnall`,
 :user:`ZiyaoWei`
 
 


### PR DESCRIPTION
By accident, @TonyBagnall did not make it on the overall contributor list of 0.12.0.
The release is already on its way, but we should add him in.

The reason for the accident is the bug https://github.com/alan-turing-institute/sktime/issues/2796 in the release script, and that @TonyBagnall did not have a PR merged that was opened between 0.11.4 and 0.12.0.
(this shows that the bug also affects the list of contributors, not just the PR which I added manually in this case)

@TonyBagnall is individually credited next to his merged PR, as well as in the first line of the "highlights", so I hope there is not too much harm done.