### PR TITLE
[ENH] subsetting transforms

### DIFF
--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -442,6 +442,20 @@ These transformers select features in `X` based on `y`.
 
     FeatureSelection
 
+Subsetting time points and variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These transformers subset `X` by time points (`pandas` index or index level) or variables (`pandas` columns).
+
+.. currentmodule:: sktime.transformations.series.subset
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ColumnSelect
+    IndexSubset
+
 Panel transformers
 ------------------
 

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -12,12 +12,12 @@ from sktime.transformations.base import BaseTransformer
 class IndexSubset(BaseTransformer):
     r"""Index subsetting transformer.
 
-    In transform, subsets X to the indices in y.index.
-    If y is None, returns X without subsetting.
-    numpy-based X are interpreted as having a RangeIndex starting at n,
+    In transform, subsets `X` to the indices in `y.index`.
+    If `y` is None, returns `X` without subsetting.
+    numpy-based `X` are interpreted as having a RangeIndex starting at n,
     where n is the number of numpy rows seen so far through `fit` and `update`.
     Non-pandas types are interpreted as having index as after conversion to pandas,
-    via convert_to, to the "pd.DataFrame" sktime type.
+    via `datatypes.convert_to`, to the `"pd.DataFrame"` sktime type.
 
     Parameters
     ----------

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -156,8 +156,9 @@ class ColumnSelect(BaseTransformer):
 
     In transform, subsets `X` to `columns` provided as hyper-parameters.
 
-    Caveat: does not change sequence in `Xt=transform(X)`.
-    Selected columns appear in same sequence in `Xt` as they appeared in `X`.
+    Sequence of columns in `Xt=transform(X)` is as in `columns` hyper-parameter.
+    Caveat: this means that `transform` may change sequence of columns,
+        even if no  columns are removed from `X` in `transform(X)`.
 
     Parameters
     ----------
@@ -231,7 +232,8 @@ class ColumnSelect(BaseTransformer):
             col_idx = X.columns[columns]
             return X[col_idx]
 
-        col_X_and_cols = X.columns.intersection(columns)
+        in_cols = columns.isin(X.columns)
+        col_X_and_cols = columns[in_cols]
 
         if index_treatment == "remove":
             Xt = X[col_X_and_cols]

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -1,0 +1,274 @@
+# -*- coding: utf-8 -*-
+"""Transformers for index and column subsetting."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
+
+__author__ = ["fkiraly"]
+
+import pandas as pd
+
+from sktime.transformations.base import BaseTransformer
+
+
+class IndexSubset(BaseTransformer):
+    r"""Index subsetting transformer.
+
+    In transform, subsets X to the indices provided by y.
+    If y is None, returns X without subsetting.
+
+    Parameters
+    ----------
+    index_treatment : str, optional, one of "keep" (default) or "remove"
+        determines which indices are kept in `Xt = transform(X, y)`
+        "keep" = all indices in y also appear in Xt. If not present in X, NA is filled.
+        "remove" = only indices that appear in both X and y are present in Xt.
+
+    Examples
+    --------
+    >>> from sktime.transformations.series.subset import IndexSubset
+    >>> from sktime.datasets import load_airline
+    >>> X = load_airline()[0:32]
+    >>> y = load_airline()[24:42]
+    >>> transformer = IndexSubset()
+    >>> X_subset = transformer.fit_transform(X=X, y=y)
+    """
+
+    _tags = {
+        "scitype:transform-input": "Series",
+        # what is the scitype of X: Series, or Panel
+        "scitype:transform-output": "Series",
+        # what scitype is returned: Primitives, Series, Panel
+        "scitype:instancewise": True,  # is this an instance-wise transform?
+        "X_inner_mtype": ["pd.DataFrame", "pd.Series"],
+        "y_inner_mtype": ["pd.DataFrame", "pd.Series"],
+        "transform-returns-same-time-index": False,
+        "fit_is_empty": False,
+        "univariate-only": False,
+        "capability:inverse_transform": False,
+    }
+
+    def __init__(self, index_treatment="keep"):
+        self.index_treatment = index_treatment
+        super(IndexSubset, self).__init__()
+
+    def _fit(self, X, y=None):
+        """
+        Fit transformer to X and y.
+
+        private _fit containing the core logic, called from fit
+
+        Parameters
+        ----------
+        X : pd.DataFrame or pd.Series
+            Data the transformer is fitted to
+        y : ignored argument for interface compatibility
+            Additional data, e.g., labels for transformation
+
+        Returns
+        -------
+        self: a fitted instance of the estimator
+        """
+        self._X = X
+        return self
+
+    def _transform(self, X, y=None):
+        """Transform X and return a transformed version.
+
+        private _transform containing the core logic, called from transform
+
+        Parameters
+        ----------
+        X : pd.DataFrame or pd.Series
+            Data to be transformed
+        y : pd.DataFrame or pd.Series
+            Additional data, e.g., labels for transformation
+
+        Returns
+        -------
+        Xt : pd.DataFrame or pd.Series, same type as X
+            transformed version of X
+        """
+        if y is None:
+            return X
+
+        X = self._X
+
+        index_treatment = self.index_treatment
+        ind_X_and_y = X.index.intersection(y.index)
+
+        if index_treatment == "remove":
+            Xt = X.loc[ind_X_and_y]
+        elif index_treatment == "keep":
+            Xt = X.loc[ind_X_and_y]
+            y_idx_frame = type(X)(index=y.index)
+            Xt = Xt.combine_first(y_idx_frame)
+        else:
+            raise ValueError(
+                f'index_treatment must be one of "remove", "keep", but found'
+                f' "{index_treatment}"'
+            )
+        return Xt
+
+    def _update(self, X, y=None):
+        """
+        Update transformer to with and y.
+
+        private _update containing the core logic, called from update
+
+        Parameters
+        ----------
+        X : pd.DataFrame or pd.Series
+            Data the transform is fitted to
+        y : ignored argument for interface compatibility
+            Additional data, e.g., labels for transformation
+
+        Returns
+        -------
+        self: a fitted instance of the estimator
+        """
+        self._X = X.combine_first(self._X)
+        return self
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params1 = {"index_treatment": "remove"}
+        params2 = {"index_treatment": "keep"}
+
+        return [params1, params2]
+
+
+class ColumnSelect(BaseTransformer):
+    r"""Column selection transformer.
+
+    In transform, subsets `X` to `columns` provided as hyper-parameters.
+
+    Caveat: does not change sequence in `Xt=transform(X)`.
+    Selected columns appear in same sequence in `Xt` as they appeared in `X`.
+
+    Parameters
+    ----------
+    columns : pandas compatible index or index coercible, optional, default = None
+        columns to which X in transform is to be subset
+    integer_treatment : str, optional, one of "col" (default) and "coerce"
+        determines how integer index columns are treated
+        "col" = subsets by column iloc index, even if columns is not in X.columns
+        "coerce" = coerces to integer pandas.Index and attempts to subset
+    index_treatment : str, optional, one of "remove" (default) or "keep"
+        determines which column are kept in `Xt = transform(X, y)`
+        "remove" = only indices that appear in both X and columns are present in Xt.
+        "keep" = all indices in columns appear in Xt. If not present in X, NA is filled.
+
+    Examples
+    --------
+    >>> from sktime.transformations.series.subset import ColumnSelect
+    >>> from sktime.datasets import load_longley
+    >>> X = load_longley()[1]
+    >>> transformer =  ColumnSelect(columns=["GNPDEFL", "POP", "FOO"])
+    >>> X_subset = transformer.fit_transform(X=X)
+    """
+
+    _tags = {
+        "scitype:transform-input": "Series",
+        # what is the scitype of X: Series, or Panel
+        "scitype:transform-output": "Series",
+        # what scitype is returned: Primitives, Series, Panel
+        "scitype:instancewise": True,  # is this an instance-wise transform?
+        "X_inner_mtype": "pd.DataFrame",
+        "y_inner_mtype": "None",
+        "transform-returns-same-time-index": False,
+        "fit_is_empty": True,
+        "univariate-only": False,
+        "capability:inverse_transform": False,
+    }
+
+    def __init__(self, columns=None, integer_treatment="col", index_treatment="remove"):
+        self.columns = columns
+        self.integer_treatment = integer_treatment
+        self.index_treatment = index_treatment
+        super(ColumnSelect, self).__init__()
+
+    def _transform(self, X, y=None):
+        """Transform X and return a transformed version.
+
+        private _transform containing the core logic, called from transform
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Data to be transformed
+        y : Ignored argument for interface compatibility
+
+        Returns
+        -------
+        Xt : pd.DataFrame
+            transformed version of X
+        """
+        columns = self.columns
+        integer_treatment = self.integer_treatment
+        index_treatment = self.index_treatment
+
+        if columns is None:
+            return X
+        else:
+            columns = pd.Index(columns)
+
+        if integer_treatment == "col" and columns.is_integer():
+            columns = [x for x in columns if x < len(X.columns)]
+            col_idx = X.columns[columns]
+            return X[col_idx]
+
+        col_X_and_cols = X.columns.intersection(columns)
+
+        if index_treatment == "remove":
+            Xt = X[col_X_and_cols]
+        elif index_treatment == "keep":
+            Xt = X[col_X_and_cols]
+            X_idx_frame = type(X)(columns=columns)
+            Xt = Xt.combine_first(X_idx_frame)
+        else:
+            raise ValueError(
+                f'index_treatment must be one of "remove", "keep", but found'
+                f' "{index_treatment}"'
+            )
+        return Xt
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params1 = {"columns": None}
+        params2 = {"columns": [0, 2, 3]}
+        params3 = {"columns": ["a", "foo", "bar"], "index_treatment": "keep"}
+
+        return [params1, params2, params3]

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -191,7 +191,7 @@ class ColumnSelect(BaseTransformer):
         "scitype:instancewise": True,  # is this an instance-wise transform?
         "X_inner_mtype": "pd.DataFrame",
         "y_inner_mtype": "None",
