### PR TITLE
[ENH] `NaiveForecaster`: remove manual vectorization layer in favour of base class vectorization

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -269,9 +269,11 @@ def get_window(obj, window_length=None, lag=None):
         # and always subset on first dimension
         if obj.ndim > 1:
             obj = obj.swapaxes(1, -1)
+        obj_len = len(obj)
         if lag is None:
             lag = 0
-        obj_len = len(obj)
+        if window_length is None:
+            window_length = obj_len
         window_start = max(-window_length - lag, -obj_len)
         window_end = max(-lag, -obj_len)
         # we need to swap first and last dimension back before returning, if done above

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -249,8 +249,8 @@ def get_window(obj, window_length=None, lag=None):
     """
     from sktime.datatypes import check_is_scitype, convert_to
 
-    if obj is None:
-        return None
+    if obj is None or (window_length is None and lag is None):
+        return obj
 
     valid, _, metadata = check_is_scitype(
         obj, scitype=["Series", "Panel", "Hierarchical"], return_metadata=True

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -163,7 +163,7 @@ class VectorizedDF:
         pair of pandas.Index or pandas.MultiIndex or None
             i-th element of list selects rows/columns in i-th iterate sub-DataFrame
             first element is row index, second element is column index
-            if rows/columns are not iterated over, row/column element is None  
+            if rows/columns are not iterated over, row/column element is None
             use to reconstruct data frame after iteration
         """
         return self.iter_indices

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -210,7 +210,7 @@ class VectorizedDF:
         row_ind, col_ind = self._iter_indices()[i]
         if isinstance(col_ind, list):
             col_ind = pd.Index(col_ind)
-        else:
+        elif not isinstance(col_ind, pd.Index):
             col_ind = [col_ind]
         item = X[col_ind].loc[row_ind]
         item = _enforce_index_freq(item)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -182,9 +182,9 @@ class VectorizedDF:
         if row_ix is None and col_ix is None:
             return (0, 0)
         elif row_ix is None:
-            return (i, 0)
-        elif col_ix is None:
             return (0, i)
+        elif col_ix is None:
+            return (i, 0)
         else:
             col_n = len(col_ix)
             return (i // col_n, i % col_n)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -96,9 +96,7 @@ class VectorizedDF:
             )
 
         if iterate_cols not in [True, False]:
-            raise ValueError(
-                f"iterate_cols must be a boolean, found {iterate_as}"
-            )
+            raise ValueError(f"iterate_cols must be a boolean, found {iterate_as}")
         self.iterate_cols = iterate_cols
 
         self.converter_store = dict()
@@ -243,7 +241,7 @@ class VectorizedDF:
             row_n = len(row_ix)
             col_n = len(col_ix)
             for i in range(row_n):
-                ith_col_block = df_list[i*col_n:(i+1)*col_n]
+                ith_col_block = df_list[i * col_n : (i + 1) * col_n]
                 col_concats += pd.concat(ith_col_block, axis=1)
             X_mi_reconstructed = pd.concat(col_concats, keys=row_ix, axis=0)
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -160,13 +160,34 @@ class VectorizedDF:
 
         Returns
         -------
-        list of pair of pandas.Index or pandas.MultiIndex
-            iterable with unique indices that are iterated over
-            use to reconstruct data frame after iteration
+        pair of pandas.Index or pandas.MultiIndex or None
             i-th element of list selects rows/columns in i-th iterate sub-DataFrame
-            first element of pair are rows, second element are columns selected
+            first element is row index, second element is column index
+            if rows/columns are not iterated over, row/column element is None  
+            use to reconstruct data frame after iteration
         """
         return self.iter_indices
+
+    def get_iloc_indexer(self, i: int):
+        """Get iloc row/column indexer for i-th list element.
+
+        Returns
+        -------
+        pair of int, indexes into get_iter_indices
+            1st element is iloc index for 1st element of get_iter_indices
+            2nd element is iloc index for 2nd element of get_iter_indices
+            together, indicate iloc index of self[i] within get_iter_indices index sets
+        """
+        row_ix, col_ix = self.iter_indices
+        if row_ix is None and col_ix is None:
+            return (0, 0)
+        elif row_ix is None:
+            return (i, 0)
+        elif col_ix is None:
+            return (0, i)
+        else:
+            col_n = len(col_ix)
+            return (i // col_n, i % col_n)
 
     def _iter_indices(self):
         """Get indices that are iterated over in vectorization.

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -109,7 +109,14 @@ class VectorizedDF:
         """Convert X to a pandas multiindex format."""
         is_scitype = self.is_scitype
 
