### PR TITLE
[ENH] Pass frequency explicitly to `sktime.utils.datetime._shift` function

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -54,7 +54,7 @@ from sktime.datatypes import (
     update_data,
 )
 from sktime.forecasting.base import ForecastingHorizon
-from sktime.utils.datetime import _shift
+from sktime.utils.datetime import _shift, infer_freq
 from sktime.utils.validation._dependencies import _check_dl_dependencies
 from sktime.utils.validation.forecasting import check_alpha, check_cv, check_fh, check_X
 from sktime.utils.validation.series import check_equal_time_index
@@ -103,6 +103,7 @@ class BaseForecaster(BaseEstimator):
         # forecasting horizon
         self._fh = None
         self._cutoff = None  # reference point for relative fh
+        self._freq = None
 
         self._converter_store_y = dict()  # storage dictionary for in/output conversion
 
@@ -1314,6 +1315,7 @@ class BaseForecaster(BaseEstimator):
 
             # set cutoff to the end of the observation horizon
             self._set_cutoff_from_y(y)
+            self._freq = infer_freq(self._y)
 
         if X is not None:
             # if _X does not exist yet, initialize it with X
@@ -2044,7 +2046,7 @@ class BaseForecaster(BaseEstimator):
             self_copy = self
 
         # set cutoff to time point before data
-        self_copy._set_cutoff(_shift(y.index[0], by=-1))
+        self_copy._set_cutoff(_shift(y.index[0], by=-1, freq=self._freq))
         # iterate over data
         for new_window, _ in cv.split(y):
             y_new = y.iloc[new_window]

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -2046,7 +2046,7 @@ class BaseForecaster(BaseEstimator):
             self_copy = self
 
         # set cutoff to time point before data
-        self_copy._set_cutoff(_shift(y.index[0], by=-1, freq=self._freq))
+        self_copy._set_cutoff(_shift(y.index[0], by=-1, freq=infer_freq(y)))
         # iterate over data
         for new_window, _ in cv.split(y):
             y_new = y.iloc[new_window]

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -152,7 +152,7 @@ class _BaseWindowForecaster(BaseForecaster):
         """Select last window."""
         # Get the start and end points of the last window.
         cutoff = self.cutoff
-        start = _shift(cutoff, by=-self.window_length_ + 1)
+        start = _shift(cutoff, by=-self.window_length_ + 1, freq=self._freq)
 
         # Get the last window of the endogenous variable.
         y = self._y.loc[start:cutoff].to_numpy()

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -30,7 +30,6 @@ from sktime.utils.datetime import (
     _get_duration,
     _get_freq,
     _get_intervals_count_and_unit,
-    _shift,
 )
 from sktime.utils.validation.series import is_in_valid_index_types, is_integer_index
 
@@ -201,29 +200,6 @@ def test_check_fh_relative_values_input_conversion_to_pandas_index(arg):
     """Test conversion of relative horizons to pandas index."""
     output = ForecastingHorizon(arg, is_relative=True).to_pandas()
     assert is_in_valid_index_types(output)
