### PR TITLE
[ENH] test estimator `fit` without soft dependencies

### DIFF
--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -259,9 +259,9 @@ def test_est_construct_without_modulenotfound(estimator):
         raise RuntimeError(
             f"Estimator {estimator.__name__} does not require soft dependencies "
             f"according to tags, but raises ModuleNotFoundError "
-            f"on __init__. Any required soft dependencies should be added "
-            f'to the "python_dependencies" tag, and python version bouds should be'
-            f' added to the "python_version" tag. Exception text: {error_msg}'
+            f"on __init__ with test parameters. Any required soft dependencies should "
+            f'be added to the "python_dependencies" tag, and python version bounds '
+            f'should be added to the "python_version" tag. Exception text: {error_msg}'
         ) from e
 
 
@@ -283,6 +283,6 @@ def test_est_fit_without_modulenotfound(estimator):
             f"Estimator {estimator.__name__} does not require soft dependencies "
             f"according to tags, but raises ModuleNotFoundError "
             f"on fit. Any required soft dependencies should be added "
-            f'to the "python_dependencies" tag, and python version bouds should be'
+            f'to the "python_dependencies" tag, and python version bounds should be'
             f' added to the "python_version" tag. Exception text: {error_msg}'
         ) from e

--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -244,6 +244,22 @@ def test_est_construct_if_softdep_available(estimator):
             ) from e
 
 
+@pytest.mark.parametrize("estimator", all_ests)
+def test_est_get_params_without_modulenotfound(estimator):
+    """Test that estimator test parameters do not rely on soft dependencies."""
+    try:
+        estimator.get_test_params()
+    except ModuleNotFoundError as e:
+        error_msg = str(e)
+        raise RuntimeError(
+            f"Estimator {estimator.__name__} does not require soft dependencies "
+            f"according to tags, but raises ModuleNotFoundError "
+            f"on __init__ with test parameters. Any required soft dependencies should "
+            f'be added to the "python_dependencies" tag, and python version bounds '
+            f'should be added to the "python_version" tag. Exception text: {error_msg}'
+        ) from e
+
+
 @pytest.mark.parametrize("estimator", est_pyok_without_soft_dep)
 def test_est_construct_without_modulenotfound(estimator):
     """Test that estimators that do not require soft dependencies construct properly."""

--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -252,11 +252,10 @@ def test_est_get_params_without_modulenotfound(estimator):
     except ModuleNotFoundError as e:
         error_msg = str(e)
         raise RuntimeError(
-            f"Estimator {estimator.__name__} does not require soft dependencies "
-            f"according to tags, but raises ModuleNotFoundError "
-            f"on __init__ with test parameters. Any required soft dependencies should "
-            f'be added to the "python_dependencies" tag, and python version bounds '
-            f'should be added to the "python_version" tag. Exception text: {error_msg}'
+            f"Estimator {estimator.__name__} requires soft dependencies for parameters "
+            f"returned by get_test_params. Test parameters should not require "
+            f"soft dependencies and use only sktime internal objects. "
+            f'Exception text: {error_msg}'
         ) from e
 
 
@@ -291,8 +290,8 @@ def test_est_fit_without_modulenotfound(estimator):
 
     try:
         scenario = retrieve_scenarios(estimator)[0]
-        estimator.create_test_instance()
-        scenario.run(estimator, method_sequence=["fit"])
+        estimator_instance = estimator.create_test_instance()
+        scenario.run(estimator_instance, method_sequence=["fit"])
     except ModuleNotFoundError as e:
         error_msg = str(e)
         raise RuntimeError(

--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -255,7 +255,7 @@ def test_est_get_params_without_modulenotfound(estimator):
             f"Estimator {estimator.__name__} requires soft dependencies for parameters "
             f"returned by get_test_params. Test parameters should not require "
             f"soft dependencies and use only sktime internal objects. "
-            f'Exception text: {error_msg}'
+            f"Exception text: {error_msg}"
         ) from e
 
 

--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -17,6 +17,7 @@ from importlib import import_module
 import pytest
 
 from sktime.registry import all_estimators
+from sktime.tests._config import EXCLUDE_ESTIMATORS
 from sktime.utils._testing.scenarios_getter import retrieve_scenarios
 from sktime.utils.validation._dependencies import _check_python_version
 
@@ -160,7 +161,8 @@ def _python_compat(est):
     return _check_python_version(est, severity="none")
 
 
-all_ests = all_estimators(return_names=False)
+# all estimators - exclude estimators on the global exclusion list
+all_ests = all_estimators(return_names=False, exclude_estimators=EXCLUDE_ESTIMATORS)
 
 
 # estimators that should fail to construct because of python version


### PR DESCRIPTION
This PR extends the `test-nosoftdep` CI element with additional tests:

* test that test parameters returned by `get_test_params` do not require soft dependencies.
* test that estimators without soft dependencies (according to tag) can be fitted without a `ModuleNotFoundError`. Currently, the `test-nosoftdep` CI only tests that estimators construct, which may be too weak, since soft dependencies may show up only in `fit`.