-        if is_scitype == "Panel":
+        if is_scitype == "Series":
+            return convert_to(
+                X,
+                to_type="pd.DataFrame",
+                as_scitype="Series",
+                store=self.converter_store,
+            )
+        elif is_scitype == "Panel":
             return convert_to(
                 X,
                 to_type="pd-multiindex",
@@ -207,7 +214,7 @@ class VectorizedDF:
             ret = [(X.index, X.columns)]
         elif row_ix is None:
             ret = product([X.index], col_ix)
-        if col_ix is None:
+        elif col_ix is None:
             ret = product(row_ix, [X.columns])
         else:  # if row_ix and col_ix are both not None
             ret = product(row_ix, col_ix)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -173,9 +173,9 @@ class VectorizedDF:
         if row_ix is None and col_ix is None:
             return [(X.index, X.columns)]
         if row_ix is None:
-            return product(X.index, col_ix)
+            return product([X.index], col_ix)
         if col_ix is None:
-            return product(row_ix, X.columns)
+            return product(row_ix, [X.columns])
         # if row_ix and col_ix are both not None
         return product(row_ix, col_ix)
 
@@ -194,8 +194,8 @@ class VectorizedDF:
     def __getitem__(self, i: int):
         """Return the i-th element iterated over in vectorization."""
         X = self.X_multiindex
-        row_ind, col_ind = self.get_iter_indices()[i]
-        item = X[[col_ind]].loc[row_ind]
+        row_ind, col_ind = list(self.get_iter_indices())[i]
+        item = X[pd.Index(col_ind)].loc[row_ind]
         item = _enforce_index_freq(item)
         # pd-multiindex type (Panel case) expects these index names:
         if self.iterate_as == "Panel":
@@ -231,7 +231,7 @@ class VectorizedDF:
                 (pd-multiindex mtype for Panel, or pd_multiindex_hier for Hierarchical)
             if convert_back=True, will have same format and mtype as X input to __init__
         """
-        row_ix, col_ix = self.get_iter_indices()
+        row_ix, col_ix = self.iter_indices
         if row_ix is None and col_ix is None:
             X_mi_reconstructed = self.X_multiindex
         elif col_ix is None:

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -5,6 +5,7 @@
 Contains VectorizedDF class.
 """
 from itertools import product
+
 import pandas as pd
 
 from sktime.datatypes._check import check_is_scitype, mtype

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -51,7 +51,7 @@ class VectorizedDF:
         Used to obtain original format after applying operations to self iterated
     """
 
-    SERIES_SCITYPES = ["Series," "Panel", "Hierarchical"]
+    SERIES_SCITYPES = ["Series", "Panel", "Hierarchical"]
 
     def __init__(
         self, X, y=None, iterate_as="Series", is_scitype="Panel", iterate_cols=False
@@ -71,7 +71,7 @@ class VectorizedDF:
         if is_scitype is not None and is_scitype not in self.SERIES_SCITYPES:
             raise ValueError(
                 'is_scitype must be None, "Hierarchical", "Panel", or "Series" ',
-                f"found {is_scitype}",
+                f"found: {is_scitype}",
             )
         self.iterate_as = iterate_as
 
@@ -81,7 +81,7 @@ class VectorizedDF:
         if iterate_as not in self.SERIES_SCITYPES:
             raise ValueError(
                 f'iterate_as must be "Series", "Panel", or "Hierarchical", '
-                f"found {iterate_as}"
+                f"found: {iterate_as}"
             )
         self.iterate_as = iterate_as
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -210,6 +210,8 @@ class VectorizedDF:
         row_ind, col_ind = self._iter_indices()[i]
         if isinstance(col_ind, list):
             col_ind = pd.Index(col_ind)
+        else:
+            col_ind = [col_ind]
         item = X[col_ind].loc[row_ind]
         item = _enforce_index_freq(item)
         # pd-multiindex type (Panel case) expects these index names:
@@ -259,7 +261,7 @@ class VectorizedDF:
             col_n = len(col_ix)
             for i in range(row_n):
                 ith_col_block = df_list[i * col_n : (i + 1) * col_n]
-                col_concats += pd.concat(ith_col_block, axis=1)
+                col_concats += [pd.concat(ith_col_block, axis=1)]
             X_mi_reconstructed = pd.concat(col_concats, keys=row_ix, axis=0)
 
         X_mi_index = X_mi_reconstructed.index

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -100,30 +100,43 @@ def test_get_window_expected_result():
     Raises
     ------
     Exception if get_window raises one
+    AssertionError if get_window output shape is not as expected
     """
     X_df = get_examples(mtype="pd.DataFrame")[0]
     assert len(get_window(X_df, 2, 1)) == 2
     assert len(get_window(X_df, 3, 1)) == 3
     assert len(get_window(X_df, 1, 2)) == 1
     assert len(get_window(X_df, 3, 4)) == 0
+    assert len(get_window(X_df, 3, None)) == 3
+    assert len(get_window(X_df, None, 2)) == 2
+    assert len(get_window(X_df, None, None)) == 4
 
     X_mi = get_examples(mtype="pd-multiindex")[0]
     assert len(get_window(X_mi, 3, 1)) == 6
     assert len(get_window(X_mi, 2, 0)) == 6
     assert len(get_window(X_mi, 2, 4)) == 0
     assert len(get_window(X_mi, 1, 2)) == 3
+    assert len(get_window(X_mi, 2, None)) == 6
+    assert len(get_window(X_mi, None, 2)) == 3
+    assert len(get_window(X_mi, None, None)) == 12
 
     X_hi = get_examples(mtype="pd_multiindex_hier")[0]
     assert len(get_window(X_hi, 3, 1)) == 12
     assert len(get_window(X_hi, 2, 0)) == 12
     assert len(get_window(X_hi, 2, 4)) == 0
     assert len(get_window(X_hi, 1, 2)) == 6
+    assert len(get_window(X_hi, 2, None)) == 12
+    assert len(get_window(X_hi, None, 2)) == 6
+    assert len(get_window(X_hi, None, None)) == 18
 
-    X_hi = get_examples(mtype="numpy3D")[0]
-    assert get_window(X_hi, 3, 1).shape == (2, 2, 3)
-    assert get_window(X_hi, 2, 0).shape == (2, 2, 3)
-    assert get_window(X_hi, 2, 4).shape == (0, 2, 3)
-    assert get_window(X_hi, 1, 2).shape == (1, 2, 3)
+    X_np3d = get_examples(mtype="numpy3D")[0]
+    assert get_window(X_np3d, 3, 1).shape == (2, 2, 3)
+    assert get_window(X_np3d, 2, 0).shape == (2, 2, 3)
+    assert get_window(X_np3d, 2, 4).shape == (0, 2, 3)
+    assert get_window(X_np3d, 1, 2).shape == (1, 2, 3)
+    assert get_window(X_np3d, 2, None).shape == (2, 2, 3)
+    assert get_window(X_np3d, None, 2).shape == (1, 2, 3)
+    assert get_window(X_np3d, None, None).shape == (3, 2, 3)
 
 
 @pytest.mark.parametrize("scitype,mtype", SCITYPE_MTYPE_PAIRS)

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -118,7 +118,7 @@ def test_get_window_expected_result():
     assert len(get_window(X_mi, 1, 2)) == 3
     assert len(get_window(X_mi, 2, None)) == 6
     assert len(get_window(X_mi, None, 2)) == 3
-    assert len(get_window(X_mi, None, None)) == 12
+    assert len(get_window(X_mi, None, None)) == 9
 
     X_hi = get_examples(mtype="pd_multiindex_hier")[0]
     assert len(get_window(X_hi, 3, 1)) == 12

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -163,7 +163,7 @@ def test_construct_vectorizeddf_errors(scitype, mtype, fixture_index):
 
     # if both iterate_as and as_scitype are "Panel", should raise an error
     with pytest.raises(ValueError, match=r'is_scitype is "Panel"'):
-        VectorizedDF(X=fixture, iterate_as="Panel", is_scitype="Panel")
+        VectorizedDF(X=fixture, iterate_as="Hierarchical", is_scitype="Panel")
 
     # invalid argument to iterate_as
     with pytest.raises(ValueError, match=r"iterate_as must be"):

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1528,11 +1528,10 @@ class BaseForecaster(BaseEstimator):
                 col_idx = ["forecasters"]
 
             self.forecasters_ = pd.DataFrame(index=row_idx, columns=col_idx)
-            c = -1
-            for j, i in product(range(len(col_idx)), range(len(row_idx))):
-                c += 1
+            for ix in len(ys):
+                i, j = y.get_iloc_indexer(ix)
                 self.forecasters_.iloc[i, j] = self.clone()
-                self.forecasters_.iloc[i, j].fit(y=ys[c], X=Xs[c], **kwargs)
+                self.forecasters_.iloc[i, j].fit(y=ys[ix], X=Xs[ix], **kwargs)
 
             return self
         elif methodname in PREDICT_METHODS:
@@ -1545,7 +1544,7 @@ class BaseForecaster(BaseEstimator):
                 Xs = X.as_list()
             y_preds = []
             c = -1
-            for j, i in product(range(m), range(n)):
+            for i, j in product(range(n), range(m)):
                 c += 1
                 method = getattr(self.forecasters_.iloc[i, j], methodname)
                 y_preds += [method(X=Xs[c], **kwargs)]

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1528,7 +1528,7 @@ class BaseForecaster(BaseEstimator):
                 col_idx = ["forecasters"]
 
             self.forecasters_ = pd.DataFrame(index=row_idx, columns=col_idx)
-            for ix in len(ys):
+            for ix in range(len(ys)):
                 i, j = y.get_iloc_indexer(ix)
                 self.forecasters_.iloc[i, j] = self.clone()
                 self.forecasters_.iloc[i, j].fit(y=ys[ix], X=Xs[ix], **kwargs)

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -39,6 +39,7 @@ __all__ = ["BaseForecaster"]
 
 from copy import deepcopy
 from itertools import product
+from multiprocessing.sharedctypes import Value
 from warnings import warn
 
 import numpy as np
@@ -1530,8 +1531,8 @@ class BaseForecaster(BaseEstimator):
             self.forecasters_ = pd.DataFrame(index=row_idx, columns=col_idx)
             for ix in range(len(ys)):
                 i, j = y.get_iloc_indexer(ix)
-                self.forecasters_.iloc[i, j] = self.clone()
-                self.forecasters_.iloc[i, j].fit(y=ys[ix], X=Xs[ix], **kwargs)
+                self.forecasters_.iloc[i].iloc[j] = self.clone()
+                self.forecasters_.iloc[i].iloc[j].fit(y=ys[ix], X=Xs[ix], **kwargs)
 
             return self
         elif methodname in PREDICT_METHODS:

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1543,11 +1543,11 @@ class BaseForecaster(BaseEstimator):
             else:
                 Xs = X.as_list()
             y_preds = []
-            c = -1
+            ix = -1
             for i, j in product(range(n), range(m)):
-                c += 1
-                method = getattr(self.forecasters_.iloc[i, j], methodname)
-                y_preds += [method(X=Xs[c], **kwargs)]
+                ix += 1
+                method = getattr(self.forecasters_.iloc[i].iloc[j], methodname)
+                y_preds += [method(X=Xs[ix], **kwargs)]
             y_pred = self._yvec.reconstruct(y_preds, overwrite_index=True)
             return y_pred
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -39,7 +39,6 @@ __all__ = ["BaseForecaster"]
 
 from copy import deepcopy
 from itertools import product
-from multiprocessing.sharedctypes import Value
 from warnings import warn
 
 import numpy as np

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -195,9 +195,7 @@ def test_vectorization_multivariate(mtype, exogeneous):
     if exogeneous:
         y_fit = get_window(y, lag=1)
         X_fit = y_fit
-        X_pred = get_window(
-            y, window_length=pd.Timedelta("1D"), lag = pd.Timedelta("0D")
-        )
+        X_pred = get_window(y, window_length=pd.Timedelta("1D"), lag=pd.Timedelta("0D"))
     else:
         y_fit = y
         X_fit = None

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -7,6 +7,7 @@ __author__ = ["fkiraly"]
 from functools import reduce
 from operator import mul
 
+import pandas as pd
 import pytest
 
 from sktime.datatypes import check_is_mtype, convert
@@ -194,7 +195,9 @@ def test_vectorization_multivariate(mtype, exogeneous):
     if exogeneous:
         y_fit = get_window(y, lag=1)
         X_fit = y_fit
-        X_pred = get_window(y, window_length=1)
+        X_pred = get_window(
+            y, window_length=pd.Timedelta("1D"), lag = pd.Timedelta("0D")
+        )
     else:
         y_fit = y
         X_fit = None
@@ -214,7 +217,7 @@ def test_vectorization_multivariate(mtype, exogeneous):
         "vectorization over variables produces wrong set of variables in predict, "
         f"expected {y_fit.columns}, found {y_pred.columns}"
     )
