### PR TITLE
[ENH] ensure data loaders produce unique instance index

### DIFF
--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -176,6 +176,7 @@ def _load_dataset(name, split, return_X_y, extract_path=None):
             result = load_from_tsfile_to_dataframe(abspath)
             X = pd.concat([X, pd.DataFrame(result[0])])
             y = pd.concat([y, pd.Series(result[1])])
+        X = X.reset_index(drop=True)
         y = pd.Series.to_numpy(y, dtype=str)
     else:
         raise ValueError("Invalid `split` value =", split)

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -220,12 +220,12 @@ def _load_provided_dataset(name, split=None, return_X_y=True, return_type=None):
             X = np.concatenate((X_train, X_test))
         elif isinstance(X_train, pd.DataFrame):
             X = pd.concat([X_train, X_test])
+            X = X.reset_index(drop=True)
         else:
             raise IOError(
                 f"Invalid data structure type {type(X_train)} for loading "
                 f"classification problem "
             )
-        X = X.reset_index(drop=True)
         y = np.concatenate((y_train, y_test))
 
     else:

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -225,6 +225,7 @@ def _load_provided_dataset(name, split=None, return_X_y=True, return_type=None):
                 f"Invalid data structure type {type(X_train)} for loading "
                 f"classification problem "
             )
+        X = X.reset_index(drop=True)
         y = np.concatenate((y_train, y_test))
 
     else:

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -306,15 +306,6 @@ def is_nested_dataframe(obj, return_metadata=False, var_name="obj"):
             msg = f"{var_name} entries must be pd.Series"
             return _ret(False, msg, None, return_metadata)
 
-    # Check instance index is unique
-    if not obj.index.is_unique:
-        duplicates = obj.index[obj.index.duplicated()].unique().to_list()
-        msg = (
-            f"The instance index of {var_name} must be unique, "
-            f"but found duplicates: {duplicates}"
-        )
-        return _ret(False, msg, None, return_metadata)
-
     metadata = dict()
     metadata["is_univariate"] = obj.shape[1] < 2
     metadata["n_instances"] = len(obj)

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -306,6 +306,15 @@ def is_nested_dataframe(obj, return_metadata=False, var_name="obj"):
             msg = f"{var_name} entries must be pd.Series"
             return _ret(False, msg, None, return_metadata)
 
+    # Check instance index is unique
+    if not obj.index.is_unique:
+        duplicates = obj.index[obj.index.duplicated()].unique().to_list()
+        msg = (
+            f"The instance index of {var_name} must be unique, "
+            f"but found duplicates: {duplicates}"
+        )
+        return _ret(False, msg, None, return_metadata)
+
     metadata = dict()
     metadata["is_univariate"] = obj.shape[1] < 2
     metadata["n_instances"] = len(obj)


### PR DESCRIPTION
#3029, but without the checks. Only has the changes that guarantee unique instance index. Fixes #1290.