### PR TITLE
[WIP] [ENH] Reimplement benchmarking with `kotsu`

### DIFF
--- a/sktime/benchmarking/__init__.py
+++ b/sktime/benchmarking/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Implements running validations on estimators storing results for benchmarking."""

--- a/sktime/benchmarking/__init__.py
+++ b/sktime/benchmarking/__init__.py
@@ -1,2 +1,6 @@
 # -*- coding: utf-8 -*-
 """Implements running validations on estimators storing results for benchmarking."""
+from kotsu import registration
+
+estimator_registry = registration.ModelRegistry()
+validation_registry = registration.ValidationRegistry()

--- a/sktime/benchmarking/__init__.py
+++ b/sktime/benchmarking/__init__.py
@@ -4,3 +4,6 @@ from kotsu import registration
 
 estimator_registry = registration.ModelRegistry()
 validation_registry = registration.ValidationRegistry()
+
+from sktime.benchmarking import estimators  # noqa
+from sktime.benchmarking import validations  # noqa

--- a/sktime/benchmarking/estimators.py
+++ b/sktime/benchmarking/estimators.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""Register estimators to compete in benchmarking."""
+
+from sktime.benchmarking import estimator_registry
+from sktime.forecasting.ets import AutoETS
+from sktime.forecasting.naive import NaiveForecaster
+
+estimator_registry.register(
+    id="Naive-v1",
+    entry_point=NaiveForecaster,
+    kwargs={"strategy": "mean", "sp": 12},
+)
+
+estimator_registry.register(
+    id="ETS-v1",
+    entry_point=AutoETS,
+    kwargs={"auto": "True", "n_jobs": -1, "sp": 12},
+)

