### PR TITLE
[ENH] `temporal_train_test_split` compatibility with all data formats and time difference input

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -83,7 +83,7 @@ GET_CUTOFF_SUPPORTED_MTYPES = [
     "np.ndarray",
     "pd-multiindex",
     "numpy3D",
-    "nested_univ"
+    "nested_univ",
     "df-list",
     "pd_multiindex_hier",
     "np.ndarray",

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -77,7 +77,21 @@ def get_index_for_series(obj, cutoff=0):
     return pd.RangeIndex(cutoff, cutoff + obj.shape[0])
 
 
-def get_cutoff(obj, cutoff=0, return_index=False):
+GET_CUTOFF_SUPPORTED_MTYPES = [
+    "pd.DataFrame",
+    "pd.Series",
+    "np.ndarray",
+    "pd-multiindex",
+    "numpy3D",
+    "nested_univ"
+    "df-list",
+    "pd_multiindex_hier",
+    "np.ndarray",
+    "numpy3D",
+]
+
+
+def get_cutoff(obj, cutoff=0, return_index=False, reverse_order=False):
     """Get cutoff = latest time point of time series or time series panel.
 
     Assumptions on obj are not checked, these should be validated separately.
@@ -86,10 +100,9 @@ def get_cutoff(obj, cutoff=0, return_index=False):
     Parameters
     ----------
     obj : sktime compatible time series data container
-        must be of one of the following mtypes:
-            pd.Series, pd.DataFrame, np.ndarray, of Series scitype
-            pd.multiindex, numpy3D, nested_univ, df-list, of Panel scitype
-            pd_multiindex_hier, of Hierarchical scitype
+        must be of Series, Panel, or Hierarchical scitype
+        all mtypes are supported via conversion to internally supported types
+        to avoid conversions, pass data in one of GET_CUTOFF_SUPPORTED_MTYPES
     cutoff : int, optional, default=0
         current cutoff, used to offset index if obj is np.ndarray
     return_index : bool, optional, default=False
@@ -97,12 +110,22 @@ def get_cutoff(obj, cutoff=0, return_index=False):
             or a pandas compatible index element (False)
         note: return_index=True may set freq attribute of time types to None
             return_index=False will typically preserve freq attribute
+    reverse_order : bool, optional, default=False
+        if False, returns largest time index. If True, returns smallest time index.
 
     Returns
     -------
     cutoff_index : pandas compatible index element (if return_index=False)
         pd.Index of length 1 (if return_index=True)
     """
+    from sktime.datatypes import check_is_scitype, convert_to
+
+    valid = check_is_scitype(obj, scitype=["Series", "Panel", "Hierarchical"])
+    if not valid:
+        raise ValueError("obj must be of Series, Panel, or Hierarchical scitype")
+
+    obj = convert_to(obj, GET_CUTOFF_SUPPORTED_MTYPES)
+
     if cutoff is None:
         cutoff = 0
 
@@ -115,26 +138,36 @@ def get_cutoff(obj, cutoff=0, return_index=False):
             cutoff_ind = obj.shape[-1] + cutoff
         if obj.ndim < 3 and obj.ndim > 0:
             cutoff_ind = obj.shape[0] + cutoff
+        if reverse_order:
+            cutoff_ind = 0
         if return_index:
             return pd.RangeIndex(cutoff_ind - 1, cutoff_ind)
         else:
             return cutoff_ind
 
+    # define "first" or "last" index depending on which is desired
+    if reverse_order:
+        ix = 0
+        agg = min
+    else:
+        ix = -1
+        agg = max
+
     if isinstance(obj, pd.Series):
-        return obj.index[[-1]] if return_index else obj.index[-1]
+        return obj.index[[ix]] if return_index else obj.index[ix]
 
     # nested_univ (Panel) or pd.DataFrame(Series)
     if isinstance(obj, pd.DataFrame) and not isinstance(obj.index, pd.MultiIndex):
         objcols = [x for x in obj.columns if obj.dtypes[x] == "object"]
         # pd.DataFrame
         if len(objcols) == 0:
-            return obj.index[[-1]] if return_index else obj.index[-1]
+            return obj.index[[ix]] if return_index else obj.index[ix]
         # nested_univ
         else:
             if return_index:
-                idxx = [x.index[[-1]] for col in objcols for x in obj[col]]
+                idxx = [x.index[[ix]] for col in objcols for x in obj[col]]
             else:
-                idxx = [x.index[-1] for col in objcols for x in obj[col]]
+                idxx = [x.index[ix] for col in objcols for x in obj[col]]
             return max(idxx)
 
     # pd-multiindex (Panel) and pd_multiindex_hier (Hierarchical)
@@ -145,15 +178,15 @@ def get_cutoff(obj, cutoff=0, return_index=False):
             cutoffs = [x[[-1]] for x in series_idx]
         else:
             cutoffs = [x[-1] for x in series_idx]
-        return max(cutoffs)
+        return agg(cutoffs)
 
     # df-list (Panel)
     if isinstance(obj, list):
         if return_index:
-            idxs = [x.index[[-1]] for x in obj]
+            idxs = [x.index[[ix]] for x in obj]
         else:
-            idxs = [x.index[-1] for x in obj]
-        return max(idxs)
+            idxs = [x.index[ix] for x in obj]
+        return agg(idxs)
 
 
 def update_data(X, X_new=None):
@@ -210,7 +243,7 @@ def update_data(X, X_new=None):
         return X_new.combine_first(X)
 
 
-GET_LATEST_WINDOW_SUPPORTED_MTYPES = [
+GET_WINDOW_SUPPORTED_MTYPES = [
     "pd.DataFrame",
     "pd-multiindex",
     "pd_multiindex_hier",
@@ -230,10 +263,9 @@ def get_window(obj, window_length=None, lag=None):
     Parameters
     ----------
     obj : sktime compatible time series data container or None
-        if not None, must be of one of the following mtypes:
-            pd.Series, pd.DataFrame, np.ndarray, of Series scitype
-            pd.multiindex, numpy3D, nested_univ, df-list, of Panel scitype
-            pd_multiindex_hier, of Hierarchical scitype
+        if not None, must be of Series, Panel, or Hierarchical scitype
+        all mtypes are supported via conversion to internally supported types
+        to avoid conversions, pass data in one of GET_WINDOW_SUPPORTED_MTYPES
     window_length : int or timedelta, optional, default=-inf
         must be int if obj is int indexed, timedelta if datetime indexed
         length of the window to slice to. Default = window of infinite size
@@ -259,7 +291,7 @@ def get_window(obj, window_length=None, lag=None):
         raise ValueError("obj must be of Series, Panel, or Hierarchical scitype")
     obj_in_mtype = metadata["mtype"]
 
-    obj = convert_to(obj, GET_LATEST_WINDOW_SUPPORTED_MTYPES)
+    obj = convert_to(obj, GET_WINDOW_SUPPORTED_MTYPES)
 
     # numpy3D (Panel) or np.npdarray (Series)
     if isinstance(obj, np.ndarray):
@@ -325,11 +357,10 @@ def get_slice(obj, start=None, end=None):
 
     Parameters
     ----------
-    obj : sktime compatible time series Series type or None
-        if not None, must be of one of the following mtypes:
-            pd.Series, pd.DataFrame, np.ndarray, of Series scitype
-            pd.multiindex, numpy3D, nested_univ, df-list, of Panel scitype
-            pd_multiindex_hier, of Hierarchical scitype
+    obj : sktime compatible time series data container or None
+        if not None, must be of Series, Panel, or Hierarchical scitype
+        all mtypes are supported via conversion to internally supported types
+        to avoid conversions, pass data in one of GET_WINDOW_SUPPORTED_MTYPES
     start : int or timestamp, optional, default = None
         must be int if obj is int indexed, timestamp if datetime indexed
         Inclusive start of slice. Default = None.
@@ -355,7 +386,7 @@ def get_slice(obj, start=None, end=None):
         raise ValueError("obj must be of Series, Panel, or Hierarchical scitype")
     obj_in_mtype = metadata["mtype"]
 
-    obj = convert_to(obj, GET_LATEST_WINDOW_SUPPORTED_MTYPES)
+    obj = convert_to(obj, GET_WINDOW_SUPPORTED_MTYPES)
 
     # numpy3D (Panel) or np.npdarray (Series)
     # Assumes the index is integer so will be exclusive by default

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -269,9 +269,11 @@ def get_window(obj, window_length=None, lag=None):
         # and always subset on first dimension
         if obj.ndim > 1:
             obj = obj.swapaxes(1, -1)
+        obj_len = len(obj)
         if lag is None:
             lag = 0
-        obj_len = len(obj)
+        if window_length is None:
+            window_length = obj_len
         window_start = max(-window_length - lag, -obj_len)
         window_end = max(-lag, -obj_len)
         # we need to swap first and last dimension back before returning, if done above

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -249,8 +249,8 @@ def get_window(obj, window_length=None, lag=None):
     """
     from sktime.datatypes import check_is_scitype, convert_to
 
-    if obj is None:
-        return None
+    if obj is None or (window_length is None and lag is None):
+        return obj
 
     valid, _, metadata = check_is_scitype(
         obj, scitype=["Series", "Panel", "Hierarchical"], return_metadata=True

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -100,30 +100,43 @@ def test_get_window_expected_result():
     Raises
     ------
     Exception if get_window raises one
+    AssertionError if get_window output shape is not as expected
     """
     X_df = get_examples(mtype="pd.DataFrame")[0]
     assert len(get_window(X_df, 2, 1)) == 2
     assert len(get_window(X_df, 3, 1)) == 3
     assert len(get_window(X_df, 1, 2)) == 1
     assert len(get_window(X_df, 3, 4)) == 0
+    assert len(get_window(X_df, 3, None)) == 3
+    assert len(get_window(X_df, None, 2)) == 2
+    assert len(get_window(X_df, None, None)) == 4
 
     X_mi = get_examples(mtype="pd-multiindex")[0]
     assert len(get_window(X_mi, 3, 1)) == 6
     assert len(get_window(X_mi, 2, 0)) == 6
     assert len(get_window(X_mi, 2, 4)) == 0
     assert len(get_window(X_mi, 1, 2)) == 3
+    assert len(get_window(X_mi, 2, None)) == 6
+    assert len(get_window(X_mi, None, 2)) == 3
+    assert len(get_window(X_mi, None, None)) == 12
 
     X_hi = get_examples(mtype="pd_multiindex_hier")[0]
     assert len(get_window(X_hi, 3, 1)) == 12
     assert len(get_window(X_hi, 2, 0)) == 12
     assert len(get_window(X_hi, 2, 4)) == 0
     assert len(get_window(X_hi, 1, 2)) == 6
+    assert len(get_window(X_hi, 2, None)) == 12
+    assert len(get_window(X_hi, None, 2)) == 6
+    assert len(get_window(X_hi, None, None)) == 18
 
-    X_hi = get_examples(mtype="numpy3D")[0]
-    assert get_window(X_hi, 3, 1).shape == (2, 2, 3)
-    assert get_window(X_hi, 2, 0).shape == (2, 2, 3)
-    assert get_window(X_hi, 2, 4).shape == (0, 2, 3)
-    assert get_window(X_hi, 1, 2).shape == (1, 2, 3)
+    X_np3d = get_examples(mtype="numpy3D")[0]
+    assert get_window(X_np3d, 3, 1).shape == (2, 2, 3)
+    assert get_window(X_np3d, 2, 0).shape == (2, 2, 3)
+    assert get_window(X_np3d, 2, 4).shape == (0, 2, 3)
+    assert get_window(X_np3d, 1, 2).shape == (1, 2, 3)
+    assert get_window(X_np3d, 2, None).shape == (2, 2, 3)
+    assert get_window(X_np3d, None, 2).shape == (1, 2, 3)
+    assert get_window(X_np3d, None, None).shape == (3, 2, 3)
 
 
 @pytest.mark.parametrize("scitype,mtype", SCITYPE_MTYPE_PAIRS)

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -118,7 +118,7 @@ def test_get_window_expected_result():
     assert len(get_window(X_mi, 1, 2)) == 3
     assert len(get_window(X_mi, 2, None)) == 6
     assert len(get_window(X_mi, None, 2)) == 3
-    assert len(get_window(X_mi, None, None)) == 12
+    assert len(get_window(X_mi, None, None)) == 9
 
     X_hi = get_examples(mtype="pd_multiindex_hier")[0]
     assert len(get_window(X_hi, 3, 1)) == 12


### PR DESCRIPTION
This PR rewrites `temporal_train_test_split` using `get_cutoff` and `get_window` from `sktime.datatypes._utilities`.

Feature/capability changes:
* `temporal_train_test_split` can now be applied to any sktime compatible data format. For panel and hierarchical data containers, the split is applied across a joint timeline, of the instances.
* `temporal_train_test_split` now accepts time difference as `train_size` and `test_size`, and splits accordingly

Relies on the upgraded `get_cutoff` from #2870.

FYI @khrapovs