### PR TITLE
[BUG] fixing type conversion for proba interval wrappers

### DIFF
--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -85,6 +85,8 @@ class ConformalIntervals(BaseForecaster):
         "handles-missing-data": False,
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
+        "y_inner_mtype": ["pd.DataFrame", "pd.Series"],
+        "X_inner_mtype": "pd.DataFrame",
     }
 
     ALLOWED_METHODS = [
@@ -123,8 +125,6 @@ class ConformalIntervals(BaseForecaster):
             "requires-fh-in-fit",
             "ignores-exogeneous-X",
             "handles-missing-data",
-            "y_inner_mtype",
-            "X_inner_mtype",
             "X-y-must-have-same-index",
             "enforce_index_type",
         ]

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -474,6 +474,8 @@ class NaiveVariance(BaseForecaster):
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
         "capability:pred_var": True,
+        "y_inner_mtype": ["pd.DataFrame", "pd.Series"],
+        "X_inner_mtype": "pd.DataFrame",
     }
 
     def __init__(self, forecaster, initial_window=1, verbose=False):
@@ -487,8 +489,6 @@ class NaiveVariance(BaseForecaster):
             "requires-fh-in-fit",
             "ignores-exogeneous-X",
             "handles-missing-data",
-            "y_inner_mtype",
-            "X_inner_mtype",
             "X-y-must-have-same-index",
             "enforce_index_type",
         ]


### PR DESCRIPTION
This fixes the outer layer of data format conversions for the wrappers that add probabilistic intervals, `NaiveVariance` and `ConformalIntervals`.

Prior to this PR, both estimators would copy over the `X_inner_mtype` and `y_inner_mtype` tags from the wrapped forecaster, but the residual matrix computation logic required specifically `pandas.Series`.

Therefore, the resulting forecaster would break whenever the internal forecaster had an inner mtype other than `pandas.Series`,  for instance `pandas.DataFrame` for multivariate forecasters or pipelines, as in bug https://github.com/alan-turing-institute/sktime/issues/2767.

This PR fixes https://github.com/alan-turing-institute/sktime/issues/2767 and similar interactions with wrapped forecasters.