### PR TITLE
[MNT] set number of `pytest-xdist` workers to auto

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ addopts =
     --showlocals
     --pyargs
     --verbose
-    -n 2
+    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
This PR sets the number of `pytest-xdist` workers to `auto`, which will use max.
This is 3 on mac, and 2 on the other OS
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
so this should cut down time on mac to 2/3.

Related PR: #2890.