### PR TITLE
[BUG] fix forecaster default `predict_quantiles` for multivariate data

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1911,8 +1911,12 @@ class BaseForecaster(BaseEstimator):
             # now we need to subset to lower/upper depending
             #   on whether alpha was < 0.5 or >= 0.5
             #   this formula gives the integer column indices giving lower/upper
-            col_selector = (np.array(alpha) >= 0.5) + 2 * np.arange(len(alpha))
-            pred_int = pred_int.iloc[:, col_selector]
+            col_selector_int = (np.array(alpha) >= 0.5) + 2 * np.arange(len(alpha))
+            col_selector_bool = np.isin(np.arange(2 * len(alpha)), col_selector_int)
+            num_var = len(pred_int.columns.get_level_values(0).unique())
+            col_selector_bool = np.tile(col_selector_bool, num_var)
+
+            pred_int = pred_int.iloc[:, col_selector_bool]
 
             # change the column labels (multiindex) to the format for intervals
             # idx returned by _predict_interval is

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -353,19 +353,21 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             # )
 
     @pytest.mark.parametrize(
-        "alpha", TEST_ALPHAS, ids=[f"alpha={a}" for a in TEST_ALPHAS]
+        "coverage", TEST_ALPHAS, ids=[f"alpha={a}" for a in TEST_ALPHAS]
     )
     @pytest.mark.parametrize(
         "fh_int_oos", TEST_OOS_FHS, ids=[f"fh={fh}" for fh in TEST_OOS_FHS]
     )
-    def test_predict_interval(self, estimator_instance, n_columns, fh_int_oos, alpha):
+    def test_predict_interval(
+        self, estimator_instance, n_columns, fh_int_oos, coverage
+    ):
         """Check prediction intervals returned by predict.
 
         Arguments
         ---------
         Forecaster: BaseEstimator class descendant, forecaster to test
         fh: ForecastingHorizon, fh at which to test prediction
-        alpha: float, coverage at which to make prediction intervals
+        coverage: float, coverage at which to make prediction intervals
 
         Raises
         ------
@@ -378,7 +380,9 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         estimator_instance.fit(y_train, fh=fh_int_oos)
         if estimator_instance.get_tag("capability:pred_int"):
 
-            pred_ints = estimator_instance.predict_interval(fh_int_oos, coverage=alpha)
+            pred_ints = estimator_instance.predict_interval(
+                fh_int_oos, coverage=coverage
+            )
             valid, msg, _ = check_is_mtype(
                 pred_ints, mtype="pred_interval", scitype="Proba", return_metadata=True
             )
@@ -386,7 +390,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
 
         else:
             with pytest.raises(NotImplementedError, match="prediction intervals"):
-                estimator_instance.predict_interval(fh_int_oos, coverage=alpha)
+                estimator_instance.predict_interval(fh_int_oos, coverage=coverage)
 
     def _check_predict_quantiles(
         self, pred_quantiles: pd.DataFrame, y_train: pd.Series, fh, alpha


### PR DESCRIPTION
This fixes a bug reported by @lbventura in https://github.com/alan-turing-institute/sktime/pull/3105: the default implementation of `_predict_quantiles`, when `_predict_interval` is implemented, would return quantiles only for the first variable - which is fine in univariate forecasting, but produces too few columns in multivariate forecasting.

This has now been fixed, the correct columns are now returned in both cases, under the condition that `_predict_quantiles` is implemented but `_predict_interval` is not.

Odd that this was not tested so far, I still need to investigate why.

To the bets of my knowledge, we should be testing the proba predict methods with multivariate scenarios?