### PR TITLE
[BUG] Vectorization in transformers overwrote y with X

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -743,7 +743,7 @@ class BaseTransformer(BaseEstimator):
         #   then apply vectorization, loop method execution over series/panels
         elif case == "case 3: requires vectorization":
             iterate_X = _most_complex_scitype(X_inner_scitype)
-            X_inner = VectorizedDF(X=X, iterate_as=iterate_X, is_scitype=y_scitype)
+            X_inner = VectorizedDF(X=X, iterate_as=iterate_X, is_scitype=X_scitype)
             # we also assume that y must be vectorized in this case
             if y_inner_mtype != ["None"] and y is not None:
                 # raise ValueError(
@@ -755,7 +755,7 @@ class BaseTransformer(BaseEstimator):
                 #     "input types natively: Panel X and non-None y."
                 # )
                 iterate_y = _most_complex_scitype(y_inner_scitype)
-                y_inner = VectorizedDF(X=y, iterate_as=iterate_y, is_scitype=X_scitype)
+                y_inner = VectorizedDF(X=y, iterate_as=iterate_y, is_scitype=y_scitype)
             else:
                 y_inner = None
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -755,7 +755,7 @@ class BaseTransformer(BaseEstimator):
                 #     "input types natively: Panel X and non-None y."
                 # )
                 iterate_y = _most_complex_scitype(y_inner_scitype)
-                y_inner = VectorizedDF(X=X, iterate_as=iterate_y, is_scitype=X_scitype)
+                y_inner = VectorizedDF(X=y, iterate_as=iterate_y, is_scitype=X_scitype)
             else:
                 y_inner = None
 


### PR DESCRIPTION
Thie fixes the following unreported bug related to https://github.com/alan-turing-institute/sktime/issues/2841 and https://github.com/alan-turing-institute/sktime/issues/2711:

when a transformer entered vectorization mode and `y` was passed (and also vectorized), then the transformer would pass the vectorized `X` to the inner methods where a vectorized `y` should have passed, i.e., passing `X` as `X` (correctly), and `y` as `X` as well (incorrectly). This has been fixed.

(was difficult to spot since the condition is a rare combination of (a) a transformer uses `y` at all, and (b) vectorization happens)

Relation to the bugs:
* after the type inference bug in #2841 is fixed, the test example posted by me breaks due to this unreported bug
* in #2711, it seem like `X` in the forecaster is not properly aggregated. There is not a clear causal link, and the vectorization in forecasters seem correct. Still there is something going on that seems similar, so I reference it.