### PR TITLE
[BUG] loosen index check related tags and fix incorrect pipeline tag inference

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1186,6 +1186,9 @@ class BaseForecaster(BaseEstimator):
         # end checking y
 
         # checking X
+        if self.get_tag("ignores-exogeneous-X"):
+            X = None
+
         if X is not None:
             X_valid, _, X_metadata = check_is_scitype(
                 X, scitype=ALLOWED_SCITYPES, return_metadata=True, var_name="X"

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1214,6 +1214,9 @@ class BaseForecaster(BaseEstimator):
             X_scitype = X_metadata["scitype"]
             requires_vectorization = X_scitype not in X_inner_scitype
         else:
+            # we can get here if X is not None, but ignored.
+            # in that case, we want to set to None in the inner methods
+            X = None
             # X_scitype is used below - set to None if X is None
             X_scitype = None
         # end checking X

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1187,7 +1187,7 @@ class BaseForecaster(BaseEstimator):
         # end checking y
 
         # checking X
-        if X is not None and not self.get_tag("ignores-exogeneous-X"):
+        if X is not None:
             X_valid, _, X_metadata = check_is_scitype(
                 X, scitype=ALLOWED_SCITYPES, return_metadata=True, var_name="X"
             )
@@ -1214,10 +1214,12 @@ class BaseForecaster(BaseEstimator):
             X_scitype = X_metadata["scitype"]
             requires_vectorization = X_scitype not in X_inner_scitype
         else:
-            # we can get here if X is not None, but ignored.
-            # in that case, we want to set to None in the inner methods
-            X = None
             # X_scitype is used below - set to None if X is None
+            X_scitype = None
+
+        # extra check: if X is ignored by inner methods, pass None to them
+        if self.get_tag("ignores-exogeneous-X"):
+            X = None
             X_scitype = None
         # end checking X
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1220,7 +1220,8 @@ class BaseForecaster(BaseEstimator):
         # compatibility checks between X and y
         if X is not None and y is not None:
             if self.get_tag("X-y-must-have-same-index"):
-                check_equal_time_index(X, y, mode="contains")
+                if not self.get_tag("ignores-exogeneous-X"):
+                    check_equal_time_index(X, y, mode="contains")
 
             if y_scitype != X_scitype:
                 raise TypeError("X and y must have the same scitype")

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1183,13 +1183,11 @@ class BaseForecaster(BaseEstimator):
         else:
             # y_scitype is used below - set to None if y is None
             y_scitype = None
+            requires_vectorization = False
         # end checking y
 
         # checking X
-        if self.get_tag("ignores-exogeneous-X"):
-            X = None
-
-        if X is not None:
+        if X is not None and not self.get_tag("ignores-exogeneous-X"):
             X_valid, _, X_metadata = check_is_scitype(
                 X, scitype=ALLOWED_SCITYPES, return_metadata=True, var_name="X"
             )

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -282,6 +282,7 @@ class ForecastingPipeline(_Pipeline):
         "requires-fh-in-fit": False,
         "handles-missing-data": False,
         "capability:pred_int": True,
+        "X-y-must-have-same-index": False,
     }
 
     def __init__(self, steps):
@@ -294,9 +295,10 @@ class ForecastingPipeline(_Pipeline):
             "capability:pred_int",  # can the estimator produce prediction intervals?
             "handles-missing-data",  # can estimator handle missing data?
             "requires-fh-in-fit",  # is forecasting horizon already required in fit?
-            "X-y-must-have-same-index",  # can estimator handle different X/y index?
             "enforce_index_type",  # index type that needs to be enforced in X/y
         ]
+        # we do not clone X-y-must-have-same-index, since transformers can
+        #   create indices, and that behaviour is not tag-inspectable
         self.clone_tags(self.forecaster_, tags_to_clone)
         self._anytagis_then_set("fit_is_empty", False, True, self.steps_)
 
@@ -653,6 +655,7 @@ class TransformedTargetForecaster(_Pipeline):
         "requires-fh-in-fit": False,
         "handles-missing-data": False,
         "capability:pred_int": True,
+        "X-y-must-have-same-index": False,
     }
 
     def __init__(self, steps):
@@ -667,9 +670,10 @@ class TransformedTargetForecaster(_Pipeline):
             "capability:pred_int",  # can the estimator produce prediction intervals?
             "handles-missing-data",  # can estimator handle missing data?
             "requires-fh-in-fit",  # is forecasting horizon already required in fit?
-            "X-y-must-have-same-index",  # can estimator handle different X/y index?
             "enforce_index_type",  # index type that needs to be enforced in X/y
         ]
+        # we do not clone X-y-must-have-same-index, since transformers can
+        #   create indices, and that behaviour is not tag-inspectable
         self.clone_tags(self.forecaster_, tags_to_clone)
         self._anytagis_then_set("fit_is_empty", False, True, self.steps_)
 

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -11,6 +11,9 @@ import pandas as pd
 from sklearn.preprocessing import MinMaxScaler
 
 from sktime.datasets import load_airline
+from sktime.datatypes import get_examples
+from sktime.datatypes._utilities import get_window
+from sktime.forecasting.arima import ARIMA
 from sktime.forecasting.compose import ForecastingPipeline, TransformedTargetForecaster
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.forecasting.naive import NaiveForecaster
@@ -20,6 +23,7 @@ from sktime.transformations.series.detrend import Detrender
 from sktime.transformations.series.exponent import ExponentTransformer
 from sktime.transformations.series.impute import Imputer
 from sktime.transformations.series.outlier_detection import HampelFilter
+from sktime.transformations.hierarchical.aggregate import Aggregator
 
 
 def test_pipeline():
