### PR TITLE
[BUG] `ExpandingWindowSplitter` constructor `sklearn` conformace fix

### DIFF
--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -904,7 +904,9 @@ class BaseWindowSplitter(BaseSplitter):
         """
         start = self._get_start(y=y, fh=fh)
         split_points = self.get_cutoffs(pd.Series(index=y, dtype=float)) + 1
-        split_points = split_points if self._initial_window is None else split_points[1:]
+        split_points = (
+            split_points if self._initial_window is None else split_points[1:]
+        )
         for split_point in split_points:
             train_start = self._get_train_start(
                 start=start if expanding else split_point,
@@ -952,7 +954,9 @@ class BaseWindowSplitter(BaseSplitter):
             if self._initial_window is not None:
 
                 if is_timedelta_or_date_offset(x=self._initial_window):
-                    start = y.get_loc(y[start] + self._initial_window + self.step_length)
+                    start = y.get_loc(
+                        y[start] + self._initial_window + self.step_length
+                    )
                 else:
                     start += self._initial_window + self.step_length
             else:

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -801,6 +801,13 @@ class BaseWindowSplitter(BaseSplitter):
         self.initial_window = initial_window
         super(BaseWindowSplitter, self).__init__(fh=fh, window_length=window_length)
 
+    @property
+    def _initial_window(self):
+        if hasattr(self, "initial_window"):
+            return self.initial_window
+        else:
+            return None
+
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
         n_timepoints = y.shape[0]
         window_length = check_window_length(
@@ -809,7 +816,7 @@ class BaseWindowSplitter(BaseSplitter):
             name="window_length",
         )
         initial_window = check_window_length(
-            window_length=self.initial_window,
+            window_length=self._initial_window,
             n_timepoints=n_timepoints,
             name="initial_window",
         )
@@ -818,7 +825,7 @@ class BaseWindowSplitter(BaseSplitter):
             y=y, fh=fh, window_length=window_length, initial_window=initial_window
         )
 
-        if self.initial_window is not None:
+        if self._initial_window is not None:
             yield self._split_for_initial_window(y)
 
         for train, test in self._split_windows(window_length=window_length, y=y, fh=fh):
@@ -843,12 +850,12 @@ class BaseWindowSplitter(BaseSplitter):
             raise ValueError(
                 "`start_with_window` must be True if `initial_window` is given"
             )
-        if self.initial_window <= self.window_length:
+        if self._initial_window <= self.window_length:
             raise ValueError("`initial_window` must greater than `window_length`")
-        if is_int(x=self.initial_window):
-            end = self.initial_window
+        if is_int(x=self._initial_window):
+            end = self._initial_window
         else:
-            end = y.get_loc(y[0] + self.initial_window)
+            end = y.get_loc(y[0] + self._initial_window)
         train = self._get_train_window(y=y, train_start=0, split_point=end)
         if array_is_int(fh):
             test = end + fh.to_numpy() - 1
@@ -897,7 +904,7 @@ class BaseWindowSplitter(BaseSplitter):
         """
         start = self._get_start(y=y, fh=fh)
         split_points = self.get_cutoffs(pd.Series(index=y, dtype=float)) + 1
-        split_points = split_points if self.initial_window is None else split_points[1:]
+        split_points = split_points if self._initial_window is None else split_points[1:]
         for split_point in split_points:
             train_start = self._get_train_start(
                 start=start if expanding else split_point,
@@ -942,12 +949,12 @@ class BaseWindowSplitter(BaseSplitter):
         # length.
         if hasattr(self, "start_with_window") and self.start_with_window:
 
-            if hasattr(self, "initial_window") and self.initial_window is not None:
+            if self._initial_window is not None:
 
-                if is_timedelta_or_date_offset(x=self.initial_window):
-                    start = y.get_loc(y[start] + self.initial_window + self.step_length)
+                if is_timedelta_or_date_offset(x=self._initial_window):
+                    start = y.get_loc(y[start] + self._initial_window + self.step_length)
                 else:
-                    start += self.initial_window + self.step_length
+                    start += self._initial_window + self.step_length
             else:
                 if is_timedelta_or_date_offset(x=self.window_length):
                     start = y.get_loc(y[start] + self.window_length)
@@ -1006,12 +1013,12 @@ class BaseWindowSplitter(BaseSplitter):
         fh = _check_fh(self.fh)
         step_length = check_step_length(self.step_length)
 
-        if self.initial_window is None:
+        if self._initial_window is None:
             start = self._get_start(y=y, fh=fh)
-        elif is_int(x=self.initial_window):
-            start = self.initial_window
+        elif is_int(x=self._initial_window):
+            start = self._initial_window
         else:
-            start = y.get_loc(y[0] + self.initial_window)
+            start = y.get_loc(y[0] + self._initial_window)
 
         end = _get_end(y_index=y, fh=fh) + 2
         if is_int(x=step_length):
@@ -1133,6 +1140,15 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
             start_with_window=start_with_window,
         )
 
+        # initial_window needs to be written to self for sklearn compatibility
+        self.initial_window = initial_window
+        # this class still acts as if it were overwritten with None,
+        # via the _initial_window property that is read everywhere
+
+    @property
+    def _initial_window(self):
+        return None
+
     def _split_windows(self, **kwargs) -> SPLIT_GENERATOR_TYPE:
         return self._split_windows_generic(expanding=True, **kwargs)
 
@@ -1157,7 +1173,7 @@ class SingleWindowSplitter(BaseSplitter):
         window_length: Optional[ACCEPTED_WINDOW_LENGTH_TYPES] = None,
     ) -> None:
         _check_inputs_for_compatibility(args=[fh, window_length])
-        super(SingleWindowSplitter, self).__init__(fh, window_length)
+        super(SingleWindowSplitter, self).__init__(fh=fh, window_length=window_length)
 
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
         n_timepoints = y.shape[0]


### PR DESCRIPTION
This PR fixes the non-conformance with `sklearn` specs in the `ExpandingWindowSplitter` constructor reported in #3119.

The problem is that `ExpandingWindowSplitter` calls its parent constructor, of `BaseWindowSplitter`, with certain parameter names switched. This has the effect of overwriting `self.initial_window` with a value that is in general not equal to that passed to the constructor, which breaks the `sklearn` constructor interface expectation.

The solution is as follows:

* `BaseWindowSplitter` internally now accesses a property `self._initial_window` wherever it previously accessed `self.initial_window`
* that property reads from `self.initial_window` if exists, otherwise returne `None`
* `ExpandingWindowSplitter` overrides the property, and does not overwrite `self.inital_window`, which fixes the interface conformance while retaining the patterns used

Tests are not being added here, they are in a separate PR #3122 which includes this PR, and they are verified to catch this issue.

Why: this is an instance of #3120 which should be addressed systemically, doing otherwise would proliferate sporadic test cases that are already covered in the framework.
The corresponding PR #3122 adds tests for all `BaseObject` descendants, and which also catches the `ExpandingWindowSplitter` issue (verified).

I have also manually verified that the example provided in #3119 now gives the expected results.