### PR TITLE
[DOC] cleaning up transformer API reference

### DIFF
--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -122,19 +122,6 @@ These transformers extract simple summary features.
     RandomIntervalFeatureExtractor
     FittedParamExtractor
 
-Dictionary-based features
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. currentmodule:: sktime.transformations.panel.dictionary_based
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    PAA
-    SFA
-    SAX
-
 Kernel and wavelet based features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -157,7 +144,7 @@ Kernel and wavelet based features
     DWTTransformer
 
 Distance-based features
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: sktime.transformations.panel.matrix_profile
 
@@ -166,6 +153,19 @@ Distance-based features
     :template: class.rst
 
     MatrixProfile
+
+Dictionary-based features
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.transformations.panel.dictionary_based
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    PAA
+    SFA
+    SAX
 
 Moment-based features
 ~~~~~~~~~~~~~~~~~~~~~
@@ -283,7 +283,7 @@ Filtering and denoising
     ThetaLinesTransformer
 
 Differencing and slope
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: sktime.transformations.series.difference
 

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -10,6 +10,33 @@ transformations.
    :no-members:
    :no-inherited-members:
 
+Transformations are categorized as follows:
+
+
+.. list-table::
+   :header-rows: 1
+
+   * - Category
+     - Explanation
+     - Example
+   * - Composition
+     - Building blocks for pipelines, wrappers, adapters
+     - Transformer pipeline
+   * - Series-to-features
+     - Transforms series to float/category vector
+     - Length and mean
+   * - Series-to-series
+     - Transforms individual series to series
+     - Differencing, detrending
+   * - Series-to-Panel
+     - transforms a series into a panel
+     - Bootstrap, sliding window
+   * - Panel transform
+     - Transforms panel to panel, not by-series
+     - Padding to equal length
+   * - Hierarchical
+     - uses hierarchy information non-trivially
+     - Reconciliation
 
 Composition
 -----------

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -45,6 +45,29 @@ Pipeline building
 
     ColumnTransformer
 
+.. currentmodule:: sktime.transformations.series.func_transform
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    FunctionTransformer
+
+.. currentmodule:: sktime.transformations.panel.compose
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    SeriesToSeriesRowTransformer
+    SeriesToPrimitivesRowTransformer
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: function.rst
+
+    make_row_transformer
+
 Sklearn and pandas adapters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -65,24 +88,28 @@ Sklearn and pandas adapters
     TabularToSeriesAdaptor
     PandasTransformAdaptor
 
-Panel transformers
-------------------
+Series-to-features transformers
+-------------------------------
 
-Dictionary-based
-~~~~~~~~~~~~~~~~
+Series-to-features transformers transform individual time series to a collection of primitive features.
+Primitive features are usually a vector of floats, but can also be categorical.
 
-.. currentmodule:: sktime.transformations.panel.dictionary_based
+When applied to panels or hierarchical data, the transformation result is a table with as many rows as time series in the collection.
+
+Summarization
+~~~~~~~~~~~~~
+
+These transformers extract simple summary features.
+
+.. currentmodule:: sktime.transformations.series.summarize
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    PAA
-    SFA
-    SAX
-
-Summarize
-~~~~~~~~~
+    SummaryTransformer
+    MeanTransformer
+    WindowSummarizer
 
 .. currentmodule:: sktime.transformations.panel.summarize
 
@@ -95,72 +122,21 @@ Summarize
     RandomIntervalFeatureExtractor
     FittedParamExtractor
 
-tsfresh
-~~~~~~~
+Dictionary-based features
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. currentmodule:: sktime.transformations.panel.tsfresh
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    TSFreshRelevantFeatureExtractor
-    TSFreshFeatureExtractor
-
-Catch22
-~~~~~~~
-
-.. currentmodule:: sktime.transformations.panel.catch22
+.. currentmodule:: sktime.transformations.panel.dictionary_based
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    Catch22
+    PAA
+    SFA
+    SAX
 
