### PR TITLE
[ENH] increase stateless scope of `FunctionTransformer` and `TabularToSeriesAdaptor`

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -958,7 +958,7 @@ class BaseTransformer(BaseEstimator):
                     raise RuntimeError(
                         "found different number of instances in transform than in fit. "
                         f"number of instances seen in fit: {n_fit}; "
-                        f"number of instances seen in transform: {n * m}"
+                        f"number of instances seen in transform: {n_trafos}"
                     )
 
                 # transform the i-th series/panel with the i-th stored transformer

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -7,7 +7,6 @@ __author__ = ["mloning", "fkiraly"]
 __all__ = ["TabularToSeriesAdaptor"]
 
 import numpy as np
-
 from sklearn.base import clone
 
 from sktime.transformations.base import BaseTransformer

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -115,7 +115,9 @@ class TabularToSeriesAdaptor(BaseTransformer):
         else:
             trafo_fit_in_transform = False
 
-        if fit_in_transform or trafo_fit_in_transform:
+        self._skip_fit = fit_in_transform or trafo_fit_in_transform
+
+        if self._skip_fit:
             self.set_tags(**{"fit_is_empty": True})
 
     def _fit(self, X, y=None):
@@ -134,7 +136,7 @@ class TabularToSeriesAdaptor(BaseTransformer):
         -------
         self: a fitted instance of the estimator
         """
-        if not self.fit_in_transform:
+        if not self._skip_fit:
             self.transformer_.fit(X)
         return self
 
@@ -155,7 +157,7 @@ class TabularToSeriesAdaptor(BaseTransformer):
         Xt : 2D np.ndarray
             transformed version of X
         """
-        if self.fit_in_transform:
+        if self._skip_fit:
             Xt = self.transformer_.fit(X).transform(X)
         else:
             Xt = self.transformer_.transform(X)

--- a/sktime/transformations/series/func_transform.py
+++ b/sktime/transformations/series/func_transform.py
@@ -84,7 +84,7 @@ class FunctionTransformer(BaseTransformer):
         "X_inner_mtype": ["pd.DataFrame", "pd.Series", "np.ndarray"],
         # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
-        "fit_is_empty": False,
+        "fit_is_empty": True,
         "handles-missing-data": True,
         "capability:inverse_transform": True,
     }
@@ -121,27 +121,6 @@ class FunctionTransformer(BaseTransformer):
                 " 'check_inverse=False'."
             )
 
-    def _fit(self, X, y=None):
-        """
-        Fit transformer to X and y.
-
-        private _fit containing the core logic, called from fit
-
-        Parameters
-        ----------
-        X : pd.Series or pd.DataFrame or 1D/2D np.ndarray
-            Data to fit transform to
-        y : ignored argument for interface compatibility
-            Additional data, e.g., labels for transformation
-
-        Returns
-        -------
-        self: a fitted instance of the estimator
-        """
-        if self.check_inverse and not (self.func is None or self.inverse_func is None):
-            self._check_inverse_transform(X)
-        return self
-
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.
 
@@ -159,6 +138,9 @@ class FunctionTransformer(BaseTransformer):
         Xt : pd.Series or pd.DataFrame or 1D/2D np.ndarray, same type as X
             transformed version of X
         """
+        if self.check_inverse and not (self.func is None or self.inverse_func is None):
+            self._check_inverse_transform(X)
+
         Xt = self._apply_function(X, func=self.func, kw_args=self.kw_args)
         return Xt
 


### PR DESCRIPTION
This PR makes a number of improvements around `FunctionTransformer` and `TabularToSeriesAdaptor`, resulting in increased scope of the case where `fit` is being skipped ("stateless" in `sklearn` terminology):

* `FunctionTransformer` has checks from `fit` moved into `transform`, in order to ensure an empty `fit` and allow vectorization with different number of instances in `fit` and `transform` for panel data
* `TabularToSeriesAdaptor` now checks if the `transformer` passed has `sklearn` tags, and if `stateless`, skips `fit` and sets the tag accordingly
* makes `TabularToSeriesAdaptor` more robust to `transform` returns that are not 2D `np.ndarray` by coercion