### PR TITLE
[BUG] Remove redundant computations in sktime.datatypes._utilities.get_cutoff

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1693,6 +1693,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "shchur",
+      "name": "Oleksandr Shchur",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6944857?v=4",
+      "profile": "https://github.com/shchur",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ],
   "projectName": "sktime",

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -297,7 +297,7 @@ def get_cutoff(
     if isinstance(obj, pd.DataFrame) and isinstance(obj.index, pd.MultiIndex):
         idx = obj.index
         series_idx = [
-                obj.loc[x].index.get_level_values(-1) for x in idx.droplevel(-1).unique()
+            obj.loc[x].index.get_level_values(-1) for x in idx.droplevel(-1).unique()
         ]
         cutoffs = [sub_idx(x, ix, return_index) for x in series_idx]
         return agg(cutoffs)

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -296,7 +296,9 @@ def get_cutoff(
     # pd-multiindex (Panel) and pd_multiindex_hier (Hierarchical)
     if isinstance(obj, pd.DataFrame) and isinstance(obj.index, pd.MultiIndex):
         idx = obj.index
-        series_idx = [obj.loc[x].index.get_level_values(-1) for x in idx.droplevel(-1)]
+        series_idx = [
+                obj.loc[x].index.get_level_values(-1) for x in idx.droplevel(-1).unique()
+        ]
         cutoffs = [sub_idx(x, ix, return_index) for x in series_idx]
         return agg(cutoffs)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #3069


#### What does this implement/fix? Explain your changes.
Removes redundant computations in L299 of [`sktime.datatypes._utilities.py`](https://github.com/alan-turing-institute/sktime/blob/5767dbaac759ed6ac43a8977f4c46beb93d0f18c/sktime/datatypes/_utilities.py#L299) 

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?
N/A

#### Any other comments?
Maybe there exists a more efficient solution?

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.


