### PR TITLE
[ENH] transformer vectorization: ensure unique column names if unvectorized output is multivariate

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -297,6 +297,8 @@ class VectorizedDF:
         def coerce_to_df(x):
             if not isinstance(x, pd.DataFrame):
                 return self._coerce_to_df(x)
+            else:
+                return x
 
         df_list = [coerce_to_df(x) for x in df_list]
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -296,7 +296,7 @@ class VectorizedDF:
 
         def coerce_to_df(x):
             if not isinstance(x, pd.DataFrame):
-                self._coerce_to_df(x)
+                return self._coerce_to_df(x)
 
         df_list = [coerce_to_df(x) for x in df_list]
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -309,9 +309,8 @@ class VectorizedDF:
         X_mi_index = X_mi_reconstructed.index
         X_orig_row_index = self.X_multiindex.index
 
-        if (
-            col_multiindex_flatten
-            and isinstance(X_mi_reconstructed.columns, pd.MultiIndex)
+        if col_multiindex_flatten and isinstance(
+            X_mi_reconstructed.columns, pd.MultiIndex
         ):
             X_mi_reconstructed.columns = flatten_multiindex(X_mi_reconstructed.columns)
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -297,7 +297,7 @@ class VectorizedDF:
         elif col_ix is None:
             X_mi_reconstructed = pd.concat(df_list, keys=row_ix, axis=0)
         elif row_ix is None:
-            if col_multiindex in ["flat", "multiindex"] and any(
+            if col_multiindex in ["flat", "multiindex"] or any(
                 len(x.columns) > 1 for x in df_list
             ):
                 col_keys = self.X_multiindex.columns
@@ -310,7 +310,7 @@ class VectorizedDF:
             col_n = len(col_ix)
             for i in range(row_n):
                 ith_col_block = df_list[i * col_n : (i + 1) * col_n]
-                if col_multiindex in ["flat", "multiindex"] and any(
+                if col_multiindex in ["flat", "multiindex"] or any(
                     len(x.columns) > 1 for x in ith_col_block
                 ):
                     col_keys = self.X_multiindex.columns

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -322,9 +322,8 @@ class VectorizedDF:
         X_mi_index = X_mi_reconstructed.index
         X_orig_row_index = self.X_multiindex.index
 
-        if (multiout or col_multiindex in ["flat"]) and isinstance(
-            X_mi_reconstructed.columns, pd.MultiIndex
-        ):
+        flatten = col_multiindex in ["flat"] or (col_multiindex == "none" and multiout)
+        if flatten and isinstance(X_mi_reconstructed.columns, pd.MultiIndex):
             X_mi_reconstructed.columns = flatten_multiindex(X_mi_reconstructed.columns)
 
         if overwrite_index and len(X_mi_index.names) == len(X_orig_row_index.names):

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -106,7 +106,7 @@ class VectorizedDF:
         self.X_multiindex = self._init_conversion(X)
         self.iter_indices = self._init_iter_indices()
 
-    def _coerce_to_pandas(self, obj, scitype=None, store=None, store_behaviour=None):
+    def _coerce_to_df(self, obj, scitype=None, store=None, store_behaviour=None):
         """Coerce obj to a pandas multiindex format."""
         pandas_dict = {
             "Series": "pd.DataFrame",
@@ -132,7 +132,7 @@ class VectorizedDF:
     def _init_conversion(self, X):
         """Convert X to a pandas multiindex format."""
         is_scitype = self.is_scitype
-        return self._coerce_to_pandas(X, is_scitype, store=self.converter_store)
+        return self._coerce_to_df(X, is_scitype, store=self.converter_store)
 
     def _init_iter_indices(self):
         """Initialize indices that are iterated over in vectorization."""
@@ -159,6 +159,11 @@ class VectorizedDF:
             col_ix = None
 
         return row_ix, col_ix
+
+    @property
+    def index(self):
+        """Defaults to pandas index of X converted to pandas type."""
+        return self.X_multiindex.index
 
     def get_iter_indices(self):
         """Get indices that are iterated over in vectorization.
@@ -288,11 +293,11 @@ class VectorizedDF:
                 (pd-multiindex mtype for Panel, or pd_multiindex_hier for Hierarchical)
             if convert_back=True, will have same format and mtype as X input to __init__
         """
-        def coerce_to_pandas(x):
-            return self._coerce_to_pandas(
+        def coerce_to_df(x):
+            return self._coerce_to_df(
                 x, self.is_scitype, store=self.converter_store, store_behaviour="freeze"
             )
-        df_list = [coerce_to_pandas(x) for x in df_list]
+        df_list = [coerce_to_df(x) for x in df_list]
 
         row_ix, col_ix = self.get_iter_indices()
         multiout = False

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -293,10 +293,12 @@ class VectorizedDF:
                 (pd-multiindex mtype for Panel, or pd_multiindex_hier for Hierarchical)
             if convert_back=True, will have same format and mtype as X input to __init__
         """
+
         def coerce_to_df(x):
             return self._coerce_to_df(
                 x, self.is_scitype, store=self.converter_store, store_behaviour="freeze"
             )
+
         df_list = [coerce_to_df(x) for x in df_list]
 
         row_ix, col_ix = self.get_iter_indices()

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -297,9 +297,8 @@ class VectorizedDF:
         elif col_ix is None:
             X_mi_reconstructed = pd.concat(df_list, keys=row_ix, axis=0)
         elif row_ix is None:
-            if (
-                col_multiindex in ["flat", "multiindex"]
-                and any(len(x.columns) > 1 for x in df_list)
+            if col_multiindex in ["flat", "multiindex"] and any(
+                len(x.columns) > 1 for x in df_list
             ):
                 col_keys = self.X_multiindex.columns
             else:
@@ -311,9 +310,8 @@ class VectorizedDF:
             col_n = len(col_ix)
             for i in range(row_n):
                 ith_col_block = df_list[i * col_n : (i + 1) * col_n]
-                if (
-                    col_multiindex in ["flat", "multiindex"]
-                    and any(len(x.columns) > 1 for x in ith_col_block)
+                if col_multiindex in ["flat", "multiindex"] and any(
+                    len(x.columns) > 1 for x in ith_col_block
                 ):
                     col_keys = self.X_multiindex.columns
                 else:

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from sktime.datatypes._check import check_is_scitype, mtype
 from sktime.datatypes._convert import convert_to
+from sktime.utils.multiindex import flatten_multiindex
 
 
 class VectorizedDF:
@@ -248,7 +249,13 @@ class VectorizedDF:
         """Shorthand to retrieve self (iterator) as list."""
         return list(self)
 
-    def reconstruct(self, df_list, convert_back=False, overwrite_index=True):
+    def reconstruct(
+        self,
+        df_list,
+        convert_back=False,
+        overwrite_index=True,
+        col_multiindex_flatten=True,
+    ):
         """Reconstruct original format from iterable of vectorization instances.
 
         Parameters
@@ -264,6 +271,7 @@ class VectorizedDF:
             if True, the resulting return will have index overwritten by that of X
                 only if applies, i.e., overwrite is possible and X had an index
             if False, no index overwrite will happen
+        col_multiindex_flatten : bool, default = True
 
         Returns
         -------
@@ -279,18 +287,34 @@ class VectorizedDF:
         elif col_ix is None:
             X_mi_reconstructed = pd.concat(df_list, keys=row_ix, axis=0)
         elif row_ix is None:
-            X_mi_reconstructed = pd.concat(df_list, axis=1)
+            if any(len(x.columns) > 1 for x in df_list):
+                col_keys = self.X_multiindex.columns
+            else:
+                col_keys = None
+            X_mi_reconstructed = pd.concat(df_list, axis=1, keys=col_keys)
         else:  # both col_ix and row_ix are not None
             col_concats = []
             row_n = len(row_ix)
             col_n = len(col_ix)
             for i in range(row_n):
                 ith_col_block = df_list[i * col_n : (i + 1) * col_n]
-                col_concats += [pd.concat(ith_col_block, axis=1)]
+                if any(len(x.columns) > 1 for x in ith_col_block):
+                    col_keys = self.X_multiindex.columns
+                else:
+                    col_keys = None
+                col_concats += [pd.concat(ith_col_block, axis=1, keys=col_keys)]
+
             X_mi_reconstructed = pd.concat(col_concats, keys=row_ix, axis=0)
 
         X_mi_index = X_mi_reconstructed.index
         X_orig_row_index = self.X_multiindex.index
+
+        if (
+            col_multiindex_flatten
+            and isinstance(X_mi_reconstructed.columns, pd.MultiIndex)
+        ):
+            X_mi_reconstructed.columns = flatten_multiindex(X_mi_reconstructed.columns)
+
         if overwrite_index and len(X_mi_index.names) == len(X_orig_row_index.names):
             X_mi_reconstructed.index = X_mi_index.set_names(X_orig_row_index.names)
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -293,7 +293,12 @@ class VectorizedDF:
                 (pd-muliindex mtype for Panel, or pd_multiindex_hier for Hierarchical)
             if convert_back=True, will have same format and mtype as X input to __init__
         """
-        df_list = [self._coerce_to_df(x) for x in df_list]
+
+        def coerce_to_df(x):
+            if not isinstance(x, pd.DataFrame):
+                self._coerce_to_df(x)
+
+        df_list = [coerce_to_df(x) for x in df_list]
 
         row_ix, col_ix = self.get_iter_indices()
         multiout = False

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -276,7 +276,9 @@ class VectorizedDF:
         col_multiindex : str, one of "none", "flat", "multiindex", default = "none"
             whether column multiindex is introduced, and if yes, what kind of,
             in case of column vectorization being applied
-            "none" - columns are concatenated, can cause non-unique column names
+            "none" - df_list are simply concatenated, unless:
+                If at least one var is transformed to two or more, "flat" is enforced.
+                If this would cause non-unique column names, "flat" is enforced.
             "multiindex" - additional level is introduced, by names of X passed to init,
                 if there would be more than one column underneath at least one level
                 this is added as an additional pandas MultiIndex level
@@ -302,15 +304,25 @@ class VectorizedDF:
 
         df_list = [coerce_to_df(x) for x in df_list]
 
+        # condition where "flat" behaviour is enforced if "none":
+        def _force_flat(df_list):
+            # transformer produces at least one multivariate output
+            # and there is more than one data frame to concatenate columns of
+            force_flat = len(df_list) > 1 and any(len(x.columns) > 1 for x in df_list)
+            # or, there would be duplicate columns, after the transformation
+            all_col_idx = [ix for df in df_list for ix in df.columns]
+            force_flat = force_flat or len(set(all_col_idx)) != len(all_col_idx)
+            return force_flat
+
         row_ix, col_ix = self.get_iter_indices()
-        multiout = False
+        force_flat = False
         if row_ix is None and col_ix is None:
             X_mi_reconstructed = self.X_multiindex
         elif col_ix is None:
             X_mi_reconstructed = pd.concat(df_list, keys=row_ix, axis=0)
         elif row_ix is None:
-            multiout = any(len(x.columns) > 1 for x in df_list)
-            if col_multiindex in ["flat", "multiindex"] or multiout:
+            force_flat = _force_flat(df_list)
+            if col_multiindex in ["flat", "multiindex"] or force_flat:
                 col_keys = self.X_multiindex.columns
             else:
                 col_keys = None
@@ -321,8 +333,8 @@ class VectorizedDF:
             col_n = len(col_ix)
             for i in range(row_n):
                 ith_col_block = df_list[i * col_n : (i + 1) * col_n]
-                multiout = any(len(x.columns) > 1 for x in ith_col_block)
-                if col_multiindex in ["flat", "multiindex"] or multiout:
+                force_flat = _force_flat(ith_col_block)
+                if col_multiindex in ["flat", "multiindex"] or force_flat:
                     col_keys = self.X_multiindex.columns
                 else:
                     col_keys = None
@@ -333,7 +345,7 @@ class VectorizedDF:
         X_mi_index = X_mi_reconstructed.index
         X_orig_row_index = self.X_multiindex.index
 
-        flatten = col_multiindex in ["flat"] or (col_multiindex == "none" and multiout)
+        flatten = col_multiindex == "flat" or (col_multiindex == "none" and force_flat)
         if flatten and isinstance(X_mi_reconstructed.columns, pd.MultiIndex):
             X_mi_reconstructed.columns = flatten_multiindex(X_mi_reconstructed.columns)
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -106,36 +106,33 @@ class VectorizedDF:
         self.X_multiindex = self._init_conversion(X)
         self.iter_indices = self._init_iter_indices()
 
+    def _coerce_to_pandas(self, obj, scitype=None, store=None, store_behaviour=None):
+        """Coerce obj to a pandas multiindex format."""
+        pandas_dict = {
+            "Series": "pd.DataFrame",
+            "Panel": "pd-multiindex",
+            "Hierarchical": "pd_multiindex_hier",
+            None: ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
+        }
+
+        if scitype not in pandas_dict.keys():
+            raise RuntimeError(
+                f"unexpected value found for attribute scitype: {scitype}"
+                f"must be one of {pandas_dict.keys()}"
+            )
+
+        return convert_to(
+            obj,
+            to_type=pandas_dict[scitype],
+            as_scitype=scitype,
+            store=store,
+            store_behaviour=store_behaviour,
+        )
+
     def _init_conversion(self, X):
         """Convert X to a pandas multiindex format."""
         is_scitype = self.is_scitype
-
-        if is_scitype == "Series":
-            return convert_to(
-                X,
-                to_type="pd.DataFrame",
-                as_scitype="Series",
-                store=self.converter_store,
-            )
-        elif is_scitype == "Panel":
-            return convert_to(
-                X,
-                to_type="pd-multiindex",
-                as_scitype="Panel",
-                store=self.converter_store,
-            )
-        elif is_scitype == "Hierarchical":
-            return convert_to(
-                X,
-                to_type="pd_multiindex_hier",
-                as_scitype="Hierarchical",
-                store=self.converter_store,
-            )
-        else:
-            raise RuntimeError(
-                f"unexpected value found for attribute self.is_scitype: {is_scitype}"
-                'must be "Panel" or "Hierarchical"'
-            )
+        return self._coerce_to_pandas(X, is_scitype, store=self.converter_store)
 
     def _init_iter_indices(self):
         """Initialize indices that are iterated over in vectorization."""
@@ -291,6 +288,12 @@ class VectorizedDF:
                 (pd-multiindex mtype for Panel, or pd_multiindex_hier for Hierarchical)
             if convert_back=True, will have same format and mtype as X input to __init__
         """
+        def coerce_to_pandas(x):
+            return self._coerce_to_pandas(
+                x, self.is_scitype, store=self.converter_store, store_behaviour="freeze"
+            )
+        df_list = [coerce_to_pandas(x) for x in df_list]
+
         row_ix, col_ix = self.get_iter_indices()
         multiout = False
         if row_ix is None and col_ix is None:

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -333,7 +333,7 @@ class VectorizedDF:
             col_n = len(col_ix)
             for i in range(row_n):
                 ith_col_block = df_list[i * col_n : (i + 1) * col_n]
-                force_flat = _force_flat(ith_col_block)
+                force_flat = force_flat or _force_flat(ith_col_block)
                 if col_multiindex in ["flat", "multiindex"] or force_flat:
                     col_keys = self.X_multiindex.columns
                 else:

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -290,16 +290,10 @@ class VectorizedDF:
         X_reconstructed_orig_format : row-concatenation of df-list,
             with keys and additional level from self.get_iter_indices
             if convert_back=False, always a pd.DataFrame in an sktime MultiIndex format
-                (pd-multiindex mtype for Panel, or pd_multiindex_hier for Hierarchical)
+                (pd-muliindex mtype for Panel, or pd_multiindex_hier for Hierarchical)
             if convert_back=True, will have same format and mtype as X input to __init__
         """
-
-        def coerce_to_df(x):
-            return self._coerce_to_df(
-                x, self.is_scitype, store=self.converter_store, store_behaviour="freeze"
-            )
-
-        df_list = [coerce_to_df(x) for x in df_list]
+        df_list = [self._coerce_to_df(x) for x in df_list]
 
         row_ix, col_ix = self.get_iter_indices()
         multiout = False

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -965,7 +965,7 @@ class BaseTransformer(BaseEstimator):
                     ix += 1
                     method = getattr(self.transformers_.iloc[i].iloc[j], methodname)
                     Xts += [method(X=Xs[ix], y=ys[i], **kwargs)]
-                Xt = X.reconstruct(Xts, overwrite_index=False)
+                Xt = X.reconstruct(Xts, overwrite_index=False, col_multiindex="flat")
 
             # if fit_is_empty: don't store transformers, run fit/transform in one
             else:
@@ -978,7 +978,7 @@ class BaseTransformer(BaseEstimator):
                     transformer = self.clone().fit(X=Xs[ix], y=ys[i], **kwargs)
                     method = getattr(transformer, methodname)
                     Xts += [method(X=Xs[ix], y=ys[i], **kwargs)]
-                Xt = X.reconstruct(Xts, overwrite_index=False)
+                Xt = X.reconstruct(Xts, overwrite_index=False, col_multiindex="flat")
 
             # # one more thing before returning:
             #

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -965,7 +965,7 @@ class BaseTransformer(BaseEstimator):
                     ix += 1
                     method = getattr(self.transformers_.iloc[i].iloc[j], methodname)
                     Xts += [method(X=Xs[ix], y=ys[i], **kwargs)]
-                Xt = X.reconstruct(Xts, overwrite_index=False, col_multiindex="flat")
+                Xt = X.reconstruct(Xts, overwrite_index=False)
 
             # if fit_is_empty: don't store transformers, run fit/transform in one
             else:
@@ -978,7 +978,7 @@ class BaseTransformer(BaseEstimator):
                     transformer = self.clone().fit(X=Xs[ix], y=ys[i], **kwargs)
                     method = getattr(transformer, methodname)
                     Xts += [method(X=Xs[ix], y=ys[i], **kwargs)]
-                Xt = X.reconstruct(Xts, overwrite_index=False, col_multiindex="flat")
+                Xt = X.reconstruct(Xts, overwrite_index=False)
 
             # # one more thing before returning:
             #

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -383,7 +383,8 @@ class SlidingWindowSegmenter(BaseTransformer):
 
     Parameters
     ----------
-        window_length : int, length of interval.
+        window_length : int, optional, default=5.
+            length of sliding window interval
 
     Returns
     -------

--- a/sktime/transformations/panel/tests/test_sliding_window_segmenter_transformer.py
+++ b/sktime/transformations/panel/tests/test_sliding_window_segmenter_transformer.py
@@ -7,6 +7,7 @@ __authors__ = ["mloning"]
 import numpy as np
 import pandas as pd
 import pytest
+
 from sktime.transformations.panel.segment import SlidingWindowSegmenter
 from sktime.utils._testing.panel import _make_nested_from_array
 

--- a/sktime/transformations/panel/tests/test_sliding_window_segmenter_transformer.py
+++ b/sktime/transformations/panel/tests/test_sliding_window_segmenter_transformer.py
@@ -1,4 +1,9 @@
 # -*- coding: utf-8 -*-
+"""Tests for SlidingWindowSegmenter."""
+
+__authors__ = ["mloning"]
+
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -11,6 +16,7 @@ from sktime.utils._testing.panel import _make_nested_from_array
 # correct input is meant to be a positive integer of 1 or more.
 @pytest.mark.parametrize("bad_window_length", ["str", 1.2, -1.2, -1, {}])
 def test_bad_input_args(bad_window_length):
+    """Test that bad inputs raise value error."""
     X = _make_nested_from_array(np.ones(10), n_instances=10, n_columns=1)
 
     if not isinstance(bad_window_length, int):
@@ -23,6 +29,7 @@ def test_bad_input_args(bad_window_length):
 
 # Check the transformer has changed the data correctly.
 def test_output_of_transformer():
+    """Test correct output of SlidingWindowSegmenter."""
     X = _make_nested_from_array(
         np.array([1, 2, 3, 4, 5, 6]), n_instances=1, n_columns=1
     )
@@ -66,6 +73,7 @@ def test_output_of_transformer():
     "time_series_length,window_length", [(5, 1), (10, 5), (15, 9), (20, 13), (25, 19)]
 )
 def test_output_dimensions(time_series_length, window_length):
+    """Test output dimensions of SlidingWindowSegmenter."""
     X = _make_nested_from_array(
         np.ones(time_series_length), n_instances=10, n_columns=1
     )
@@ -83,17 +91,8 @@ def test_output_dimensions(time_series_length, window_length):
     assert num_cols == time_series_length
 
 
-# Test that subsequence transformer fails when a multivariate ts
-# is fed into it.
-def test_fails_if_multivariate():
-    X = _make_nested_from_array(np.ones(5), n_instances=10, n_columns=5)
-
-    with pytest.raises(ValueError):
-        SlidingWindowSegmenter().fit(X).transform(X)
-
-
 def convert_list_to_dataframe(list_to_convert):
-    # Convert this into a panda's data frame
+    """Convert list into a pandas data frame."""
     df = pd.DataFrame()
     for i in range(len(list_to_convert)):
         inst = list_to_convert[i]
@@ -105,9 +104,7 @@ def convert_list_to_dataframe(list_to_convert):
 
 
 def check_if_dataframes_are_equal(df1, df2):
-    """
-    for some reason, this is how you check that two dataframes are equal.
-    """
+    """Check that pandas DataFrames are equal."""
     from pandas.testing import assert_frame_equal
 
     try:

--- a/sktime/transformations/tests/test_base.py
+++ b/sktime/transformations/tests/test_base.py
@@ -15,7 +15,9 @@ __all__ = []
 
 from inspect import isclass
 
-from sktime.datatypes import check_is_scitype, mtype_to_scitype
+import pandas as pd
+
+from sktime.datatypes import check_is_scitype, get_examples, mtype_to_scitype
 from sktime.transformations.compose import FitInTransform
 from sktime.transformations.panel.padder import PaddingTransformer
 from sktime.transformations.panel.tsfresh import (
@@ -585,3 +587,25 @@ def test_vectorization_multivariate_and_hierarchical_empty_fit():
     # length of Xt should be number of hierarchy levels times number of time points
     assert len(Xt) == len(scenario.args["fit"]["X"])
     assert len(Xt.columns) == len(scenario.args["fit"]["X"].columns)
+
+
+def test_vectorize_reconstruct_unique_columns():
+    """Tests that vectorization on multivariate output yields unique columns.
+
+    Raises
+    ------
+    AssertionError if output columns are not as expected.
+    """
+    from sktime.transformations.series.theta import ThetaLinesTransformer
+
+    X = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    X_mi = get_examples("pd_multiindex_hier")[0]
+
+    t = ThetaLinesTransformer()
+
+    X_t_cols = t.fit_transform(X).columns
+
+    assert set(X_t_cols) == set(["a__0", "a__2", "b__0", "b__2", "c__0", "c__2"])
+
+    X_mi_cols = t.fit_transform(X_mi)
+    assert set(X_mi_cols) == set(["var_0__0", "var_0__2", "var_1__0", "var_1__2"])

--- a/sktime/transformations/tests/test_base.py
+++ b/sktime/transformations/tests/test_base.py
@@ -35,6 +35,7 @@ from sktime.utils._testing.scenarios_transformers import (
     TransformerFitTransformSeriesMultivariate,
     TransformerFitTransformSeriesUnivariate,
 )
+from sktime.utils._testing.series import _make_series
 
 # other scenarios that might be needed later in development:
 # TransformerFitTransformPanelUnivariateWithClassY,
@@ -592,10 +593,15 @@ def test_vectorization_multivariate_and_hierarchical_empty_fit():
 def test_vectorize_reconstruct_unique_columns():
     """Tests that vectorization on multivariate output yields unique columns.
 
+    Also test that the column names are as expected:
+    <variable>__<transformed> if multiple transformed variables per variable are present
+    <variable> if one variable is transformed to one output
+
     Raises
     ------
     AssertionError if output columns are not as expected.
     """
+    from sktime.transformations.series.detrend import Detrender
     from sktime.transformations.series.theta import ThetaLinesTransformer
 
     X = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
@@ -609,3 +615,8 @@ def test_vectorize_reconstruct_unique_columns():
 
     X_mi_cols = t.fit_transform(X_mi)
     assert set(X_mi_cols) == set(["var_0__0", "var_0__2", "var_1__0", "var_1__2"])
+
+    X = _make_series(n_columns=2, n_timepoints=15)
+    t = Detrender.create_test_instance()
+    Xt = t.fit_transform(X)
+    assert set(Xt.columns) == set([0, 1])


### PR DESCRIPTION
This PR deals with an edge case where a transformer is vectorized that transforms a univariate series or panel into a multivariate series or panel.

In such a case, automated vectorization would typically produce non-unique columns.
This PR modifies the `VectorizedDF.reconstruct` function to create a flattened multiindex that makes the columns unique, by introducing a level for the variable name, in such a case.

Example where non-unique variable names are produced currently after transform:

```python
from sktime.transformations.series.theta import ThetaLinesTransformer

X = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})

t = ThetaLinesTransformer()

t.fit_transform(X)
```

This PR also contains:
* tests that check that unique columns are produced in the above case, and in a similar case.
* a simplification and refactor of `VectorizedDF` functionality for coercion to `pandas.DataFrame`

Also fixes some ancient tests around `SlidingWindowSegmenter`, removes one test that no longer fails due to vectorization, and fixes docstrings/linting.