### PR TITLE
[MNT] remove custom `__repr__` from `BaseTask`, inherit from `BaseObject`

### DIFF
--- a/sktime/benchmarking/tasks.py
+++ b/sktime/benchmarking/tasks.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Unified high-level interface for various time series related learning tasks."""
 
 from inspect import signature
@@ -67,9 +68,9 @@ class BaseTask(BaseObject):
         # error
         if self._metadata is not None:
             raise AttributeError(
-                'Metadata is already set and can only be set once, create a '
-                'new task for different '
-                'metadata')
+                "Metadata is already set and can only be set once, create a "
+                "new task for different metadata"
+            )
 
         # check for consistency of information provided in task with given
         # metadata
@@ -84,10 +85,10 @@ class BaseTask(BaseObject):
         self._metadata = {
             "nrow": metadata.shape[0],
             "ncol": metadata.shape[1],
-            "target_type": {self.target: type(i) for i in
-                            metadata[self.target]},
-            "feature_type": {col: {type(i) for i in metadata[col]} for col in
-                             self.features}
+            "target_type": {self.target: type(i) for i in metadata[self.target]},
+            "feature_type": {
+                col: {type(i) for i in metadata[col]} for col in self.features
+            },
         }
         return self
 
@@ -101,8 +102,9 @@ class BaseTask(BaseObject):
         """
         if not isinstance(metadata, pd.DataFrame):
             raise ValueError(
-                f'Metadata must be provided in form of a pandas dataframe, '
-                f'but found: {type(metadata)}')
+                f"Metadata must be provided in form of a pandas dataframe, "
+                f"but found: {type(metadata)}"
+            )
 
         if self.target not in metadata.columns:
             raise ValueError(f"Target: {self.target} not found in metadata")
@@ -110,7 +112,8 @@ class BaseTask(BaseObject):
         if self.features is not None:
             if not np.all(self.features.isin(metadata.columns)):
                 raise ValueError(
-                    f"Features: {list(self.features)} not found in metadata")
+                    f"Features: {list(self.features)} not found in metadata"
+                )
 
         if isinstance(self, (TSCTask, TSRTask)):
             if self.features is None:
@@ -118,20 +121,22 @@ class BaseTask(BaseObject):
                     raise ValueError(
                         f"For task of type: {type(self)}, at least one "
                         f"feature must be given, "
-                        f"but found none")
+                        f"but found none"
+                    )
 
             if metadata.shape[0] <= 1:
                 raise ValueError(
                     f"For task of type: {type(self)}, several samples (rows) "
                     f"must be given, but only "
-                    f"found: {metadata.shape[0]} samples")
+                    f"found: {metadata.shape[0]} samples"
+                )
 
     @classmethod
     def _get_param_names(cls):
         """Get parameter names for the task."""
         # fetch the constructor or the original constructor before
         # deprecation wrapping if any
-        init = getattr(cls.__init__, 'deprecated_original', cls.__init__)
+        init = getattr(cls.__init__, "deprecated_original", cls.__init__)
         if init is object.__init__:
             # No explicit constructor to introspect
             return []
@@ -140,9 +145,11 @@ class BaseTask(BaseObject):
         # to represent
         init_signature = signature(init)
         # Consider the constructor parameters excluding 'self'
-        parameters = [p for p in init_signature.parameters.values()
-                      if p.name != 'self' and p.kind != p.VAR_KEYWORD]
-
+        parameters = [
+            p
+            for p in init_signature.parameters.values()
+            if p.name != "self" and p.kind != p.VAR_KEYWORD
+        ]
         # Extract and sort argument names excluding 'self'
         return sorted([p.name for p in parameters])
 
@@ -154,8 +161,7 @@ class BaseTask(BaseObject):
         params : mapping of string to any
             Parameter names mapped to their values.
         """
-        out = {key: getattr(self, key, None) for key in
-               self._get_param_names()}
+        out = {key: getattr(self, key, None) for key in self._get_param_names()}
         return out
 
 
@@ -181,9 +187,8 @@ class TSCTask(BaseTask):
     """
 
     def __init__(self, target, features=None, metadata=None):
-        self._case = 'TSC'
-        super(TSCTask, self).__init__(target, features=features,
-                                      metadata=metadata)
+        self._case = "TSC"
+        super(TSCTask, self).__init__(target, features=features, metadata=metadata)
 
 
 class TSRTask(BaseTask):