--- a/sktime/benchmarking/run.ipynb
+++ b/sktime/benchmarking/run.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b99fe5e9",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "145d5a96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from kotsu import run\n",
+    "\n",
+    "from sktime.benchmarking import estimator_registry, validation_registry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a84db36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validation_registry.all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "023bef3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimator_registry.all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "637b1a67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run.run(estimator_registry, validation_registry, \"./results.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85c1d549",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(\"./results.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea465ffa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sktime/benchmarking/tests/test_validations.py
+++ b/sktime/benchmarking/tests/test_validations.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""Tests for benchmarking validation functions."""
+
+import numpy as np
+import pandas as pd
+
+from sktime.benchmarking import validations
+from sktime.forecasting.base import BaseForecaster
+from sktime.forecasting.model_selection._split import BaseSplitter
+from sktime.performance_metrics.forecasting import MeanAbsoluteError, MeanSquaredError
+
+
+class FakeSplitter(BaseSplitter):
+    """A fake splitter that returns the whole series (for train and test) each split."""
+
+    def __init__(self, n_splits, fh):
+        self.n_splits = n_splits
+        self.fh = fh
+        super().__init__()
+
+    def _split(self, y):
+        for _ in range(self.n_splits):
+            yield y, y
+
+
+class LastValueEstimator(BaseForecaster):
+    """An estimator that repeats the last value of the train data as the forecast."""
+
+    _tags = {
+        "requires-fh-in-fit": False,
+        # "scitype:y": "univariate",
+    }
+
+    def __init__(self):
+        self.last_value = None
+        super().__init__()
+
+    def _fit(self, y, X=None, fh=None):
+        self.last_value = y.iloc[-1]
+
+    def _predict(self, fh=None, X=None):
+        return pd.Series(np.full(fill_value=self.last_value, shape=len(fh)))
+
+
+def test_forecasting_validation():
+    """Test that output dict of the validation function is as expected.
+
+    We want to avoid testing sktime functionality outside of the validator, so we use
+    fake splitters and estimators and just check the results dict.
+    """
+
+    def dataset_loader():
+        return pd.Series([1, 2, 3, 4])
+
+    # Fake splitter will give the whole series as train and test data for each split
+    cv_splitter = FakeSplitter(n_splits=2, fh=4)
+    # Our estimator predicts the final value of the train data, so all 4s for each split
+    estimator = LastValueEstimator()
+
+    results = validations.forecasting_validation(
+        dataset_loader=dataset_loader,
+        cv_splitter=cv_splitter,
+        scorers=[MeanAbsoluteError(), MeanSquaredError()],
+        estimator=estimator,
+    )
+
+    # Just check that we have the results keys that we expect
+    assert len(results) == 8
+    assert results["MeanAbsoluteError_fold_0_test"] == 1.5
+    assert results["MeanAbsoluteError_fold_1_test"] == 1.5
+    assert results["MeanSquaredError_fold_0_test"] == 3.5
+    assert results["MeanSquaredError_fold_1_test"] == 3.5
+    assert results["MeanAbsoluteError_mean"] == 1.5
+    assert results["MeanSquaredError_mean"] == 3.5
+    # All the splits are the same, so the std will be 0
+    assert results["MeanAbsoluteError_std"] == 0
+    assert results["MeanSquaredError_std"] == 0
+
+
+def test_forecasting_validation_deterministic():
+    """Test validation gives deterministic results using a deterministic splitter."""
+
+    def dataset_loader():
+        return pd.Series([1, 2, 3, 4])
+
+    # Fake splitter will give the whole series as train and test data for each split
+    # And it's clearly deterministic
+    cv_splitter = FakeSplitter(n_splits=2, fh=4)
+    # Our estimator predicts the final value of the train data, so all 4s for each split
+    estimator = LastValueEstimator()
+
+    results = validations.forecasting_validation(
+        dataset_loader=dataset_loader,
+        cv_splitter=cv_splitter,
+        scorers=[MeanAbsoluteError(), MeanSquaredError()],
+        estimator=estimator,
+    )
+    repeated_results = validations.forecasting_validation(
+        dataset_loader=dataset_loader,
+        cv_splitter=cv_splitter,
+        scorers=[MeanAbsoluteError(), MeanSquaredError()],
+        estimator=estimator,
+    )
+
+    assert results == repeated_results

--- a/sktime/benchmarking/validations.py
+++ b/sktime/benchmarking/validations.py
@@ -3,10 +3,14 @@
 import functools
 from typing import Callable, Dict, List, Union
 
+from sktime.benchmarking import validation_registry
+from sktime.datasets import load_airline
 from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.model_evaluation import evaluate
+from sktime.forecasting.model_selection import ExpandingWindowSplitter
 from sktime.forecasting.model_selection._split import BaseSplitter
 from sktime.performance_metrics.base import BaseMetric
+from sktime.performance_metrics.forecasting import MeanSquaredPercentageError
 
 
 def forecasting_validation(
@@ -40,4 +44,20 @@ def factory_forecasting_validation(
         dataset_loader,
         cv_splitter,
         scorers,
+    )
+
+
+for dataset_loader in [load_airline]:
+    validation_registry.register(
+        id=f"forecasting_[dataset={dataset_loader.__name__}]_ExpandingWindow-v1",
+        entry_point=factory_forecasting_validation,
+        kwargs={
+            "dataset_loader": dataset_loader,
+            "cv_splitter": ExpandingWindowSplitter(
+                initial_window=24,
+                step_length=12,
+                fh=12,
+            ),
+            "scorers": [MeanSquaredPercentageError()],
+        },
     )

--- a/sktime/benchmarking/validations.py
+++ b/sktime/benchmarking/validations.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Implement and register validations, which compute benchmark results."""
+from typing import Callable, Dict, List, Union
+
+from sktime.forecasting.base import BaseForecaster
+from sktime.forecasting.model_evaluation import evaluate
+from sktime.forecasting.model_selection._split import BaseSplitter
+from sktime.performance_metrics.base import BaseMetric
+
+
+def forecasting_validation(
+    dataset_loader: Callable,
+    cv_splitter: BaseSplitter,
+    scorers: List[BaseMetric],
+    estimator: BaseForecaster,
+    **kwargs,
+) -> Dict[str, Union[float, str]]:
+    """Run validation for forecasting benchmarks."""
+    y = dataset_loader()
+    results = {}
+    for scorer in scorers:
+        scorer_name = scorer.name
+        scores_df = evaluate(forecaster=estimator, y=y, cv=cv_splitter, scoring=scorer)
+        for ix, row in scores_df.iterrows():
+            results[f"{scorer_name}_fold_{ix}_test"] = row[f"test_{scorer_name}"]
+        results[f"{scorer_name}_mean"] = scores_df[f"test_{scorer_name}"].mean()
+        results[f"{scorer_name}_std"] = scores_df[f"test_{scorer_name}"].std()
+    return results

--- a/sktime/benchmarking/validations.py
+++ b/sktime/benchmarking/validations.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Implement and register validations, which compute benchmark results."""
+import functools
 from typing import Callable, Dict, List, Union
 
 from sktime.forecasting.base import BaseForecaster
@@ -26,3 +27,17 @@ def forecasting_validation(
         results[f"{scorer_name}_mean"] = scores_df[f"test_{scorer_name}"].mean()
         results[f"{scorer_name}_std"] = scores_df[f"test_{scorer_name}"].std()
     return results
+
+
+def factory_forecasting_validation(
+    dataset_loader: Callable,
+    cv_splitter: BaseSplitter,
+    scorers: List[BaseMetric],
+) -> Callable:
+    """Build forecasting validation func which just takes an estimator."""
+    return functools.partial(
+        forecasting_validation,
+        dataset_loader,
+        cv_splitter,
+        scorers,
+    )


### PR DESCRIPTION
#### To do:
- [ ] Generally, shift use case from "benchmarking all sktime estimators" to "enable a user to benchmark something they care about"
- [ ] Spike on implementing new interface that wraps kotsu and only relies on sktime objects, for easy user life
- [ ] Implement storing folds and predictions
- [ ] Add dependencies 
- [ ] Move nb to https://github.com/alan-turing-institute/sktime/tree/main/examples
- [ ] Expand nb to include examples, to guide a user on its usage (?)

#### Usage instructions:
- Dependencies to install specific for this PR: `kotsu`, `jupyter`, `autoreload` `typing_extensions`
- Start a jupyter server and run the `sktime/benchmarking/run.ipynb`

#### Reference Issues/PRs
See discussion: https://github.com/alan-turing-institute/sktime/issues/2777
See discussion: https://github.com/alan-turing-institute/sktime/issues/2804
See spike: https://github.com/alan-turing-institute/sktime/pull/2805


#### What does this implement/fix? Explain your changes.
Implement benchmarking using `kotsu`. 
- Instantiation of a `validation_registry` and `estimator_registry` in `benchmarking`'s `init`
- A `validations.py` module which defines a paramaterised validation run, which takes a `dataset_loader: Callable`, a `cv_splitter: BaseSplitter`, and a list of `scorers: List[BaseMetric]`. The module registers an example specification.
- An `estimators.py` module which imports and registers estimators + their configs (i.e. param specifications)
- A `run.ipynb` which runs the registry of estimators through the validations, storing the benchmark results

Likely we will eventually want to have separate registries corresponding to different types of predictions (classification, regression, etc.), for now this just implements for regression (point prediction).  

#### Does your contribution introduce a new dependency? If yes, which one?
- `kotsu` - soft dependency
- TBC: `jupyter` - soft dependency - depending on discussions outcome

#### What should a reviewer concentrate their feedback on?

The understandability, flexibility, extendability, and maintainability, of this benchmarking system implementation.

#### To discuss at Tuesday 28th June meeting:
("we" refers to @DBCerigo @alex-hh @ali-tny) 
- [x] What [type of dependency](https://www.sktime.org/en/latest/developer_guide/dependencies.html#types-of-dependencies) will `kotsu` be? We think `soft`.
    - Answer: TBD, but maybe a core dep given benchmarking is intended to be a core functionality. 
- [x] What interface wanted for running the benchmarking? We implemented a jupyter notebook.
    - Answer: Likely jupyter notebook yes. Should put it in https://github.com/alan-turing-institute/sktime/tree/main/examples
- [x] How much is the `benchmarking` module intended to "enable an `sktime` user to do the benchmarking they want to do" vs "do benchmarking of all `sktime` estimators and have the results for anyone to see"?
    - Answer: Primarily the former. 
- [x] Should we register estimators in estimator modules or in benchmarking module? We think within benchmarking.
    - Answer: In benchmarking module/not even at all, and just let users register on the models they want to, in a notebook.
- [x] When we use kotsu, we often store copies of the folds, copies of the predictions on the training folds and predictions on the test folds - this enables one to read the predictions for an estimator easily to do deep-dive/comparison analysis. Would this be wanted in `sktime` benchmarking?
    - Answer: Yep, probably want this. 
- [x] Should we implement visualisations/explorations/further analysis? In benchmarking there's some analysis (e.g. t-tests etc.) modules. Or should `sktime` just store the base benchmark results and let users do analysis on those as they see fit?
    - Answer: Maybe add at least 1 basic plot/analysis in the example notebook. 
- [x] We're trying to write as little code as possible and rely on sktime functionality as much as possible . 
    - [x] `evaluate` only takes a single `scorer` - we would want to avoid re-running training and predictions for every scoring metric as occurs in this PR. We could extend `evaluate` to take a list of scorers?
        - Answer: Probably resolved when implementing storing fold data + predictions.  

#### Any other comments?

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.
