### PR TITLE
[ENH] remove old `multiindex-df` index convention hack from `VectorizedDF`

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -150,9 +150,6 @@ class VectorizedDF:
         ind = self.get_iter_indices()[i]
         item = X.loc[ind]
         item = _enforce_index_freq(item)
-        # pd-multiindex type (Panel case) expects these index names:
-        if self.iterate_as == "Panel":
-            item.index.set_names(["instances", "timepoints"], inplace=True)
         return item
 
     def as_list(self):


### PR DESCRIPTION
`VectorizedDF` had a few lines of hack to ensure compliance with a legacy convention on `multiindex-df`, namely the naming of the row index levels.

This convention is no longer part of the data type speification, and also not enforced elsewhere, so the lines can be removed.