### PR TITLE
[DOC] code quality docs expanded with instructions for local code quality checking set-up

### DIFF
--- a/docs/source/developer_guide/coding_standards.rst
+++ b/docs/source/developer_guide/coding_standards.rst
@@ -64,15 +64,17 @@ Using pre-commit
 ^^^^^^^^^^^^^^^^
 
 To set up pre-commit, follow these steps in a python environment
-with the ``sktime`` ``dev`` dependencies installed:
+with the ``sktime`` ``dev`` dependencies installed.
 
-1. Install pre-commit:
+Type the below in your python environment, and in the root of your local repository clone:
+
+1. If not already done, ensure ``sktime`` with ``dev`` dependencies is installed, this includes ``pre-commit``:
 
 .. code:: bash
 
-   pip install pre-commit
+   pip install .[dev]
 
-2. Set up pre-commit (in root of local repository clone):
+2. Set up pre-commit:
 
 .. code:: bash
 

--- a/docs/source/developer_guide/coding_standards.rst
+++ b/docs/source/developer_guide/coding_standards.rst
@@ -80,7 +80,7 @@ Type the below in your python environment, and in the root of your local reposit
 
    pre-commit install
 
-Once installed, pre-commit will automatically run our code quality
+Once installed, pre-commit will automatically run all ``sktime`` code quality
 checks on the files you changed whenever you make a new commit.
 
 You can find our pre-commit configuration in

--- a/docs/source/developer_guide/coding_standards.rst
+++ b/docs/source/developer_guide/coding_standards.rst
@@ -1,5 +1,6 @@
 .. _coding_standards:
 
+================
 Coding standards
 ================
 
@@ -7,25 +8,41 @@ Coding standards
    :local:
 
 Coding style
-------------
+============
 
-We follow the `PEP8 <https://www.python.org/dev/peps/pep-0008/>`__
+In coding, we follow:
+
+* the `PEP8 <https://www.python.org/dev/peps/pep-0008/>`__
 coding guidelines. A good example can be found
 `here <https://gist.github.com/nateGeorge/5455d2c57fb33c1ae04706f2dc4fee01>`__.
+* code formatting according to ``black``, ``flake8``, ``isort``, ``numpydoc``
 
-We use the `pre-commit <https://pre-commit.com/>`_ workflow together with
-`black <https://black.readthedocs.io/en/stable/>`__ and
-`flake8 <https://flake8.pycqa.org/en/latest/>`__ to apply
-consistent formatting and check if your contribution complies with
-the PEP8 style.
+Code formatting and linting
+---------------------------
 
-For docstrings, we use the `numpy docstring standard <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_, along with sktime specific conventions described in our :ref:`developer_guide`'s :ref:`documentation section <developer_guide_documentation>`.
+We adhere to the following code formatting standards:
+* `black <https://black.readthedocs.io/en/stable/>`__ with default settings
+* `flake8 <https://flake8.pycqa.org/en/latest/>`__ with a ``max_line_length=88`` and some exceptions as per ``setup.cfg``
+* ``isort`` with default settings
+* ``numpydoc``to enforce numpy docstring standard <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_, along with sktime specific conventions described in our :ref:`developer_guide`'s :ref:`documentation section <developer_guide_documentation>`.
 
-In addition, ensure that you:
+This is enforced through our CI/CD workflows via `pre-commit <https://pre-commit.com/>`_.
+
+The full pre-commit configuration can be found in
+`.pre-commit-config.yaml <https://github.com/alan-turing-institute/sktime/blob/main/.pre-commit-config.yaml>`_.
+Additional configurations can be found in
+`setup.cfg <https://github.com/alan-turing-institute/sktime/blob/main/setup.cfg>`_.
+
+``sktime`` specific code formatting conventions
+-----------------------------------------------
 
 -  Check out our :ref:`glossary`.
 -  Use underscores to separate words in non-class names: ``n_instances``
    rather than ``ninstances``.
+-  exceptionally, capital letters ``X``, ``Y``, ``Z``, are permissible as variable names
+   or part of variable names such as ``X_train`` if referring to data sets, in accordance
+   with the PEP8 convention that such variable names are permissible if in prior use in an area
+   (here, this is the ``scikit-learn`` adjacenet ecosystem)
 -  Avoid multiple statements on one line. Prefer a line return after a
    control flow statement (``if``/``for``).
 -  Use absolute imports for references inside sktime.
