### PR TITLE
[BUG] fixes `RandomIntervalFeatureExtractor` to have unique column names

### DIFF
--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -315,10 +315,10 @@ class RandomIntervalFeatureExtractor(BaseTransformer):
                     else:
                         raise
                 new_col_name = f"{start}_{end}_{func.__name__}"
-                if new_col_name not in columns:
+                if new_col_name in columns:
                     drop_list += [i]
                 else:
-                    columns.append(new_col_name)
+                    columns = columns + [new_col_name]
                 i += 1
 
         Xt = pd.DataFrame(Xt)

--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -322,7 +322,7 @@ class RandomIntervalFeatureExtractor(BaseTransformer):
 
         Xt = pd.DataFrame(Xt)
         Xt.columns = columns
-        Xt = Xt.drop(columns=X.columns[drop_list])
+        Xt = Xt.drop(columns=Xt.columns[drop_list])
 
         return Xt
 

--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -315,14 +315,15 @@ class RandomIntervalFeatureExtractor(BaseTransformer):
                     else:
                         raise
                 new_col_name = f"{start}_{end}_{func.__name__}"
-                columns.append(new_col_name)
                 if new_col_name not in columns:
                     drop_list += [i]
+                else:
+                    columns.append(new_col_name)
                 i += 1
 
         Xt = pd.DataFrame(Xt)
-        Xt.columns = columns
         Xt = Xt.drop(columns=Xt.columns[drop_list])
+        Xt.columns = columns
 
         return Xt
 

--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -294,6 +294,7 @@ class RandomIntervalFeatureExtractor(BaseTransformer):
         columns = []
 
         i = 0
+        drop_list = []
         for func in features:
             # TODO generalise to series-to-series functions and function kwargs
             for start, end in intervals:
@@ -313,11 +314,16 @@ class RandomIntervalFeatureExtractor(BaseTransformer):
                         ).squeeze()
                     else:
                         raise
+                new_col_name = f"{start}_{end}_{func.__name__}"
+                columns.append(new_col_name)
+                if new_col_name not in columns:
+                    drop_list += [i]
                 i += 1
-                columns.append(f"{start}_{end}_{func.__name__}")
 
         Xt = pd.DataFrame(Xt)
         Xt.columns = columns
+        Xt = Xt.drop(columns=X.columns[drop_list])
+
         return Xt
 
 


### PR DESCRIPTION
`RandomIntervelFeatureExtractor` had the same sporadic column non-uniquness as `IntervalSegmenter`, see here: https://github.com/alan-turing-institute/sktime/pull/2970

This PR makes the columns unique