### PR TITLE
[ENH] run test suite only for estimators with dependencies present in python environment

### DIFF
--- a/sktime/dists_kernels/compose_from_align.py
+++ b/sktime/dists_kernels/compose_from_align.py
@@ -16,13 +16,14 @@ class DistFromAligner(BasePairwiseTransformerPanel):
     Components
     ----------
     aligner: BaseAligner, must implement get_distances method
+        if None, distance is equal zero
     """
 
     _tags = {
         "symmetric": True,  # all the distances are symmetric
     }
 
-    def __init__(self, aligner):
+    def __init__(self, aligner=None):
 
         self.aligner = aligner
 
@@ -50,8 +51,6 @@ class DistFromAligner(BasePairwiseTransformerPanel):
         distmat: np.array of shape [n, m]
             (i,j)-th entry contains distance/kernel between X.iloc[i] and X2.iloc[j]
         """
-        aligner = self.aligner.clone()
-
         # find out whether we know that the resulting matrix is symmetric
         #   since aligner distances are always symmetric,
         #   we know it's the case for sure if X equals X2
@@ -65,6 +64,11 @@ class DistFromAligner(BasePairwiseTransformerPanel):
         m = len(X2)
 
         distmat = np.zeros((n, m), dtype="float")
+
+        if self.aligner is not None:
+            aligner = self.aligner.clone()
+        else:
+            return distmat
 
         for i in range(n):
             for j in range(m):
@@ -80,5 +84,9 @@ class DistFromAligner(BasePairwiseTransformerPanel):
         """Test parameters for DistFromAligner."""
         # importing inside to avoid circular dependencies
         from sktime.alignment.dtw_python import AlignerDTW
+        from sktime.utils.validation._dependencies import _check_estimator_deps
 
-        return {"aligner": AlignerDTW()}
+        if _check_estimator_deps(AlignerDTW):
+            return {"aligner": AlignerDTW()}
+        else:
+            return {}

--- a/sktime/dists_kernels/compose_from_align.py
+++ b/sktime/dists_kernels/compose_from_align.py
@@ -86,7 +86,7 @@ class DistFromAligner(BasePairwiseTransformerPanel):
         from sktime.alignment.dtw_python import AlignerDTW
         from sktime.utils.validation._dependencies import _check_estimator_deps
 
-        if _check_estimator_deps(AlignerDTW):
+        if _check_estimator_deps(AlignerDTW, severity="none"):
             return {"aligner": AlignerDTW()}
         else:
             return {}

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -21,6 +21,7 @@ class _ProphetAdapter(BaseForecaster):
         "capability:pred_int": True,
         "requires-fh-in-fit": False,
         "handles-missing-data": False,
+        "y_inner_mtype": "pd.DataFrame",
         "python_dependencies": "prophet",
     }
 
@@ -69,7 +70,10 @@ class _ProphetAdapter(BaseForecaster):
             X = self._convert_int_to_date(X)
 
         # We have to bring the data into the required format for fbprophet:
-        df = pd.DataFrame({"y": y, "ds": y.index})
+        df = y.copy()
+        df.columns = ["y"]
+        df.index.name = "ds"
+        df = df.reset_index()
 
         # Add seasonality/seasonalities
         if self.add_seasonality:
@@ -163,10 +167,13 @@ class _ProphetAdapter(BaseForecaster):
         out.set_index("ds", inplace=True)
         y_pred = out.loc[:, "yhat"]
 
+        # bring outputs into required format
+        # same column names as training data, index should be index, not "ds"
         y_pred = pd.DataFrame(y_pred)
         y_pred.reset_index(inplace=True)
         y_pred.index = y_pred["ds"].values
         y_pred.drop("ds", axis=1, inplace=True)
+        y_pred.columns = self._y.columns
 
         if self.y_index_was_int_:
             y_pred.index = self.fh.to_absolute(cutoff=self.cutoff)

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -224,7 +224,7 @@ class _Pipeline(
         ]
         params1 = {"steps": STEPS1}
 