@@ -35,7 +52,55 @@ In addition, ensure that you:
    referenced, but most important, it prevents using a static analysis
    tool like pyflakes to automatically find bugs.
 
-.. _infrastructure::
+Setting up local code quality checks
+------------------------------------
+
+There are two options to set up local code quality checks:
+
+* using ``pre-commit`` for automated code formatting
+* setting up ``black``, ``flake8``, ``isort`` and/or ``numpydoc`` manually in a local dev IDE
+
+Using pre-commit
+^^^^^^^^^^^^^^^^
+
+To set up pre-commit, follow these steps in a python environment
+with the ``sktime`` ``dev`` dependencies installed:
+
+1. Install pre-commit:
+
+.. code:: bash
+
+   pip install pre-commit
+
+2. Set up pre-commit (in root of local repository clone):
+
+.. code:: bash
+
+   pre-commit install
+
+Once installed, pre-commit will automatically run our code quality
+checks on the files you changed whenever you make a new commit.
+
+You can find our pre-commit configuration in
+`.pre-commit-config.yaml <https://github.com/alan-turing-institute/sktime/blob/main/.pre-commit-config.yaml>`_.
+Additional configurations can be found in
+`setup.cfg <https://github.com/alan-turing-institute/sktime/blob/main/setup.cfg>`_.
+
+.. note::
+   If you want to exclude some line of code from being checked, you can add a ``# noqa`` (no quality assurance) comment at the end of that line.
+
+Integrating with your local developer IDE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Local developer IDEs will usually integrate with common code quality checks, but need setting them up in IDE specific ways.
+
+For Visual Studio Code, ``black``, ``flake8``, ``isort`` and/or ``numpydoc`` will need to be activated individually in the preferences
+(e.g., search for ``black`` and check the box). The packages ``black`` etc will need to be installed in the python environment used by the IDE,
+this can be achieved by an install of ``sktime`` with ``dev`` dependencies.
+
+Visual Studio Code preferences also allow setting of parameters such as ``max_line_length=88`` for ``flake8``.
+
+In Visual Studio Code, we also recommend to add ``"editor.ruler": 88`` to your local ``settings.json`` to display the max line length.
 
 API design
 ----------

--- a/docs/source/developer_guide/coding_standards.rst
+++ b/docs/source/developer_guide/coding_standards.rst
@@ -105,7 +105,7 @@ Visual Studio Code preferences also allow setting of parameters such as ``max_li
 In Visual Studio Code, we also recommend to add ``"editor.ruler": 88`` to your local ``settings.json`` to display the max line length.
 
 API design
-----------
+============
 
 The general design approach of sktime is described in the
 paper `“Designing Machine Learning Toolboxes: Concepts, Principles and

--- a/docs/source/developer_guide/coding_standards.rst
+++ b/docs/source/developer_guide/coding_standards.rst
@@ -72,7 +72,7 @@ Type the below in your python environment, and in the root of your local reposit
 
 .. code:: bash
 
-   pip install .[dev]
+   pip install -e .[dev]
 
 2. Set up pre-commit:
 

--- a/docs/source/developer_guide/continuous_integration.rst
+++ b/docs/source/developer_guide/continuous_integration.rst
@@ -18,30 +18,8 @@ Code quality checks
 We use `pre-commit <precommit>`_ for code quality checks.
 These checks run automatically before you make a new commit.
 
-To set up pre-commit, follow these steps:
-
-1. Install pre-commit:
-
-.. code:: bash
-
-   pip install pre-commit
-
-2. Set up pre-commit:
-
-.. code:: bash
-
-   pre-commit install
-
-Once installed, pre-commit will automatically run our code quality
-checks on the files you changed whenever you make a new commit.
-
-You can find our pre-commit configuration in
-`.pre-commit-config.yaml <https://github.com/alan-turing-institute/sktime/blob/main/.pre-commit-config.yaml>`_.
-Additional configurations can be found in
-`setup.cfg <https://github.com/alan-turing-institute/sktime/blob/main/setup.cfg>`_.
-
-.. note::
-   If you want to exclude some line of code from being checked, you can add a ``# noqa`` (no quality assurance) comment at the end of that line.
+See the guide on `coding style <#Coding-style>`__ on how to set up local code quality checks,
+to ensure the code reaches GitHub CI while satisfying code formatting requirements.
 
 
 Unit testing


### PR DESCRIPTION
This PR updates and clarifies the documentation on coding standards and how to set up local linting, including a new section on vs code.

Moves the section on "setting up pre-commit" to the "coding standards" section, and leaves a reference in place.