@@ -208,6 +213,5 @@ class TSRTask(BaseTask):
     """
 
     def __init__(self, target, features=None, metadata=None):
-        self._case = 'TSR'
-        super(TSRTask, self).__init__(target, features=features,
-                                      metadata=metadata)
+        self._case = "TSR"
+        super(TSRTask, self).__init__(target, features=features, metadata=metadata)

--- a/sktime/benchmarking/tasks.py
+++ b/sktime/benchmarking/tasks.py
@@ -33,9 +33,6 @@ class BaseTask(BaseObject):
 
     def __init__(self, target, features=None, metadata=None):
         # TODO input checks on target and feature args
-        self.target = target
-        self.features = features
-        self.metadata = metadata
         self._target = target
         self._features = features if features is None else pd.Index(features)
 
@@ -43,6 +40,23 @@ class BaseTask(BaseObject):
         # through setter method below
         if metadata is not None:
             self.set_metadata(metadata)  # using the modified setter method below
+
+    @property
+    def target(self):
+        """Variable target - read-only."""
+        return self._target
+
+    @property
+    def features(self):
+        """Variable features - read-only."""
+        return self._features
+
+    @property
+    def metadata(self):
+        """Variable metadata - read-only."""
+        # TODO if metadata is a mutable object itself, its contents may
+        #  still be mutable
+        return self._metadata
 
     def set_metadata(self, metadata):
         """Provide missing metadata information to task if not already set.

--- a/sktime/benchmarking/tasks.py
+++ b/sktime/benchmarking/tasks.py
@@ -42,8 +42,7 @@ class BaseTask(BaseObject):
         self._metadata = None  # initialised as None, properly updated
         # through setter method below
         if metadata is not None:
-            self.set_metadata(
-                metadata)  # using the modified setter method below
+            self.set_metadata(metadata)  # using the modified setter method below
 
     def set_metadata(self, metadata):
         """Provide missing metadata information to task if not already set.

--- a/sktime/benchmarking/tasks.py
+++ b/sktime/benchmarking/tasks.py
@@ -1,17 +1,15 @@
-"""
-Unified high-level interface for various time series related learning tasks.
-"""
+"""Unified high-level interface for various time series related learning tasks."""
 
 from inspect import signature
 
 import numpy as np
 import pandas as pd
-from sklearn.base import _pprint
+
+from sktime.base import BaseObject
 
 
-class BaseTask:
-    """
-    Abstract base task class.
+class BaseTask(BaseObject):
+    """Abstract base task class.
 
     A task encapsulates metadata information such as the feature and
     target variable which to fit the data to and additional necessary
@@ -34,6 +32,9 @@ class BaseTask:
 
     def __init__(self, target, features=None, metadata=None):
         # TODO input checks on target and feature args
+        self.target = target
+        self.features = features
+        self.metadata = metadata
         self._target = target
         self._features = features if features is None else pd.Index(features)
 
@@ -43,32 +44,8 @@ class BaseTask:
             self.set_metadata(
                 metadata)  # using the modified setter method below
 
-    @property
-    def target(self):
-        """
-        Make attributes read-only.
-        """
-        return self._target
-
-    @property
-    def features(self):
-        """
-        Make attributes read-only.
-        """
-        return self._features
-
-    @property
-    def metadata(self):
-        """
-        Make attributes read-only.
-        """
-        # TODO if metadata is a mutable object itself, its contents may
-        #  still be mutable
-        return self._metadata
-
     def set_metadata(self, metadata):
-        """
-        Provide missing metadata information to task if not already set.
+        """Provide missing metadata information to task if not already set.
 
         This method is especially useful in orchestration where metadata may
         not be
@@ -115,8 +92,7 @@ class BaseTask:
         return self
 
     def check_data_compatibility(self, metadata):
-        """
-        Check compatibility of task with passed metadata.
+        """Check compatibility of task with passed metadata.
 
         Parameters
         ----------
@@ -152,7 +128,7 @@ class BaseTask:
 
     @classmethod
     def _get_param_names(cls):
-        """Get parameter names for the task"""
+        """Get parameter names for the task."""
         # fetch the constructor or the original constructor before
         # deprecation wrapping if any
         init = getattr(cls.__init__, 'deprecated_original', cls.__init__)
@@ -181,11 +157,6 @@ class BaseTask:
         out = {key: getattr(self, key, None) for key in
                self._get_param_names()}
         return out
-
-    def __repr__(self):
-        class_name = self.__class__.__name__
-        return '%s(%s)' % (class_name, _pprint(self._get_params(),
-                                               offset=len(class_name), ),)
 
 
 class TSCTask(BaseTask):


### PR DESCRIPTION
This PR addresses imminent removal/change in `sklearn` `_pprint` and the private import in `sktime` `BaseTask`, and partially addresses #3037.

`BaseObject` has its own `__repr__` and could be used here, but `BaseTask` did not inherit from `BaseObject`.

To address the change in `__repr__`, `BaseTask` was changed to inherit from `BaseObject`, with some compatibility changes towards the `sklearn` interface. The complete removal of the custom `__repr__` in favour of `BaseObject.__repr__` should address this instance of `_pprint` import.