### PR TITLE
[ENH] AutoARIMA update options

### DIFF
--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -469,7 +469,15 @@ class AutoARIMA(_PmdArimaAdapter):
             "max_q": 2,
             "seasonal": False,
         }
-        return params
+        params2 = {
+            "d": 0,
+            "suppress_warnings": True,
+            "max_p": 2,
+            "max_q": 2,
+            "seasonal": False,
+            "update_pdq": True,
+        }
+        return [params, params2]
 
 
 class ARIMA(_PmdArimaAdapter):

--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -208,6 +208,10 @@ class AutoARIMA(_PmdArimaAdapter):
         A dictionary of key-word arguments to be passed to the scoring metric.
     with_intercept : bool, optional (default=True)
         Whether to include an intercept term.
+    update_pdq : bool, optional (default=True)
+        whether to update pdq parameters in update
+        True: model is refit on all data seen so far, potentially updating p,d,q
+        False: model updates only ARIMA coefficients via likelihood, as in pmdarima
     Further arguments to pass to the SARIMAX constructor:
     - time_varying_regression : boolean, optional (default=False)
         Whether or not coefficients on the exogenous regressors are allowed
@@ -317,6 +321,7 @@ class AutoARIMA(_PmdArimaAdapter):
         scoring="mse",
         scoring_args=None,
         with_intercept=True,
+        update_pdq=True,
         time_varying_regression=False,
         enforce_stationarity=True,
         enforce_invertibility=True,
@@ -365,6 +370,7 @@ class AutoARIMA(_PmdArimaAdapter):
         self.scoring = scoring
         self.scoring_args = scoring_args
         self.with_intercept = with_intercept
+        self.update_pdq = update_pdq
         for key in self.SARIMAX_KWARGS_KEYS:
             setattr(self, key, eval(key))
 
@@ -417,6 +423,30 @@ class AutoARIMA(_PmdArimaAdapter):
             with_intercept=self.with_intercept,
             **sarimax_kwargs,
         )
+
+    def _update(self, y, X=None, update_params=True):
+        """Update model with data.
+
+        Parameters
+        ----------
+        y : pd.Series
+            Target time series to which to fit the forecaster.
+        X : pd.DataFrame, optional (default=None)
+            Exogenous variables are ignored
+
+        Returns
+        -------
+        self : returns an instance of self.
+        """
+        update_pdq = self.update_pdq
+        if update_params:
+            if update_pdq:
+                self._fit(y=self._y, X=self._X)
+            else:
+                if X is not None:
+                    X = X.loc[y.index]
+                self._forecaster.update(y=y, X=X)
+        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -52,6 +52,26 @@ class _PmdArimaAdapter(BaseForecaster):
         self._forecaster.fit(y, X=X)
         return self
 
+    def _update(self, y, X=None, update_params=True):
+        """Update model with data.
+
+        Parameters
+        ----------
+        y : pd.Series
+            Target time series to which to fit the forecaster.
+        X : pd.DataFrame, optional (default=None)
+            Exogenous variables are ignored
+
+        Returns
+        -------
+        self : returns an instance of self.
+        """
+        if update_params:
+            if X is not None:
+                X = X.loc[y.index]
+            self._forecaster.update(y, X=X)
+        return self
+
     def _predict(self, fh, X=None):
         """Make forecasts.
 


### PR DESCRIPTION
Implements #3064.

One difference, in the adapter which also adapts `ARIMA`, the `_update` just calls `pmdarima` `update`.
This is overridden in `AutoARIMA`, which has the `update_pdq` option.