### PR TITLE
[ENH] regular update for stream forecasting, and "no update" wrappers

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -268,7 +268,9 @@ Online and stream forecasting
     :toctree: auto_generated/
     :template: class.rst
 
+    UpdateEvery
     UpdateRefitsEvery
+    DontUpdate
 
 Model selection and tuning
 --------------------------

--- a/sktime/forecasting/stream/__init__.py
+++ b/sktime/forecasting/stream/__init__.py
@@ -3,7 +3,9 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 __all__ = [
+    "DontUpdate",
+    "UpdateEvery",
     "UpdateRefitsEvery",
 ]
 
-from sktime.forecasting.stream._update import UpdateRefitsEvery
+from sktime.forecasting.stream._update import DontUpdate, UpdateEvery, UpdateRefitsEvery

--- a/sktime/forecasting/stream/_update.py
+++ b/sktime/forecasting/stream/_update.py
@@ -160,11 +160,265 @@ class UpdateRefitsEvery(_DelegatedForecaster):
                 X_win = get_window(
                     _X, window_length=refit_window_size, lag=refit_window_lag
                 )
-                fh = self._fh
+            else:
+                y_win = _y
+                X_win = _X
+            fh = self._fh
             estimator.fit(y=y_win, X=X_win, fh=fh, update_params=update_params)
         else:
             # if no: call update as usual
             estimator.update(y=y, X=X, update_params=update_params)
