### PR TITLE
[ENH] add check for `nested_univ` duplicate index and ensure unique instance index in `sktime` datasets

### DIFF
--- a/sktime/benchmarking/data.py
+++ b/sktime/benchmarking/data.py
@@ -66,9 +66,7 @@ class UEADataset(HDDBaseDataset):
 
         # concatenate the two dataframes, keeping training and test split in
         # index, necessary for later optional CV
-        data = pd.concat(
-            [data_train, data_test], axis=0, keys=["train", "test"]
-        ).reset_index(level=1, drop=True)
+        data = pd.concat([data_train, data_test], axis=0, keys=["train", "test"])
 
         return data
 

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -176,6 +176,7 @@ def _load_dataset(name, split, return_X_y, extract_path=None):
             result = load_from_tsfile_to_dataframe(abspath)
             X = pd.concat([X, pd.DataFrame(result[0])])
             y = pd.concat([y, pd.Series(result[1])])
+        X = X.reset_index(drop=True)
         y = pd.Series.to_numpy(y, dtype=str)
     else:
         raise ValueError("Invalid `split` value =", split)

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -220,12 +220,12 @@ def _load_provided_dataset(name, split=None, return_X_y=True, return_type=None):
             X = np.concatenate((X_train, X_test))
         elif isinstance(X_train, pd.DataFrame):
             X = pd.concat([X_train, X_test])
+            X = X.reset_index(drop=True)
         else:
             raise IOError(
                 f"Invalid data structure type {type(X_train)} for loading "
                 f"classification problem "
             )
-        X = X.reset_index(drop=True)
         y = np.concatenate((y_train, y_test))
 
     else:

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -225,6 +225,7 @@ def _load_provided_dataset(name, split=None, return_X_y=True, return_type=None):
                 f"Invalid data structure type {type(X_train)} for loading "
                 f"classification problem "
             )
+        X = X.reset_index(drop=True)
         y = np.concatenate((y_train, y_test))
 
     else:

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -306,6 +306,15 @@ def is_nested_dataframe(obj, return_metadata=False, var_name="obj"):
             msg = f"{var_name} entries must be pd.Series"
             return _ret(False, msg, None, return_metadata)
 
+    # Check instance index is unique
+    if not obj.index.is_unique:
+        duplicates = obj.index[obj.index.duplicated()].unique().to_list()
+        msg = (
+            f"The instance index of {var_name} must be unique, "
+            f"but found duplicates: {duplicates}"
+        )
+        return _ret(False, msg, None, return_metadata)
+
     metadata = dict()
     metadata["is_univariate"] = obj.shape[1] < 2
     metadata["n_instances"] = len(obj)

--- a/sktime/series_as_features/model_selection/_split.py
+++ b/sktime/series_as_features/model_selection/_split.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = ["PresplitFilesCV", "SingleSplit"]
 
 import numpy as np
@@ -39,7 +39,7 @@ class PresplitFilesCV:
         # check input
         if not isinstance(data, pd.DataFrame):
             raise ValueError(f"Data must be pandas DataFrame, but found {type(data)}")
-        if not np.all(data.index.unique().isin(["train", "test"])):
+        if not np.all(data.index.get_level_values(0).unique().isin(["train", "test"])):
             raise ValueError(
                 "Train-test split not properly defined in "
                 "index of passed pandas DataFrame"
@@ -53,8 +53,10 @@ class PresplitFilesCV:
         # dataframe, and split them here again
         n_instances = data.shape[0]
         idx = np.arange(n_instances)
-        train = idx[data.index == "train"]
-        test = idx[data.index == "test"]
+        train = data.index.get_level_values(0) == "train"
+        test = data.index.get_level_values(0) == "test"
+        train = idx[train]
+        test = idx[test]
         yield train, test
 
         # if additionally a cv iterator is provided, yield the predefined

--- a/sktime/transformations/panel/compose.py
+++ b/sktime/transformations/panel/compose.py
@@ -350,7 +350,12 @@ class SeriesToSeriesRowTransformer(_RowTransformer, _PanelToPanelTransformer):
         for i in range(X.shape[0]):
             xt = self.transformer_[i].fit_transform(X[i].T)
             xts.append(from_2d_array_to_nested(xt.T).T)
-        return pd.concat(xts, axis=0)
+        Xt = pd.concat(xts, axis=0)
+        if isinstance(X, pd.DataFrame):
+            Xt.index = X.index
+        else:
+            Xt = Xt.reset_index(drop=True)
+        return Xt
 
 
 def make_row_transformer(transformer, transformer_type=None, **kwargs):


### PR DESCRIPTION
This fixes a recurring issue with duplicated indices from the time series classification datasets. This has been repeatedly breaking things downstream and made refactors difficult. Fixes #1290, fixes #2331 for the instance index, addresses the example in #1893 fixes the problem that prevents #2379 to be refactored.

Initial bug report about duplicate indices: https://github.com/alan-turing-institute/sktime/issues/1290

Nature of the fix:
* adds a check for `nested_univ` mtype that prohibits duplicate instance index
* makes changes in the `datasets` module that ensures unique index for loaded time series classification datasets, via `reset_index(drop=True)`
* fixes an instance of duplicate indices in the benchmarking module
* ensures that any `nested_univ` returns of the old `SeriesToSeriesRowTransformer` have unique instance index

Note: this does *not* prohibit duplicate time index, only duplicate instance name (index of the outer `DataFrame` in `nested_univ`).
