### PR TITLE
[BUG] fix NaN columns in bootstrap transformers

### DIFF
--- a/sktime/transformations/bootstrap/_mbb.py
+++ b/sktime/transformations/bootstrap/_mbb.py
@@ -174,7 +174,7 @@ class STLBootstrapTransformer(BaseTransformer):
         # todo: what is the scitype of y: None (not needed), Primitives, Series, Panel
         "scitype:transform-labels": "None",
         "scitype:instancewise": True,  # is this an instance-wise transform?
-        "X_inner_mtype": "pd.Series",  # which mtypes do _fit/_predict support for X?
+        "X_inner_mtype": "pd.DataFrame",  # which mtypes do _fit/_predict support for X?
         # X_inner_mtype can be Panel mtype even if transform-input is Series, vectorized
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
         "capability:inverse_transform": False,
@@ -293,6 +293,9 @@ class STLBootstrapTransformer(BaseTransformer):
         -------
         transformed version of X
         """
+        Xcol = X.columns
+        X = X[X.columns[0]]
+
         if len(X) <= self.block_length_:
             raise ValueError(
                 "STLBootstrapTransformer requires that block_length is"
@@ -366,7 +369,10 @@ class STLBootstrapTransformer(BaseTransformer):
                 )
             )
 
-        return pd.concat(df_list)
+        Xt = pd.concat(df_list)
+        Xt.columns = Xcol
+
+        return Xt
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -479,7 +485,7 @@ class MovingBlockBootstrapTransformer(BaseTransformer):
         # todo: what is the scitype of y: None (not needed), Primitives, Series, Panel
         "scitype:transform-labels": "None",
         "scitype:instancewise": True,  # is this an instance-wise transform?
-        "X_inner_mtype": "pd.Series",  # which mtypes do _fit/_predict support for X?
+        "X_inner_mtype": "pd.DataFrame",  # which mtypes do _fit/_predict support for X?
         # X_inner_mtype can be Panel mtype even if transform-input is Series, vectorized
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
         "capability:inverse_transform": False,
@@ -525,6 +531,9 @@ class MovingBlockBootstrapTransformer(BaseTransformer):
         -------
         transformed version of X
         """
+        Xcol = X.columns
+        X = X[X.columns[0]]
+
         if len(X) <= self.block_length:
             raise ValueError(
                 "MovingBlockBootstrapTransformer requires that block_length is"
@@ -573,7 +582,10 @@ class MovingBlockBootstrapTransformer(BaseTransformer):
                 )
             )
 
-        return pd.concat(df_list)
+        Xt = pd.concat(df_list)
+        Xt.columns = Xcol
+
+        return Xt
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
This fixes an unreported bug with the boostrap transformers `MovingBlockBootstrapTransformer` and `STLBootstrapTransformer` that return a `pd.DataFrame` with `NaN` in the column label.

The column names are now replaced with the names of the input data frame (or data frame coercion).