### PR TITLE
[ENH] weighted ensemble compositor for classifiers to allow users to build their own HIVE-COTE like ensembles

### DIFF
--- a/sktime/classification/compose/__init__.py
+++ b/sktime/classification/compose/__init__.py
@@ -8,10 +8,14 @@ __all__ = [
     "ComposableTimeSeriesForestClassifier",
     "ColumnEnsembleClassifier",
     "SklearnClassifierPipeline",
+    "WeightedEnsembleClassifier",
 ]
 
 from sktime.classification.compose._column_ensemble import ColumnEnsembleClassifier
-from sktime.classification.compose._ensemble import ComposableTimeSeriesForestClassifier
+from sktime.classification.compose._ensemble import (
+    ComposableTimeSeriesForestClassifier,
+    WeightedEnsembleClassifier,
+)
 from sktime.classification.compose._pipeline import (
     ClassifierPipeline,
     SklearnClassifierPipeline,

--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Configurable time series ensembles."""
-__author__ = ["mloning", "AyushmaanSeth"]
+__author__ = ["mloning", "AyushmaanSeth", "fkiraly"]
 __all__ = ["ComposableTimeSeriesForestClassifier"]
 
 import numbers
@@ -732,11 +732,6 @@ class WeightedEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
                         train_preds[i] = train_probs[i, np.argmax(train_probs[i, :])]
                 metric = self._metric
                 self.weights_[clf_name] = metric(y, train_preds) ** exponent
-
-        # # Find TDE weight using train set estimate
-        # train_probs = self._tde._get_train_probs(X, y, train_estimate_method="loocv")
-        # train_preds = self._tde.classes_[np.argmax(train_probs, axis=1)]
-        # self.tde_weight_ = accuracy_score(y, train_preds) ** 4
 
         return self
 

--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -752,7 +752,7 @@ class WeightedEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
         if not isinstance(self.weights, (float, int)):
             for _, classifier in self.classifiers_:
                 classifier.fit(X=X, y=y)
-        # if weights are calculated by training loss, we fit_predict
+        # if weights are calculated by training loss, we fit_predict and evaluate
         else:
             exponent = self.weights
             for clf_name, clf in self.classifiers_:

--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -752,24 +752,6 @@ class WeightedEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
 
         return self
 
-    def _predict(self, X) -> np.ndarray:
-        """Predicts labels for sequences in X.
-
-        Parameters
-        ----------
-        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
-            The data to make predictions for.
-
-        Returns
-        -------
-        y : array-like, shape = [n_instances]
-            Predicted class labels.
-        """
-        y_proba = self.predict_proba(X)
-        y_pred = y_proba.argmax(axis=1)
-
-        return y_pred
-
     def _predict_proba(self, X) -> np.ndarray:
         """Predicts labels probabilities for sequences in X.
 

--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -831,6 +831,6 @@ class WeightedEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
                 RocketClassifier.create_test_instance(),
             ],
             "weights": 2,
-            "cv": 3
+            "cv": 3,
         }
         return [params1, params2]

--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -803,12 +803,13 @@ class WeightedEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
         """
         from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
         from sktime.classification.kernel_based import RocketClassifier
+
         params1 = {
             "classifiers": [
                 KNeighborsTimeSeriesClassifier.create_test_instance(),
                 RocketClassifier.create_test_instance(),
             ],
-            "weights": [42, 1]
+            "weights": [42, 1],
         }
 
         params2 = {

--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -656,7 +656,8 @@ class WeightedEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
 
         # pass on random state
         for _, clf in self.classifiers_:
-            if "random_state" in clf.get_params().keys():
+            params = clf.get_params()
+            if "random_state" in params and params["random_state"] is None:
                 clf.set_params(random_state=random_state)
 
         if weights is None:


### PR DESCRIPTION
A number of popular (and not so popular) time series classifiers in `sktime` use a weighted ensemble strategy for ensembling a selected set of other classifiers.

Despite this being a repeated pattern, there does not seem to be a compositor in `sktime` that would allow users to build similar ensembles - restricting users to those hand-picked sets of base classifiers and "special ensembles", rather than being given the tools to build their own ensembles.

Instead of building more and more of those special ensemble classifiers a la HIVE-COTE with repetitive, copy-pasted boilerplate, I think we should just give users a compositor to build these ensembles.

So here it is, voila!

(finally there is an "actual" ensemble compositor in the `classification` `_ensemble` module)