### PR TITLE
[MNT] revert recent CI changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,6 @@ jobs:
           mkdir -p testdir/
           cp .coveragerc testdir/
           cp setup.cfg testdir/
-          cd testdir/
           python -m pytest
 
       - name: Publish code coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.7
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -50,7 +50,6 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10']
-
     steps:
       - uses: actions/checkout@v2
 
@@ -81,18 +80,46 @@ jobs:
           mkdir -p testdir/
           cp .coveragerc testdir/
           cp setup.cfg testdir/
+          cd testdir/
           python -m pytest
 
       - name: Publish code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v2
 
-  test-unix:
+  test-linux:
     needs: code-quality
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10']
-        os: [ubuntu-20.04, macOS-11]
-    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install sktime and dependencies
+        run: |
+          python -m pip install .[all_extras,dev]
+
+      - name: Show dependecies
+        run: python -m pip list
+
+      - name: Run tests
+        run: make test
+
+      - name: Publish code coverage
+        uses: codecov/codecov-action@v2
+
+  test-mac:
+    needs: code-quality
+    runs-on: macOS-10.15
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -113,7 +140,7 @@ jobs:
         run: make test
 
       - name: Publish code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v2
 
   test-nosoftdeps:
     needs: code-quality

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10']
+
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Update: CI does not fail on this, compared to current PR where almost always sth fails. This indicates that we have probably identified a change condition, even if not the root cause.

This indicates that revert will fix the issues, until the point where we understand the root cause better.

---
This is a diagnostic PR to investigate https://github.com/alan-turing-institute/sktime/issues/3103

Purpose: see whether the tests complete when these recent changes to CI are reverted:
https://github.com/alan-turing-institute/sktime/pull/2896
https://github.com/alan-turing-institute/sktime/pull/3107

If the theory is correct thatsaid changes are the culprit, this should pass. Otherwise, it would fail.