### PR TITLE
[ENH] upgrade the "all" modules to automatic retrieval

### DIFF
--- a/sktime/classification/all/__init__.py
+++ b/sktime/classification/all/__init__.py
@@ -1,24 +1,27 @@
 # -*- coding: utf-8 -*-
-"""All time series classifiers."""
+"""All time series classifiers and some classification data sets."""
 
-__author__ = ["mloning"]
-__all__ = [
-    "ShapeletTransformClassifier",
-    "RocketClassifier",
-    "BOSSEnsemble",
-    "IndividualBOSS",
-    "TemporalDictionaryEnsemble",
-    "IndividualTDE",
-    "KNeighborsTimeSeriesClassifier",
-    "ProximityStump",
-    "ProximityTree",
-    "ProximityForest",
-    "ElasticEnsemble",
-    "RandomIntervalSpectralEnsemble",
-    "TimeSeriesForestClassifier",
-    "SupervisedTimeSeriesForest",
-    "ComposableTimeSeriesForestClassifier",
-    "ColumnEnsembleClassifier",
+__author__ = ["mloning", "fkiraly"]
+
+import numpy as np
+import pandas as pd
+
+from sktime.datasets import (
+    load_arrow_head,
+    load_basic_motions,
+    load_gunpoint,
+    load_osuleaf,
+)
+from sktime.registry import all_estimators
+
+
+est_tuples = all_estimators(estimator_types="classifier", return_names=True)
+est_names, ests = zip(*est_tuples)
+
+for i, x in enumerate(est_tuples):
+    exec(f"{x[0]} = ests[{i}]")
+
+__all__ = list(est_names) + [
     "pd",
     "np",
     "load_gunpoint",
@@ -26,37 +29,3 @@ __all__ = [
     "load_basic_motions",
     "load_arrow_head",
 ]
-
-import numpy as np
-import pandas as pd
-
-from sktime.classification.compose import (
-    ColumnEnsembleClassifier,
-    ComposableTimeSeriesForestClassifier,
-)
-from sktime.classification.dictionary_based import (
-    BOSSEnsemble,
-    IndividualBOSS,
-    IndividualTDE,
-    TemporalDictionaryEnsemble,
-)
-from sktime.classification.distance_based import (
-    ElasticEnsemble,
-    KNeighborsTimeSeriesClassifier,
-    ProximityForest,
-    ProximityStump,
-    ProximityTree,
-)
-from sktime.classification.interval_based import (
-    RandomIntervalSpectralEnsemble,
-    SupervisedTimeSeriesForest,
-    TimeSeriesForestClassifier,
-)
-from sktime.classification.kernel_based import RocketClassifier
-from sktime.classification.shapelet_based import ShapeletTransformClassifier
-from sktime.datasets import (
-    load_arrow_head,
-    load_basic_motions,
-    load_gunpoint,
-    load_osuleaf,
-)

--- a/sktime/classification/all/__init__.py
+++ b/sktime/classification/all/__init__.py
@@ -14,7 +14,6 @@ from sktime.datasets import (
 )
 from sktime.registry import all_estimators
 
-
 est_tuples = all_estimators(estimator_types="classifier", return_names=True)
 est_names, ests = zip(*est_tuples)
 

--- a/sktime/forecasting/all/__init__.py
+++ b/sktime/forecasting/all/__init__.py
@@ -3,112 +3,22 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Import all time series forecasting functionality available in sktime."""
 
-__author__ = ["mloning"]
-__all__ = [
-    "ForecastingHorizon",
-    "load_lynx",
-    "load_longley",
-    "load_airline",
-    "load_shampoo_sales",
-    "CutoffSplitter",
-    "ForecastingGridSearchCV",
-    "ForecastingRandomizedSearchCV",
-    "SlidingWindowSplitter",
-    "SingleWindowSplitter",
-    "ExpandingWindowSplitter",
-    "temporal_train_test_split",
-    "NaiveForecaster",
-    "ExponentialSmoothing",
-    "ThetaForecaster",
-    "AutoARIMA",
-    "ARIMA",
-    "AutoETS",
-    "Prophet",
-    "TrendForecaster",
-    "PolynomialTrendForecaster",
-    "TransformedTargetForecaster",
-    "MultiplexForecaster",
-    "Deseasonalizer",
-    "EnsembleForecaster",
-    "Detrender",
-    "pd",
-    "np",
-    "plot_series",
-    "NormalHedgeEnsemble",
-    "NNLSEnsemble",
-    "OnlineEnsembleForecaster",
-    "evaluate",
-    "make_forecasting_scorer",
-    "MeanAbsoluteScaledError",
-    "MedianAbsoluteScaledError",
-    "MeanSquaredScaledError",
-    "MedianSquaredScaledError",
-    "MeanAbsoluteError",
-    "MeanSquaredError",
-    "MedianAbsoluteError",
-    "MedianSquaredError",
-    "MeanAbsolutePercentageError",
-    "MedianAbsolutePercentageError",
-    "MeanSquaredPercentageError",
-    "MedianSquaredPercentageError",
-    "MeanRelativeAbsoluteError",
-    "MedianRelativeAbsoluteError",
-    "GeometricMeanRelativeAbsoluteError",
-    "GeometricMeanRelativeSquaredError",
-    "MeanAsymmetricError",
-    "RelativeLoss",
-    "mean_absolute_scaled_error",
-    "median_absolute_scaled_error",
-    "mean_squared_scaled_error",
-    "median_squared_scaled_error",
-    "mean_absolute_error",
-    "mean_squared_error",
-    "median_absolute_error",
-    "median_squared_error",
-    "mean_absolute_percentage_error",
-    "median_absolute_percentage_error",
-    "mean_squared_percentage_error",
-    "median_squared_percentage_error",
-    "mean_relative_absolute_error",
-    "median_relative_absolute_error",
-    "geometric_mean_relative_absolute_error",
-    "geometric_mean_relative_squared_error",
-    "relative_loss",
-    "mean_asymmetric_error",
-]
+__author__ = ["mloning", "fkiraly"]
+
 
 import numpy as np
 import pandas as pd
 
 from sktime.datasets import load_airline, load_longley, load_lynx, load_shampoo_sales
-from sktime.forecasting.arima import ARIMA, AutoARIMA
 from sktime.forecasting.base import ForecastingHorizon
-from sktime.forecasting.compose import (
-    EnsembleForecaster,
-    MultiplexForecaster,
-    TransformedTargetForecaster,
-)
-from sktime.forecasting.ets import AutoETS
-from sktime.forecasting.exp_smoothing import ExponentialSmoothing
-from sktime.forecasting.fbprophet import Prophet
 from sktime.forecasting.model_evaluation import evaluate
 from sktime.forecasting.model_selection import (
     CutoffSplitter,
     ExpandingWindowSplitter,
-    ForecastingGridSearchCV,
-    ForecastingRandomizedSearchCV,
     SingleWindowSplitter,
     SlidingWindowSplitter,
     temporal_train_test_split,
 )
-from sktime.forecasting.naive import NaiveForecaster
-from sktime.forecasting.online_learning._online_ensemble import OnlineEnsembleForecaster
-from sktime.forecasting.online_learning._prediction_weighted_ensembler import (
-    NNLSEnsemble,
-    NormalHedgeEnsemble,
-)
-from sktime.forecasting.theta import ThetaForecaster
-from sktime.forecasting.trend import PolynomialTrendForecaster, TrendForecaster
 from sktime.performance_metrics.forecasting import (
     GeometricMeanRelativeAbsoluteError,
     GeometricMeanRelativeSquaredError,
@@ -148,5 +58,69 @@ from sktime.performance_metrics.forecasting import (
     median_squared_scaled_error,
     relative_loss,
 )
+from sktime.registry import all_estimators
 from sktime.transformations.series.detrend import Deseasonalizer, Detrender
 from sktime.utils.plotting import plot_series
+
+
+est_tuples = all_estimators(estimator_types="forecaster", return_names=True)
+est_names, ests = zip(*est_tuples)
+
+for i, x in enumerate(est_tuples):
+    exec(f"{x[0]} = ests[{i}]")
+
+__all__ = list(est_names) + [
+    "ForecastingHorizon",
+    "load_lynx",
+    "load_longley",
+    "load_airline",
+    "load_shampoo_sales",
+    "CutoffSplitter",
+    "SlidingWindowSplitter",
+    "SingleWindowSplitter",
+    "ExpandingWindowSplitter",
+    "temporal_train_test_split",
+    "Deseasonalizer",
+    "Detrender",
+    "pd",
+    "np",
+    "plot_series",
+    "evaluate",
+    "make_forecasting_scorer",
+    "MeanAbsoluteScaledError",
+    "MedianAbsoluteScaledError",
+    "MeanSquaredScaledError",
+    "MedianSquaredScaledError",
+    "MeanAbsoluteError",
+    "MeanSquaredError",
+    "MedianAbsoluteError",
+    "MedianSquaredError",
+    "MeanAbsolutePercentageError",
+    "MedianAbsolutePercentageError",
+    "MeanSquaredPercentageError",
+    "MedianSquaredPercentageError",
+    "MeanRelativeAbsoluteError",
+    "MedianRelativeAbsoluteError",
+    "GeometricMeanRelativeAbsoluteError",
+    "GeometricMeanRelativeSquaredError",
+    "MeanAsymmetricError",
+    "RelativeLoss",
+    "mean_absolute_scaled_error",
+    "median_absolute_scaled_error",
+    "mean_squared_scaled_error",
+    "median_squared_scaled_error",
+    "mean_absolute_error",
+    "mean_squared_error",
+    "median_absolute_error",
+    "median_squared_error",
+    "mean_absolute_percentage_error",
+    "median_absolute_percentage_error",
+    "mean_squared_percentage_error",
+    "median_squared_percentage_error",
+    "mean_relative_absolute_error",
+    "median_relative_absolute_error",
+    "geometric_mean_relative_absolute_error",
+    "geometric_mean_relative_squared_error",
+    "relative_loss",
+    "mean_asymmetric_error",
+]

--- a/sktime/forecasting/all/__init__.py
+++ b/sktime/forecasting/all/__init__.py
@@ -62,7 +62,6 @@ from sktime.registry import all_estimators
 from sktime.transformations.series.detrend import Deseasonalizer, Detrender
 from sktime.utils.plotting import plot_series
 
-
 est_tuples = all_estimators(estimator_types="forecaster", return_names=True)
 est_names, ests = zip(*est_tuples)
 

--- a/sktime/transformations/all/__init__.py
+++ b/sktime/transformations/all/__init__.py
@@ -8,7 +8,6 @@ import pandas as pd
 
 from sktime.registry import all_estimators
 
-
 est_tuples = all_estimators(estimator_types="transformer", return_names=True)
 est_names, ests = zip(*est_tuples)
 

--- a/sktime/transformations/all/__init__.py
+++ b/sktime/transformations/all/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""All transformers in sktime."""
+
+__author__ = ["fkiraly"]
+
+import numpy as np
+import pandas as pd
+
+from sktime.registry import all_estimators
+
+
+est_tuples = all_estimators(estimator_types="transformer", return_names=True)
+est_names, ests = zip(*est_tuples)
+
+for i, x in enumerate(est_tuples):
+    exec(f"{x[0]} = ests[{i}]")
+
+__all__ = list(est_names) + ["pd", "np"]


### PR DESCRIPTION
This PR upgrades the `all` modules to automatic retrieval and export of all estimators of a certain type, and adds an `all` module for `transformations`.

Intended use is via `from modulename.all import *` which then loads all estimators and relevant objects (like `ForecastingHorizon` for forecasters) in memory.

The `all` modules have fallen very much out of date, current `main` state is perhaps around 0.7.X or 0.8.X. Part of the reason is that the extension guidelines did not list "add your estimator to the export list in the `all` module.
This PR also removes the need for doing that, as retrieval is automatic, via the `all_estimators` utility.
