### PR TITLE
[MNT] Update numpy to <=1.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ requires-python = ">=3.7,<3.11"
 dependencies = [
     "deprecated>=1.2.13",
     "numba>=0.53",
-    "numpy>=1.21.0,<1.22",
+    "numpy>=1.21.0,<1.23",
     "pandas>=1.1.0,<1.5.0",
     "scikit-learn>=0.24.0,<1.2.0",
     "statsmodels>=0.12.1",


### PR DESCRIPTION
Enable using numpy 1.22. This is the change suggested in #2978 


