### PR TITLE
[ENH] Refactor transformers in `_deseasonalize` module

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -29,10 +29,6 @@ from sktime.transformations.panel.summarize import FittedParamExtractor
 # The following estimators currently do not pass all unit tests
 # https://github.com/alan-turing-institute/sktime/issues/1627
 EXCLUDE_ESTIMATORS = [
-    # ConditionalDeseasonalizer and STLtransformer still need refactoring
-    #  (see PR 1773, blocked through open discussion) escaping until then
-    "ConditionalDeseasonalizer",
-    "STLTransformer",
     # SFA is non-compliant with any transformer interfaces, #2064
     "SFA",
     # requires y in fit, this is incompatible with the old testing framework

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -412,9 +412,9 @@ class STLTransformer(BaseTransformer):
     --------
     >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.detrend import STLTransformer
-    >>> y = load_airline()
+    >>> X = load_airline()
     >>> transformer = STLTransformer(sp=12)
-    >>> y_hat = transformer.fit_transform(y)
+    >>> Xt = transformer.fit_transform(X)
     """
 
     _tags = {
@@ -427,7 +427,7 @@ class STLTransformer(BaseTransformer):
         "y_inner_mtype": "pd.Series",  # which mtypes do _fit/_predict support for y?
         "transform-returns-same-time-index": True,
         "univariate-only": True,
-        "fit-in-transform": False,
+        "fit_is_empty": False,
     }
 
     def __init__(
@@ -499,9 +499,9 @@ class STLTransformer(BaseTransformer):
             low_pass_jump=self.low_pass_jump,
         ).fit()
 
-        self.seasonal_ = pd.Series(self._stl.seasonal, index=X.index)
-        self.resid_ = pd.Series(self._stl.resid, index=X.index)
-        self.trend_ = pd.Series(self._stl.trend, index=X.index)
+        self.seasonal_ = pd.Series(self.stl_.seasonal, index=X.index)
+        self.resid_ = pd.Series(self.stl_.resid, index=X.index)
+        self.trend_ = pd.Series(self.stl_.trend, index=X.index)
 
         return self
 

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -84,7 +84,7 @@ class Deseasonalizer(BaseTransformer):
                 f"`model` must be one of {allowed_models}, " f"but found: {model}"
             )
         self.model = model
-        self._y_index = None
+        self._X = None
         self.seasonal_ = None
         super(Deseasonalizer, self).__init__()
 
@@ -198,8 +198,9 @@ class Deseasonalizer(BaseTransformer):
         -------
         self: a fitted instance of the estimator
         """
-        self._set_y_index(X)
-        return self
+        X_full = X.combine_first(self._X)
+        self._X = X_full
+        return self._fit(X_full, update_params=update_params)
 
 
 class ConditionalDeseasonalizer(Deseasonalizer):
@@ -461,7 +462,7 @@ class STLTransformer(BaseTransformer):
         self.trend_jump = trend_jump
         self.low_pass_jump = low_pass_jump
         self.return_components = return_components
-        self._Z_index = None
+        self._X = None
         super(STLTransformer, self).__init__()
 
     def _fit(self, X, y=None):
@@ -507,7 +508,7 @@ class STLTransformer(BaseTransformer):
     def _transform(self, X, y=None):
 
         # fit again if indices not seen, but don't store anything
-        if not X.index.equals(self._X_index):
+        if not X.index.equals(self._X.index):
             X_full = X.combine_first(self._X)
             new_stl = _STL(
                 X_full.values,

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -15,7 +15,6 @@ from sktime.transformations.base import BaseTransformer
 from sktime.utils.datetime import _get_duration, _get_freq
 from sktime.utils.seasonality import autocorrelation_seasonality_test
 from sktime.utils.validation.forecasting import check_sp
-from sktime.utils.validation.series import check_series
 
 
 class Deseasonalizer(BaseTransformer):
@@ -100,7 +99,7 @@ class Deseasonalizer(BaseTransformer):
             )
             % self.sp
         )
-        return np.resize(np.roll(self.seasonal_, shift=shift), y.shape[0])
+        return np.resize(np.roll(self.seasonal_, shift=shift), X.shape[0])
 
     def _fit(self, X, y=None):
         """Fit transformer to X and y.


### PR DESCRIPTION
Two transformers in the `_deseasonalize` have not been refactored to the modern transformer interface (`_fit`, `_transform`, removal of mixins).

This has been done in this PR for:
* `ConditionalDeseasonalizer`
* `STLTransformer`

This should address the failures in the new soft dependency tests https://github.com/alan-turing-institute/sktime/pull/3039