### PR TITLE
[ENH] turn private cutoff of forecasters into an index that carries `freq`

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -166,13 +166,13 @@ def get_cutoff(
     # numpy3D (Panel) or np.npdarray (Series)
     if isinstance(obj, np.ndarray):
         if obj.ndim == 3:
-            cutoff_ind = obj.shape[-1] + cutoff
+            cutoff_ind = obj.shape[-1] + cutoff - 1
         if obj.ndim < 3 and obj.ndim > 0:
-            cutoff_ind = obj.shape[0] + cutoff
+            cutoff_ind = obj.shape[0] + cutoff - 1
         if reverse_order:
             cutoff_ind = 0
         if return_index:
-            return pd.RangeIndex(cutoff_ind - 1, cutoff_ind)
+            return pd.RangeIndex(cutoff_ind, cutoff_ind + 1)
         else:
             return cutoff_ind
 

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -189,7 +189,7 @@ def get_cutoff(
         if not return_index:
             return idx[ix]
         res = idx[[ix]]
-        if idx.freq is not None:
+        if hasattr(idx, "freq") and idx.freq is not None:
             res.freq = idx.freq
         return res
 

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -218,18 +218,12 @@ def get_cutoff(
     if isinstance(obj, pd.DataFrame) and isinstance(obj.index, pd.MultiIndex):
         idx = obj.index
         series_idx = [obj.loc[x].index.get_level_values(-1) for x in idx.droplevel(-1)]
-        if return_index:
-            cutoffs = [x[[-1]] for x in series_idx]
-        else:
-            cutoffs = [x[-1] for x in series_idx]
+        cutoffs = [sub_idx(x, ix, return_index) for x in series_idx]
         return agg(cutoffs)
 
     # df-list (Panel)
     if isinstance(obj, list):
-        if return_index:
-            idxs = [x.index[[ix]] for x in obj]
-        else:
-            idxs = [x.index[ix] for x in obj]
+        idxs = [sub_idx(x.index, ix, return_index) for x in obj]
         return agg(idxs)
 
 

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -190,7 +190,8 @@ def get_cutoff(
             return idx[ix]
         res = idx[[ix]]
         if hasattr(idx, "freq") and idx.freq is not None:
-            res.freq = idx.freq
+            if res.freq != idx.freq:
+                res.freq = idx.freq
         return res
 
     if isinstance(obj, pd.Series):

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -159,11 +159,6 @@ def get_cutoff(
                 f" found a pd.Index with length {len(cutoff)}"
             )
         cutoff = cutoff[0]
-    elif not isinstance(cutoff, int):
-        raise TypeError(
-            "cutoff must be an integer, length 1 pd.Index of int, or None, but"
-            f" found {type(cutoff)}"
-        )
 
     if len(obj) == 0:
         return cutoff

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -199,7 +199,7 @@ def get_cutoff(
         return res
 
     if isinstance(obj, pd.Series):
-        return sub_idx(obj.index, ix) if return_index else obj.index[ix]
+        return sub_idx(obj.index, ix, return_index)
 
     # nested_univ (Panel) or pd.DataFrame(Series)
     if isinstance(obj, pd.DataFrame) and not isinstance(obj.index, pd.MultiIndex):

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -26,6 +26,7 @@ Inspection methods:
     hyper-parameter inspection  - get_params()
     fitted parameter inspection - get_fitted_params()
     current ForecastingHorizon  - fh
+    current cutoff              - cutoff
 
 State:
     fitted model/strategy   - by convention, any attributes ending in "_"
@@ -1377,7 +1378,7 @@ class BaseForecaster(BaseEstimator):
 
         Notes
         -----
-        Set self._cutoff is to `cutoff`.
+        Set self._cutoff to `cutoff`, coerced to a pandas.Index.
         """
         if not isinstance(cutoff, pd.Index):
             cutoff = pd.Index([cutoff])
@@ -1395,7 +1396,7 @@ class BaseForecaster(BaseEstimator):
                 pd_multiindex_hier, of Hierarchical scitype
         Notes
         -----
-        Set self._cutoff to latest index seen in `y`.
+        Set self._cutoff to pandas.Index containing latest index seen in `y`.
         """
         cutoff_idx = get_cutoff(y, self.cutoff, return_index=True)
         self._cutoff = cutoff_idx

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1362,7 +1362,8 @@ class BaseForecaster(BaseEstimator):
 
         Returns
         -------
-        cutoff : pandas compatible index element
+        cutoff : pandas compatible index element, or None
+            pandas compatible index element, if cutoff has been set; None otherwise
         """
         if self._cutoff is None:
             return None

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -2058,7 +2058,8 @@ class BaseForecaster(BaseEstimator):
             self_copy = self
 
         # set cutoff to time point before data
-        self_copy._set_cutoff(_shift(y.index[0], by=-1))
+        y_first_index = get_cutoff(y, return_index=True, reverse_order=True)
+        self_copy._set_cutoff(_shift(y_first_index, by=-1, return_index=True))
         # iterate over data
         for new_window, _ in cv.split(y):
             y_new = y.iloc[new_window]

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -709,7 +709,7 @@ class BaseForecaster(BaseEstimator):
 
         Writes to self:
             Update self._y and self._X with `y` and `X`, by appending rows.
-            Updates self. cutoff and self._cutoff to last index seen in `y`.
+            Updates self.cutoff and self._cutoff to last index seen in `y`.
             If update_params=True,
                 updates fitted model attributes ending in "_".
 
@@ -893,7 +893,7 @@ class BaseForecaster(BaseEstimator):
 
         Writes to self:
             Update self._y and self._X with `y` and `X`, by appending rows.
-            Updates self. cutoff and self._cutoff to last index seen in `y`.
+            Updates self.cutoff and self._cutoff to last index seen in `y`.
             If update_params=True,
                 updates fitted model attributes ending in "_".
 
@@ -1363,19 +1363,24 @@ class BaseForecaster(BaseEstimator):
         -------
         cutoff : pandas compatible index element
         """
-        return self._cutoff
+        if self._cutoff is None:
+            return None
+        else:
+            return self._cutoff[0]
 
     def _set_cutoff(self, cutoff):
         """Set and update cutoff.
 
         Parameters
         ----------
-        cutoff: pandas compatible index element
+        cutoff: pandas compatible index or index element
 
         Notes
         -----
         Set self._cutoff is to `cutoff`.
         """
+        if not isinstance(cutoff, pd.Index):
+            cutoff = pd.Index([cutoff])
         self._cutoff = cutoff
 
     def _set_cutoff_from_y(self, y):
@@ -1392,7 +1397,7 @@ class BaseForecaster(BaseEstimator):
         -----
         Set self._cutoff to latest index seen in `y`.
         """
-        cutoff_idx = get_cutoff(y, self.cutoff)
+        cutoff_idx = get_cutoff(y, self.cutoff, return_index=True)
         self._cutoff = cutoff_idx
 
     @property

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -151,8 +151,9 @@ class _BaseWindowForecaster(BaseForecaster):
     def _get_last_window(self):
         """Select last window."""
         # Get the start and end points of the last window.
-        cutoff = self.cutoff
+        cutoff = self._cutoff
         start = _shift(cutoff, by=-self.window_length_ + 1)
+        cutoff = cutoff[0]
 
         # Get the last window of the endogenous variable.
         y = self._y.loc[start:cutoff].to_numpy()

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -59,7 +59,7 @@ def test_vectorization_series_to_panel(mtype):
 
     msg = (
         "estimator in vectorization test does not properly update cutoff, "
-        f"expected {y}, but found {f.cutoff}"
+        f"expected {get_cutoff(y)}, but found {f.cutoff}"
     )
     assert f.cutoff == get_cutoff(y), msg
 

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -57,11 +57,12 @@ def test_vectorization_series_to_panel(mtype):
     )
     assert y_pred_equal_length, msg
 
+    cutoff_expected = get_cutoff(y)
     msg = (
         "estimator in vectorization test does not properly update cutoff, "
-        f"expected {get_cutoff(y)}, but found {f.cutoff}"
+        f"expected {cutoff_expected}, but found {f.cutoff}"
     )
-    assert f.cutoff == get_cutoff(y), msg
+    assert f.cutoff == cutoff_expected, msg
 
 
 @pytest.mark.parametrize("mtype", HIER_MTYPES)

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -209,7 +209,7 @@ TIMEPOINTS = [
     3,
 ]
 
-LENGTH1_INDICES = [pd.Index(x) for x in TIMEPOINTS]
+LENGTH1_INDICES = [pd.Index([x]) for x in TIMEPOINTS]
 LENGTH1_INDICES += [pd.DatetimeIndex(["2000-01-01"], freq="D")]
 
 

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -205,16 +205,18 @@ def test_check_fh_relative_values_input_conversion_to_pandas_index(arg):
 
 TIMEPOINTS = [
     pd.Period("2000", freq="M"),
-    pd.Timestamp("2000-01-01", freq="D"),
     int(1),
     3,
 ]
+
+LENGTH1_INDICES = [pd.Index(x) for x in TIMEPOINTS]
+LENGTH1_INDICES += [pd.DatetimeIndex(["2000-01-01"], freq="D")]
 
 
 @pytest.mark.parametrize("timepoint", TIMEPOINTS)
 @pytest.mark.parametrize("by", [-3, -1, 0, 1, 3])
 def test_shift(timepoint, by):
-    """Test shifting of ForecastingHorizon."""
+    """Test shifting of cutoff index element."""
     ret = _shift(timepoint, by=by)
 
     # check output type, pandas index types inherit from each other,
@@ -224,6 +226,21 @@ def test_shift(timepoint, by):
     # check if for a zero shift, input and output are the same
     if by == 0:
         assert timepoint == ret
+
+
+@pytest.mark.parametrize("timepoint", LENGTH1_INDICES)
+@pytest.mark.parametrize("by", [-3, -1, 0, 1, 3])
+def test_shift_index(timepoint, by):
+    """Test shifting of cutoff index, length 1 pandas.Index type."""
+    ret = _shift(timepoint, by=by, return_index=True)
+
+    # check output type, pandas index types inherit from each other,
+    # hence check for type equality here rather than using isinstance
+    assert type(ret) is type(timepoint)
+
+    # check if for a zero shift, input and output are the same
+    if by == 0:
+        assert (timepoint == ret).all()
 
 
 DURATIONS_ALLOWED = [

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -475,8 +475,8 @@ class _RecursiveReducer(_Reducer):
     def _get_shifted_window(self, shift=0, y_update=None, X_update=None):
         """Select shifted window."""
         # Get the start and end points of the last window.
-        cutoff = _shift(self.cutoff, by=shift)
-        start = _shift(cutoff, by=-self.window_length_ + 1)
+        cutoff = _shift(self._cutoff, by=shift)
+        start = _shift(self._cutoff, by=shift - self.window_length_ + 1)
 
         if self.transformers_ is not None:
             # Get the last window of the endogenous variable.

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -110,8 +110,6 @@ def _shift(x, by=1, return_index=False):
         warn("_shift no longer supports x: pd.Timestamp fom 0.14.0", DeprecationWarning)
         if not hasattr(x, "freq") or x.freq is None:
             raise ValueError("No `freq` information available")
-        by *= x.freq
-        return x + by
         # raise TypeError("_shift no longer supports x: pd.Timestamp")
 
     # we ensure idx is pd.Index, x is first (and usually only) element

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -114,7 +114,6 @@ def _shift(x, by=1, return_index=False):
         return x + by
         # raise TypeError("_shift no longer supports x: pd.Timestamp")
 
-
     # we ensure idx is pd.Index, x is first (and usually only) element
     if isinstance(x, pd.Index):
         idx = x

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -128,15 +128,9 @@ def _shift(x, by=1, return_index=False):
         else:
             return idx.shift(by)
 
-    assert isinstance(x, (pd.Period, pd.Timestamp, int, np.integer)), type(x)
+    assert isinstance(x, (pd.Period, int, np.integer)), type(x)
     assert isinstance(by, (int, np.integer)) or is_integer_index(by), type(by)
 
-    # if we want index element, we can still use add, except if timestamp
-    # deprecate this in 0.13.0 and remove in 0.14.0
-    if isinstance(x, pd.Timestamp):
-        if not hasattr(idx, "freq") or idx.freq is None:
-            raise ValueError(f"No `freq` information available, object {idx}")
-        by *= idx.freq
     return x + by
 
 

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -88,26 +88,49 @@ def _get_freq(x):
         return None
 
 
-def _shift(x, by=1):
+def _shift(x, by=1, return_index=False):
     """Shift time point `x` by a step (`by`) given frequency of `x`.
 
     Parameters
     ----------
     x : pd.Period, pd.Timestamp, int
         Time point
-    by : int
+    by : int, optional, default=1
+    return_index : bool, optional, default=False
+        whether to return an index element (False) or a pandas Index (True)
 
     Returns
     -------
     ret : pd.Period, pd.Timestamp, int
         Shifted time point
     """
+    # deprecate in 0.13.0, pd.Timestamp will not have freq
+    if isinstance(x, pd.Timestamp):
+        raise TypeError("_shift no longer supports x: pd.Timestamp")
+    #     if not hasattr(x, "freq") or x.freq is None:
+    #         raise ValueError("No `freq` information available")
+    #     by *= x.freq
+    #     return x + by
+
+    if isinstance(x, pd.Index):
+        idx = x
+        x = idx[0]
+    else:
+        idx = pd.Index([x])
+
+    if return_index:
+        if idx.is_integer():
+            return idx + by
+        else:
+            return idx.shift(by)
+
     assert isinstance(x, (pd.Period, pd.Timestamp, int, np.integer)), type(x)
     assert isinstance(by, (int, np.integer)) or is_integer_index(by), type(by)
+
     if isinstance(x, pd.Timestamp):
-        if not hasattr(x, "freq") or x.freq is None:
-            raise ValueError("No `freq` information available")
-        by *= x.freq
+        if not hasattr(idx, "freq") or idx.freq is None:
+            raise ValueError(f"No `freq` information available, object {idx}")
+        by *= idx.freq
     return x + by
 
 

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -7,6 +7,7 @@ __all__ = []
 
 import re
 from typing import Tuple, Union
+from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -106,11 +107,13 @@ def _shift(x, by=1, return_index=False):
     """
     # deprecate in 0.13.0 and remove in 0.14.0, pd.Timestamp will not have freq
     if isinstance(x, pd.Timestamp):
-        raise TypeError("_shift no longer supports x: pd.Timestamp")
-    #     if not hasattr(x, "freq") or x.freq is None:
-    #         raise ValueError("No `freq` information available")
-    #     by *= x.freq
-    #     return x + by
+        warn("_shift no longer supports x: pd.Timestamp fom 0.14.0", DeprecationWarning)
+        if not hasattr(x, "freq") or x.freq is None:
+            raise ValueError("No `freq` information available")
+        by *= x.freq
+        return x + by
+        # raise TypeError("_shift no longer supports x: pd.Timestamp")
+
 
     # we ensure idx is pd.Index, x is first (and usually only) element
     if isinstance(x, pd.Index):

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -94,16 +94,21 @@ def _shift(x, by=1, return_index=False):
 
     Parameters
     ----------
-    x : pd.Period, pd.Timestamp, int
-        Time point
+    x : pd.Index, pd.Period, int. If pd.Index or pd.Peeriod, must have `freq` attribute.
+        If pd.Index, must be of integer type, PeriodIndex, or DateTimeIndex
+        Time point to shift
     by : int, optional, default=1
     return_index : bool, optional, default=False
         whether to return an index element (False) or a pandas Index (True)
 
     Returns
     -------
-    ret : pd.Period, pd.Timestamp, int
-        Shifted time point
+    ret : pd.Index if return_index = True; int, pd.Period, or pd.Timestamp if False.
+        Shifted time point, `x` shifted by `by` periods
+        if return_index = True: pd.Index coerced `x`, shifted by `by` periods.
+        if return_index = False: index element coerced `x`, shifted by `by` periods.
+            if `x` is index, is coerced to index element by selecting first element
+        Period shift is integer for `x: int`, and `freq` if `x` is temporal with `freq`
     """
     # deprecate in 0.13.0 and remove in 0.14.0, pd.Timestamp will not have freq
     if isinstance(x, pd.Timestamp):

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -104,7 +104,7 @@ def _shift(x, by=1, return_index=False):
     ret : pd.Period, pd.Timestamp, int
         Shifted time point
     """
-    # deprecate in 0.13.0, pd.Timestamp will not have freq
+    # deprecate in 0.13.0 and remove in 0.14.0, pd.Timestamp will not have freq
     if isinstance(x, pd.Timestamp):
         raise TypeError("_shift no longer supports x: pd.Timestamp")
     #     if not hasattr(x, "freq") or x.freq is None:
@@ -119,6 +119,7 @@ def _shift(x, by=1, return_index=False):
     else:
         idx = pd.Index([x])
 
+    # if we want index, we can simply use add dunder or shift
     if return_index:
         if idx.is_integer():
             return idx + by
@@ -128,6 +129,8 @@ def _shift(x, by=1, return_index=False):
     assert isinstance(x, (pd.Period, pd.Timestamp, int, np.integer)), type(x)
     assert isinstance(by, (int, np.integer)) or is_integer_index(by), type(by)
 
+    # if we want index element, we can still use add, except if timestamp
+    # deprecate this in 0.13.0 and remove in 0.14.0
     if isinstance(x, pd.Timestamp):
         if not hasattr(idx, "freq") or idx.freq is None:
             raise ValueError(f"No `freq` information available, object {idx}")

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -128,9 +128,15 @@ def _shift(x, by=1, return_index=False):
         else:
             return idx.shift(by)
 
-    assert isinstance(x, (pd.Period, int, np.integer)), type(x)
+    assert isinstance(x, (pd.Period, pd.Timestamp, int, np.integer)), type(x)
     assert isinstance(by, (int, np.integer)) or is_integer_index(by), type(by)
 
+    # if we want index element, we can still use add, except if timestamp
+    # deprecate this in 0.13.0 and remove in 0.14.0
+    if isinstance(x, pd.Timestamp):
+        if not hasattr(idx, "freq") or idx.freq is None:
+            raise ValueError(f"No `freq` information available, object {idx}")
+        by *= idx.freq
     return x + by
 
 

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -112,6 +112,7 @@ def _shift(x, by=1, return_index=False):
     #     by *= x.freq
     #     return x + by
 
+    # we ensure idx is pd.Index, x is first (and usually only) element
     if isinstance(x, pd.Index):
         idx = x
         x = idx[0]

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -128,14 +128,12 @@ def _shift(x, by=1, return_index=False):
         else:
             return idx.shift(by)
 
+    # if not return_index, i.e., we want an index element
     assert isinstance(x, (pd.Period, pd.Timestamp, int, np.integer)), type(x)
     assert isinstance(by, (int, np.integer)) or is_integer_index(by), type(by)
 
-    # if we want index element, we can still use add, except if timestamp
-    # deprecate this in 0.13.0 and remove in 0.14.0
+    # we need to get freq from idx, since pd.Timestamp freq is deprecated
     if isinstance(x, pd.Timestamp):
-        if not hasattr(idx, "freq") or idx.freq is None:
-            raise ValueError(f"No `freq` information available, object {idx}")
         by *= idx.freq
     return x + by
 


### PR DESCRIPTION
This PR is an attemted partial fix to the `freq` issue, by ensuring the private `_cutoff` attribute of forecasters is always a `pandas.Index` that carries `freq` (when `freq` is present or inferrable).

Relies on PR https://github.com/alan-turing-institute/sktime/pull/2908 which ensures that `get_cutoff` extracts and preserves `freq`.

The public `cutoff` is unchanged, a `pandas` compatible index element rather than an index, which means that no deprecation is necessary.