-Compose
-~~~~~~~
-
-.. currentmodule:: sktime.transformations.panel.compose
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    ColumnConcatenator
-    SeriesToSeriesRowTransformer
-    SeriesToPrimitivesRowTransformer
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: function.rst
-
-    make_row_transformer
-
-Matrix profile
-~~~~~~~~~~~~~~
-
-.. currentmodule:: sktime.transformations.panel.matrix_profile
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    MatrixProfile
-
-PCA
-~~~
-
-.. currentmodule:: sktime.transformations.panel.pca
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    PCATransformer
-
-Rocket
-~~~~~~
+Kernel and wavelet based features
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: sktime.transformations.panel.rocket
 
@@ -172,20 +148,27 @@ Rocket
     MiniRocket
     MiniRocketMultivariate
 
-Segment
-~~~~~~~
-
-.. currentmodule:: sktime.transformations.panel.segment
+.. currentmodule:: sktime.transformations.panel.dwt
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    IntervalSegmenter
-    RandomIntervalSegmenter
+    DWTTransformer
 
-Signature
-~~~~~~~~~
+Distance-based features
+~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.transformations.panel.matrix_profile
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    MatrixProfile
+
+Moment-based features
+~~~~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: sktime.transformations.panel.signature_based
 
@@ -195,26 +178,41 @@ Signature
 
     SignatureTransformer
 
+Feature collections
+~~~~~~~~~~~~~~~~~~~
 
-Series transformers
--------------------
+These transformers extract larger collections of features.
 
-Detrend
-~~~~~~~
-
-.. currentmodule:: sktime.transformations.series.detrend
+.. currentmodule:: sktime.transformations.panel.tsfresh
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    Detrender
-    Deseasonalizer
-    ConditionalDeseasonalizer
-    STLTransformer
+    TSFreshRelevantFeatureExtractor
+    TSFreshFeatureExtractor
 
-Box-Cox, log, logit
-~~~~~~~~~~~~~~~~~~~
+.. currentmodule:: sktime.transformations.panel.catch22
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    Catch22
+
+Series-to-series transformers
+-----------------------------
+
+Series-to-series transformers transform individual time series into another time series.
+
+When applied to panels or hierarchical data, individual series are transformed.
+
+Element-wise transforms
+~~~~~~~~~~~~~~~~~~~~~~~
+
+These transformations apply a function element-wise.
+
+Depending on the transformer, the transformation parameters can be fitted.
 
 .. currentmodule:: sktime.transformations.series.boxcox
 
@@ -233,45 +231,6 @@ Box-Cox, log, logit
 
     ScaledLogitTransformer
 
-Summarization
-~~~~~~~~~~~~~
-
-.. currentmodule:: sktime.transformations.series.summarize
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    SummaryTransformer
-    MeanTransformer
-    WindowSummarizer
-
-Differencing
-~~~~~~~~~~~~
-
-.. currentmodule:: sktime.transformations.series.difference
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    Differencer
-
-Auto-correlation features
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. currentmodule:: sktime.transformations.series.acf
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    AutoCorrelationTransformer
-    PartialAutoCorrelationTransformer
-
-Element-wise transforms
-~~~~~~~~~~~~~~~~~~~~~~~
-
 .. currentmodule:: sktime.transformations.series.cos
 
 .. autosummary::
@@ -289,16 +248,78 @@ Element-wise transforms
     ExponentTransformer
     SqrtTransformer
 
-Matrix Profile
-~~~~~~~~~~~~~~
+Detrending
+~~~~~~~~~~
 
-.. currentmodule:: sktime.transformations.series.matrix_profile
+.. currentmodule:: sktime.transformations.series.detrend
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    MatrixProfileTransformer
+    Detrender
+    Deseasonalizer
+    ConditionalDeseasonalizer
+    STLTransformer
+
+Filtering and denoising
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.transformations.series.kalman_filter
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    KalmanFilterTransformerPK
+    KalmanFilterTransformerFP
+
+.. currentmodule:: sktime.transformations.series.theta
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ThetaLinesTransformer
+
+Differencing and slope
+~~~~~~~~~~~~
+
+.. currentmodule:: sktime.transformations.series.difference
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    Differencer
+
+.. currentmodule:: sktime.transformations.panel.slope
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    SlopeTransformer
+
+Binning and segmentation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.transformations.panel.interpolate
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    TSInterpolator
+
+.. currentmodule:: sktime.transformations.panel.segment
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    IntervalSegmenter
+    RandomIntervalSegmenter
 
 Missing value imputation
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -322,25 +343,51 @@ Datetime feature generation
 
     DateTimeFeatures
 
