### PR TITLE
[ENH] fix `get_window` utility when `window_length` was `None`

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -269,9 +269,11 @@ def get_window(obj, window_length=None, lag=None):
         # and always subset on first dimension
         if obj.ndim > 1:
             obj = obj.swapaxes(1, -1)
+        obj_len = len(obj)
         if lag is None:
             lag = 0
-        obj_len = len(obj)
+        if window_length is None:
+            window_length = obj_len
         window_start = max(-window_length - lag, -obj_len)
         window_end = max(-lag, -obj_len)
         # we need to swap first and last dimension back before returning, if done above

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -249,8 +249,8 @@ def get_window(obj, window_length=None, lag=None):
     """
     from sktime.datatypes import check_is_scitype, convert_to
 
-    if obj is None:
-        return None
+    if obj is None or (window_length is None and lag is None):
+        return obj
 
     valid, _, metadata = check_is_scitype(
         obj, scitype=["Series", "Panel", "Hierarchical"], return_metadata=True

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -100,30 +100,43 @@ def test_get_window_expected_result():
     Raises
     ------
     Exception if get_window raises one
+    AssertionError if get_window output shape is not as expected
     """
     X_df = get_examples(mtype="pd.DataFrame")[0]
     assert len(get_window(X_df, 2, 1)) == 2
     assert len(get_window(X_df, 3, 1)) == 3
     assert len(get_window(X_df, 1, 2)) == 1
     assert len(get_window(X_df, 3, 4)) == 0
+    assert len(get_window(X_df, 3, None)) == 3
+    assert len(get_window(X_df, None, 2)) == 2
+    assert len(get_window(X_df, None, None)) == 4
 
     X_mi = get_examples(mtype="pd-multiindex")[0]
     assert len(get_window(X_mi, 3, 1)) == 6
     assert len(get_window(X_mi, 2, 0)) == 6
     assert len(get_window(X_mi, 2, 4)) == 0
     assert len(get_window(X_mi, 1, 2)) == 3
+    assert len(get_window(X_mi, 2, None)) == 6
+    assert len(get_window(X_mi, None, 2)) == 3
+    assert len(get_window(X_mi, None, None)) == 12
 
     X_hi = get_examples(mtype="pd_multiindex_hier")[0]
     assert len(get_window(X_hi, 3, 1)) == 12
     assert len(get_window(X_hi, 2, 0)) == 12
     assert len(get_window(X_hi, 2, 4)) == 0
     assert len(get_window(X_hi, 1, 2)) == 6
+    assert len(get_window(X_hi, 2, None)) == 12
+    assert len(get_window(X_hi, None, 2)) == 6
+    assert len(get_window(X_hi, None, None)) == 18
 
-    X_hi = get_examples(mtype="numpy3D")[0]
-    assert get_window(X_hi, 3, 1).shape == (2, 2, 3)
-    assert get_window(X_hi, 2, 0).shape == (2, 2, 3)
-    assert get_window(X_hi, 2, 4).shape == (0, 2, 3)
-    assert get_window(X_hi, 1, 2).shape == (1, 2, 3)
+    X_np3d = get_examples(mtype="numpy3D")[0]
+    assert get_window(X_np3d, 3, 1).shape == (2, 2, 3)
+    assert get_window(X_np3d, 2, 0).shape == (2, 2, 3)
+    assert get_window(X_np3d, 2, 4).shape == (0, 2, 3)
+    assert get_window(X_np3d, 1, 2).shape == (1, 2, 3)
+    assert get_window(X_np3d, 2, None).shape == (2, 2, 3)
+    assert get_window(X_np3d, None, 2).shape == (1, 2, 3)
+    assert get_window(X_np3d, None, None).shape == (3, 2, 3)
 
 
 @pytest.mark.parametrize("scitype,mtype", SCITYPE_MTYPE_PAIRS)

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -118,7 +118,7 @@ def test_get_window_expected_result():
     assert len(get_window(X_mi, 1, 2)) == 3
     assert len(get_window(X_mi, 2, None)) == 6
     assert len(get_window(X_mi, None, 2)) == 3
-    assert len(get_window(X_mi, None, None)) == 12
+    assert len(get_window(X_mi, None, None)) == 9
 
     X_hi = get_examples(mtype="pd_multiindex_hier")[0]
     assert len(get_window(X_hi, 3, 1)) == 12


### PR DESCRIPTION
The `get_window` utility was broken when `window_length` was `None`, it would return the object `obj` unchanged.

This has now been fixed.

In addition, the `lag` default has been set to zero, which is interpreted as a zero integer or `timedelta`, depending on `obj`.

Test cases for `None` input behaviour have been added.