-        "transform-returns-same-time-index": False,
+        "transform-returns-same-time-index": True,
         "fit_is_empty": True,
         "univariate-only": False,
         "capability:inverse_transform": False,

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -51,8 +51,7 @@ class IndexSubset(BaseTransformer):
         super(IndexSubset, self).__init__()
 
     def _fit(self, X, y=None):
-        """
-        Fit transformer to X and y.
+        """Fit transformer to X and y.
 
         private _fit containing the core logic, called from fit
 
@@ -109,8 +108,7 @@ class IndexSubset(BaseTransformer):
         return Xt
 
     def _update(self, X, y=None):
-        """
-        Update transformer to with and y.
+        """Update transformer with X and y.
 
         private _update containing the core logic, called from update
 

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -14,7 +14,8 @@ class IndexSubset(BaseTransformer):
 
     In transform, subsets X to the indices in y.index.
     If y is None, returns X without subsetting.
-    numpy-based y is interpreted as having RangeIndex starting at 0.
+    numpy-based X are interpreted as having a RangeIndex starting at n,
+    where n is the number of numpy rows seen so far through `fit` and `update`.
     Non-pandas types are interpreted as having index as after conversion to pandas,
     via convert_to, to the "pd.DataFrame" sktime type.
 

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -12,8 +12,11 @@ from sktime.transformations.base import BaseTransformer
 class IndexSubset(BaseTransformer):
     r"""Index subsetting transformer.
 
-    In transform, subsets X to the indices provided by y.
+    In transform, subsets X to the indices in y.index.
     If y is None, returns X without subsetting.
+    numpy-based y is interpreted as having RangeIndex starting at 0.
+    Non-pandas types are interpreted as having index as after conversion to pandas,
+    via convert_to, to the "pd.DataFrame" sktime type.
 
     Parameters
     ----------

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -245,6 +245,7 @@ class ColumnSelect(BaseTransformer):
             Xt = X[col_X_and_cols]
             X_idx_frame = type(X)(columns=columns)
             Xt = Xt.combine_first(X_idx_frame)
+            Xt = Xt[columns]
         else:
             raise ValueError(
                 f'index_treatment must be one of "remove", "keep", but found'

--- a/sktime/transformations/series/tests/test_subset.py
+++ b/sktime/transformations/series/tests/test_subset.py
@@ -31,8 +31,12 @@ def test_columnselect_indextreatment(index_treatment):
     columns = ["GNPDEFL", "POP", "FOO"]
     transformer = ColumnSelect(columns=columns, index_treatment=index_treatment)
     X_subset = transformer.fit_transform(X=X)
+
+    in_cols = columns.isin(X.columns)
+    col_X_and_cols = pd.Index(columns)[in_cols]
+
     if index_treatment == "remove":
-        assert X_subset.columns.equals(X.index.intersection(columns))
+        assert X_subset.columns.equals(col_X_and_cols)
     elif index_treatment == "keep":
         assert X_subset.columns.equals(pd.Index(columns))
 

--- a/sktime/transformations/series/tests/test_subset.py
+++ b/sktime/transformations/series/tests/test_subset.py
@@ -32,7 +32,7 @@ def test_columnselect_indextreatment(index_treatment):
     transformer = ColumnSelect(columns=columns, index_treatment=index_treatment)
     X_subset = transformer.fit_transform(X=X)
 
-    columns_idx =  pd.Index(columns)
+    columns_idx = pd.Index(columns)
     in_cols = columns_idx.isin(X.columns)
     col_X_and_cols = columns_idx[in_cols]
 

--- a/sktime/transformations/series/tests/test_subset.py
+++ b/sktime/transformations/series/tests/test_subset.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Tests for the subsetting transformers."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
+
+__author__ = ["fkiraly"]
+
+import pandas as pd
+import pytest
+
+from sktime.transformations.series.subset import ColumnSelect, IndexSubset
+from sktime.datasets import load_airline, load_longley
+
+
+@pytest.mark.parametrize("index_treatment", ["keep", "remove"])
+def test_indexsubset_indextreatment(index_treatment):
+    """Test that index_treatment behaviour in IndexSubsetworks as intended."""
+    X = load_airline()[0:32]
+    y = load_airline()[24:42]
+    transformer = IndexSubset(index_treatment=index_treatment)
+    X_subset = transformer.fit_transform(X=X, y=y)
+    if index_treatment == "remove":
+        assert X_subset.index == X.index.intersect(y.index)
+    elif index_treatment == "keep":
+        assert X_subset.index == y.index
+
+
+@pytest.mark.parametrize("index_treatment", ["keep", "remove"])
+def test_columnselect_indextreatment(index_treatment):
+    """Test that index_treatment behaviour in ColumnSelect works as intended."""
+    X = load_longley()[1]
+    columns = ["GNPDEFL", "POP", "FOO"]
+    transformer = ColumnSelect(
+        columns=columns, index_treatment=index_treatment
+    )
+    X_subset = transformer.fit_transform(X=X)
+    if index_treatment == "remove":
+        assert X_subset.columns == X.index.intersect(columns)
+    elif index_treatment == "keep":
+        assert X_subset.columns == pd.Index(columns)
+
+
+def test_columnselect_int():
+    """Test that integer/iloc subsetting in ColumnSelect works as intended."""
+    X = load_longley()[1]
+    columns = [0, 2, 4, 10]
+    transformer = ColumnSelect(columns=columns)
+    X_subset = transformer.fit_transform(X=X)
+
+    assert X_subset.columns == X.columns[[0, 2, 4]]

--- a/sktime/transformations/series/tests/test_subset.py
+++ b/sktime/transformations/series/tests/test_subset.py
@@ -7,8 +7,8 @@ __author__ = ["fkiraly"]
 import pandas as pd
 import pytest
 
-from sktime.transformations.series.subset import ColumnSelect, IndexSubset
 from sktime.datasets import load_airline, load_longley
+from sktime.transformations.series.subset import ColumnSelect, IndexSubset
 
 
 @pytest.mark.parametrize("index_treatment", ["keep", "remove"])
@@ -29,9 +29,7 @@ def test_columnselect_indextreatment(index_treatment):
     """Test that index_treatment behaviour in ColumnSelect works as intended."""
     X = load_longley()[1]
     columns = ["GNPDEFL", "POP", "FOO"]
-    transformer = ColumnSelect(
-        columns=columns, index_treatment=index_treatment
-    )
+    transformer = ColumnSelect(columns=columns, index_treatment=index_treatment)
     X_subset = transformer.fit_transform(X=X)
     if index_treatment == "remove":
         assert X_subset.columns == X.index.intersect(columns)

--- a/sktime/transformations/series/tests/test_subset.py
+++ b/sktime/transformations/series/tests/test_subset.py
@@ -32,13 +32,14 @@ def test_columnselect_indextreatment(index_treatment):
     transformer = ColumnSelect(columns=columns, index_treatment=index_treatment)
     X_subset = transformer.fit_transform(X=X)
 
-    in_cols = columns.isin(X.columns)
-    col_X_and_cols = pd.Index(columns)[in_cols]
+    columns_idx =  pd.Index(columns)
+    in_cols = columns_idx.isin(X.columns)
+    col_X_and_cols = columns_idx[in_cols]
 
     if index_treatment == "remove":
         assert X_subset.columns.equals(col_X_and_cols)
     elif index_treatment == "keep":
-        assert X_subset.columns.equals(pd.Index(columns))
+        assert X_subset.columns.equals(columns_idx)
 
 
 def test_columnselect_int():

--- a/sktime/transformations/series/tests/test_subset.py
+++ b/sktime/transformations/series/tests/test_subset.py
@@ -19,9 +19,9 @@ def test_indexsubset_indextreatment(index_treatment):
     transformer = IndexSubset(index_treatment=index_treatment)
     X_subset = transformer.fit_transform(X=X, y=y)
     if index_treatment == "remove":
-        assert X_subset.index == X.index.intersect(y.index)
+        assert X_subset.index.equals(X.index.intersect(y.index))
     elif index_treatment == "keep":
-        assert X_subset.index == y.index
+        assert X_subset.index.equals(y.index)
 
 
 @pytest.mark.parametrize("index_treatment", ["keep", "remove"])
@@ -32,9 +32,9 @@ def test_columnselect_indextreatment(index_treatment):
     transformer = ColumnSelect(columns=columns, index_treatment=index_treatment)
     X_subset = transformer.fit_transform(X=X)
     if index_treatment == "remove":
-        assert X_subset.columns == X.index.intersect(columns)
+        assert X_subset.columns.equals(X.index.intersect(columns))
     elif index_treatment == "keep":
-        assert X_subset.columns == pd.Index(columns)
+        assert X_subset.columns.equals(pd.Index(columns))
 
 
 def test_columnselect_int():
@@ -44,4 +44,4 @@ def test_columnselect_int():
     transformer = ColumnSelect(columns=columns)
     X_subset = transformer.fit_transform(X=X)
 
-    assert X_subset.columns == X.columns[[0, 2, 4]]
+    assert X_subset.columns.equals(X.columns[[0, 2, 4]])

--- a/sktime/transformations/series/tests/test_subset.py
+++ b/sktime/transformations/series/tests/test_subset.py
@@ -19,7 +19,7 @@ def test_indexsubset_indextreatment(index_treatment):
     transformer = IndexSubset(index_treatment=index_treatment)
     X_subset = transformer.fit_transform(X=X, y=y)
     if index_treatment == "remove":
-        assert X_subset.index.equals(X.index.intersect(y.index))
+        assert X_subset.index.equals(X.index.intersection(y.index))
     elif index_treatment == "keep":
         assert X_subset.index.equals(y.index)
 
@@ -32,7 +32,7 @@ def test_columnselect_indextreatment(index_treatment):
     transformer = ColumnSelect(columns=columns, index_treatment=index_treatment)
     X_subset = transformer.fit_transform(X=X)
     if index_treatment == "remove":
-        assert X_subset.columns.equals(X.index.intersect(columns))
+        assert X_subset.columns.equals(X.index.intersection(columns))
     elif index_treatment == "keep":
         assert X_subset.columns.equals(pd.Index(columns))
 


### PR DESCRIPTION
This PR contains two transformers for subsetting/slicing:

* `IndexSubset`, which subsets a time series `X` to indices of `y`
* `ColumnSelect`, which subsets a multivariate time series `X` to a pre-specified set of column names or integer indices of columns

Tests specific to the transformers are included.