### PR TITLE
add testdir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ pip-log.txt
 pip-delete-this-directory.txt
 pip-wheel-metadata/
 
+# folder created by `make test`
+testdir/
+
 # Unit test / coverage reports
 htmlcov/
 .tox/


### PR DESCRIPTION
when one runs `make test` it produces a directory `testdir/`. this should be ignored by git.