### PR TITLE
[ENH] Adding | dunder for MultiplexTransformer

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -40,7 +40,7 @@ State:
     fitted state inspection - check_is_fitted()
 """
 
-__author__ = ["mloning, fkiraly"]
+__author__ = ["mloning, fkiraly", "miraep8"]
 __all__ = [
     "BaseTransformer",
     "_SeriesToPrimitivesTransformer",
@@ -195,6 +195,29 @@ class BaseTransformer(BaseEstimator):
         if isinstance(other, BaseTransformer) or is_sklearn_transformer(other):
             self_as_pipeline = TransformerPipeline(steps=[self])
             return other * self_as_pipeline
+        else:
+            return NotImplemented
+
+    def __or__(self, other):
+        """Magic | method, return MultiplexTranformer.
+
+        Implemented for `other` being either a MultiplexTransformer or a transformer.
+
+        Parameters
+        ----------
+        other: `sktime` transformer or sktime MultiplexTransformer
+
+        Returns
+        -------
+        MultiplexTransformer object
+        """
+        from sktime.transformations.compose import MultiplexTransformer
+
+        if isinstance(other, MultiplexTransformer) or isinstance(
+            other, BaseTransformer
+        ):
+            multiplex_self = MultiplexTransformer([self])
+            return multiplex_self | other
         else:
             return NotImplemented
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -40,7 +40,7 @@ State:
     fitted state inspection - check_is_fitted()
 """
 
