### PR TITLE
DIAGNOSTIC: `pandas` input with nullable `dtype`-s - do not merge

### DIFF
--- a/sktime/utils/_testing/scenarios_classification.py
+++ b/sktime/utils/_testing/scenarios_classification.py
@@ -13,6 +13,7 @@ from inspect import isclass
 
 from sktime.base import BaseObject
 from sktime.classification.base import BaseClassifier
+from sktime.datatypes import convert_to
 from sktime.regression.base import BaseRegressor
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_classification_y, _make_panel_X
@@ -104,6 +105,9 @@ X_test_multivariate = _make_panel_X(
     n_instances=5, n_columns=2, n_timepoints=20, random_state=RAND_SEED
 )
 
+X_multivariate = convert_to(X_multivariate, "pd-multiindex").convert_dtypes()
+X_test_multivariate = convert_to(X_test_multivariate, "pd-multiindex").convert_dtypes()
+
 
 class ClassifierFitPredict(ClassifierTestScenario):
     """Fit/predict with univariate panel X and labels y."""
@@ -143,10 +147,10 @@ class ClassifierFitPredictMultivariate(ClassifierTestScenario):
 
 X_unequal_length = _make_hierarchical(
     hierarchy_levels=(10,), min_timepoints=10, max_timepoints=15, random_state=RAND_SEED
-)
+).convert_dtypes()
 X_unequal_length_test = _make_hierarchical(
     hierarchy_levels=(5,), min_timepoints=10, max_timepoints=15, random_state=RAND_SEED
-)
+).convert_dtypes()
 
 
 class ClassifierFitPredictUnequalLength(ClassifierTestScenario):

--- a/sktime/utils/_testing/scenarios_forecasting.py
+++ b/sktime/utils/_testing/scenarios_forecasting.py
@@ -19,6 +19,7 @@ from inspect import isclass
 import pandas as pd
 
 from sktime.base import BaseObject
+from sktime.datatypes import convert_to
 from sktime.forecasting.base import BaseForecaster
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_panel_X
@@ -152,6 +153,7 @@ class ForecasterFitPredictUnivariateNoXLongFh(ForecasterTestScenario):
 
 
 LONG_X = _make_series(n_columns=2, n_timepoints=30, random_state=RAND_SEED)
+LONG_X = LONG_X.convert_dtypes()
 X = LONG_X.iloc[0:20]
 X_test = LONG_X.iloc[20:23]
 X_test_short = LONG_X.iloc[20:21]
@@ -223,6 +225,7 @@ class ForecasterFitPredictMultivariateWithX(ForecasterTestScenario):
 y_panel = _make_panel_X(
     n_instances=3, n_timepoints=10, n_columns=1, random_state=RAND_SEED
 )
+y_panel = convert_to(y_panel, "pd-multiindex").convert_ctypes()
 
 
 class ForecasterFitPredictPanelSimple(ForecasterTestScenario):
@@ -235,6 +238,7 @@ class ForecasterFitPredictPanelSimple(ForecasterTestScenario):
 
 
 y_hierarchical = _make_hierarchical(n_columns=1, random_state=RAND_SEED)
+y_hierarchical = y_hierarchical.convert_dtypes()
 
 
 class ForecasterFitPredictHierarchicalSimple(ForecasterTestScenario):

--- a/sktime/utils/_testing/scenarios_transformers.py
+++ b/sktime/utils/_testing/scenarios_transformers.py
@@ -14,7 +14,7 @@ from inspect import isclass
 import pandas as pd
 
 from sktime.base import BaseObject
-from sktime.datatypes import mtype_to_scitype
+from sktime.datatypes import convert_to, mtype_to_scitype
 from sktime.transformations.base import (
     _PanelToPanelTransformer,
     _PanelToTabularTransformer,
@@ -187,9 +187,11 @@ class TransformerTestScenario(TestScenario, BaseObject):
 
 
 X_series = _make_series(n_timepoints=10, random_state=RAND_SEED)
+X_series = convert_to(X_series, "pd.DataFrame").convert_dtypes()
 X_panel = _make_panel_X(
     n_instances=7, n_columns=1, n_timepoints=10, random_state=RAND_SEED
 )
+X_panel = convert_to(X_series, "pd-multiindex").convert_dtypes()
 
 
 class TransformerFitTransformSeriesUnivariate(TransformerTestScenario):
@@ -241,18 +243,7 @@ class TransformerFitTransformPanelUnivariate(TransformerTestScenario):
         "is_enabled": False,
     }
 
-    args = {
-        "fit": {
-            "X": _make_panel_X(
-                n_instances=7, n_columns=1, n_timepoints=10, random_state=RAND_SEED
-            )
-        },
-        "transform": {
-            "X": _make_panel_X(
-                n_instances=7, n_columns=1, n_timepoints=10, random_state=RAND_SEED
-            )
-        },
-    }
+    args = {"fit": {"X": X_panel}, "transform": {"X": X_panel}}
     default_method_sequence = ["fit", "transform"]
 
 
@@ -330,10 +321,10 @@ class TransformerFitTransformPanelUnivariateWithClassYOnlyFit(TransformerTestSce
 
     args = {
         "fit": {
-            "X": _make_panel_X(n_instances=7, n_columns=1, n_timepoints=10),
+            "X": X_panel,
             "y": _make_classification_y(n_instances=7, n_classes=2),
         },
-        "transform": {"X": _make_panel_X(n_instances=7, n_columns=1, n_timepoints=10)},
+        "transform": {"X": X_panel},
     }
     default_method_sequence = ["fit", "transform"]
 


### PR DESCRIPTION
DO NOT MERGE

It seems that `sktime` is not robust w.r.t. `pandas` input with nullable `dtype`, see, e.g., https://github.com/alan-turing-institute/sktime/pull/2379

This PR is to diagnose type and extent of the failures, by replacing most fixtures with `pandas` based variants, coerced to nullable `dtype`.