### PR TITLE
[MNT] removal of pytest pyargs in CI/CD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,6 @@ jobs:
           mkdir -p testdir/
           cp .coveragerc testdir/
           cp setup.cfg testdir/
-          cd testdir/
           python -m pytest
 
       - name: Publish code coverage

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -115,7 +115,6 @@ jobs:
           mkdir -p testdir/
           cp .coveragerc testdir/
           cp setup.cfg testdir/
-          cd testdir/
           python -m pytest
 
   upload_wheels:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: ## Run unit tests
 	mkdir -p ${TEST_DIR}
 	cp .coveragerc ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
-	cd ${TEST_DIR}; python -m pytest
+	python -m pytest
 
 test_softdeps: ## Run unit tests
 	-rm -rf ${TEST_DIR}

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,6 @@ filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed
     ignore:numpy.ufunc size changed
-testpaths =
-    sktime
 
 [flake8]
 # Default flake8 3.5 ignored flags

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ addopts =
     --cov-report xml
     --cov-report html
     --showlocals
-    --pyargs
     --verbose
     -n 2
 filterwarnings =


### PR DESCRIPTION
This PR removes use of `pyargs` from `pytest`.

According to @tarpas, --pyargs are no longer needed since we no longer have cython, and --pyargs stand in the way of the `testmon` approach to #2890