### PR TITLE
[ENH] default implementation for `get_fitted_params` and nested fitted params interface

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -825,6 +825,7 @@ class BaseEstimator(BaseObject):
         Returns
         -------
         fitted_params : dict of fitted parameters, keys are str names of parameters
+            parameters of components are indexed as [componentname]__[paramname]
         """
         if not self.is_fitted:
             raise NotFittedError(

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -816,6 +816,61 @@ class BaseEstimator(BaseObject):
                 f"been fitted yet; please call `fit` first."
             )
 
+    def get_fitted_params(self):
+        """Get fitted parameters.
+
+        State required:
+            Requires state to be "fitted".
+
+        Returns
+        -------
+        fitted_params : dict of fitted parameters, keys are str names of parameters
+        """
+        if not self.is_fitted:
+            raise NotFittedError(
+                f"parameter estimator of type {type(self).__name__} has not been "
+                "fitted yet, please call fit on data before get_fitted_params"
+            )
+
+        fitted_params = dict()
+        c_dict = self._components()
+
+        def sh(x):
+            """Shorthand to remove all underscores at end of a string."""
+            if x.endswith("_"):
+                return sh(x[:-1])
+            else:
+                return x
+
+        for c in c_dict.keys():
+            c_f_params = c_dict[c].get_fitted_params()
+            c_f_params = {f"{sh(c)}__{k}": c_f_params[k] for k in c_f_params.keys()}
+            fitted_params.update(c_f_params)
+
+        fitted_params.update(self._get_fitted_params())
+
+        return fitted_params
+
+    def _get_fitted_params(self):
+        """Get fitted parameters.
+
+        private _get_fitted_params, called from get_fitted_params
+
+        State required:
+            Requires state to be "fitted".
+
+        Returns
+        -------
+        fitted_params : dict
+        """
+        # default retrieves all self attributes ending in "_"
+        # and returns them with keys that have the "_" removed
+        fitted_params = [attr for attr in dir(self) if attr.endswith("_")]
+        fitted_params = [x for x in fitted_params if not x.startswith("_")]
+        fitted_param_dict = {p[:-1]: getattr(self, p) for p in fitted_params}
+
+        return fitted_param_dict
+
 
 def _clone_estimator(base_estimator, random_state=None):
     estimator = clone(base_estimator)

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -31,7 +31,7 @@ from copy import deepcopy
 
 import pytest
 
-from sktime.base import BaseObject
+from sktime.base import BaseEstimator, BaseObject
 
 
 # Fixture class for testing tag system
@@ -275,3 +275,45 @@ def test_components():
     assert set(comp_comps.keys()) == set(["foo_"])
     assert comp_comps["foo_"] == composite.foo_
     assert comp_comps["foo_"] != composite.foo
+
+
+class FittableCompositionDummy(BaseEstimator):
+    """Potentially composite object, for testing."""
+
+    def __init__(self, foo, bar=84):
+        self.foo = foo
+        self.foo_ = deepcopy(foo)
+        self.bar = bar
+
+    def fit(self):
+        if hasattr(self.foo_, "fit"):
+            self.foo_.fit()
+        self._is_fitted = True
+
+
+def test_get_fitted_params():
+    """Tests fitted parameter retrieval.
+
+    Raises
+    ------
+    AssertionError if logic behind _components is incorrect, logic tested:
+        calling _components on a non-composite returns an empty dict
+        calling _components on a composite returns name/BaseObject pair in dict,
+        and BaseObject returned is identical with attribute of the same name
+    """
+    non_composite = FittableCompositionDummy(foo=42)
+    composite = FittableCompositionDummy(foo=deepcopy(non_composite))
+
+    non_composite.fit()
+    composite.fit()
+
+    non_comp_f_params = non_composite.get_fitted_params()
+    comp_f_params = composite.get_fitted_params()
+
+    assert isinstance(non_comp_f_params, dict)
+    assert set(non_comp_f_params.keys()) == set(["foo"])
+
+    assert isinstance(comp_f_params, dict)
+    assert set(comp_f_params) == set(["foo", "foo__foo"])
+    assert comp_f_params["foo"] == composite.foo_
+    assert comp_f_params["foo"] != composite.foo

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -296,10 +296,9 @@ def test_get_fitted_params():
 
     Raises
     ------
-    AssertionError if logic behind _components is incorrect, logic tested:
-        calling _components on a non-composite returns an empty dict
-        calling _components on a composite returns name/BaseObject pair in dict,
-        and BaseObject returned is identical with attribute of the same name
+    AssertionError if logic behind get_fitted_params is incorrect, logic tested:
+        calling get_fitted_params on a non-composite fittable returns the fitted param
+        calling get_fitted_params on a composite returns all nested params
     """
     non_composite = FittableCompositionDummy(foo=42)
     composite = FittableCompositionDummy(foo=deepcopy(non_composite))


### PR DESCRIPTION
This partially addresses #971 by providing a default `get_fitted_params` interface, in `BaseEstimator`.

Behaviour of `get_fitted_params` is as follows:

* returns a `dict` with `str` keys, obtained from private `_get_fitted_params` and nested component `get_fitted_params`
* component `get_fitted_params` are indexed by `[componentname]__[paramname]`, in analogy to `get_params`
* raises a `NotFittedError` when called before estimator is fitted.

Default behaviour is also implemented:
* `_get_fitted_params` retrievese all attributes ending in `_`, and presents them with keys where the ending `_` is removed
* the default is compatible with the nesting interface

A test is added to check the expected behaviour.