### PR TITLE
[ENH] refactored test params for ColumnTransformer

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -98,20 +98,7 @@ SERIES_TO_SERIES_TRANSFORMER = StandardScaler()
 SERIES_TO_PRIMITIVES_TRANSFORMER = FunctionTransformer(
     np.mean, kw_args={"axis": 0}, check_inverse=False
 )
-TRANSFORMERS = [
-    (
-        "transformer1",
-        SeriesToSeriesRowTransformer(
-            SERIES_TO_SERIES_TRANSFORMER, check_transformer=False
-        ),
-    ),
-    (
-        "transformer2",
-        SeriesToSeriesRowTransformer(
-            SERIES_TO_SERIES_TRANSFORMER, check_transformer=False
-        ),
-    ),
-]
+
 ESTIMATOR_TEST_PARAMS = {
     FittedParamExtractor: {
         "forecaster": ExponentialSmoothing(),
@@ -124,9 +111,6 @@ ESTIMATOR_TEST_PARAMS = {
     SeriesToSeriesRowTransformer: {
         "transformer": SERIES_TO_SERIES_TRANSFORMER,
         "check_transformer": False,
-    },
-    ColumnTransformer: {
-        "transformers": [(name, estimator, [0]) for name, estimator in TRANSFORMERS]
     },
     RandomShapeletTransform: {
         "max_shapelets": 5,

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -19,7 +19,6 @@ from sktime.registry import (
 from sktime.regression.compose import ComposableTimeSeriesForestRegressor
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.panel.compose import (
-    ColumnTransformer,
     SeriesToPrimitivesRowTransformer,
     SeriesToSeriesRowTransformer,
 )

--- a/sktime/transformations/panel/compose.py
+++ b/sktime/transformations/panel/compose.py
@@ -9,6 +9,7 @@ import pandas as pd
 from scipy import sparse
 from sklearn.base import clone
 from sklearn.compose import ColumnTransformer as _ColumnTransformer
+
 from sktime.datatypes._panel._convert import (
     from_2d_array_to_nested,
     from_3d_numpy_to_2d_array,
@@ -188,6 +189,7 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
         from sklearn.preprocessing import StandardScaler
+
         from sktime.transformations.panel.compose import SeriesToSeriesRowTransformer
 
         SERIES_TO_SERIES_TRANSFORMER = StandardScaler()

--- a/sktime/transformations/panel/compose.py
+++ b/sktime/transformations/panel/compose.py
@@ -178,6 +178,7 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
     @classmethod
     def get_test_params(cls):
         """Return testing parameter settings for the estimator.
+
         Returns
         -------
         params : dict or list of dict, default = {}
@@ -205,7 +206,9 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
             ),
         ]
 
-        return {"transformers": [(name, estimator, [0]) for name, estimator in TRANSFORMERS] }
+        return {
+            "transformers": [(name, estimator, [0]) for name, estimator in TRANSFORMERS]
+        }
 
     def fit(self, X, y=None):
         """Fit the transformer."""

--- a/sktime/transformations/panel/compose.py
+++ b/sktime/transformations/panel/compose.py
@@ -9,7 +9,6 @@ import pandas as pd
 from scipy import sparse
 from sklearn.base import clone
 from sklearn.compose import ColumnTransformer as _ColumnTransformer
-
 from sktime.datatypes._panel._convert import (
     from_2d_array_to_nested,
     from_3d_numpy_to_2d_array,
@@ -175,6 +174,38 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
                     "The output of the '{0}' transformer should be 2D (scipy "
                     "matrix, array, or pandas DataFrame).".format(name)
                 )
+
+    @classmethod
+    def get_test_params(cls):
+        """Return testing parameter settings for the estimator.
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        from sklearn.preprocessing import StandardScaler
+        from sktime.transformations.panel.compose import SeriesToSeriesRowTransformer
+
+        SERIES_TO_SERIES_TRANSFORMER = StandardScaler()
+        TRANSFORMERS = [
+            (
+                "transformer1",
+                SeriesToSeriesRowTransformer(
+                    SERIES_TO_SERIES_TRANSFORMER, check_transformer=False
+                ),
+            ),
+            (
+                "transformer2",
+                SeriesToSeriesRowTransformer(
+                    SERIES_TO_SERIES_TRANSFORMER, check_transformer=False
+                ),
+            ),
+        ]
+
+        return {"transformers": [(name, estimator, [0]) for name, estimator in TRANSFORMERS] }
 
     def fit(self, X, y=None):
         """Fit the transformer."""


### PR DESCRIPTION
#### Reference Issues/PRs
Related to estimator test parameter refactoring in #1678.

#### What does this implement/fix? Explain your changes.

Refactoring applied to ColumnTransformer by creating get_test_params method as explained in issue https://github.com/alan-turing-institute/sktime/issues/1678 and removed params from tests/_config.py.

#### Does your contribution introduce a new dependency? If yes, which one?
No.