### PR TITLE
[ENH] allow `sp=None` in the `NaiveForecaster`

### DIFF
--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -168,9 +168,7 @@ class NaiveForecaster(_BaseWindowForecaster):
 
         # check window length
         if self.window_length_ > len(self._y):
-            param = (
-                "sp" if self.strategy == "last" and sp != 1 else "window_length_"
-            )
+            param = "sp" if self.strategy == "last" and sp != 1 else "window_length_"
             raise ValueError(
                 f"The {param}: {self.window_length_} is larger than "
                 f"the training series."


### PR DESCRIPTION
This allows `sp=None` in the `NaiveForecaster`, as an alias to `sp=1`.

This makes it consistent with `ExponentialSmoothing`, `TBATS`, and `BoxCoxTransformer`.