### PR TITLE
[ENH] `set_params` to call `reset`, to comply with `sklearn` parameter interface assumptions

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -14,9 +14,11 @@ Interface specifications below.
 
     class name: BaseObject
 
-Hyper-parameter inspection and setter methods
-    inspect hyper-parameters      - get_params()
-    setting hyper-parameters      - set_params(**params)
+Parameter inspection and setter methods
+    inspect parameter values      - get_params()
+    setting parameter values      - set_params(**params)
+    list of parameter names       - get_param_names()
+    dict of parameter defaults    - get_param_defaults()
 
 Tag inspection and setter methods
     inspect tags (all)            - get_tags()
@@ -112,8 +114,80 @@ class BaseObject(_BaseEstimator):
         A clone is a different object without shared references, in post-init state.
         This function is equivalent to returning sklearn.clone of self.
         Equal in value to `type(self)(**self.get_params(deep=False))`.
+
+        Returns
+        -------
+        instance of type(self), clone of self (see above)
         """
         return clone(self)
+
+    @classmethod
+    def _get_init_signature(cls):
+        """Get init sigature of cls, for use in parameter inspection.
+
+        Returns
+        -------
+        list of inspect Parameter objects (including defaults)
+
+        Raises
+        ------
+        RuntimeError if cls has varargs in __init__
+        """
+        # fetch the constructor or the original constructor before
+        # deprecation wrapping if any
+        init = getattr(cls.__init__, "deprecated_original", cls.__init__)
+        if init is object.__init__:
+            # No explicit constructor to introspect
+            return []
+
+        # introspect the constructor arguments to find the model parameters
+        # to represent
+        init_signature = inspect.signature(init)
+
+        # Consider the constructor parameters excluding 'self'
+        parameters = [
+            p
+            for p in init_signature.parameters.values()
+            if p.name != "self" and p.kind != p.VAR_KEYWORD
+        ]
+        for p in parameters:
+            if p.kind == p.VAR_POSITIONAL:
+                raise RuntimeError(
+                    "scikit-learn compatible estimators should always "
+                    "specify their parameters in the signature"
+                    " of their __init__ (no varargs)."
+                    " %s with constructor %s doesn't "
+                    " follow this convention." % (cls, init_signature)
+                )
+        return parameters
+
+    @classmethod
+    def get_param_names(cls):
+        """Get parameter names for the object.
+
+        Returns
+        -------
+        param_names: list of str, alphabetically sorted list of parameter names of cls
+        """
+        parameters = cls._get_init_signature()
+        param_names = sorted([p.name for p in parameters])
+        return param_names
+
+    @classmethod
+    def get_param_defaults(cls):
+        """Get parameter defaults for the object.
+
+        Returns
+        -------
+        default_dict: dict with str keys
+            keys are all parameters of cls that have a default defined in __init__
+            values are the defaults, as defined in __init__
+        """
+        parameters = cls._get_init_signature()
+        default_dict = {
+            x.name: x.default for x in parameters if x.default != inspect._empty
+        }
+        return default_dict
 
     def set_params(self, **params):
         """Set the parameters of this object.

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -154,8 +154,11 @@ class BaseObject(_BaseEstimator):
 
         self.reset()
 
+        # recurse in components
         for key, sub_params in nested_params.items():
             valid_params[key].set_params(**sub_params)
+
+        return self
 
     @classmethod
     def get_class_tags(cls):

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -20,7 +20,6 @@ from sklearn.utils._testing import set_random_state
 from sklearn.utils.estimator_checks import (
     check_get_params_invariance as _check_get_params_invariance,
 )