-__author__ = ["mloning, fkiraly", "miraep8"]
+__author__ = ["mloning", "fkiraly", "miraep8"]
 __all__ = [
     "BaseTransformer",
     "_SeriesToPrimitivesTransformer",
@@ -213,9 +213,7 @@ class BaseTransformer(BaseEstimator):
         """
         from sktime.transformations.compose import MultiplexTransformer
 
-        if isinstance(other, MultiplexTransformer) or isinstance(
-            other, BaseTransformer
-        ):
+        if isinstance(other, BaseTransformer):
             multiplex_self = MultiplexTransformer([self])
             return multiplex_self | other
         else:

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -854,8 +854,8 @@ class MultiplexTransformer(_DelegatedTransformer, _HeterogenousMetaEstimator):
         the estimators passed in transformers passed. If transformers was passed
         without names, those be auto-generated and put here.
 
-    Example 1 - Use in GridSearch
-    -----------------------------
+    Examples
+    --------
     >>> from sktime.datasets import load_shampoo_sales
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.transformations.compose import MultiplexTransformer
@@ -888,13 +888,6 @@ class MultiplexTransformer(_DelegatedTransformer, _HeterogenousMetaEstimator):
     >>> # randomly make some of the values nans:
     >>> y.loc[y.sample(frac=0.1).index] = -1
     >>> gscv = gscv.fit(y)
-    Example 2 - Creation with or dunder:
-    ------------------------------------
-    >>> from sktime.transformations.compose import MultiplexTransformer
-    >>> from sktime.transformations.series.impute import Imputer
-    >>> multiplexer = Imputer(method="mean", missing_values = -1) |
-    ...     Imputer(method="nearest", missing_values = -1) |
-    ...     Imputer(method="random", missing_values = -1)
     """
 
     # tags will largely be copied from selected_transformer

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -220,6 +220,7 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
         # if sklearn classifier, use sklearn classifier pipeline
         if is_sklearn_classifier(other):
             return SklearnClassifierPipeline(classifier=other, transformers=self.steps)
+
         return self._dunder_concat(
             other=other,
             base_class=BaseTransformer,

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -888,8 +888,8 @@ class MultiplexTransformer(_DelegatedTransformer, _HeterogenousMetaEstimator):
     >>> # randomly make some of the values nans:
     >>> y.loc[y.sample(frac=0.1).index] = -1
     >>> gscv = gscv.fit(y)
-    Example 2 - Creation with | dunder:
-    -----------------------------------
+    Example 2 - Creation with or dunder:
+    ------------------------------------
     >>> from sktime.transformations.compose import MultiplexTransformer
     >>> from sktime.transformations.series.impute import Imputer
     >>> multiplexer = Imputer(method="mean", missing_values = -1) |

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -854,8 +854,8 @@ class MultiplexTransformer(_DelegatedTransformer, _HeterogenousMetaEstimator):
         the estimators passed in transformers passed. If transformers was passed
         without names, those be auto-generated and put here.
 
-    Examples
-    --------
+    Example 1 - Use in GridSearch
+    -----------------------------
     >>> from sktime.datasets import load_shampoo_sales
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.transformations.compose import MultiplexTransformer
@@ -888,6 +888,13 @@ class MultiplexTransformer(_DelegatedTransformer, _HeterogenousMetaEstimator):
     >>> # randomly make some of the values nans:
     >>> y.loc[y.sample(frac=0.1).index] = -1
     >>> gscv = gscv.fit(y)
+    Example 2 - Creation with | dunder:
+    -----------------------------------
+    >>> from sktime.transformations.compose import MultiplexTransformer
+    >>> from sktime.transformations.series.impute import Imputer
+    >>> multiplexer = Imputer(method="mean", missing_values = -1) |
+    ...     Imputer(method="nearest", missing_values = -1) |
+    ...     Imputer(method="random", missing_values = -1)
     """
 
     # tags will largely be copied from selected_transformer
@@ -1009,3 +1016,55 @@ class MultiplexTransformer(_DelegatedTransformer, _HeterogenousMetaEstimator):
             ],
         }
         return [params1, params2]
+
+    def __or__(self, other):
+        """Magic | (or) method, return (right) concatenated MultiplexTransformer.
+
+        Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
+
+        Parameters
+        ----------
+        other: `sktime` transformer, must inherit from BaseTransformer
+            otherwise, `NotImplemented` is returned
+
+        Returns
+        -------
+        MultiplexTransformer object, concatenation of `self` (first) with `other`
+            (last).not nested, contains only non-MultiplexTransformer `sktime`
+            transformers
+
+        Raises
+        ------
+        ValueError if other is not of type MultiplexTransformer or BaseTransformer.
+        """
+        return self._dunder_concat(
+            other=other,
+            base_class=BaseTransformer,
+            composite_class=MultiplexTransformer,
+            attr_name="transformers",
+            concat_order="left",
+        )
+
+    def __ror__(self, other):
+        """Magic | (or) method, return (left) concatenated MultiplexTransformer.
+
+        Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
+
+        Parameters
+        ----------
+        other: `sktime` transformer, must inherit from BaseTransformer
+            otherwise, `NotImplemented` is returned
+
+        Returns
+        -------
+        MultiplexTransformer object, concatenation of `self` (last) with `other`
+            (first). not nested, contains only non-MultiplexTransformer `sktime`
+            transformers
+        """
+        return self._dunder_concat(
+            other=other,
+            base_class=BaseTransformer,
+            composite_class=MultiplexTransformer,
+            attr_name="forecasters",
+            concat_order="right",
+        )

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -20,7 +20,7 @@ __all__ = [
 ]
 
 
-def coerce_to_sktime(other):
+def _coerce_to_sktime(other):
     """Check and format inputs to dunders for compose."""
     from sktime.transformations.series.adapt import TabularToSeriesAdaptor
 
@@ -215,7 +215,7 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
         """
         from sktime.classification.compose import SklearnClassifierPipeline
 
-        other = coerce_to_sktime(other)
+        other = _coerce_to_sktime(other)
 
         # if sklearn classifier, use sklearn classifier pipeline
         if is_sklearn_classifier(other):
@@ -244,7 +244,7 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
         TransformerPipeline object, concatenation of `other` (first) with `self` (last).
             not nested, contains only non-TransformerPipeline `sktime` steps
         """
-        other = coerce_to_sktime(other)
+        other = _coerce_to_sktime(other)
         return self._dunder_concat(
             other=other,
             base_class=BaseTransformer,
@@ -1019,7 +1019,7 @@ class MultiplexTransformer(_DelegatedTransformer, _HeterogenousMetaEstimator):
         ------
         ValueError if other is not of type MultiplexTransformer or BaseTransformer.
         """
-        other = coerce_to_sktime(other)
+        other = _coerce_to_sktime(other)
         return self._dunder_concat(
             other=other,
             base_class=BaseTransformer,
@@ -1044,7 +1044,7 @@ class MultiplexTransformer(_DelegatedTransformer, _HeterogenousMetaEstimator):
             (first). not nested, contains only non-MultiplexTransformer `sktime`
             transformers
         """
-        other = coerce_to_sktime(other)
+        other = _coerce_to_sktime(other)
         return self._dunder_concat(
             other=other,
             base_class=BaseTransformer,

--- a/sktime/transformations/tests/test_multiplexer.py
+++ b/sktime/transformations/tests/test_multiplexer.py
@@ -6,6 +6,7 @@
 __author__ = ["miraep8"]
 
 import pandas as pd
+import pytest
 from numpy.testing import assert_array_equal
 from sklearn.base import clone
 
@@ -32,7 +33,7 @@ def test_multiplex_transformer_alone():
     y = load_shampoo_sales()
     # randomly make some of the values nans:
     y.loc[y.sample(frac=0.1).index] = pd.np.nan
-    # Note - we select two forecasters which are deterministic.
+    # Note - we select two transformers which are deterministic.
     transformer_tuples = [
         ("two", ExponentTransformer(2)),
         ("three", ExponentTransformer(3)),
@@ -40,20 +41,20 @@ def test_multiplex_transformer_alone():
     transformer_names = [name for name, _ in transformer_tuples]
     transformers = [transformer for _, transformer in transformer_tuples]
     multiplex_transformer = MultiplexTransformer(transformers=transformer_tuples)
-    # for each of the forecasters - check that the wrapped forecaster predictions
-    # agree with the unwrapped forecaster predictions!
+    # for each of the transformers - check that the wrapped transformer predictions
+    # agree with the unwrapped transformer (in combo with forecaster) predictions!
     for ind, name in enumerate(transformer_names):
         # make a copy to ensure we don't reference the same objectL
         test_transformer = clone(transformers[ind])
         y_transform_indiv = test_transformer.fit_transform(X=y)
         multiplex_transformer.selected_transformer = name
-        # Note- MultiplexForecaster will make a copy of the forecaster before fitting.
+        # Note- MultiplexTransformer will make a copy of the transformer before fitting.
         y_transform_multi = multiplex_transformer.fit_transform(X=y)
         assert_array_equal(y_transform_indiv, y_transform_multi)
 
 
 def _find_best_transformer(forecaster, transformers, cv, y):
-    """Evaluate all the forecasters on y and return the name of best."""
+    """Evaluate all the transformers on y and return the name of best."""
     scoring = check_scoring(None)
     scoring_name = f"test_{scoring.name}"
     score = None
@@ -79,7 +80,7 @@ def test_multiplex_transformer_in_grid():
     y = load_shampoo_sales()
     # randomly make some of the values nans:
     y.iloc[[5, 10, 15, 25, 32]] = -1
-    # Note - we select two forecasters which are deterministic.
+    # Note - we select two transformers which are deterministic.
     transformer_tuples = [
         ("two", ExponentTransformer(2)),
         ("three", ExponentTransformer(3)),
@@ -109,3 +110,42 @@ def test_multiplex_transformer_in_grid():
         NaiveForecaster(strategy="mean"), transformer_tuples, cv, y
     )
     assert gscv_best_name == best_name
+
+
+def test_multiplex_or_dunder():
+    """Test that the MultiplexTransforemer magic "|" dunder works.
+
+    A MultiplexTransformer can be created by using the "|" dunder method on
+    either transformer or MultiplexTransformer objects. Here we test that it performs
+    as expected on all the use cases, and raises the expected error in some others.
+    """
+    # test a simple | example with two transformers:
+    multiplex_two_transformers = ExponentTransformer(2) | ExponentTransformer(3)
+    assert isinstance(multiplex_two_transformers, MultiplexTransformer)
+    assert len(multiplex_two_transformers.transformers) == 2
+    # now test that | also works on two MultiplexTransformers:
+    multiplex_one = MultiplexTransformer(
+        [("exp_2", ExponentTransformer(2)), ("exp_3", ExponentTransformer(3))]
+    )
+    multiplex_two = MultiplexTransformer(
+        [("exp_4", ExponentTransformer(4)), ("exp_5", ExponentTransformer(5))]
+    )
+
+    multiplex_two_multiplex = multiplex_one | multiplex_two
+    assert isinstance(multiplex_two_multiplex, MultiplexTransformer)
+    assert len(multiplex_two_multiplex.transformers) == 4
+    # last we will check 3 transformers with the same name - should check both that
+    # MultiplexTransformer | transformer works, and that ensure_unique_names works
+    multiplex_same_name_three_test = (
+        ExponentTransformer(2) | ExponentTransformer(3) | ExponentTransformer(4)
+    )
+    assert isinstance(multiplex_same_name_three_test, MultiplexTransformer)
+    assert len(multiplex_same_name_three_test._transformers) == 3
+    transformer_param_names = multiplex_same_name_three_test._get_estimator_names(
+        multiplex_same_name_three_test._transformers
+    )
+    assert len(set(transformer_param_names)) == 3
+
+    # test we get a ValueError if we try to | with anything else:
+    with pytest.raises(TypeError):
+        multiplex_one | "this shouldn't work"


### PR DESCRIPTION
Related to design discussion on transformer dunder methods in #2459.  Also related to #2670 #2738

The `|` dunder is implemented the same way it is for `MultiplexForecaster` (ie makes use of `dunder_concat`). There are also tests for this that pass locally. 