-    assert y_fit.columns == y_pred.columns, msg
+    assert set(y_fit.columns) == set(y_pred.columns), msg
 
     y_pred_instances = metadata["n_instances"]
     msg = (

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -193,7 +193,7 @@ def test_vectorization_multivariate(mtype, exogeneous):
     )
 
     if exogeneous:
-        y_fit = get_window(y, lag=1)
+        y_fit = get_window(y, lag=pd.Timedelta("1D"))
         X_fit = y_fit
         X_pred = get_window(y, window_length=pd.Timedelta("1D"), lag=pd.Timedelta("0D"))
     else:

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -193,9 +193,9 @@ def test_vectorization_multivariate(mtype, exogeneous):
     )
 
     if exogeneous:
-        y_fit = get_window(y, lag=pd.Timedelta("1D"))
+        y_fit = get_window(y, lag=pd.Timedelta("3D"))
         X_fit = y_fit
-        X_pred = get_window(y, window_length=pd.Timedelta("1D"), lag=pd.Timedelta("0D"))
+        X_pred = get_window(y, window_length=pd.Timedelta("3D"), lag=pd.Timedelta("0D"))
     else:
         y_fit = y
         X_fit = None

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -23,22 +23,78 @@ from sktime.datatypes._convert import convert, convert_to
 from sktime.datatypes._utilities import get_slice
 from sktime.forecasting.base._base import DEFAULT_ALPHA, BaseForecaster
 from sktime.forecasting.base._sktime import _BaseWindowForecaster
