### PR TITLE
[BUG] fixing `get_time_index` for 1D and 2D numpy formats

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -9,8 +9,12 @@ import pandas as pd
 def _get_index(x):
     if hasattr(x, "index"):
         return x.index
+    elif isinstance(x, np.ndarray):
+        if x.ndim < 3:
+            return pd.RangeIndex(x.shape[0])
+        else:
+            return pd.RangeIndex(x.shape[-1])
     else:
-        # select last dimension for time index
         return pd.RangeIndex(x.shape[-1])
 
 
@@ -23,7 +27,7 @@ def get_time_index(X):
     in one of the following sktime mtype specifications for Series, Panel, Hierarchical:
     pd.DataFrame, pd.Series, np.ndarray, pd-multiindex, nested_univ, pd_multiindex_hier
     assumes all time series have equal length and equal index set
-    will *not* work for list-of-df, pd-wide, pd-long
+    will *not* work for list-of-df, pd-wide, pd-long, numpyflat
 
     Returns
     -------
@@ -45,8 +49,10 @@ def get_time_index(X):
             return X.index
     # numpy3D and np.ndarray
     elif isinstance(X, np.ndarray):
+        # np.ndarray
         if X.ndim < 3:
             return pd.RangeIndex(X.shape[0])
+        # numpy3D
         else:
             return pd.RangeIndex(X.shape[-1])
     elif hasattr(X, "X"):

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -19,7 +19,7 @@ def get_time_index(X):
 
     Parameters
     ----------
-    X : pd.DataFrame / pd.Series / np.ndarray
+    X : pd.DataFrame, pd.Series, np.ndarray, or VectorizedDF
     in one of the following sktime mtype specifications for Series, Panel, Hierarchical:
     pd.DataFrame, pd.Series, np.ndarray, pd-multiindex, nested_univ, pd_multiindex_hier
     assumes all time series have equal length and equal index set
@@ -27,7 +27,7 @@ def get_time_index(X):
 
     Returns
     -------
-    time_index : pandas Index
+    time_index : pandas.Index
         Index of time series
     """
     # assumes that all samples share the same the time index, only looks at
@@ -45,10 +45,15 @@ def get_time_index(X):
             return X.index
     # numpy3D and np.ndarray
     elif isinstance(X, np.ndarray):
-        return _get_index(X)
+        if X.ndim < 3:
+            return pd.RangeIndex(X.shape[0])
+        else:
+            return pd.RangeIndex(X.shape[-1])
+    elif hasattr(X, "X"):
+        return get_time_index(X.X)
     else:
         raise ValueError(
-            f"X must be a pandas DataFrame or Series, but found: {type(X)}"
+            f"X must be pd.DataFrame, pd.Series, or np.ndarray, but found: {type(X)}"
         )
 
 

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -16,7 +16,6 @@ from sktime.datatypes._utilities import (
     get_window,
 )
 
-
 SCITYPE_MTYPE_PAIRS = [
     ("Series", "pd.Series"),
     ("Series", "pd.DataFrame"),

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -42,6 +42,10 @@ def test_get_time_index(scitype, mtype):
     AssertionError if get_cutoff does not return a length 1 pandas.index
         for any fixture example of given scitype, mtype
     """
+    # get_time_index currently does not work for df-list type, skip
+    if mtype == "df-list":
+        return None
+
     # retrieve example fixture
     fixtures = get_examples(mtype=mtype, as_scitype=scitype, return_lossy=False)
 

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -9,7 +9,13 @@ import pytest
 
 from sktime.datatypes._check import check_is_mtype
 from sktime.datatypes._examples import get_examples
-from sktime.datatypes._utilities import get_cutoff, get_slice, get_window
+from sktime.datatypes._utilities import (
+    get_cutoff,
+    get_slice,
+    get_time_index,
+    get_window,
+)
+
 
 SCITYPE_MTYPE_PAIRS = [
     ("Series", "pd.Series"),
@@ -21,6 +27,47 @@ SCITYPE_MTYPE_PAIRS = [
     ("Panel", "df-list"),
     ("Hierarchical", "pd_multiindex_hier"),
 ]
+
+
+@pytest.mark.parametrize("scitype,mtype", SCITYPE_MTYPE_PAIRS)
+def test_get_time_index(scitype, mtype):
+    """Tests that conversions for scitype agree with from/to example fixtures.
+
+    Parameters
+    ----------
+    scitype : str - scitype of input
+    mtype : str - mtype of input
+
+    Raises
+    ------
+    AssertionError if get_cutoff does not return a length 1 pandas.index
+        for any fixture example of given scitype, mtype
+    """
+    # retrieve example fixture
+    fixtures = get_examples(mtype=mtype, as_scitype=scitype, return_lossy=False)
+
+    for fixture in fixtures.values():
+        if fixture is None:
+            continue
+
+        idx = get_time_index(fixture)
+
+        msg = f"get_time_index should return pd.Index, but found {type(idx)}"
+        assert isinstance(idx, pd.Index), msg
+
+        if mtype in ["pd.Series", "pd.DataFrame"]:
+            assert (idx == fixture.index).all()
+
+        if mtype in ["np.ndarray", "numpy3D"]:
+            assert isinstance(idx, pd.RangeIndex)
+            if mtype == "np.ndarray":
+                assert len(idx) == fixture.shape[0]
+            else:
+                assert len(idx) == fixture.shape[-1]
+
+        if mtype in ["pd-multiindex", "pd_multiindex_hier"]:
+            exp_idx = fixture.index.get_level_values(-1).unique()
+            assert (idx == exp_idx).all()
 
 
 @pytest.mark.parametrize("return_index", [True, False])


### PR DESCRIPTION
The utility function was incorrect for `get_time_index` for 1D and 2D numpy formats, where the 0-th index is time. This has been fixed.

Also adds functionality for `VectorizedDF` (by looking for the `X` attribute)