-Outlier detection, changepoint detection
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Auto-correlation series
+~~~~~~~~~~~~~~~~~~~~~~~
 
-.. currentmodule:: sktime.transformations.series.outlier_detection
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    HampelFilter
-
-.. currentmodule:: sktime.transformations.series.clasp
+.. currentmodule:: sktime.transformations.series.acf
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    ClaSPTransformer
+    AutoCorrelationTransformer
+    PartialAutoCorrelationTransformer
 
+Window-based series transforms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These transformers create a series based on a sequence of sliding windows.
+
+.. currentmodule:: sktime.transformations.series.matrix_profile
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    MatrixProfileTransformer
+
+.. currentmodule:: sktime.transformations.panel.hog1d
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    HOG1DTransformer
+
+Multivariate-to-univariate
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These transformers convert multivariate series to univariate.
+
+.. currentmodule:: sktime.transformations.panel.compose
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ColumnConcatenator
 
 Augmentation
 ~~~~~~~~~~~~
@@ -359,6 +406,8 @@ Augmentation
 FeatureSelection
 ~~~~~~~~~~~~~~~~
 
+These transformers select features in `X` based on `y`.
+
 .. currentmodule:: sktime.transformations.series.feature_selection
 
 .. autosummary::
@@ -367,26 +416,50 @@ FeatureSelection
 
     FeatureSelection
 
-Filtering and denoising
+Panel transformers
+------------------
+
+Panel transformers transform a panel of time series into a panel of time series.
+
+A panel transformer is fitted on an entire panel, and not per series.
+
+Equal length transforms
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. currentmodule:: sktime.transformations.series.kalman_filter
+These transformations ensure all series in a panel have equal length
+
+.. currentmodule:: sktime.transformations.panel.padder
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    KalmanFilterTransformerPK
-    KalmanFilterTransformerFP
+    PaddingTransformer
 
-.. currentmodule:: sktime.transformations.series.theta
+.. currentmodule:: sktime.transformations.panel.truncation
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    ThetaLinesTransformer
+    TruncationTransformer
 
+
+Dimension reduction
+~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.transformations.panel.pca
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    PCATransformer
+
+Series-to-Panel transformers
+----------------------------
+
+Thee transformers create a panel from a single series.
 
 Bootstrap transformations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -399,3 +472,45 @@ Bootstrap transformations
 
     STLBootstrapTransformer
     MovingBlockBootstrapTransformer
+
+Outlier detection, changepoint detection
+----------------------------------------
+
+.. currentmodule:: sktime.transformations.series.outlier_detection
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    HampelFilter
+
+.. currentmodule:: sktime.transformations.series.clasp
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ClaSPTransformer
+
+Hierarchical transformers
+-------------------------
+
+These transformers are specifically for hierarchical data and panel data.
+
+The transformation depends on the specified hierarchy in a non-trivial way.
+
+.. currentmodule:: sktime.transformations.hierarchical.aggregate
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    Aggregator
+
+.. currentmodule:: sktime.transformations.hierarchical.reconcile
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    Reconciler

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -12,7 +12,6 @@ transformations.
 
 Transformations are categorized as follows:
 
-
 .. list-table::
    :header-rows: 1
 

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -485,7 +485,7 @@ Dimension reduction
 Series-to-Panel transformers
 ----------------------------
 
-Thee transformers create a panel from a single series.
+These transformers create a panel from a single series.
 
 Bootstrap transformations
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR cleans up the transformer API reference:

* a lot of transformers were simply missing. Included a number of transformers contributed by non-core-devs, and hierarchical transformers (aggregation, reconciliation). They were added.
* the high-level taxonomy of transformers was re-ordered, e.g., to be clear about what the return is (primitives, series, panel, etc). This is explained in a table at the start.
* new mid-level taxonomy of transformers. Parts correspond to the TSC estimator taxonomy, parts based on methodological details.

Further, it seems that the transformers have been placed in the `series` and `panel` folders more or less at random, historically. The taxonomy does not reflect well the folder structure, so we may like to move around things in the folders at some point in the future.