-
-
-TIMEPOINTS = [
-    pd.Period("2000", freq="M"),
-    pd.Timestamp("2000-01-01", freq="D"),
-    int(1),
-    3,
-]
-
-
-@pytest.mark.parametrize("timepoint", TIMEPOINTS)
-@pytest.mark.parametrize("by", [-3, -1, 0, 1, 3])
-def test_shift(timepoint, by):
-    """Test shifting of ForecastingHorizon."""
-    ret = _shift(timepoint, by=by)
-
-    # check output type, pandas index types inherit from each other,
-    # hence check for type equality here rather than using isinstance
-    assert type(ret) is type(timepoint)
-
-    # check if for a zero shift, input and output are the same
-    if by == 0:
-        assert timepoint == ret
 
 
 DURATIONS_ALLOWED = [

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -475,8 +475,8 @@ class _RecursiveReducer(_Reducer):
     def _get_shifted_window(self, shift=0, y_update=None, X_update=None):
         """Select shifted window."""
         # Get the start and end points of the last window.
-        cutoff = _shift(self.cutoff, by=shift)
-        start = _shift(cutoff, by=-self.window_length_ + 1)
+        cutoff = _shift(self.cutoff, by=shift, freq=self._freq)
+        start = _shift(cutoff, by=-self.window_length_ + 1, freq=self._freq)
 
         if self.transformers_ is not None:
             # Get the last window of the endogenous variable.

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -5,12 +5,14 @@
 __author__ = ["mloning", "xiaobenbenecho", "khrapovs"]
 __all__ = []
 
-import re
-from typing import Tuple, Union
+from functools import singledispatch
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
 
+from sktime.datatypes import VectorizedDF
+from sktime.datatypes._utilities import get_time_index
 from sktime.utils.validation.series import check_time_index, is_integer_index
 
 
@@ -67,12 +69,10 @@ def _get_intervals_count_and_unit(freq: str) -> Tuple[int, str]:
     """
     if freq is None:
         raise ValueError("frequency is missing")
-    m = re.match(r"(?P<count>\d*)(?P<unit>[a-zA-Z]+)$", freq)
-    if not m:
-        raise ValueError(f"pandas frequency {freq} not understood.")
-    count, unit = m.groups()
-    count = 1 if not count else int(count)
-    return count, unit
+    else:
+        offset = pd.tseries.frequencies.to_offset(freq)
+        count, unit = offset.n, offset.base.freqstr
+        return count, unit
 
 
 def _get_freq(x):
@@ -88,7 +88,58 @@ def _get_freq(x):
         return None
 
 
-def _shift(x: Union[pd.Period, pd.Timestamp, int], freq: str, by: int = 1):
+@singledispatch
+def infer_freq(y=None) -> Optional[str]:
+    """Infer frequency string from the time series object.
+
+    Parameters
+    ----------
+    y : Series, Panel, or Hierarchical object, or VectorizedDF, optional (default=None)
+
+    Returns
+    -------
+    str
+        Frequency string inferred from the pandas index,
+        or `None`, if inference fails.
+    """
+    return None
+
+
+@infer_freq.register(pd.DataFrame)
+@infer_freq.register(pd.Series)
+@infer_freq.register(np.ndarray)
+def _(y) -> Optional[str]:
+    return _infer_freq_from_index(get_time_index(y))
+
+
+@infer_freq.register(VectorizedDF)
+def _(y) -> Optional[str]:
+    return _infer_freq_from_index(get_time_index(y.as_list()[0]))
+
+
+def _infer_freq_from_index(index: pd.Index) -> Optional[str]:
+    """Infer frequency string from the pandas index.
+
+    Parameters
+    ----------
+    index : pd.Index
+
+    Returns
+    -------
+    str
+        Frequency string inferred from the pandas index,
+        or `None`, if inference fails.
+    """
+    if hasattr(index, "freqstr"):
+        return index.freqstr
+    else:
+        try:
+            return pd.infer_freq(index, warn=False)
+        except (TypeError, ValueError):
+            return None
+
+
+def _shift(x: Union[pd.Period, pd.Timestamp, int], by: int = 1, freq: str = None):
     """Shift time point `x` by a step (`by`) given frequency of `x`.
 
     Parameters

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -88,7 +88,7 @@ def _get_freq(x):
         return None
 
 
-def _shift(x, by=1):
+def _shift(x: Union[pd.Period, pd.Timestamp, int], freq: str, by: int = 1):
     """Shift time point `x` by a step (`by`) given frequency of `x`.
 
     Parameters
@@ -105,9 +105,7 @@ def _shift(x, by=1):
     assert isinstance(x, (pd.Period, pd.Timestamp, int, np.integer)), type(x)
     assert isinstance(by, (int, np.integer)) or is_integer_index(by), type(by)
     if isinstance(x, pd.Timestamp):
-        if not hasattr(x, "freq") or x.freq is None:
-            raise ValueError("No `freq` information available")
-        by *= x.freq
+        by *= pd.tseries.frequencies.to_offset(freq)
     return x + by
 
 

--- a/sktime/utils/tests/test_datetime.py
+++ b/sktime/utils/tests/test_datetime.py
@@ -7,8 +7,9 @@ import datetime
 
 import numpy as np
 import pandas as pd
+import pytest
 
-from sktime.utils.datetime import _coerce_duration_to_int, _get_freq
+from sktime.utils.datetime import _coerce_duration_to_int, _get_freq, _shift
 
 
 def test_get_freq():
@@ -58,3 +59,26 @@ def test_coerce_duration_to_int() -> None:
         _coerce_duration_to_int(duration=duration, freq="25T"),
         pd.Index([3, 4], dtype=int),
     )
+
+
+TIMEPOINTS = [
+    pd.Period("2000", freq="D"),
+    pd.Timestamp("2000-01-01", freq="D"),
+    int(1),
+    3,
+]
+
+
+@pytest.mark.parametrize("timepoint", TIMEPOINTS)
+@pytest.mark.parametrize("by", [-3, -1, 0, 1, 3])
+def test_shift(timepoint, by):
+    """Test shifting of ForecastingHorizon."""
+    ret = _shift(timepoint, by=by, freq="D")
+
+    # check output type, pandas index types inherit from each other,
+    # hence check for type equality here rather than using isinstance
+    assert type(ret) is type(timepoint)
+
+    # check if for a zero shift, input and output are the same
+    if by == 0:
+        assert timepoint == ret

--- a/sktime/utils/tests/test_datetime.py
+++ b/sktime/utils/tests/test_datetime.py
@@ -128,15 +128,9 @@ def test_shift_against_expectations() -> None:
     )
 
 
-TIMEPOINTS = [
-    pd.Period("2000", freq="D"),
-    pd.Timestamp("2000-01-01", freq="D"),
-    int(1),
-    3,
-]
-
-
-@pytest.mark.parametrize("timepoint", TIMEPOINTS)
+@pytest.mark.parametrize(
+    "timepoint", [pd.Period("2000", freq="D"), pd.Timestamp("2000-01-01"), int(1), 3]
+)
 @pytest.mark.parametrize("by", [-3, -1, 0, 1, 3])
 def test_shift(timepoint, by):
     """Test _shift."""

--- a/sktime/utils/tests/test_datetime.py
+++ b/sktime/utils/tests/test_datetime.py
@@ -107,8 +107,8 @@ def test_shift_raises_attribute_error_with_wrong_by(by) -> None:
         _shift(pd.Period("2021-01-01"), by=by)
 
 
-def test_shift() -> None:
-    """Test _shift."""
+def test_shift_against_expectations() -> None:
+    """Test _shift for equality with expectation."""
     assert _shift(1, by=2) == 3
     assert _shift(1, by=2, freq="D") == 3
     with pytest.raises(TypeError):
@@ -126,3 +126,26 @@ def test_shift() -> None:
     assert _shift(pd.Period("2021-01-15", freq="M"), by=2, freq="D") == pd.Period(
         "2021-03"
     )
+
+
+TIMEPOINTS = [
+    pd.Period("2000", freq="D"),
+    pd.Timestamp("2000-01-01", freq="D"),
+    int(1),
+    3,
+]
+
+
+@pytest.mark.parametrize("timepoint", TIMEPOINTS)
+@pytest.mark.parametrize("by", [-3, -1, 0, 1, 3])
+def test_shift(timepoint, by):
+    """Test _shift."""
+    ret = _shift(timepoint, by=by, freq="D")
+
+    # check output type, pandas index types inherit from each other,
+    # hence check for type equality here rather than using isinstance
+    assert type(ret) is type(timepoint)
+
+    # check if for a zero shift, input and output are the same
+    if by == 0:
+        assert timepoint == ret


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Partially addresses #1750 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

On master function `_shift` extracts the frequency information from `pd.Timestamp` object which in future will cot contain it. Hence, here I explicitly pass frequency from the outside. This frequency is used to calculate offset for `pd.Timestamp` input, Frequency is inferred from `self._y` and stored in `self._freq` attribute of `sktime.forecasting.base._base.BaseForecaster` after `fit` is invoked.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [X] I've added unit tests and made sure they pass locally.
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.