### PR TITLE
[MNT] Removed hcrystalball from all_extras

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -59,9 +59,6 @@ sktime/forecasting/sarimax.py @TNTran92
 sktime/performance_metrics/forecasting/_functions.py @aiwalter @rnkuhns
 sktime/performance_metrics/forecasting/_classes.py @rnkuhns
 
-sktime/forecasting/hcrystalball.py @MichalChromcak
-sktime/forecasting/test/test_hcrystalball.py @MichalChromcak
-
 sktime/annotation/clasp.py @patrickzib @ermshaua
 sktime/transformations/series/clasp.py @patrickzib @ermshaua
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ all_extras = [
     "dtw-python",
     "esig==0.9.7; python_version < '3.10'",
     "filterpy>=1.4.5",
-    "hcrystalball>=0.1.9",
     "matplotlib>=3.3.2",
     "pmdarima>=1.8.0,!=1.8.1",
     "prophet>=1.1",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
#2677 

#### What does this implement/fix? Explain your changes.
removed leftover `hcrystalball `stuff