### PR TITLE
[BUG] fix `Prophet` to have correct output column names

### DIFF
--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -21,6 +21,7 @@ class _ProphetAdapter(BaseForecaster):
         "capability:pred_int": True,
         "requires-fh-in-fit": False,
         "handles-missing-data": False,
+        "y_inner_mtype": "pd.DataFrame",
         "python_dependencies": "prophet",
     }
 
@@ -69,7 +70,10 @@ class _ProphetAdapter(BaseForecaster):
             X = self._convert_int_to_date(X)
 
         # We have to bring the data into the required format for fbprophet:
-        df = pd.DataFrame({"y": y, "ds": y.index})
+        df = y.copy()
+        df.columns = ["y"]
+        df.index.name = "ds"
+        df = df.reset_index()
 
         # Add seasonality/seasonalities
         if self.add_seasonality:
@@ -163,10 +167,13 @@ class _ProphetAdapter(BaseForecaster):
         out.set_index("ds", inplace=True)
         y_pred = out.loc[:, "yhat"]
 
+        # bring outputs into required format
+        # same column names as training data, index should be index, not "ds"
         y_pred = pd.DataFrame(y_pred)
         y_pred.reset_index(inplace=True)
         y_pred.index = y_pred["ds"].values
         y_pred.drop("ds", axis=1, inplace=True)
+        y_pred.columns = self._y.columns
 
         if self.y_index_was_int_:
             y_pred.index = self.fh.to_absolute(cutoff=self.cutoff)


### PR DESCRIPTION
This fixes an unreported bug where `Prophet.predict` would always return columns named `yhat` rather than columnes named as in the input data.

A test is added in separate PR https://github.com/alan-turing-institute/sktime/pull/2972, that PR is separate because other estimators also have the problem.