### PR TITLE
[ENH] `VectorizedDF` to support vectorization across columns/variables

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -163,7 +163,7 @@ class VectorizedDF:
         pair of pandas.Index or pandas.MultiIndex or None
             i-th element of list selects rows/columns in i-th iterate sub-DataFrame
             first element is row index, second element is column index
-            if rows/columns are not iterated over, row/column element is None  
+            if rows/columns are not iterated over, row/column element is None
             use to reconstruct data frame after iteration
         """
         return self.iter_indices

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -210,7 +210,7 @@ class VectorizedDF:
         row_ind, col_ind = self._iter_indices()[i]
         if isinstance(col_ind, list):
             col_ind = pd.Index(col_ind)
-        else:
+        elif not isinstance(col_ind, pd.Index):
             col_ind = [col_ind]
         item = X[col_ind].loc[row_ind]
         item = _enforce_index_freq(item)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -182,9 +182,9 @@ class VectorizedDF:
         if row_ix is None and col_ix is None:
             return (0, 0)
         elif row_ix is None:
-            return (i, 0)
-        elif col_ix is None:
             return (0, i)
+        elif col_ix is None:
+            return (i, 0)
         else:
             col_n = len(col_ix)
             return (i // col_n, i % col_n)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -96,9 +96,7 @@ class VectorizedDF:
             )
 
         if iterate_cols not in [True, False]:
-            raise ValueError(
-                f"iterate_cols must be a boolean, found {iterate_as}"
-            )
+            raise ValueError(f"iterate_cols must be a boolean, found {iterate_as}")
         self.iterate_cols = iterate_cols
 
         self.converter_store = dict()
@@ -243,7 +241,7 @@ class VectorizedDF:
             row_n = len(row_ix)
             col_n = len(col_ix)
             for i in range(row_n):
-                ith_col_block = df_list[i*col_n:(i+1)*col_n]
+                ith_col_block = df_list[i * col_n : (i + 1) * col_n]
                 col_concats += pd.concat(ith_col_block, axis=1)
             X_mi_reconstructed = pd.concat(col_concats, keys=row_ix, axis=0)
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -160,13 +160,34 @@ class VectorizedDF:
 
         Returns
         -------
-        list of pair of pandas.Index or pandas.MultiIndex
-            iterable with unique indices that are iterated over
-            use to reconstruct data frame after iteration
+        pair of pandas.Index or pandas.MultiIndex or None
             i-th element of list selects rows/columns in i-th iterate sub-DataFrame
-            first element of pair are rows, second element are columns selected
+            first element is row index, second element is column index
+            if rows/columns are not iterated over, row/column element is None  
+            use to reconstruct data frame after iteration
         """
         return self.iter_indices
