### PR TITLE
[ENH] caching fitted estimators in base estimator testing - indirect fixtures

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -439,6 +439,7 @@ class BaseObject(_BaseEstimator):
         Returns
         -------
         instance : instance of the class with default parameters
+            and with additional attribute _test_param_id = 0
 
         Notes
         -----
@@ -465,7 +466,10 @@ class BaseObject(_BaseEstimator):
                 "get_test_params should either return a dict or list of dict."
             )
 
-        return cls(**params)
+        obj = cls(**params)
+        obj._test_param_id = 0
+
+        return obj
 
     @classmethod
     def create_test_instances_and_names(cls, parameter_set="default"):
@@ -481,6 +485,7 @@ class BaseObject(_BaseEstimator):
         -------
         objs : list of instances of cls
             i-th instance is cls(**cls.get_test_params()[i])
+            with additional attribute _test_param_id = i
         names : list of str, same length as objs
             i-th element is name of i-th instance of obj in tests
             convention is {cls.__name__}-{i} if more than one instance
@@ -502,13 +507,15 @@ class BaseObject(_BaseEstimator):
             )
         if isinstance(param_list, dict):
             param_list = [param_list]
-        for params in param_list:
+        for i, params in enumerate(param_list):
             if not isinstance(params, dict):
                 raise RuntimeError(
                     f"Error in {cls.__name__}.get_test_params, "
                     "return must be param dict for class, or list thereof"
                 )
-            objs += [cls(**params)]
+            obj = cls(**params)
+            obj._test_param_id = i
+            objs += [obj]
 
         num_instances = len(param_list)
         if num_instances > 1:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -343,6 +343,15 @@ class BaseFixtureGenerator:
 
         return fitted_ests, fitted_est_names
 
+    # this is executed before each test instance call
+    #   if this were not executed, estimator_instance would keep state changes
+    #   within executions of the same test with different parameters
+    @pytest.fixture(scope="session")
+    def estimator_fitted(self, request):
+        """estimator_fitted fixture definition for indirect use."""
+        # esetimator_instance is cloned at the start of every test
+        return request.param.clone()
+
     def _generate_method_nsc(self, test_name, **kwargs):
         """Return estimator test scenario.
 


### PR DESCRIPTION
Splices https://github.com/alan-turing-institute/sktime/pull/2024 into the current test framework and `sktime` version, in an attempt to address https://github.com/alan-turing-institute/sktime/issues/2890

Attempt using indirect fixtures, compare #2913 which uses `lru_cache`.