-from sktime.forecasting.compose import ColumnEnsembleForecaster
 from sktime.utils.validation import check_window_length
 from sktime.utils.validation.forecasting import check_sp
 
 
-class _NaiveForecaster(_BaseWindowForecaster):
-    """Univariate NaiveForecaster."""
+class NaiveForecaster(_BaseWindowForecaster):
+    """Forecast based on naive assumptions about past trends continuing.
+
+    NaiveForecaster is a forecaster that makes forecasts using simple
+    strategies. Two out of three strategies are robust against NaNs. The
+    NaiveForecaster can also be used for multivariate data and it then
+    applies internally the ColumnEnsembleForecaster, so each column
+    is forecasted with the same strategy.
+
+    Internally, this forecaster does the following:
+    - obtains the so-called "last window", a 1D array that denotes the
+      most recent time window that the forecaster is allowed to use
+    - reshapes the last window into a 2D array according to the given
+      seasonal periodicity (prepended with NaN values to make it fit);
+    - make a prediction for each column, using the given strategy:
+      - "last": last non-NaN row
+      - "mean": np.nanmean over rows
+    - tile the predictions using the seasonal periodicity
+
+    Parameters
+    ----------
+    strategy : {"last", "mean", "drift"}, default="last"
+        Strategy used to make forecasts:
+
+        * "last":   (robust against NaN values)
+                    forecast the last value in the
+                    training series when sp is 1.
+                    When sp is not 1,
+                    last value of each season
+                    in the last window will be
+                    forecasted for each season.
+        * "mean":   (robust against NaN values)
+                    forecast the mean of last window
+                    of training series when sp is 1.
+                    When sp is not 1, mean of all values
+                    in a season from last window will be
+                    forecasted for each season.
+        * "drift":  (not robust against NaN values)
+                    forecast by fitting a line between the
+                    first and last point of the window and
+                    extrapolating it into the future.
+
+    sp : int, default=1
+        Seasonal periodicity to use in the seasonal forecasting.
+
+    window_length : int or None, default=None
+        Window length to use in the `mean` strategy. If None, entire training
+            series will be used.
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> y = load_airline()
+    >>> forecaster = NaiveForecaster(strategy="drift")
+    >>> forecaster.fit(y)
+    NaiveForecaster(...)
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
+    """
 
     _tags = {
         "requires-fh-in-fit": False,
-        "handles-missing-data": True,  # todo: switch to True if GH1367 is fixed
+        "handles-missing-data": True,
         "scitype:y": "univariate",
     }
 
     def __init__(self, strategy="last", window_length=None, sp=1):
