### PR TITLE
[ENH] classifier `fit_predict` methods and default `_predict`

### DIFF
--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -495,7 +495,7 @@ class BaseClassifier(BaseEstimator, ABC):
         y : 1D np.array of int, of shape [n_instances] - predicted class labels
             indices correspond to instance indices in X
         """
-        y_proba = self.predict_proba(X)
+        y_proba = self._predict_proba(X)
         y_pred = y_proba.argmax(axis=1)
 
         return y_pred

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -301,6 +301,8 @@ class BaseClassifier(BaseEstimator, ABC):
 
         if cv is None:
             return getattr(est.fit(X, y), method)(X)
+        elif change_state:
+            self.fit(X, y)
 
         # we now know that cv is an sklearn splitter
         X, y = _internal_convert(X, y)

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -266,7 +266,9 @@ class BaseClassifier(BaseEstimator, ABC):
                 where multiple X_train, y_train, X_test are obtained from cv folds
                 returned y is union over all test fold predictions
                 cv test folds must be non-intersecting
-            int : equivalent to cv=Kfold(int), i.e., k-fold cross-validation predictions
+            int : equivalent to cv=KFold(cv, shuffle=True, random_state=x),
+                i.e., k-fold cross-validation predictions out-of-sample
+                random_state x is taken from self if exists, otherwise x=None
         change_state : bool, optional (default=True)
             if False, will not change the state of the classifier,
                 i.e., fit/predict sequence is run with a copy, self does not change
@@ -289,7 +291,7 @@ class BaseClassifier(BaseEstimator, ABC):
 
         if isinstance(cv, int):
             random_state = getattr(self, "random_state", None)
-            cv = KFold(cv, random_state=random_state)
+            cv = KFold(cv, random_state=random_state, shuffle=True)
 
         if change_state:
             self.reset()

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -288,7 +288,8 @@ class BaseClassifier(BaseEstimator, ABC):
         from sklearn.model_selection import KFold
 
         if isinstance(cv, int):
-            cv = KFold(cv)
+            random_state = getattr(self, "random_state", None)
+            cv = KFold(cv, random_state=random_state)
 
         if change_state:
             self.reset()

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -349,7 +349,7 @@ def test_fit_predict_cv(method):
 
     clf = KNeighborsTimeSeriesClassifier()
     clf.random_state = 42
-    cv = KFold(3, random_state=42)
+    cv = KFold(3, random_state=42, shuffle=True)
 
     y_pred_cv_int = getattr(clf, method)(X, y, cv=3, change_state=False)
     y_pred_cv_obj = getattr(clf, method)(X, y, cv=cv, change_state=False)

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -353,6 +353,7 @@ def test_fit_predict_cv(method):
 
     y_pred_cv_int = getattr(clf, method)(X, y, cv=3, change_state=False)
     y_pred_cv_obj = getattr(clf, method)(X, y, cv=cv, change_state=False)
+    assert not clf.is_fitted
 
     _assert_array_almost_equal(y_pred_cv_int, y_pred_cv_obj)
     assert -1 not in y_pred_cv_int
@@ -361,3 +362,14 @@ def test_fit_predict_cv(method):
     if method == "fit_predict_proba":
         n_cl = len(y.unique())
         assert y_pred_cv_int.shape[1] == n_cl
+
+    # check that state is same as self.fit(X, y) if change_state=True
+    y_pred_cv_obj_fit = getattr(clf, method)(X, y, cv=cv, change_state=True)
+    assert clf.is_fitted
+
+    # get output from fit and predict or predict_proba
+    clf = KNeighborsTimeSeriesClassifier()
+    normal_method = method.partition("_")[2]
+    y_pred_normal = getattr(clf.fit(X, y), normal_method)(X)
+
+    _assert_array_almost_equal(y_pred_normal, y_pred_cv_obj_fit)

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -12,7 +12,12 @@ from sktime.classification.base import (
     _check_classifier_input,
     _internal_convert,
 )
+from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
 from sktime.classification.feature_based import Catch22Classifier
+from sktime.utils._testing.estimator_checks import (
+    _assert_array_almost_equal,
+    make_classification_problem,
+)
 from sktime.utils._testing.panel import _make_classification_y, _make_panel
 
 
@@ -301,3 +306,58 @@ def test_input_conversion_fit_predict(mtype):
     clf = _DummyConvertPandas()
     clf.fit(X, y)
     clf.predict(X)
+
+
+@pytest.mark.parametrize("method", ["fit_predict", "fit_predict_proba"])
+def test_fit_predict_change_state(method):
+    """Test change_state flag in fit_predict, fit_predict_proba works as intended."""
+    X, y = make_classification_problem()
+
+    clf = KNeighborsTimeSeriesClassifier()
+
+    y_pred = getattr(clf, method)(X, y, change_state=False)
+    assert not clf.is_fitted
+
+    y_pred_post_fit = getattr(clf, method)(X, y, change_state=True)
+    assert clf.is_fitted
+
+    y_pred_post_fit2 = getattr(clf, method)(X, y, change_state=False)
+    assert clf.is_fitted
+
+    # get output from fit and predict or predict_proba
+    clf = KNeighborsTimeSeriesClassifier()
+    normal_method = method.partition("_")[2]
+    y_pred_normal = getattr(clf.fit(X, y), normal_method)(X)
+
+    # all the above outputs should be equal
+    _assert_array_almost_equal(y_pred_normal, y_pred)
+    _assert_array_almost_equal(y_pred_post_fit, y_pred)
+    _assert_array_almost_equal(y_pred_post_fit, y_pred_post_fit2)
+
+    assert len(y_pred) == len(y)
+    if method == "fit_predict_proba":
+        n_cl = len(y.unique())
+        assert y_pred.shape[1] == n_cl
+
+
+@pytest.mark.parametrize("method", ["fit_predict", "fit_predict_proba"])
+def test_fit_predict_cv(method):
+    """Test cv argument in fit_predict, fit_predict_proba."""
+    from sklearn.model_selection import KFold
+
+    X, y = make_classification_problem()
+
+    clf = KNeighborsTimeSeriesClassifier()
+    clf.random_state = 42
+    cv = KFold(3, random_state=42)
+
+    y_pred_cv_int = getattr(clf, method)(X, y, cv=3, change_state=False)
+    y_pred_cv_obj = getattr(clf, method)(X, y, cv=cv, change_state=False)
+
+    _assert_array_almost_equal(y_pred_cv_int, y_pred_cv_obj)
+    assert -1 not in y_pred_cv_int
+
+    assert len(y) == len(y_pred_cv_int)
+    if method == "fit_predict_proba":
+        n_cl = len(y.unique())
+        assert y_pred_cv_int.shape[1] == n_cl


### PR DESCRIPTION
This PR makes the following additions to the classifier base class:

* a default for `_predict` if `_predict_proba` is implemented: predicting the most probable class (distribution mode). This allows the implementer to pick one of `_predict` and `_predict_proba` to implement, the other one is filled in. Currently, `_predict` must be implemented even if `_predict_proba` is available.
* a `fit_predict` to obtain a full set of predictions on a training set, in-sample or out-of-sample. A `cv` argument controls whether in-sample or out-of-sample. If `cv=None`, equivalent to `fit(X, y).predict(X)`. If `cv` is provided, cross-validated predictions for the entirety of `X` are produced according to an sklearn splitter.
* `fit_predict_proba`, same as `fit_predict` but for probabilistic predictions.
* tests for correctness of the above.

The typical use case would be in tuning or ensemble methods such as #3036, or a benchmarking module, by providing common boilerplate for obtaining cross-validated or in-sample predictions.