+        return self
+
+    @classmethod
+    def get_test_params(cls):
+        """Return testing parameter settings for the estimator.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        from sktime.forecasting.trend import TrendForecaster
+
+        forecaster = TrendForecaster.create_test_instance()
+
+        param1 = {"forecaster": forecaster}
+        param2 = {"forecaster": forecaster, "refit_interval": 2, "refit_window_size": 3}
+
+        return [param1, param2]
+
+
+class UpdateEvery(_DelegatedForecaster):
+    """Update only periodically when update is called.
+
+    If update is called, behaves like update_params=False, unless update_interval has
+        elapsed since the last "true" update = inner update with update_params=False.
+        update_window controls the lookback window on which refitting is done
+            refit data is cutoff (inclusive) to cutoff minus refit_window (exclusive)
+
+    Caution: default value of update_interval means *no updates* after `fit`.
+
+    Parameters
+    ----------
+    update_interval : difference of sktime time indices (int or timedelta), optional
+        interval that needs to elapse until inner update call with update_params=True
+        default = inf, i.e., never updates
+        if index of y seen in fit is integer or y is index-free container type,
+            update_interval must be int, is interpreted as difference of int location
+        if index of y seen in fit is timestamp, must be int or pd.Timedelta
+            if pd.Timedelta, will be interpreted as time since last true update elapsed
+            if int, will be interpreted as number of time stamps seen since last update
+    """
+
+    _delegate_name = "forecaster_"
+
+    _tags = {"fit_is_empty": False, "requires-fh-in-fit": False}
+
+    def __init__(self, forecaster, update_interval=None):
+        self.forecaster = forecaster
+        self.forecaster_ = forecaster.clone()
+
+        self.update_interval = update_interval
+
+        super(UpdateEvery, self).__init__()
+
+        self.clone_tags(forecaster)
+
+        # fit must be executed to fit the wrapped estimator and remember the cutoff
+        self.set_tags(fit_is_empty=False)
+
+    def _fit(self, y, X=None, fh=None):
+        """Fit forecaster to training data.
+
+        private _fit containing the core logic, called from fit
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+            Time series to which to fit the forecaster.
+            if self.get_tag("scitype:y")=="univariate":
+                guaranteed to have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+                guaranteed to have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions apply
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            Required (non-optional) here if self.get_tag("requires-fh-in-fit")==True
+            Otherwise, if not passed in _fit, guaranteed to be passed in _predict
+        X : optional (default=None)
+            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Exogeneous time series to fit to.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        # we need to remember the time we last fit, to compare to it in _update
+        self.last_update_cutoff_ = self.cutoff
+        estimator = self._get_delegate()
+        estimator.fit(y=y, fh=fh, X=X)
+        return self
+
+    def _update(self, y, X=None, update_params=True):
+        """Update time series to incremental training data.
+
+        private _update containing the core logic, called from update
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Writes to self:
+            Sets fitted model attributes ending in "_", if update_params=True.
+            Does not write to self if update_params=False.
+
+        Parameters
+        ----------
+        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+            Time series with which to update the forecaster.
+            if self.get_tag("scitype:y")=="univariate":
+                guaranteed to have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+                guaranteed to have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions apply
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+        update_params : bool, optional (default=True)
+            whether model parameters should be updated
+
+        Returns
+        -------
+        self : reference to self
+        """
+        estimator = self._get_delegate()
+        time_since_last_update = self.cutoff - self.last_update_cutoff_
+        update_interval = self.update_interval
+
+        _y = self._y
+
+        # treat situation where indexing of y is in timedelta but differences are int
+        #   in that case, interpret any integers as iloc index differences
+        #   and replace integers with timedelta quantities before proceeding
+        if isinstance(time_since_last_update, pd.Timedelta):
+            if isinstance(update_interval, int):
+                index = min(update_interval, len(_y))
+                update_interval = self.cutoff - _y.index[-index]
+        # case distinction based on whether the update_interval period has elapsed
+        #   if yes: call inner update with update_params=True, aka "true" update
+        if time_since_last_update >= update_interval and update_params:
+            estimator.update(y=y, X=X, update_params=update_params)
+        else:
+            # if no: call update, but with update_params=False
+            estimator.update(y=y, X=X, update_params=False)
+        return self
+
+    @classmethod
+    def get_test_params(cls):
+        """Return testing parameter settings for the estimator.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        from sktime.forecasting.trend import TrendForecaster
+
+        forecaster = TrendForecaster.create_test_instance()
+
+        param1 = {"forecaster": forecaster}
+        param2 = {"forecaster": forecaster, "update_interval": 2}
+
+        return [param1, param2]
+
+
+class DontUpdate(_DelegatedForecaster):
+    """Turns off updates, i.e., ensures that forecaster is only fit and never updated.
+
+    This is useful when comparing forecasters that update with forecasters that don't,
+    in a set-up where all forecasters' `update` has `update_params=True` set.
+
+    Shorthand for UpdateEvery with default values.
+
+    Parameters
+    ----------
+    refit_interval : difference of sktime time indices (int or timedelta), optional
+        interval that needs to elapse after which the first update defaults to fit
+        default = 0, i.e., always refits, never updates
+        if index of y seen in fit is integer or y is index-free container type,
+            refit_interval must be int, and is interpreted as difference of int location
+        if index of y seen in fit is timestamp, must be int or pd.Timedelta
+            if pd.Timedelta, will be interpreted as time since last refit elapsed
+            if int, will be interpreted as number of time stamps seen since last refit
+    refit_window_size : difference of sktime time indices (int or timedelta), optional
+        length of the data window to refit to in case update calls fit
+        default = inf, i.e., refits to entire training data seen so far
+    refit_window_lag : difference of sktime indices (int or timedelta), optional
+        lag of the data window to refit to, w.r.t. cutoff, in case update calls fit
+        default = 0, i.e., refit window ends with and includes cutoff
+    """
+
+    _delegate_name = "forecaster_"
+
+    _tags = {"fit_is_empty": False, "requires-fh-in-fit": False}
+
+    def __init__(self, forecaster):
+        self.forecaster = forecaster
+        self.forecaster_ = forecaster.clone()
+
+        super(DontUpdate, self).__init__()
+
+        self.clone_tags(forecaster)
+
+    def _update(self, y, X=None, update_params=True):
+        """Update time series to incremental training data.
+
+        private _update containing the core logic, called from update
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Writes to self:
+            Sets fitted model attributes ending in "_", if update_params=True.
+            Does not write to self if update_params=False.
+
+        Parameters
+        ----------
+        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+            Time series with which to update the forecaster.
+            if self.get_tag("scitype:y")=="univariate":
+                guaranteed to have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+                guaranteed to have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions apply
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+        update_params : bool, optional (default=True)
+            whether model parameters should be updated
+
+        Returns
+        -------
+        self : reference to self
+        """
+        estimator = self._get_delegate()
+        # we need to call this to ensure cutoff of estimator is updated
+        estimator.update(y=y, X=X, update_params=False)
         return self
 
     @classmethod

--- a/sktime/forecasting/stream/_update.py
+++ b/sktime/forecasting/stream/_update.py
@@ -444,7 +444,4 @@ class DontUpdate(_DelegatedForecaster):
 
         forecaster = TrendForecaster.create_test_instance()
 
-        param1 = {"forecaster": forecaster}
-        param2 = {"forecaster": forecaster, "refit_interval": 2, "refit_window_size": 3}
-
-        return [param1, param2]
+        return {"forecaster": forecaster}


### PR DESCRIPTION
This PR adds two wrappesr that control frequency of updates in stream forecasting:

* `DontUpdate`, wraps a forecaster and turns off update. I.e., the internal model is not updated, irrespective of whether `update_params=True` or not, in `update`. This is the "variant of model X without update".
* `UpdateEvery`, wraps a forecaster and carries out a "true update" only every time after `update_interval` time difference has elapsed, similar to `UpdateRefitsEvery`

This PR also fixes an bugs with `UpdateRefitsEvery`:
the "last refit timestamp" was not updated, so `UpdateRefitsEvery` would refit only once after it has been fitted.