### PR TITLE
[BUG] fixes to `BaseClassifier._predict_proba` default and `SklearnClassifierPipeline` in case `predict_proba` is not implemented

### DIFF
--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -524,9 +524,10 @@ class BaseClassifier(BaseEstimator, ABC):
             2nd dimension indices correspond to possible labels (integers)
             (i, j)-th entry is predictive probability that i-th instance is of class j
         """
-        dists = np.zeros((X.shape[0], self.n_classes_))
         preds = self._predict(X)
-        for i in range(0, X.shape[0]):
+        n_pred = len(preds)
+        dists = np.zeros((n_pred, self.n_classes_))
+        for i in range(n_pred):
             dists[i, self._class_dictionary[preds[i]]] = 1
 
         return dists

--- a/sktime/classification/compose/_pipeline.py
+++ b/sktime/classification/compose/_pipeline.py
@@ -423,7 +423,7 @@ class SklearnClassifierPipeline(ClassifierPipeline):
 
         # can handle multivariate iff all transformers can
         # sklearn transformers always support multivariate
-        multivariate = self.transformers_.get_tag("univariate-only", True)
+        multivariate = not self.transformers_.get_tag("univariate-only", True)
         # can handle missing values iff transformer chain removes missing data
         # sklearn classifiers might be able to handle missing data (but no tag there)
         # so better set the tag liberally
@@ -546,8 +546,12 @@ class SklearnClassifierPipeline(ClassifierPipeline):
         y : predictions of probabilities for class values of X, np.ndarray
         """
         Xt = self.transformers_.transform(X)
-        Xt_sklearn = self._convert_X_to_sklearn(Xt)
-        return self.classifier_.predict_proba(Xt_sklearn)
+        if hasattr(self.classifier_, "predict_proba"):
+            Xt_sklearn = self._convert_X_to_sklearn(Xt)
+            return self.classifier_.predict_proba(Xt_sklearn)
+        else:
+            # if sklearn classifier does not have predict_proba
+            return BaseClassifier._predict_proba(self, X)
 
     def set_params(self, **kwargs):
         """Set the parameters of estimator in `transformers`.


### PR DESCRIPTION
This fixes some unreported bugs with `BaseClassifier` default methods and `SklearnClassifierPipeline` for `predict_proba`.

* `BaseClassifier._predict_proba` worked only for certain mtypes, since `n_instances` was obtained as `len(X)` which is correct only for some mtypes. This has been replaced by `len(y)` which is always the same as `n_instances`.
* `SklearnClassifierPipeline._predict_proba` would break if the `sklearn` classifier interfaced had no `predict_proba`. This was fixed by defaulting to the `BaseClassifier._predict_proba`.
* `SklearnClassifierPipeline` had the `capability:multivariate` tag set exactly the wrong way, a `not` was missing. This did not cause a breakage but a lot of incorrect warnings.