### PR TITLE
[ENH] missing `tsfresh` depependency tags

### DIFF
--- a/sktime/classification/feature_based/_fresh_prince.py
+++ b/sktime/classification/feature_based/_fresh_prince.py
@@ -66,6 +66,7 @@ class FreshPRINCE(BaseClassifier):
         "capability:train_estimate": True,
         "classifier_type": "feature",
         "python_version": "<3.10",
+        "python_dependencies": "tsfresh",
     }
 
     def __init__(

--- a/sktime/classification/feature_based/_tsfresh_classifier.py
+++ b/sktime/classification/feature_based/_tsfresh_classifier.py
@@ -69,6 +69,7 @@ class TSFreshClassifier(BaseClassifier):
         "capability:multithreading": True,
         "classifier_type": "feature",
         "python_version": "<3.10",
+        "python_dependencies": "tsfresh",
     }
 
     def __init__(


### PR DESCRIPTION
python dependency tags were missing in `tsfresh` dependent estimators `FreshPRINCE` and `TSFreshClassifier`, these have been added.