-        super(_NaiveForecaster, self).__init__()
+        super(NaiveForecaster, self).__init__()
         self.strategy = strategy
         self.sp = sp
         self.window_length = window_length
@@ -245,111 +301,6 @@ class _NaiveForecaster(_BaseWindowForecaster):
         fh_idx = fh.to_indexer(self.cutoff)
         return y_pred[fh_idx]
 
-
-class NaiveForecaster(BaseForecaster):
-    """Forecast based on naive assumptions about past trends continuing.
-
-    NaiveForecaster is a forecaster that makes forecasts using simple
-    strategies. Two out of three strategies are robust against NaNs. The
-    NaiveForecaster can also be used for multivariate data and it then
-    applies internally the ColumnEnsembleForecaster, so each column
-    is forecasted with the same strategy.
-
-    Internally, this forecaster does the following:
-    - obtains the so-called "last window", a 1D array that denotes the
-      most recent time window that the forecaster is allowed to use
-    - reshapes the last window into a 2D array according to the given
-      seasonal periodicity (prepended with NaN values to make it fit);
-    - make a prediction for each column, using the given strategy:
-      - "last": last non-NaN row
-      - "mean": np.nanmean over rows
-    - tile the predictions using the seasonal periodicity
-
-    Parameters
-    ----------
-    strategy : {"last", "mean", "drift"}, default="last"
-        Strategy used to make forecasts:
-
-        * "last":   (robust against NaN values)
-                    forecast the last value in the
-                    training series when sp is 1.
-                    When sp is not 1,
-                    last value of each season
-                    in the last window will be
-                    forecasted for each season.
-        * "mean":   (robust against NaN values)
-                    forecast the mean of last window
-                    of training series when sp is 1.
-                    When sp is not 1, mean of all values
-                    in a season from last window will be
-                    forecasted for each season.
-        * "drift":  (not robust against NaN values)
-                    forecast by fitting a line between the
-                    first and last point of the window and
-                    extrapolating it into the future.
-
-    sp : int, default=1
-        Seasonal periodicity to use in the seasonal forecasting.
-
-    window_length : int or None, default=None
-        Window length to use in the `mean` strategy. If None, entire training
-            series will be used.
-
-    Examples
-    --------
-    >>> from sktime.datasets import load_airline
-    >>> from sktime.forecasting.naive import NaiveForecaster
-    >>> y = load_airline()
-    >>> forecaster = NaiveForecaster(strategy="drift")
-    >>> forecaster.fit(y)
-    NaiveForecaster(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])
-    """
-
-    _tags = {
-        "y_inner_mtype": ["pd.DataFrame", "pd.Series"],
-        "scitype:y": "both",
-        "requires-fh-in-fit": False,
-        "handles-missing-data": True,  # todo: switch to True if GH1367 is fixed
-    }
-
-    def __init__(self, strategy="last", window_length=None, sp=1):
-        self.strategy = strategy
-        self.sp = sp
-        self.window_length = window_length
-        super(NaiveForecaster, self).__init__()
-
-    def _fit(self, y, X=None, fh=None):
-        """Fit to training data.
-
-        Parameters
-        ----------
-        y : pd.Series, pd.DataFrame
-            Target time series to which to fit the forecaster.
-        fh : int, list or np.array, default=None
-            The forecasters horizon with the steps ahead to to predict.
-        X : pd.DataFrame, default=None
-            Exogenous variables are ignored.
-
-        Returns
-        -------
-        self : returns an instance of self.
-        """
-        self._forecaster = ColumnEnsembleForecaster(
-            _NaiveForecaster(
-                strategy=self.strategy, sp=self.sp, window_length=self.window_length
-            )
-        )
-
-        # 1st part of preserving name/columns, otherwise they get lost on occasion
-        # provisionally hard-fixing the mess of 100 nested function calls
-        # until someone finds it in their heart to simplify the NaiveForecaster
-        if isinstance(y, pd.Series):
-            self.cols_ = y.name
-        else:
-            self.cols_ = y.columns
-        self._forecaster.fit(y=y, X=X, fh=fh)
-
     def _predict(self, fh=None, X=None):
         """Forecast time series at future horizon.
 
@@ -360,40 +311,14 @@ class NaiveForecaster(BaseForecaster):
         X : pd.DataFrame, optional (default=None)
             Exogenous time series
         """
