### PR TITLE
[BUG] enable forecaster vectorized update

### DIFF
--- a/sktime/utils/_testing/forecasting.py
+++ b/sktime/utils/_testing/forecasting.py
@@ -23,12 +23,10 @@ from sktime.utils.validation.forecasting import check_fh
 def _get_n_columns(tag):
     """Return the the number of columns to use in tests."""
     n_columns_list = []
-    if tag == "univariate":
-        n_columns_list = [1]
+    if tag in ["univariate", "both"]:
+        n_columns_list = [1, 2]
     elif tag == "multivariate":
         n_columns_list = [2]
-    elif tag == "both":
-        n_columns_list = [1, 2]
     else:
         raise ValueError(f"Unexpected tag {tag} in _get_n_columns.")
     return n_columns_list


### PR DESCRIPTION
This PR fixes a number of unreported bugs around vectorization of forecaters, and enables tests to check for them:

* ensures that multivariate data are now passed in `TestAllForecasters` even to univariate estimators - this is fine since column vectorization is now enabled.
* Vectorization was forgotten in `update` of forecasters, and tests did not pick up that this was broken due to the multivariate inputs not being enabled. This has been fixed.