### PR TITLE
[MNT] xfail known sporadic test failure #2368

### DIFF
--- a/sktime/benchmarking/tests/test_evaluator.py
+++ b/sktime/benchmarking/tests/test_evaluator.py
@@ -189,7 +189,7 @@ def test_nemenyi():
     return np.array_equal(expected, result)
 
 
-@pytest.mark.skip(reason="known sporadic failure of unknown cause, see #2368")
+@pytest.mark.xfail(reason="known sporadic failure of unknown cause, see #2368")
 def test_plots():
     """Test plots."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)

--- a/sktime/benchmarking/tests/test_evaluator.py
+++ b/sktime/benchmarking/tests/test_evaluator.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 from sklearn.metrics import accuracy_score
 
 from sktime.benchmarking.evaluation import Evaluator
@@ -188,6 +189,7 @@ def test_nemenyi():
     return np.array_equal(expected, result)
 
 
+@pytest.mark.skip(reason="known sporadic failure of unknown cause, see #2368")
 def test_plots():
     """Test plots."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)


### PR DESCRIPTION
This adds a test xfail of the known sporadic test failure reported as  bug #2368.

The cause of the bug is not known, and the skip is added to avoid sporadic test crashes unrelated to the addition.