### PR TITLE
[ENH] `all_estimators` authors variable

### DIFF
--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -12,6 +12,10 @@ all_tags(estimator_types)
     lookup and filtering of estimator tags
 """
 
+__author__ = ["fkiraly", "mloning", "katiebuc", "miraep8", "xloem"]
+# all_estimators is also based on the sklearn utility of the same name
+
+
 import inspect
 import pkgutil
 from copy import deepcopy


### PR DESCRIPTION
The registry lookup utility file was missing an `__author__` variable, this has been added based on commit history.

FYI @mloning, @KatieBuc, @miraep8, @xloem.