### PR TITLE
[MNT] Bump macos github actions host to macos-11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10']
-        os: [ubuntu-20.04, macOS-10.15]
+        os: [ubuntu-20.04, macOS-11]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-10.15]
+        os: [ubuntu-20.04, macOS-11]
         python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

Bumping the CI host/runner for macos from 10.15 to 11 since github is going to deprecate macos-10.15 soon. 

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

see: https://github.com/actions/virtual-environments/issues/5583

ongoing migration work might be related to some issues with macos referenced in #3103 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->


