### PR TITLE
[MNT] fix issue with 3.10 wheels (use string to avoid coercion to version 3.1)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Build wheel
         run: |
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macOS-10.15]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2
@@ -72,6 +72,16 @@ jobs:
           - os: windows-2019
             python: 38
             python-version: 3.8
+            bitness: 64
+            platform_id: win_amd64
+          - os: windows-2019
+            python: 38
+            python-version: 3.9
+            bitness: 64
+            platform_id: win_amd64
+          - os: windows-2019
+            python: 38
+            python-version: 3.10
             bitness: 64
             platform_id: win_amd64
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macOS-10.15]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v2
@@ -66,22 +66,22 @@ jobs:
           # Window 64 bit
           - os: windows-2019
             python: 37
-            python-version: 3.7
+            python-version: '3.7'
             bitness: 64
             platform_id: win_amd64
           - os: windows-2019
             python: 38
-            python-version: 3.8
+            python-version: '3.8'
             bitness: 64
             platform_id: win_amd64
           - os: windows-2019
-            python: 38
-            python-version: 3.9
+            python: 39
+            python-version: '3.9'
             bitness: 64
             platform_id: win_amd64
           - os: windows-2019
-            python: 38
-            python-version: 3.10
+            python: 310
+            python-version: '3.10'
             bitness: 64
             platform_id: win_amd64
 


### PR DESCRIPTION
Uses strings for version numbers to comply with `setup-python` spec