### PR TITLE
[ENH] Refactor dataset loader

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -584,6 +584,15 @@
       ]
     },
     {
+      "login": "achieveordie",
+      "name": "Sagar Mishra",
+      "avatar_url": "https://avatars.githubusercontent.com/u/54197164?v=4",
+      "profile": "https://github.com/achieveordie",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
       "login": "krumeto",
       "name": "Krum Arnaudov",
       "avatar_url": "https://avatars3.githubusercontent.com/u/11272436?v=4",

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -160,11 +160,19 @@ def _load_dataset(name, split, return_X_y, return_type=None, extract_path=None):
                     + "is available on http://timeseriesclassification.com/.",
                 ) from e
 
-    return _load_provided_dataset(name, split, return_X_y, return_type, local_module, local_dirname)
+    return _load_provided_dataset(
+        name, split, return_X_y, return_type, local_module, local_dirname
+    )
 
 
-def _load_provided_dataset(name, split=None, return_X_y=True, return_type=None,
-                           local_module=MODULE, local_dirname=DIRNAME):
+def _load_provided_dataset(
+    name,
+    split=None,
+    return_X_y=True,
+    return_type=None,
+    local_module=MODULE,
+    local_dirname=DIRNAME,
+):
     """Load baked in time series classification datasets (helper function).
 
     Loads data from the provided files from sktime/datasets/data only.
@@ -178,7 +186,6 @@ def _load_provided_dataset(name, split=None, return_X_y=True, return_type=None,
         local_module: default = os.path.dirname(__file__),
         local_dirname: default = "data"
     """
-
     if isinstance(split, str):
         split = split.upper()
 

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -123,7 +123,7 @@ def _list_available_datasets(extract_path):
     return datasets
 
 
-def _load_dataset(name, split, return_X_y, extract_path=None):
+def _load_dataset(name, split, return_X_y, return_type=None, extract_path=None):
     """Load time series classification datasets (helper function)."""
     # Allow user to have non standard extract path
     if extract_path is not None:
@@ -159,37 +159,12 @@ def _load_dataset(name, split, return_X_y, extract_path=None):
                     "Please make sure the dataset "
                     + "is available on http://timeseriesclassification.com/.",
                 ) from e
-    if isinstance(split, str):
-        split = split.upper()
 
-    if split in ("TRAIN", "TEST"):
-        fname = name + "_" + split + ".ts"
-        abspath = os.path.join(local_module, local_dirname, name, fname)
-        X, y = load_from_tsfile_to_dataframe(abspath)
-    # if split is None, load both train and test set
-    elif split is None:
-        X = pd.DataFrame(dtype="object")
-        y = pd.Series(dtype="object")
-        for split in ("TRAIN", "TEST"):
-            fname = name + "_" + split + ".ts"
-            abspath = os.path.join(local_module, local_dirname, name, fname)
-            result = load_from_tsfile_to_dataframe(abspath)
-            X = pd.concat([X, pd.DataFrame(result[0])])
-            y = pd.concat([y, pd.Series(result[1])])
-        X = X.reset_index(drop=True)
-        y = pd.Series.to_numpy(y, dtype=str)
-    else:
-        raise ValueError("Invalid `split` value =", split)
-
-    # Return appropriately
-    if return_X_y:
-        return X, y
-    else:
-        X["class_val"] = pd.Series(y)
-        return X
+    return _load_provided_dataset(name, split, return_X_y, return_type, local_module, local_dirname)
 
 
-def _load_provided_dataset(name, split=None, return_X_y=True, return_type=None):
+def _load_provided_dataset(name, split=None, return_X_y=True, return_type=None,
+                           local_module=MODULE, local_dirname=DIRNAME):
     """Load baked in time series classification datasets (helper function).
 
     Loads data from the provided files from sktime/datasets/data only.
@@ -200,24 +175,29 @@ def _load_provided_dataset(name, split=None, return_X_y=True, return_type=None):
         split : string, default = None, or one of "TRAIN" or "TEST".
         return_X_y : default = True, if true, returns X and y separately.
         return_type : default = None,
+        local_module: default = os.path.dirname(__file__),
+        local_dirname: default = "data"
     """
+
     if isinstance(split, str):
         split = split.upper()
 
     if split in ("TRAIN", "TEST"):
         fname = name + "_" + split + ".ts"
-        abspath = os.path.join(MODULE, DIRNAME, name, fname)
+        abspath = os.path.join(local_module, local_dirname, name, fname)
         X, y = load_from_tsfile(abspath, return_data_type=return_type)
     # if split is None, load both train and test set
     elif split is None:
         fname = name + "_TRAIN.ts"
-        abspath = os.path.join(MODULE, DIRNAME, name, fname)
+        abspath = os.path.join(local_module, local_dirname, name, fname)
         X_train, y_train = load_from_tsfile(abspath, return_data_type=return_type)
+
         fname = name + "_TEST.ts"
-        abspath = os.path.join(MODULE, DIRNAME, name, fname)
+        abspath = os.path.join(local_module, local_dirname, name, fname)
         X_test, y_test = load_from_tsfile(abspath, return_data_type=return_type)
+
         if isinstance(X_train, np.ndarray):
-            X = np.concatenate((X_train, X_test))
+            X = np.concatenate([X_train, X_test])
         elif isinstance(X_train, pd.DataFrame):
             X = pd.concat([X_train, X_test])
             X = X.reset_index(drop=True)
@@ -226,7 +206,7 @@ def _load_provided_dataset(name, split=None, return_X_y=True, return_type=None):
                 f"Invalid data structure type {type(X_train)} for loading "
                 f"classification problem "
             )
-        y = np.concatenate((y_train, y_test))
+        y = np.concatenate([y_train, y_test])
 
     else:
         raise ValueError("Invalid `split` value =", split)
@@ -315,8 +295,8 @@ def load_from_tsfile(
     """Load time series .ts file into X and (optionally) y.
 
     Data from a .ts file is loaded into a nested pd.DataFrame, or optionally into a
-    2d np.ndarray (equal length, univariate problem) or 3d np.ndarray (eqal length,
-    multivariate problem) if requested. If present, y is loaded into a 1d .
+    2d np.ndarray (equal length, univariate problem) or 3d np.ndarray (equal length,
+    multivariate problem) if requested. If present, y is loaded into a 1d np.ndarray.
 
     Parameters
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
As per #2697, reduced some boilerplate code in the loader functions

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
- In the `_data_io.py` file,  Private functions `_load_provided_dataset()` and `_load_dataset()` were refactored in a manner that `_load_dataset()` takes care extraction of data and then calls the former to load the provided data.
- Only use `load_from_tsfile()` as the sole entrypoint. Initially, both `load_from_tsfile()` and `load_from_tsfile_to_dataframe()` were used in private functions mentioned above which is un-necessary since the former calls later anyways. This also gives more control over how data is to be returned.
- Owing to above changes, three default parameters were introduced in both functions combined. Namely, `return_type=None` in `load_dataset()` and `local_module`, `local_dirname` in `_load_provided_dataset()` with the default values as the global variable `MODULE` and `DIRNAME` respectively.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
None

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
None

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
None

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.


<!--
Thanks for contributing!
-->
