### PR TITLE
[BUG] fix duplicate classifier tests being run in tests for early classification

### DIFF
--- a/sktime/classification/early_classification/tests/test_all_early_classifiers.py
+++ b/sktime/classification/early_classification/tests/test_all_early_classifiers.py
@@ -5,7 +5,9 @@ __author__ = ["mloning", "TonyBagnall", "fkiraly", "MatthewMiddlehurst"]
 
 import numpy as np
 
-from sktime.classification.tests.test_all_classifiers import TestAllClassifiers
+from sktime.classification.tests.test_all_classifiers import (
+    TestAllClassifiers as _TestAllClassifiers
+)
 from sktime.tests.test_all_estimators import BaseFixtureGenerator, QuickTester
 
 
@@ -35,7 +37,7 @@ class TestAllEarlyClassifiers(EarlyClassifierFixtureGenerator, QuickTester):
 
     def test_multivariate_input_exception(self, estimator_instance):
         """Test univariate early classifiers raise exception on multivariate X."""
-        test = TestAllClassifiers.test_multivariate_input_exception
+        test = _TestAllClassifiers.test_multivariate_input_exception
         test(self, estimator_instance)
 
     def test_classifier_output(self, estimator_instance, scenario):


### PR DESCRIPTION
All classifier tests from `TestAllClassifiers` are run twice, because a second copy is exported by `test_all_early_classifiers`.

This PR fixes that duplication, and doesn´t change anything else (unlike https://github.com/alan-turing-institute/sktime/pull/2980)