### PR TITLE
[ENH] parameter checking and move of `super.__init__` in extension templates

### DIFF
--- a/extension_templates/annotation.py
+++ b/extension_templates/annotation.py
@@ -89,16 +89,19 @@ class MySeriesAnnotator(BaseSeriesAnnotator):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
-        # important: no checking or other logic should happen here
+
+        # todo: change "MySeriesAnnotator" to the name of the class
+        super(MySeriesAnnotator, self).__init__(fmt=fmt, labels=labels)
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
 
         # todo: default estimators should have None arg defaults
         #  and be initialized here
         #  do this only with default estimators, not with parameters
         # if est2 is None:
         #     self.estimator = MyDefaultEstimator()
-
-        # todo: change "MySeriesAnnotator" to the name of the class
-        super(MySeriesAnnotator, self).__init__(fmt=fmt, labels=labels)
 
         # todo: if tags of estimator depend on component tags, set these here
         #  only needed if estimator is a composite

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -90,16 +90,19 @@ class MyTimeSeriesClassifier(BaseClassifier):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
-        # important: no checking or other logic should happen here
+
+        # todo: change "MyTimeSeriesClassifier" to the name of the class
+        super(MyTimeSeriesClassifier, self).__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
 
         # todo: default estimators should have None arg defaults
         #  and be initialized here
         #  do this only with default estimators, not with parameters
         # if est2 is None:
         #     self.estimator = MyDefaultEstimator()
-
-        # todo: change "MyTimeSeriesClassifier" to the name of the class
-        super(MyTimeSeriesClassifier, self).__init__()
 
         # todo: if tags of estimator depend on component tags, set these here
         #  only needed if estimator is a composite

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -85,16 +85,19 @@ class MyClusterer(BaseClusterer):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
-        # important: no checking or other logic should happen here
+
+        # todo: change "MyClusterer" to the name of the class
+        super(MyClusterer, self).__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
 
         # todo: default estimators should have None arg defaults
         #  and be initialized here
         #  do this only with default estimators, not with parameters
         # if est2 is None:
         #     self.estimator = MyDefaultEstimator()
-
-        # todo: change "MyClusterer" to the name of the class
-        super(MyClusterer, self).__init__()
 
     # todo: implement this abstract class, mandatory
     def _fit(self, X):

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -71,16 +71,19 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
-        # important: no checking or other logic should happen here
+
+        # todo: change "MyTrafoPwPanel" to the name of the class
+        super(MyTrafoPwPanel, self).__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
 
         # todo: default estimators should have None arg defaults
         #  and be initialized here
         #  do this only with default estimators, not with parameters
         # if est2 is None:
         #     self.estimator = MyDefaultEstimator()
-
-        # todo: change "MyTrafoPwPanel" to the name of the class
-        super(MyTrafoPwPanel, self).__init__()
 
         # todo: if tags of estimator depend on component tags, set these here
         #  only needed if estimator is a composite

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -71,16 +71,19 @@ class MyTrafoPw(BasePairwiseTransformer):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
-        # important: no checking or other logic should happen here
+
+        # todo: change "MyTrafoPw" to the name of the class
+        super(MyTrafoPw, self).__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
 
         # todo: default estimators should have None arg defaults
         #  and be initialized here
         #  do this only with default estimators, not with parameters
         # if est2 is None:
         #     self.estimator = MyDefaultEstimator()
-
-        # todo: change "MyTrafoPw" to the name of the class
-        super(MyTrafoPw, self).__init__()
 
         # todo: if tags of estimator depend on component tags, set these here
         #  only needed if estimator is a composite

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -92,16 +92,19 @@ class MyEarlyTimeSeriesClassifier(BaseEarlyClassifier):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
-        # important: no checking or other logic should happen here
+
+        # todo: change "MyEarlyTimeSeriesClassifier" to the name of the class
+        super(MyEarlyTimeSeriesClassifier, self).__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
 
         # todo: default estimators should have None arg defaults
         #  and be initialized here
         #  do this only with default estimators, not with parameters
         # if est2 is None:
         #     self.estimator = MyDefaultEstimator()
-
-        # todo: change "MyEarlyTimeSeriesClassifier" to the name of the class
-        super(MyEarlyTimeSeriesClassifier, self).__init__()
 
         # todo: if tags of estimator depend on component tags, set these here
         #  only needed if estimator is a composite

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -104,16 +104,19 @@ class MyForecaster(BaseForecaster):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
-        # important: no checking or other logic should happen here
+
+        # todo: change "MyForecaster" to the name of the class
+        super(MyForecaster, self).__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
 
         # todo: default estimators should have None arg defaults
         #  and be initialized here
         #  do this only with default estimators, not with parameters
         # if est2 is None:
         #     self.estimator = MyDefaultEstimator()
-
-        # todo: change "MyForecaster" to the name of the class
-        super(MyForecaster, self).__init__()
 
         # todo: if tags of estimator depend on component tags, set these here
         #  only needed if estimator is a composite

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -88,10 +88,13 @@ class MyForecaster(BaseForecaster):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
-        # important: no checking or other logic should happen here
 
         # todo: change "MyForecaster" to the name of the class
         super(MyForecaster, self).__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
 
     # todo: implement this, mandatory
     def _fit(self, y, X=None, fh=None):

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -136,16 +136,19 @@ class MyTransformer(BaseTransformer):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
-        # important: no checking or other logic should happen here
+
+        # todo: change "MyTransformer" to the name of the class
+        super(MyTransformer, self).__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
 
         # todo: default estimators should have None arg defaults
         #  and be initialized here
         #  do this only with default estimators, not with parameters
         # if est2 is None:
         #     self.est2 = MyDefaultEstimator()
-
-        # todo: change "MyTransformer" to the name of the class
-        super(MyTransformer, self).__init__()
 
         # todo: if tags of estimator depend on component tags, set these here
         #  only needed if estimator is a composite

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -123,10 +123,13 @@ class MyTransformer(BaseTransformer):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
-        # important: no checking or other logic should happen here
 
         # todo: change "MyTransformer" to the name of the class
         super(MyTransformer, self).__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
 
     # todo: implement this, mandatory (except in special case below)
     def _fit(self, X, y=None):


### PR DESCRIPTION
This PR updates extension templates to the decision in https://github.com/alan-turing-institute/sktime/issues/2573.

That is, `__init__` can now contain additional logic of parameter checking kind, or tag setting, but it must be after the call to `super.__init__`.