-from sklearn.utils.estimator_checks import check_set_params as _check_set_params
 
 from sktime.base import BaseEstimator
 from sktime.dists_kernels._base import (

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -780,10 +780,12 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         msg = f"set_params of {type(estimator).__name__} does not return self"
         assert estimator.set_params(**params) is estimator, msg
 
-        is_equal, equals_msg = deep_equals(estimator.get_params(), params)
+        is_equal, equals_msg = deep_equals(
+            estimator.get_params(), params, return_msg=True
+        )
         msg = (
-            f"get_params result of {type(estimator).__name__} does not match "
-            f"what was passed to set_params. Reason for discrepancy: {equals_msg}"
+            f"get_params result of {type(estimator).__name__} (x) does not match "
+            f"what was passed to set_params (y). Reason for discrepancy: {equals_msg}"
         )
         assert is_equal, msg
 
@@ -796,15 +798,23 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         """
         estimator = estimator_class.create_test_instance()
         test_params = estimator_class.get_test_params()
+        if not isinstance(test_params, list):
+            test_params = [test_params]
+        orig_params = estimator.get_params(deep=False)
 
         for params in test_params:
+            params_full = deepcopy(orig_params)
+            params_full.update(params)
             msg = f"set_params of {estimator_class.__name__} does not return self"
-            assert estimator.set_params(**params) is estimator, msg
+            assert estimator.set_params(**params_full) is estimator, msg
 
-            is_equal, equals_msg = deep_equals(estimator.get_params(deep=False), params)
+            is_equal, equals_msg = deep_equals(
+                estimator.get_params(deep=False), params_full, return_msg=True
+            )
             msg = (
-                f"get_params result of {estimator_class.__name__} does not match "
-                f"what was passed to set_params. Reason for discrepancy: {equals_msg}"
+                f"get_params result of {estimator_class.__name__} (x) does not match "
+                f"what was passed to set_params (y). "
+                f"Reason for discrepancy: {equals_msg}"
             )
             assert is_equal, msg
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -799,11 +799,14 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         test_params = estimator_class.get_test_params()
         if not isinstance(test_params, list):
             test_params = [test_params]
-        orig_params = estimator.get_params(deep=False)
 
         for params in test_params:
-            params_full = deepcopy(orig_params)
+            # we construct the full parameter set for params
+            # params may only have parameters that are deviating from defaults
+            # in order to set non-default parameters back to defaults
+            params_full = estimator_class.get_param_defaults()
             params_full.update(params)
+
             msg = f"set_params of {estimator_class.__name__} does not return self"
             est_after_set = estimator.set_params(**params_full)
             assert est_after_set is estimator, msg

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -805,7 +805,8 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
             params_full = deepcopy(orig_params)
             params_full.update(params)
             msg = f"set_params of {estimator_class.__name__} does not return self"
-            assert estimator.set_params(**params_full) is estimator, msg
+            est_after_set = estimator.set_params(**params_full)
+            assert est_after_set is estimator, msg
 
             is_equal, equals_msg = deep_equals(
                 estimator.get_params(deep=False), params_full, return_msg=True

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -776,8 +776,37 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         """Check that set_params works correctly."""
         estimator = estimator_instance
         params = estimator.get_params()
-        assert estimator.set_params(**params) is estimator
-        _check_set_params(estimator.__class__.__name__, estimator)
+
+        msg = f"set_params of {type(estimator).__name__} does not return self"
+        assert estimator.set_params(**params) is estimator, msg
+
+        is_equal, equals_msg = deep_equals(estimator.get_params(), params)
+        msg = (
+            f"get_params result of {type(estimator).__name__} does not match "
+            f"what was passed to set_params. Reason for discrepancy: {equals_msg}"
+        )
+        assert is_equal, msg
+
+    def test_set_params_sklearn(self, estimator_class):
+        """Check that set_params works correctly, mirrors sklearn check_set_params.
+
+        Instead of the "fuzz values" in sklearn's check_set_params,
+        we use the other test parameter settings (which are assumed valid).
+        This guarantees settings which play along with the __init__ content.
+        """
+        estimator = estimator_class.create_test_instance()
+        test_params = estimator_class.get_test_params()
+
+        for params in test_params:
+            msg = f"set_params of {estimator_class.__name__} does not return self"
+            assert estimator.set_params(**params) is estimator, msg
+
+            is_equal, equals_msg = deep_equals(estimator.get_params(deep=False), params)
+            msg = (
+                f"get_params result of {estimator_class.__name__} does not match "
+                f"what was passed to set_params. Reason for discrepancy: {equals_msg}"
+            )
+            assert is_equal, msg
 
     def test_clone(self, estimator_instance):
         """Check we can call clone from scikit-learn."""


### PR DESCRIPTION
This PR modifies `set_params` to also execute a full `reset`, which calls any `__init__` code such as dynamic tag setting.

Also adds parameter inspection related class methods to `BaseObject`:
* `get_param_names` - retrieves list of parameter names
* `get_param_defaults` - retrieves name/default dict of parameter defaults

Why `set_params` should execute a `reset`: @aiwalter pointed me to this specification document in `sklearn` which makes a key interface assumption explicit, namely that the result of `set_params` must be the same as `__init__(**self.get_params())`.

Since `sktime` may have some `__init__` content besides `self` writes (in deviation from `sklearn` due to varia discussed in #2573), we can ensure consistency here by calling `reset` from `set_params`.
This relates to discussion in, and also partially addresses https://github.com/alan-turing-institute/sktime/issues/2573 .

As a secondary effect of this, the `test_set_params` test was failing in instances where parameter related logic was present in `__init__`, e.g., cloning estimators to `component_name_`, due to testing logic in `sklearn`'s `check_set_params` which was called from `test_set_params`. The reason for that is that `sklearn`'s test would overwrite parameters with `np.inf` etc to mimic a change, which is fine in `sklearn` since it strictly has no logic in `__init__`. However, `sktime` estimators may have logic, such as dynamic tag setting, which therefore would break the `set_params` now identical with `__init__`.

Therefore, the `test_set_params` test was changed from overwriting with `np.inf` etc, to overwriting with values from other test cases as available through `get_test_params` and `get_param_defaults` (needed for full set), which ensures validity.