### PR TITLE
[ENH] refactoring to move default params for fittedparamextractor to concre…

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1682,9 +1682,10 @@
       "profile": "https://github.com/mariamjabara",
       "contributions": [
         "code"
-      ] 
+
+      ]
     },
-    {    
+    {
       "login": "lbventura",
       "name": "Luis Ventura",
       "avatar_url": "https://avatars.githubusercontent.com/u/68004282?s=96&v=4",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1675,7 +1675,15 @@
         "test",
         "ideas"
       ]
-    }
+    },
+    {
+      "login": "mariamjabara",
+      "name": "Mariam Jabara",
+      "profile": "https://github.com/mariamjabara",
+      "contributions": [
+        "code"
+      ] }
+      
   ],
   "projectName": "sktime",
   "projectOwner": "alan-turing-institute",

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -8,7 +8,6 @@ from sklearn.preprocessing import FunctionTransformer, StandardScaler
 
 from sktime.annotation.clasp import ClaSPSegmentation
 from sktime.base import BaseEstimator
-from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.structural import UnobservedComponents
 from sktime.registry import (
     BASE_CLASS_LIST,
@@ -25,7 +24,6 @@ from sktime.transformations.panel.compose import (
 )
 from sktime.transformations.panel.random_intervals import RandomIntervals
 from sktime.transformations.panel.shapelet_transform import RandomShapeletTransform
-from sktime.transformations.panel.summarize import FittedParamExtractor
 
 # The following estimators currently do not pass all unit tests
 # https://github.com/alan-turing-institute/sktime/issues/1627

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -113,10 +113,6 @@ TRANSFORMERS = [
     ),
 ]
 ESTIMATOR_TEST_PARAMS = {
-    FittedParamExtractor: {
-        "forecaster": ExponentialSmoothing(),
-        "param_names": ["initial_level"],
-    },
     SeriesToPrimitivesRowTransformer: {
         "transformer": SERIES_TO_PRIMITIVES_TRANSFORMER,
         "check_transformer": False,

--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -440,9 +440,5 @@ class FittedParamExtractor(BaseTransformer):
             Each dict are parameters to construct an "interesting" test instance, i.e.,
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
-        """  
-        return{
-            "forecaster": ExponentialSmoothing(),
-            "param_names": ["initial_level"]
-        }
-
+        """
+        return {"forecaster": ExponentialSmoothing(), "param_names": ["initial_level"]}

--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -9,6 +9,7 @@ import pandas as pd
 from joblib import Parallel, delayed
 
 from sktime.datatypes import convert_to
+from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.panel.segment import RandomIntervalSegmenter
 
@@ -420,3 +421,28 @@ class FittedParamExtractor(BaseTransformer):
                 f"but found: {type(param_names)}"
             )
         return param_names
+
+    @classmethod
+    def get_test_params(cls):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for distance/kernel transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """  
+        return{
+            "forecaster": ExponentialSmoothing(),
+            "param_names": ["initial_level"]
+        }
+


### PR DESCRIPTION
…te estimators and out of config file.

#### Reference Issues/PRs
Fixes #1678 



#### What does this implement/fix? Explain your changes.
Moves default test params from out of tests/_config into FittedParamExtractor class as a get_test_params method.


#### Does your contribution introduce a new dependency? If yes, which one?
N/A


#### What should a reviewer concentrate their feedback on?

#### Any other comments?

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.
- [ X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