-        y_pred = self._forecaster.predict(fh=fh, X=X)
+        y_pred = super(NaiveForecaster, self)._predict(fh=fh, X=X)
 
         # check for in-sample prediction, if first time point needs to be imputed
         if self._y.index[0] in y_pred.index:
             # fill NaN with next row values
             y_pred.loc[self._y.index[0]] = y_pred.loc[self._y.index[1]]
 
-        # 2nd part of preserving name/columns, otherwise they get lost on occasion
-        # provisionally hard-fixing the mess of 100 nested function calls
-        # until someone finds it in their heart to simplify the NaiveForecaster
-        if isinstance(y_pred, pd.Series):
-            y_pred.name = self.cols_
-        else:  # is pd.DataFrame
-            y_pred.columns = self.cols_
-
         return y_pred
-
-    def _update(self, y, X=None, update_params=True):
-        """Update cutoff value and, optionally, fitted parameters.
-
-        Parameters
-        ----------
-        y : pd.Series, pd.DataFrame, or np.array
-            Target time series to which to fit the forecaster.
-        X : pd.DataFrame, optional (default=None)
-            Exogeneous data
-        update_params : bool, optional (default=True)
-            whether model parameters should be updated
-
-        Returns
-        -------
-        self : reference to self
-        """
-        return self._forecaster.update(y=y, X=X, update_params=update_params)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -167,7 +167,6 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
 
     def test_y_multivariate_raises_error(self, estimator_instance):
         """Test that wrong y scitype raises error (uni/multivariate not supported)."""