-        if _check_estimator_deps(ARIMA):
+        if _check_estimator_deps(ARIMA, severity="none"):
             # ARIMA has probabilistic methods, ExponentTransformer skips fit
             STEPS2 = [
                 ("transformer", ExponentTransformer()),

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -215,6 +215,7 @@ class _Pipeline(
         from sktime.forecasting.naive import NaiveForecaster
         from sktime.transformations.series.adapt import TabularToSeriesAdaptor
         from sktime.transformations.series.exponent import ExponentTransformer
+        from sktime.utils.validation._dependencies import _check_estimator_deps
 
         # StandardScaler does not skip fit, NaiveForecaster is not probabilistic
         STEPS1 = [
@@ -223,16 +224,20 @@ class _Pipeline(
         ]
         params1 = {"steps": STEPS1}
 
-        # ARIMA has probabilistic methods, ExponentTransformer skips fit
-        STEPS2 = [
-            ("transformer", ExponentTransformer()),
-            ("forecaster", ARIMA()),
-        ]
-        params2 = {"steps": STEPS2}
+        if _check_estimator_deps(ARIMA):
+            # ARIMA has probabilistic methods, ExponentTransformer skips fit
+            STEPS2 = [
+                ("transformer", ExponentTransformer()),
+                ("forecaster", ARIMA()),
+            ]
+            params2 = {"steps": STEPS2}
 
-        params3 = {"steps": [ExponentTransformer(), ARIMA()]}
+            params3 = {"steps": [ExponentTransformer(), ARIMA()]}
 
-        return [params1, params2, params3]
+            return [params1, params2, params3]
+
+        else:
+            return params1
 
 
 # we ensure that internally we convert to pd.DataFrame for now

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -184,11 +184,10 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         -------
         params : dict or list of dict
         """
-        from sktime.forecasting.arima import ARIMA
         from sktime.forecasting.naive import NaiveForecaster
 
         f1 = NaiveForecaster()
-        f2 = ARIMA()
+        f2 = NaiveForecaster(strategy="mean", window_length=3)
         params = {"forecasters": [("f1", f1), ("f2", f2)]}
 
         return params

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -90,6 +90,7 @@ EXCLUDED_TESTS = {
         "test_fit_idempotent",
         "test_persistence_via_pickle",
     ],
+    "VARMAX": "test_update_predict_single",  # see 2997, sporadic failure, unknown cause
 }
 
 # We here configure estimators for basic unit testing, including setting of

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -52,7 +52,7 @@ from sktime.utils._testing.estimator_checks import (
 from sktime.utils._testing.scenarios_getter import retrieve_scenarios
 from sktime.utils.validation._dependencies import (
     _check_dl_dependencies,
-    _check_python_version,
+    _check_estimator_deps,
 )
 
 
@@ -210,7 +210,7 @@ class BaseFixtureGenerator:
         estimator_classes_to_test = [
             est
             for est in estimator_classes_to_test
-            if _check_python_version(est, severity="none")
+            if _check_estimator_deps(est, severity="none")
         ]
 
         estimator_names = [est.__name__ for est in estimator_classes_to_test]

--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -37,12 +37,7 @@ MODULES_TO_IGNORE = ("sktime._contrib", "sktime.utils._testing")
 # e.g., forecasting pipeline with an ARIMA estimator
 # todo: long-term all example parameter settings should be soft dependency free
 # strings of class names to avoid the imports
-EXCEPTED_FROM_NO_DEP_CHECK = [
-    "DistFromAligner",
-    "ForecastingPipeline",
-    "TransformedTargetForecaster",
-    "StackingForecaster",
-]
+EXCEPTED_FROM_NO_DEP_CHECK = []
 
 
 def _is_test(module):

--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -39,7 +39,6 @@ MODULES_TO_IGNORE = ("sktime._contrib", "sktime.utils._testing")
 # strings of class names to avoid the imports
 EXCEPTED_FROM_NO_DEP_CHECK = [
     "DistFromAligner",
-    "HCrystalBallForecaster",  # on the list because will soon be removed
     "ForecastingPipeline",
     "TransformedTargetForecaster",
     "StackingForecaster",

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -251,7 +251,7 @@ def _check_estimator_deps(obj, msg=None, severity="error"):
     """Check all dependencies of estimator, packages and python.
 
     Convenience wrapper around _check_python_version and _check_soft_dependencies,
-    checking against estimator tags "python_version_upper_bound", "python_dependencies".
+    checking against estimator tags "python_version", "python_dependencies".
 
     Parameters
     ----------

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -264,7 +264,9 @@ def _check_estimator_deps(obj, msg=None, severity="error"):
 
     Returns
     -------
-    reference to obj
+    compatible : bool, whether obj is compatible with python environment
+        checks for python version using the python_version tag of obj
+        checks for soft dependencies present using the python_dependencies tag of obj
 
     Raises
     ------
@@ -275,12 +277,14 @@ def _check_estimator_deps(obj, msg=None, severity="error"):
         User friendly error if obj has package dependencies that are not satisfied.
         Packages are determined based on the "python_dependencies" tag of obj.
     """
-    _check_python_version(obj, severity=severity)
+    compatible = True
+    compatible = compatible and _check_python_version(obj, severity=severity)
 
     pkg_deps = obj.get_tag("python_dependencies", None, raise_error=False)
     if pkg_deps is not None and not isinstance(pkg_deps, list):
         pkg_deps = [pkg_deps]
     if pkg_deps is not None:
-        _check_soft_dependencies(*pkg_deps, severity=severity, object=obj)
+        pkg_deps_ok = _check_soft_dependencies(*pkg_deps, severity=severity, object=obj)
+        compatible = compatible and pkg_deps_ok
 
-    return obj
+    return compatible

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -259,12 +259,17 @@ def _check_estimator_deps(obj, msg=None, severity="error"):
         used to check python version
     msg : str, optional, default = default message (msg below)
         error message to be returned in the `ModuleNotFoundError`, overrides default
-    severity : str, "error" (default) or "warning"
-        whether the check should raise an error, or only a warning
-
+    severity : str, "error" (default), "warning", or "none"
+        behaviour for raising errors or warnings
+        "error" - raises a ModuleNotFoundException if environment is incompatible
+        "warning" - raises a warning if environment is incompatible
+            function returns False if environment is incompatible, otherwise True
+        "none" - does not raise exception or warning
+            function returns False if environment is incompatible, otherwise True
     Returns
     -------
     compatible : bool, whether obj is compatible with python environment
+        False is returned only if no exception is raised by the function
         checks for python version using the python_version tag of obj
         checks for soft dependencies present using the python_dependencies tag of obj
 

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -280,7 +280,7 @@ def _check_estimator_deps(obj, msg=None, severity="error"):
     compatible = True
     compatible = compatible and _check_python_version(obj, severity=severity)
 
-    pkg_deps = obj.get_tag("python_dependencies", None, raise_error=False)
+    pkg_deps = obj.get_class_tag("python_dependencies", None)
     if pkg_deps is not None and not isinstance(pkg_deps, list):
         pkg_deps = [pkg_deps]
     if pkg_deps is not None:


### PR DESCRIPTION
This PR changes the `pytest` test generator in `TestAllEstimators` and similar classes to collect only tests involving estimators that are compatible with the current developer environment (python version and dependencies).

This should improve developer experience and get us a good way along the way towards a state where the full test suite on core estimators can be run without the `all_extras` packages installed locally, or running tests based on a custom dependency set.

Some notes:
* this change is imo low risk, since the estimators broken by a change are typically estimators whose soft dependencies are installed by a developer; and the full suite with all soft dependencies will always be run on the remote CI.
* this PR does not get us fully to the point where the entire test suite runs with core dependencies only. The reason are custom tests which are not controlled from the `TestAllEstimators` style classes, they need to be switched to `pytest.mark.skipif` manually.

Contains https://github.com/alan-turing-institute/sktime/pull/2994 which adds some missing tags for this to work properly.