### PR TITLE
[BUG] transformers: output type check fix for ambiguous return types

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -677,12 +677,11 @@ class BaseTransformer(BaseEstimator):
 
         if y_inner_mtype != ["None"] and y is not None:
 
-            if X_scitype == "Series":
-                y_possible_scitypes = "Series"
-            elif X_scitype == "Panel":
-                y_possible_scitypes = ["Table", "Panel"]
-            elif X_scitype == "Hierarchical":
-                y_possible_scitypes = ["Table", "Panel", "Hierarchical"]
+            output_type = self.get_tag("scitype:transform-output")
+            if output_type == "Primitives":
+                y_possible_scitypes = "Table"
+            else:
+                y_possible_scitypes = ["Series", "Panel", "Hierarchical"]
 
             y_valid, _, y_metadata = check_is_scitype(
                 y, scitype=y_possible_scitypes, return_metadata=True, var_name="y"

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -677,11 +677,14 @@ class BaseTransformer(BaseEstimator):
 
         if y_inner_mtype != ["None"] and y is not None:
 
-            output_type = self.get_tag("scitype:transform-output")
-            if output_type == "Primitives":
+            if "Table" in y_inner_scitype:
                 y_possible_scitypes = "Table"
-            else:
-                y_possible_scitypes = ["Series", "Panel", "Hierarchical"]
+            elif X_scitype == "Series":
+                y_possible_scitypes = "Series"
+            elif X_scitype == "Panel":
+                y_possible_scitypes = "Panel"
+            elif X_scitype == "Hierarchical":
+                y_possible_scitypes = ["Panel", "Hierarchical"]
 
             y_valid, _, y_metadata = check_is_scitype(
                 y, scitype=y_possible_scitypes, return_metadata=True, var_name="y"


### PR DESCRIPTION
Fixes #2841.

The output type checks in transformers could run into problems in the specific case where the inner `_transform` produced a `pd.DataFrame` that was compliant both with a `Panel` and a `Table` specification.

In cases where this happened, the transformer would error out.

This is easily fixed, since we *know*  when to expect a `Panel` or a `Table`, based on the output scitype. The bug has been fixed by using that tag to restrict the expected outputs, which prevents multiple type identifications.