-
         if estimator_instance.get_tag("scitype:y") == "multivariate":
             y = _make_series(n_columns=1)
             with pytest.raises(ValueError, match=r"two or more variables"):

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -167,17 +167,15 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
 
     def test_y_multivariate_raises_error(self, estimator_instance):
         """Test that wrong y scitype raises error (uni/multivariate not supported)."""
-        if estimator_instance.get_tag("scitype:y") == "univariate":
-            y = _make_series(n_columns=2)
-            with pytest.raises(ValueError, match=r"univariate"):
-                estimator_instance.fit(y, fh=FH0)
 
         if estimator_instance.get_tag("scitype:y") == "multivariate":
             y = _make_series(n_columns=1)
             with pytest.raises(ValueError, match=r"two or more variables"):
                 estimator_instance.fit(y, fh=FH0)
 
-        if estimator_instance.get_tag("scitype:y") == "both":
+        if estimator_instance.get_tag("scitype:y") in ["univariate", "both"]:
+            # this should pass since "both" allows any number of variables
+            # and "univariate" automatically vectorizes, behaves multivariate
             pass
 
     # todo: should these not be "negative scenarios", tested in test_all_estimators?

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -888,7 +888,7 @@ class BaseTransformer(BaseEstimator):
             X = kwargs.pop("X")
             y = kwargs.pop("y", None)
 
-            row_idx, col_idx = y.get_iter_indices()
+            row_idx, col_idx = X.get_iter_indices()
             if row_idx is None:
                 row_idx = ["transformers"]
             if col_idx is None:

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -952,14 +952,14 @@ class BaseTransformer(BaseEstimator):
 
             # if fit_is_empty: don't store transformers, run fit/transform in one
             else:
-                X, _, Xs, ys, n, _ = unwrap(kwargs)
+                X, _, Xs, ys, n, _, _ = unwrap(kwargs)
 
                 # fit/transform the i-th series/panel with a new clone of self
                 Xts = []
-                for i in range(n):
-                    transformer = self.clone().fit(X=Xs[i], y=ys[i], **kwargs)
+                for ix in range(n):
+                    transformer = self.clone().fit(X=Xs[ix], y=ys[ix], **kwargs)
                     method = getattr(transformer, methodname)
-                    Xts += [method(X=Xs[i], y=ys[i], **kwargs)]
+                    Xts += [method(X=Xs[ix], y=ys[ix], **kwargs)]
                 Xt = X.reconstruct(Xts, overwrite_index=False)
 
             # # one more thing before returning:

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -913,7 +913,7 @@ class BaseTransformer(BaseEstimator):
             # if fit is called, create container of transformers, but not in update
             if methodname == "fit":
                 self.transformers_ = pd.DataFrame(index=row_idx, columns=col_idx)
-                for ix in range(len(Xs)):
+                for ix in range(n):
                     i, j = X.get_iloc_indexer(ix)
                     self.transformers_.iloc[i].iloc[j] = self.clone()
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -49,6 +49,7 @@ __all__ = [
     "_PanelToPanelTransformer",
 ]
 
+from itertools import product
 from typing import Union
 
 import numpy as np
@@ -887,55 +888,66 @@ class BaseTransformer(BaseEstimator):
             X = kwargs.pop("X")
             y = kwargs.pop("y", None)
 
-            idx = X.get_iter_indices()
-            n = len(idx)
+            row_idx, col_idx = y.get_iter_indices()
             Xs = X.as_list()
+            n = len(Xs)
 
             if y is None:
