### PR TITLE
[MNT] Remove `cmdstanpy` from `all_extras`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dependencies = [
 
 [project.optional-dependencies]
 all_extras = [
-    "cmdstanpy<1.0.2", # can be relaxed if issue is resolved at prophet or cmdstanpy side
     "dtw-python",
     "esig==0.9.7",
     "filterpy>=1.4.5",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

closes #2898 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Remove `cmdstanpy` from `all_extras` since it is installed as a direct dependency of `prophet`.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

No

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [X] I've added unit tests and made sure they pass locally.
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.