+
+    def get_iloc_indexer(self, i: int):
+        """Get iloc row/column indexer for i-th list element.
+
+        Returns
+        -------
+        pair of int, indexes into get_iter_indices
+            1st element is iloc index for 1st element of get_iter_indices
+            2nd element is iloc index for 2nd element of get_iter_indices
+            together, indicate iloc index of self[i] within get_iter_indices index sets
+        """
+        row_ix, col_ix = self.iter_indices
+        if row_ix is None and col_ix is None:
+            return (0, 0)
+        elif row_ix is None:
+            return (i, 0)
+        elif col_ix is None:
+            return (0, i)
+        else:
+            col_n = len(col_ix)
+            return (i // col_n, i % col_n)
 
     def _iter_indices(self):
         """Get indices that are iterated over in vectorization.

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -109,7 +109,14 @@ class VectorizedDF:
         """Convert X to a pandas multiindex format."""
         is_scitype = self.is_scitype
 
-        if is_scitype == "Panel":
+        if is_scitype == "Series":
+            return convert_to(
+                X,
+                to_type="pd.DataFrame",
+                as_scitype="Series",
+                store=self.converter_store,
+            )
+        elif is_scitype == "Panel":
             return convert_to(
                 X,
                 to_type="pd-multiindex",
@@ -207,7 +214,7 @@ class VectorizedDF:
             ret = [(X.index, X.columns)]
         elif row_ix is None:
             ret = product([X.index], col_ix)
-        if col_ix is None:
+        elif col_ix is None:
             ret = product(row_ix, [X.columns])
         else:  # if row_ix and col_ix are both not None
             ret = product(row_ix, col_ix)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -173,9 +173,9 @@ class VectorizedDF:
         if row_ix is None and col_ix is None:
             return [(X.index, X.columns)]
         if row_ix is None:
-            return product(X.index, col_ix)
+            return product([X.index], col_ix)
         if col_ix is None:
-            return product(row_ix, X.columns)
+            return product(row_ix, [X.columns])
         # if row_ix and col_ix are both not None
         return product(row_ix, col_ix)
 
@@ -194,8 +194,8 @@ class VectorizedDF:
     def __getitem__(self, i: int):
         """Return the i-th element iterated over in vectorization."""
         X = self.X_multiindex
-        row_ind, col_ind = self.get_iter_indices()[i]
-        item = X[[col_ind]].loc[row_ind]
+        row_ind, col_ind = list(self.get_iter_indices())[i]
+        item = X[pd.Index(col_ind)].loc[row_ind]
         item = _enforce_index_freq(item)
         # pd-multiindex type (Panel case) expects these index names:
         if self.iterate_as == "Panel":
@@ -231,7 +231,7 @@ class VectorizedDF:
                 (pd-multiindex mtype for Panel, or pd_multiindex_hier for Hierarchical)
             if convert_back=True, will have same format and mtype as X input to __init__
         """
-        row_ix, col_ix = self.get_iter_indices()
+        row_ix, col_ix = self.iter_indices
         if row_ix is None and col_ix is None:
             X_mi_reconstructed = self.X_multiindex
         elif col_ix is None:

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -5,6 +5,7 @@
 Contains VectorizedDF class.
 """
 from itertools import product
+
 import pandas as pd
 
 from sktime.datatypes._check import check_is_scitype, mtype

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -51,7 +51,7 @@ class VectorizedDF:
         Used to obtain original format after applying operations to self iterated
     """
 
-    SERIES_SCITYPES = ["Series," "Panel", "Hierarchical"]
+    SERIES_SCITYPES = ["Series", "Panel", "Hierarchical"]
 
     def __init__(
         self, X, y=None, iterate_as="Series", is_scitype="Panel", iterate_cols=False
@@ -71,7 +71,7 @@ class VectorizedDF:
         if is_scitype is not None and is_scitype not in self.SERIES_SCITYPES:
             raise ValueError(
                 'is_scitype must be None, "Hierarchical", "Panel", or "Series" ',
-                f"found {is_scitype}",
+                f"found: {is_scitype}",
             )
         self.iterate_as = iterate_as
 
@@ -81,7 +81,7 @@ class VectorizedDF:
         if iterate_as not in self.SERIES_SCITYPES:
             raise ValueError(
                 f'iterate_as must be "Series", "Panel", or "Hierarchical", '
-                f"found {iterate_as}"
+                f"found: {iterate_as}"
             )
         self.iterate_as = iterate_as
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -210,6 +210,8 @@ class VectorizedDF:
         row_ind, col_ind = self._iter_indices()[i]
         if isinstance(col_ind, list):
             col_ind = pd.Index(col_ind)
+        else:
+            col_ind = [col_ind]
         item = X[col_ind].loc[row_ind]
         item = _enforce_index_freq(item)
         # pd-multiindex type (Panel case) expects these index names:
@@ -259,7 +261,7 @@ class VectorizedDF:
             col_n = len(col_ix)
             for i in range(row_n):
                 ith_col_block = df_list[i * col_n : (i + 1) * col_n]
-                col_concats += pd.concat(ith_col_block, axis=1)
+                col_concats += [pd.concat(ith_col_block, axis=1)]
             X_mi_reconstructed = pd.concat(col_concats, keys=row_ix, axis=0)
 
         X_mi_index = X_mi_reconstructed.index

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -39,6 +39,27 @@ def _get_all_mtypes_for_scitype(scitype):
     return mtypes
 
 
+def _is_valid_iterate_as(scitype, iterate_as):
+    """Return whether iterate_as has equal or lower type as scitype.
+
+    Parameters
+    ----------
+    scitype : str - scitype
+    iterate_as : str - scitype
+
+    Returns
+    -------
+    valid : bool, whether iterate_as can be iterated over (lower or equal type)
+    """
+    if scitype == "Hierarchical":
+        return True
+    if scitype == "Panel" and iterate_as == "Hierarchical":
+        return False
+    if scitype == "Series" and iterate_as != "Series":
+        return False
+    return True
+
+
 def _generate_scitype_mtype_combinations():
     """Return scitype/mtype tuples for pytest_generate_tests.
 
@@ -124,13 +145,15 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("scitype,mtype", keys, ids=ids)
 
     if "iterate_as" in fixturenames:
-        metafunc.parametrize("iterate_as", ["Panel", "Series"])
+        metafunc.parametrize("iterate_as", ["Hierarchical", "Panel", "Series"])
 
     if "iterate_cols" in fixturenames:
         metafunc.parametrize("iterate_cols", [False, True])
 
 
-def test_construct_vectorizeddf(scitype, mtype, fixture_index, iterate_cols):
+def test_construct_vectorizeddf(
+    scitype, mtype, fixture_index, iterate_cols, iterate_as
+):
     """Test that VectorizedDF constructs with valid arguments.
 
     Fixtures parameterized
@@ -140,22 +163,20 @@ def test_construct_vectorizeddf(scitype, mtype, fixture_index, iterate_cols):
     fixture_index : int - index of fixture tuple with that scitype and mtype
     iterate_cols : bool - whether to iterate over columns
     """
+    if not _is_valid_iterate_as(scitype, iterate_as):
+        return None
+
     # retrieve fixture for checking
     fixture = get_examples(mtype=mtype, as_scitype=scitype).get(fixture_index)
 
     # iterate as Series, without automated identification of scitype
     VectorizedDF(
-        X=fixture, iterate_as="Series", is_scitype=scitype, iterate_cols=iterate_cols
+        X=fixture, iterate_as=iterate_as, is_scitype=scitype, iterate_cols=iterate_cols
     )
 
     # iterate as Series, with automated identification of scitype
     VectorizedDF(
-        X=fixture, iterate_as="Series", is_scitype=None, iterate_cols=iterate_cols
-    )
-
-    # iterate as Panel, with automated identification of scitype
-    VectorizedDF(
-        X=fixture, iterate_as="Panel", is_scitype=None, iterate_cols=iterate_cols
+        X=fixture, iterate_as=iterate_as, is_scitype=None, iterate_cols=iterate_cols
     )
 
 
@@ -196,7 +217,9 @@ def test_item_len(scitype, mtype, fixture_index, iterate_as, iterate_cols):
     iterate_as : str - level on which to iterate over
     iterate_cols : bool - whether to iterate over columns
     """
-    # escape for the invalid Panel/Panel combination, see above
+    # escape for the invalid combinations, see above
+    if not _is_valid_iterate_as(scitype, iterate_as):
+        return None
 
     # retrieve fixture for checking
     fixture = get_examples(mtype=mtype, as_scitype=scitype).get(fixture_index)
@@ -242,8 +265,8 @@ def test_iteration(scitype, mtype, fixture_index, iterate_as, iterate_cols):
     iterate_as : str - level on which to iterate over
     iterate_cols : bool - whether to iterate over columns
     """
-    # escape for the invalid Panel/Panel combination, see above
-    if iterate_as == "Panel" and scitype == "Panel":
+    # escape for the invalid combinations, see above
+    if not _is_valid_iterate_as(scitype, iterate_as):
         return None
 
     # retrieve fixture for checking
@@ -282,8 +305,8 @@ def test_series_item_mtype(scitype, mtype, fixture_index, iterate_as, iterate_co
     iterate_as : str - level on which to iterate over
     iterate_cols : bool - whether to iterate over columns
     """
-    # escape for the invalid Panel/Panel combination, see above
-    if iterate_as == "Panel" and scitype == "Panel":
+    # escape for the invalid combinations, see above
+    if not _is_valid_iterate_as(scitype, iterate_as):
         return None
 
     # retrieve fixture for checking
@@ -302,8 +325,10 @@ def test_series_item_mtype(scitype, mtype, fixture_index, iterate_as, iterate_co
         correct_mtype = "pd.DataFrame"
     elif iterate_as == "Panel":
         correct_mtype = "pd-multiindex"
+    elif iterate_as == "Hierarchical":
+        correct_mtype = "pd_multiindex_hier"
     else:
-        RuntimeError(f"found unexpected iterate_as value: {iterate_as}")
+        raise RuntimeError(f"found unexpected iterate_as value: {iterate_as}")
 
     X_list_valid = [
         check_is_mtype(X, mtype=correct_mtype, scitype=iterate_as) for X in X_list
@@ -331,8 +356,8 @@ def test_reconstruct_identical(scitype, mtype, fixture_index, iterate_as, iterat
     AssertionError if examples are not correctly identified
     error if check itself raises an error
     """
-    # escape for the invalid Panel/Panel combination, see above
-    if iterate_as == "Panel" and scitype == "Panel":
+    # escape for the invalid combinations, see above
+    if not _is_valid_iterate_as(scitype, iterate_as):
         return None
 
     # retrieve fixture for checking

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -225,7 +225,7 @@ def test_item_len(scitype, mtype, fixture_index, iterate_as, iterate_cols):
     fixture = get_examples(mtype=mtype, as_scitype=scitype).get(fixture_index)
 
     # get true length
-    if iterate_as == "Panel" and scitype == "Panel":
+    if iterate_as == scitype:
         true_length = 1
     elif iterate_as == "Series":
         _, _, metadata = check_is_mtype(

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -163,7 +163,7 @@ def test_construct_vectorizeddf_errors(scitype, mtype, fixture_index):
 
     # if both iterate_as and as_scitype are "Panel", should raise an error
     with pytest.raises(ValueError, match=r'is_scitype is "Panel"'):
-        VectorizedDF(X=fixture, iterate_as="Panel", is_scitype="Panel")
+        VectorizedDF(X=fixture, iterate_as="Hierarchical", is_scitype="Panel")
 
     # invalid argument to iterate_as
     with pytest.raises(ValueError, match=r"iterate_as must be"):

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1528,11 +1528,10 @@ class BaseForecaster(BaseEstimator):
                 col_idx = ["forecasters"]
 
             self.forecasters_ = pd.DataFrame(index=row_idx, columns=col_idx)
-            c = -1
-            for j, i in product(range(len(col_idx)), range(len(row_idx))):
-                c += 1
+            for ix in len(ys):
+                i, j = y.get_iloc_indexer(ix)
                 self.forecasters_.iloc[i, j] = self.clone()
-                self.forecasters_.iloc[i, j].fit(y=ys[c], X=Xs[c], **kwargs)
+                self.forecasters_.iloc[i, j].fit(y=ys[ix], X=Xs[ix], **kwargs)
 
             return self
         elif methodname in PREDICT_METHODS:
@@ -1545,7 +1544,7 @@ class BaseForecaster(BaseEstimator):
                 Xs = X.as_list()
             y_preds = []
             c = -1
-            for j, i in product(range(m), range(n)):
+            for i, j in product(range(n), range(m)):
                 c += 1
                 method = getattr(self.forecasters_.iloc[i, j], methodname)
                 y_preds += [method(X=Xs[c], **kwargs)]

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1528,7 +1528,7 @@ class BaseForecaster(BaseEstimator):
                 col_idx = ["forecasters"]
 
             self.forecasters_ = pd.DataFrame(index=row_idx, columns=col_idx)
-            for ix in len(ys):
+            for ix in range(len(ys)):
                 i, j = y.get_iloc_indexer(ix)
                 self.forecasters_.iloc[i, j] = self.clone()
                 self.forecasters_.iloc[i, j].fit(y=ys[ix], X=Xs[ix], **kwargs)

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -39,6 +39,7 @@ __all__ = ["BaseForecaster"]
 
 from copy import deepcopy
 from itertools import product
+from multiprocessing.sharedctypes import Value
 from warnings import warn
 
 import numpy as np
@@ -1530,8 +1531,8 @@ class BaseForecaster(BaseEstimator):
             self.forecasters_ = pd.DataFrame(index=row_idx, columns=col_idx)
             for ix in range(len(ys)):
                 i, j = y.get_iloc_indexer(ix)
-                self.forecasters_.iloc[i, j] = self.clone()
-                self.forecasters_.iloc[i, j].fit(y=ys[ix], X=Xs[ix], **kwargs)
+                self.forecasters_.iloc[i].iloc[j] = self.clone()
+                self.forecasters_.iloc[i].iloc[j].fit(y=ys[ix], X=Xs[ix], **kwargs)
 
             return self
         elif methodname in PREDICT_METHODS:

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1543,11 +1543,11 @@ class BaseForecaster(BaseEstimator):
             else:
                 Xs = X.as_list()
             y_preds = []
-            c = -1
+            ix = -1
             for i, j in product(range(n), range(m)):
-                c += 1
-                method = getattr(self.forecasters_.iloc[i, j], methodname)
-                y_preds += [method(X=Xs[c], **kwargs)]
+                ix += 1
+                method = getattr(self.forecasters_.iloc[i].iloc[j], methodname)
+                y_preds += [method(X=Xs[ix], **kwargs)]
             y_pred = self._yvec.reconstruct(y_preds, overwrite_index=True)
             return y_pred
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -39,7 +39,6 @@ __all__ = ["BaseForecaster"]
 
 from copy import deepcopy
 from itertools import product
-from multiprocessing.sharedctypes import Value
 from warnings import warn
 
 import numpy as np

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -888,7 +888,7 @@ class BaseTransformer(BaseEstimator):
             X = kwargs.pop("X")
             y = kwargs.pop("y", None)
 
-            row_idx, col_idx = y.get_iter_indices()
+            row_idx, col_idx = X.get_iter_indices()
             if row_idx is None:
                 row_idx = ["transformers"]
             if col_idx is None:

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -952,14 +952,14 @@ class BaseTransformer(BaseEstimator):
 
             # if fit_is_empty: don't store transformers, run fit/transform in one
             else:
-                X, _, Xs, ys, n, _ = unwrap(kwargs)
+                X, _, Xs, ys, n, _, _ = unwrap(kwargs)
 
                 # fit/transform the i-th series/panel with a new clone of self
                 Xts = []
-                for i in range(n):
-                    transformer = self.clone().fit(X=Xs[i], y=ys[i], **kwargs)
+                for ix in range(n):
+                    transformer = self.clone().fit(X=Xs[ix], y=ys[ix], **kwargs)
                     method = getattr(transformer, methodname)
-                    Xts += [method(X=Xs[i], y=ys[i], **kwargs)]
+                    Xts += [method(X=Xs[ix], y=ys[ix], **kwargs)]
                 Xt = X.reconstruct(Xts, overwrite_index=False)
 
             # # one more thing before returning:

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -913,7 +913,7 @@ class BaseTransformer(BaseEstimator):
             # if fit is called, create container of transformers, but not in update
             if methodname == "fit":
                 self.transformers_ = pd.DataFrame(index=row_idx, columns=col_idx)
-                for ix in range(len(Xs)):
+                for ix in range(n):
                     i, j = X.get_iloc_indexer(ix)
                     self.transformers_.iloc[i].iloc[j] = self.clone()
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -49,6 +49,7 @@ __all__ = [
     "_PanelToPanelTransformer",
 ]
 
+from itertools import product
 from typing import Union
 
 import numpy as np
@@ -887,55 +888,66 @@ class BaseTransformer(BaseEstimator):
             X = kwargs.pop("X")
             y = kwargs.pop("y", None)
 
-            idx = X.get_iter_indices()
-            n = len(idx)
+            row_idx, col_idx = y.get_iter_indices()
             Xs = X.as_list()
+            n = len(Xs)
 
             if y is None:
-                ys = [None] * len(Xs)
+                ys = [None] * n
             else:
                 ys = y.as_list()
 
-            return X, y, Xs, ys, n, idx
+            return X, y, Xs, ys, n, row_idx, col_idx
 
         FIT_METHODS = ["fit", "update"]
         TRAFO_METHODS = ["transform", "inverse_transform"]
 
         if methodname in FIT_METHODS:
-            X, _, Xs, ys, n, idx = unwrap(kwargs)
+            X, _, Xs, ys, n, row_idx, col_idx = unwrap(kwargs)
 
             # if fit is called, create container of transformers, but not in update
             if methodname == "fit":
-                self.transformers_ = pd.DataFrame(index=idx, columns=["transformers"])
-                for i in range(n):
-                    self.transformers_.iloc[i, 0] = self.clone()
+                if row_idx is None:
+                    row_idx = ["transformers"]
+                if col_idx is None:
+                    col_idx = ["transformers"]
 
-            # fit/update the i-th transformer with the i-th series/panel
-            for i in range(n):
-                method = getattr(self.transformers_.iloc[i, 0], methodname)
-                method(X=Xs[i], y=ys[i], **kwargs)
+                self.transformers_ = pd.DataFrame(index=row_idx, columns=col_idx)
+                for ix in range(len(Xs)):
+                    i, j = X.get_iloc_indexer(ix)
+                    self.transformers_.iloc[i].iloc[j] = self.clone()
+
+            # fit/update the ix-th transformer with the ix-th series/panel
+            for ix in range(n):
+                i, j = X.get_iloc_indexer(ix)
+                method = getattr(self.transformers_.iloc[i].iloc[j], methodname)
+                method(X=Xs[ix], y=ys[ix], **kwargs)
 
             return self
 
         if methodname in TRAFO_METHODS:
             # loop through fitted transformers one-by-one, and transform series/panels
             if not self.get_tag("fit_is_empty"):
-                X, _, Xs, ys, n, _ = unwrap(kwargs)
+                X, _, Xs, ys, n_trafos, _, _ = unwrap(kwargs)
 
-                n_fit = len(self.transformers_.index)
+                n = len(self.transformers_.index)
+                m = len(self.transformers_.columns)
+                n_fit = n * m
 
-                if n != n_fit:
+                if n_trafos != n_fit:
                     raise RuntimeError(
                         "found different number of instances in transform than in fit. "
                         f"number of instances seen in fit: {n_fit}; "
-                        f"number of instances seen in transform: {n}"
+                        f"number of instances seen in transform: {n * m}"
                     )
 
                 # transform the i-th series/panel with the i-th stored transformer
                 Xts = []
-                for i in range(n):
-                    method = getattr(self.transformers_.iloc[i, 0], methodname)
-                    Xts += [method(X=Xs[i], y=ys[i], **kwargs)]
+                ix = -1
+                for i, j in product(range(n), range(m)):
+                    ix += 1
+                    method = getattr(self.transformers_.iloc[i].iloc[j], methodname)
+                    Xts += [method(X=Xs[ix], y=ys[ix], **kwargs)]
                 Xt = X.reconstruct(Xts, overwrite_index=False)
 
             # if fit_is_empty: don't store transformers, run fit/transform in one

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -889,6 +889,11 @@ class BaseTransformer(BaseEstimator):
             y = kwargs.pop("y", None)
 
             row_idx, col_idx = y.get_iter_indices()
+            if row_idx is None:
+                row_idx = ["transformers"]
+            if col_idx is None:
+                col_idx = ["transformers"]
+
             Xs = X.as_list()
             n = len(Xs)
 
@@ -907,11 +912,6 @@ class BaseTransformer(BaseEstimator):
 
             # if fit is called, create container of transformers, but not in update
             if methodname == "fit":
-                if row_idx is None:
-                    row_idx = ["transformers"]
-                if col_idx is None:
-                    col_idx = ["transformers"]
-
                 self.transformers_ = pd.DataFrame(index=row_idx, columns=col_idx)
                 for ix in range(len(Xs)):
                     i, j = X.get_iloc_indexer(ix)


### PR DESCRIPTION
This PR adds functionality in `VectorizedDF` to vectorize across columns/variables.

* adds an `iterate_cols` arg to the `VectorizedDF` constructor which enables vectorization across columns.
* changes `get_iter_indices` to produce row/column indices for subsetting
* relaxes requirements on scitypes so that `iterate_as` and `is_scitype` can be equal, i.e., when iteration/vectorization is only over columns and not of rows
* tests are kept for regression testing, only negative tests are relaxed where previously `iterate_as=is_scitype` was tested to raise an error
* tests are extended to also test column vectorization
* since the interface of `get_iter_indices` changed to return cols/rows, counter-adaptation in the `BaseForecaster` and `BaseTransformer` were necessary. In the future, this should be refactored into an "apply-to" interface of `VectorizedDF`, there is repetitive boilerplate and logic that should not be in the base classes. Deprecation is not necessary since the public interfaces of the base classes did not change.

This PR is needed to addess https://github.com/alan-turing-institute/sktime/issues/2547 for univariate/multivariate, see #2865.