-                ys = [None] * len(Xs)
+                ys = [None] * n
             else:
                 ys = y.as_list()
 
-            return X, y, Xs, ys, n, idx
+            return X, y, Xs, ys, n, row_idx, col_idx
 
         FIT_METHODS = ["fit", "update"]
         TRAFO_METHODS = ["transform", "inverse_transform"]
 
         if methodname in FIT_METHODS:
-            X, _, Xs, ys, n, idx = unwrap(kwargs)
+            X, _, Xs, ys, n, row_idx, col_idx = unwrap(kwargs)
 
             # if fit is called, create container of transformers, but not in update
             if methodname == "fit":
-                self.transformers_ = pd.DataFrame(index=idx, columns=["transformers"])
-                for i in range(n):
-                    self.transformers_.iloc[i, 0] = self.clone()
+                if row_idx is None:
+                    row_idx = ["transformers"]
+                if col_idx is None:
+                    col_idx = ["transformers"]
 
-            # fit/update the i-th transformer with the i-th series/panel
-            for i in range(n):
-                method = getattr(self.transformers_.iloc[i, 0], methodname)
-                method(X=Xs[i], y=ys[i], **kwargs)
+                self.transformers_ = pd.DataFrame(index=row_idx, columns=col_idx)
+                for ix in range(len(Xs)):
+                    i, j = X.get_iloc_indexer(ix)
+                    self.transformers_.iloc[i].iloc[j] = self.clone()
+
+            # fit/update the ix-th transformer with the ix-th series/panel
+            for ix in range(n):
+                i, j = X.get_iloc_indexer(ix)
+                method = getattr(self.transformers_.iloc[i].iloc[j], methodname)
+                method(X=Xs[ix], y=ys[ix], **kwargs)
 
             return self
 
         if methodname in TRAFO_METHODS:
             # loop through fitted transformers one-by-one, and transform series/panels
             if not self.get_tag("fit_is_empty"):
-                X, _, Xs, ys, n, _ = unwrap(kwargs)
+                X, _, Xs, ys, n_trafos, _, _ = unwrap(kwargs)
 
-                n_fit = len(self.transformers_.index)
+                n = len(self.transformers_.index)
+                m = len(self.transformers_.columns)
+                n_fit = n * m
 
-                if n != n_fit:
+                if n_trafos != n_fit:
                     raise RuntimeError(
                         "found different number of instances in transform than in fit. "
                         f"number of instances seen in fit: {n_fit}; "
-                        f"number of instances seen in transform: {n}"
+                        f"number of instances seen in transform: {n * m}"
                     )
 
                 # transform the i-th series/panel with the i-th stored transformer
                 Xts = []
-                for i in range(n):
-                    method = getattr(self.transformers_.iloc[i, 0], methodname)
-                    Xts += [method(X=Xs[i], y=ys[i], **kwargs)]
+                ix = -1
+                for i, j in product(range(n), range(m)):
+                    ix += 1
+                    method = getattr(self.transformers_.iloc[i].iloc[j], methodname)
+                    Xts += [method(X=Xs[ix], y=ys[ix], **kwargs)]
                 Xt = X.reconstruct(Xts, overwrite_index=False)
 
             # if fit_is_empty: don't store transformers, run fit/transform in one

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -889,6 +889,11 @@ class BaseTransformer(BaseEstimator):
             y = kwargs.pop("y", None)
 
             row_idx, col_idx = y.get_iter_indices()
+            if row_idx is None:
+                row_idx = ["transformers"]
+            if col_idx is None:
+                col_idx = ["transformers"]
+
             Xs = X.as_list()
             n = len(Xs)
 
@@ -907,11 +912,6 @@ class BaseTransformer(BaseEstimator):
 
             # if fit is called, create container of transformers, but not in update
             if methodname == "fit":
-                if row_idx is None:
-                    row_idx = ["transformers"]
-                if col_idx is None:
-                    col_idx = ["transformers"]
-
                 self.transformers_ = pd.DataFrame(index=row_idx, columns=col_idx)
                 for ix in range(len(Xs)):
                     i, j = X.get_iloc_indexer(ix)


### PR DESCRIPTION
This PR removes the manual vectorization lazer of `NaiveForecaster` in favour of the forecaster base class vectorization introduced in https://github.com/alan-turing-institute/sktime/pull/2865.

This is a refactor and should not impact the functionality or behaviour of `NaiveForecaster` in any way, except removing one layer of nesting.

Relies on #2865, the PR which adds automatic forecaster vectorization across variables (columns).