@@ -122,3 +126,53 @@ def test_pipeline_with_detrender():
     )
     trans_fc.fit(y)
     trans_fc.predict(1)
+
+
+def test_nested_pipeline_with_index_creation_y_before_X():
+    """Tests a nested pipeline where y indices are created before X indices.
+
+    The potential failure mode is the pipeline failing as y has more indices than X,
+    in an intermediate stage and erroneous checks from the pipeline raise an error.
+    """
+    X = get_examples("pd_multiindex_hier")[0]
+    y = get_examples("pd_multiindex_hier")[1]
+
+    X_train = get_window(X, lag=1)
+    y_train = get_window(y, lag=1)
+    X_test = get_window(X, window_length=1)
+
+    # Aggregator creates indices for y (via *), then for X (via ForecastingPipeline)
+    f = Aggregator() * ForecastingPipeline([Aggregator(), ARIMA()])
+
+    f.fit(y=y_train, X=X_train, fh=1)
+    y_pred = f.predict(X=X_test)
+
+    # some basic expected output format checks
+    assert isinstance(y_pred, pd.DataFrame)
+    assert isinstance(y_pred.index, pd.MultiIndex)
+    assert len() == 9
+
+
+def test_nested_pipeline_with_index_creation_X_before_y():
+    """Tests a nested pipeline where X indices are created before y indices.
+
+    The potential failure mode is the pipeline failing as X has more indices than y,
+    in an intermediate stage and erroneous checks from the pipeline raise an error.
+    """
+    X = get_examples("pd_multiindex_hier")[0]
+    y = get_examples("pd_multiindex_hier")[1]
+
+    X_train = get_window(X, lag=1)
+    y_train = get_window(y, lag=1)
+    X_test = get_window(X, window_length=1)
+
+    # Aggregator creates indices for X (via ForecastingPipeline), then for y (via *)
+    f = ForecastingPipeline([Aggregator(), Aggregator() * ARIMA()])
+
+    f.fit(y=y_train, X=X_train, fh=1)
+    y_pred = f.predict(X=X_test)
+
+    # some basic expected output format checks
+    assert isinstance(y_pred, pd.DataFrame)
+    assert isinstance(y_pred.index, pd.MultiIndex)
+    assert len() == 9

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -18,12 +18,12 @@ from sktime.forecasting.compose import ForecastingPipeline, TransformedTargetFor
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.forecasting.trend import PolynomialTrendForecaster
+from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.transformations.series.adapt import TabularToSeriesAdaptor
 from sktime.transformations.series.detrend import Detrender
 from sktime.transformations.series.exponent import ExponentTransformer
 from sktime.transformations.series.impute import Imputer
 from sktime.transformations.series.outlier_detection import HampelFilter
-from sktime.transformations.hierarchical.aggregate import Aggregator
 
 
 def test_pipeline():

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -150,7 +150,7 @@ def test_nested_pipeline_with_index_creation_y_before_X():
     # some basic expected output format checks
     assert isinstance(y_pred, pd.DataFrame)
     assert isinstance(y_pred.index, pd.MultiIndex)
-    assert len() == 9
+    assert len(y_pred) == 9
 
 
 def test_nested_pipeline_with_index_creation_X_before_y():
@@ -175,4 +175,4 @@ def test_nested_pipeline_with_index_creation_X_before_y():
     # some basic expected output format checks
     assert isinstance(y_pred, pd.DataFrame)
     assert isinstance(y_pred.index, pd.MultiIndex)
-    assert len() == 9
+    assert len(y_pred) == 9

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -444,7 +444,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
 
         Arguments
         ---------
-        Forecaster: BaseEstimator class descendant, forecaster to test
+        estimator_instance : instance of BaseForecaster
 
         Raises
         ------

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -124,7 +124,7 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
             "nested_univ",
             "numpy3D",
             "pd_multiindex_hier",
-        ]
+        ],
     }
 
     # no further default tag values - these are set dynamically below
@@ -157,7 +157,6 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
         self._anytag_notnone_set("scitype:transform-labels", ests)
 
         self._anytagis_then_set("scitype:instancewise", False, True, ests)
-        self._anytagis_then_set("X-y-must-have-same-index", True, False, ests)
         self._anytagis_then_set("fit_is_empty", False, True, ests)
         self._anytagis_then_set("transform-returns-same-time-index", False, True, ests)
         self._anytagis_then_set("skip-inverse-transform", True, False, ests)


### PR DESCRIPTION
This PR loosens checks related to index equality related tags:

* if a forecaster has `"X-y-must-have-same-index"` and `"ignores-exogeneous-X"` tag both set to True, this will no longer result in an exception if `X` is passed and is not index compliant with `y`. Why: if `X` is ignored, then `X.index` should also not matter for anything, including checks.
* In transformer and forecaster pipelines, the `"X-y-must-have-same-index"` tag is no longer copied from forecaster or conjunction-inferred from transformers. This was logically incorrect, as there are transformers that can add or remove indices. There have been actual instances of unexpected behaviour around this in pipelines. Example 1: `Aggregator` which adds indices https://github.com/alan-turing-institute/sktime/issues/2711; example 2: `Differencer` which removes indices https://github.com/alan-turing-institute/sktime/issues/2807, https://github.com/alan-turing-institute/sktime/issues/2452
(FYI @ngupta23, @anthonygiorgio97)
* if a forecaster has `"ignores-exogeneous-X"`, then `X=None` is passed to the inner methods, instead of performing unnecessary conversions on `X` and passing the result to the inner methods. This is done after performing input checks on `X`, to let the user know early of non-conformant `X` - even if `X` is never used.

The PR also adds two tests that ensure that the ablated examples from https://github.com/alan-turing-institute/sktime/issues/2711 run.