### PR TITLE
[ENH] Rocket regressor and regressor pipelines, regressor delegators

### DIFF
--- a/sktime/regression/_delegate.py
+++ b/sktime/regression/_delegate.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""Delegator mixin that delegates all methods to wrapped regressors.
+
+Useful for building estimators where all but one or a few methods are delegated.
+For that purpose, inherit from this estimator and then override only the methods
+    that are not delegated.
+"""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+__author__ = ["fkiraly"]
+__all__ = ["_DelegatedRegressor"]
+
+from sktime.regression.base import BaseRegressor
+
+
+class _DelegatedRegressor(BaseRegressor):
+    """Delegator mixin that delegates all methods to wrapped regressor.
+
+    Delegates inner regressor methods to a wrapped estimator.
+        Wrapped estimator is value of attribute with name self._delegate_name.
+        By default, this is "estimator_", i.e., delegates to self.estimator_
+        To override delegation, override _delegate_name attribute in child class.
+
+    Delegates the following inner underscore methods:
+        _fit, _predict, _predict_proba
+
+    Does NOT delegate get_params, set_params.
+        get_params, set_params will hence use one additional nesting level by default.
+
+    Does NOT delegate or copy tags, this should be done in a child class if required.
+    """
+
+    _delegate_name = "estimator_"
+
+    def _get_delegate(self):
+        return getattr(self, self._delegate_name)
+
+    def _fit(self, X, y):
+        """Fit time series regressor to training data.
+
+        private _fit containing the core logic, called from fit
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            if self.get_tag("X_inner_mtype") = "numpy3D":
+                3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
+            if self.get_tag("X_inner_mtype") = "nested_univ":
+                pd.DataFrame with each column a dimension, each cell a pd.Series
+            for list of other mtypes, see datatypes.SCITYPE_REGISTER
+            for specifications, see examples/AA_datatypes_and_datasets.ipynb
+        y : 1D np.array of float, of shape [n_instances] - regression labels for fitting
+            indices correspond to instance indices in X
+
+        Returns
+        -------
+        self : Reference to self.
+        """
+        estimator = self._get_delegate()
+        estimator.fit(X=X, y=y)
+        return self
+
+    def _predict(self, X):
+        """Predict labels for sequences in X.
+
+        private _predict containing the core logic, called from predict
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+
+        Parameters
+        ----------
+        X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            if self.get_tag("X_inner_mtype") = "numpy3D":
+                3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
+            if self.get_tag("X_inner_mtype") = "nested_univ":
+                pd.DataFrame with each column a dimension, each cell a pd.Series
+            for list of other mtypes, see datatypes.SCITYPE_REGISTER
+            for specifications, see examples/AA_datatypes_and_datasets.ipynb
+
+        Returns
+        -------
+        y : 1D np.array of float, of shape [n_instances] - predicted regression labels
+            indices correspond to instance indices in X
+        """
+        estimator = self._get_delegate()
+        return estimator.predict(X=X)

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -66,6 +66,7 @@ class BaseRegressor(BaseEstimator, ABC):
         self.fit_time_ = 0
         self._class_dictionary = {}
         self._threads_to_use = 1
+        self._X_metadata = {}
 
         # required for compatability with some sklearn interfaces
         # i.e. CalibratedRegressorCV
@@ -142,6 +143,7 @@ class BaseRegressor(BaseEstimator, ABC):
         # if X is 2D array, convert to 3D, if y is Series, convert to numpy
         X, y = _internal_convert(X, y)
         X_metadata = _check_regressor_input(X, y)
+        self._X_metadata = X_metadata
         missing = X_metadata["has_nans"]
         multivariate = not X_metadata["is_univariate"]
         unequal = not X_metadata["is_equal_length"]

--- a/sktime/regression/compose/__init__.py
+++ b/sktime/regression/compose/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Implement composite time series regression estimators."""
 
-__all__ = ["ComposableTimeSeriesForestRegressor"]
+__all__ = ["ComposableTimeSeriesForestRegressor", "RegressorPipeline"]
 
 from sktime.regression.compose._ensemble import ComposableTimeSeriesForestRegressor
+from sktime.regression.compose._pipeline import RegressorPipeline

--- a/sktime/regression/compose/__init__.py
+++ b/sktime/regression/compose/__init__.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 """Implement composite time series regression estimators."""
 
-__all__ = ["ComposableTimeSeriesForestRegressor", "RegressorPipeline"]
+__all__ = [
+    "ComposableTimeSeriesForestRegressor",
+    "RegressorPipeline",
+    "SklearnRegressorPipeline",
+]
 
 from sktime.regression.compose._ensemble import ComposableTimeSeriesForestRegressor
-from sktime.regression.compose._pipeline import RegressorPipeline
+from sktime.regression.compose._pipeline import (
+    RegressorPipeline,
+    SklearnRegressorPipeline,
+)

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -1,0 +1,568 @@
+# -*- coding: utf-8 -*-
+"""Pipeline with a regressor."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+import numpy as np
+
+from sktime.base import _HeterogenousMetaEstimator
+from sktime.datatypes import convert_to
+from sktime.regression.base import BaseRegressor
+from sktime.transformations.base import BaseTransformer
+from sktime.transformations.compose import TransformerPipeline
+from sktime.utils.sklearn import is_sklearn_regressor
+
+__author__ = ["fkiraly"]
+__all__ = ["RegressorPipeline", "SklearnRegressorPipeline"]
+
+
+class RegressorPipeline(BaseRegressor, _HeterogenousMetaEstimator):
+    """Pipeline of transformers and a regressor.
+
+    The `RegressorPipeline` compositor chains transformers and a single regressor.
+    The pipeline is constructed with a list of sktime transformers, plus a regressor,
+        i.e., estimators following the BaseTransformer resp BaseRegressor interface.
+    The transformer list can be unnamed - a simple list of transformers -
+        or string named - a list of pairs of string, estimator.
+
+    For a list of transformers `trafo1`, `trafo2`, ..., `trafoN` and a regressor `reg`,
+        the pipeline behaves as follows:
+    `fit(X, y)` - changes styte by running `trafo1.fit_transform` on `X`,
+        them `trafo2.fit_transform` on the output of `trafo1.fit_transform`, etc
+        sequentially, with `trafo[i]` receiving the output of `trafo[i-1]`,
+        and then running `reg.fit` with `X` being the output of `trafo[N]`,
+        and `y` identical with the input to `self.fit`
+    `predict(X)` - result is of executing `trafo1.transform`, `trafo2.transform`, etc
+        with `trafo[i].transform` input = output of `trafo[i-1].transform`,
+        then running `reg.predict` on the output of `trafoN.transform`,
+        and returning the output of `reg.predict`
+
+    `get_params`, `set_params` uses `sklearn` compatible nesting interface
+        if list is unnamed, names are generated as names of classes
+        if names are non-unique, `f"_{str(i)}"` is appended to each name string
+            where `i` is the total count of occurrence of a non-unique string
+            inside the list of names leading up to it (inclusive)
+
+    `RegressorPipeline` can also be created by using the magic multiplication
+        on any regressor, i.e., if `my_reg` inherits from `BaseRegressor`,
+            and `my_trafo1`, `my_trafo2` inherit from `BaseTransformer`, then,
+            for instance, `my_trafo1 * my_trafo2 * my_reg`
+            will result in the same object as  obtained from the constructor
+            `RegressorPipeline(regressor=my_reg, transformers=[my_trafo1, my_trafo2])`
+        magic multiplication can also be used with (str, transformer) pairs,
+            as long as one element in the chain is a transformer
+
+    Parameters
+    ----------
+    regressor : sktime regressor, i.e., estimator inheriting from BaseRegressor
+        this is a "blueprint" regressor, state does not change when `fit` is called
+    transformers : list of sktime transformers, or
+        list of tuples (str, transformer) of sktime transformers
+        these are "blueprint" transformers, states do not change when `fit` is called
+
+    Attributes
+    ----------
+    regressor_ : sktime regressor, clone of regressor in `regressor`
+        this clone is fitted in the pipeline when `fit` is called
+    transformers_ : list of tuples (str, transformer) of sktime transformers
+        clones of transformers in `transformers` which are fitted in the pipeline
+        is always in (str, transformer) format, even if transformers is just a list
+        strings not passed in transformers are unique generated strings
+        i-th transformer in `transformers_` is clone of i-th in `transformers`
+
+    Examples
+    --------
+    >>> from sktime.transformations.panel.pca import PCATransformer
+    >>> from sktime.classification.distance_based import KNeighborsTimeSeriesRegressor
+    >>> from sktime.datasets import load_unit_test
+    >>> from sktime.classification.compose import RegressorPipeline
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
+    >>> pipeline = RegressorPipeline(
+    ...     KNeighborsTimeSeriesRegressor(n_neighbors=2), [PCATransformer()]
+    ... )
+    >>> pipeline.fit(X_train, y_train)
+    RegressorPipeline(...)
+    >>> y_pred = pipeline.predict(X_test)
+
+    Alternative construction via dunder method:
+    >>> pipeline = PCATransformer() * KNeighborsTimeSeriesRegressor(n_neighbors=2)
+    """
+
+    _tags = {
+        "X_inner_mtype": "pd-multiindex",  # which type do _fit/_predict accept
+        "capability:multivariate": False,
+        "capability:unequal_length": False,
+        "capability:missing_values": False,
+        "capability:train_estimate": False,
+        "capability:contractable": False,
+        "capability:multithreading": False,
+    }
+
+    _required_parameters = ["regressor"]
+
+    # no default tag values - these are set dynamically below
+
+    def __init__(self, regressor, transformers):
+
+        self.regressor = regressor
+        self.regressor_ = regressor.clone()
+        self.transformers = transformers
+        self.transformers_ = TransformerPipeline(transformers)
+
+        super(RegressorPipeline, self).__init__()
+
+        # can handle multivariate iff: both regressor and all transformers can
+        multivariate = regressor.get_tag("capability:multivariate", False)
+        multivariate = multivariate and not self.transformers_.get_tag(
+            "univariate-only", True
+        )
+        # can handle missing values iff: both regressor and all transformers can,
+        #   *or* transformer chain removes missing data
+        missing = regressor.get_tag("capability:missing_values", False)
+        missing = missing and self.transformers_.get_tag("handles-missing-data", False)
+        missing = missing or self.transformers_.get_tag(
+            "capability:missing_values:removes", False
+        )
+        # can handle unequal length iff: regressor can and transformers can,
+        #   *or* transformer chain renders the series equal length
+        unequal = regressor.get_tag("capability:unequal_length")
+        unequal = unequal and self.transformers_.get_tag(
+            "capability:unequal_length", False
+        )
+        unequal = unequal or self.transformers_.get_tag(
+            "capability:unequal_length:removes", False
+        )
+        # last three tags are always False, since not supported by transformers
+        tags_to_set = {
+            "capability:multivariate": multivariate,
+            "capability:missing_values": missing,
+            "capability:unequal_length": unequal,
+            "capability:contractable": False,
+            "capability:train_estimate": False,
+            "capability:multithreading": False,
+        }
+        self.set_tags(**tags_to_set)
+
+    @property
+    def _transformers(self):
+        return self.transformers_._steps
+
+    @_transformers.setter
+    def _transformers(self, value):
+        self.transformers_._steps = value
+
+    def __rmul__(self, other):
+        """Magic * method, return concatenated RegressorPipeline, transformers on left.
+
+        Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
+
+        Parameters
+        ----------
+        other: `sktime` transformer, must inherit from BaseTransformer
+            otherwise, `NotImplemented` is returned
+
+        Returns
+        -------
+        RegressorPipeline object, concatenation of `other` (first) with `self` (last).
+        """
+        if isinstance(other, BaseTransformer):
+            # use the transformers dunder to get a TransformerPipeline
+            trafo_pipeline = other * self.transformers_
+            # then stick the expanded pipeline in a RegressorPipeline
+            new_pipeline = RegressorPipeline(
+                regressor=self.regressor,
+                transformers=trafo_pipeline.steps,
+            )
+            return new_pipeline
+        else:
+            return NotImplemented
+
+    def _fit(self, X, y):
+        """Fit time series regressor to training data.
+
+        core logic
+
+        Parameters
+        ----------
+        X : Training data of type self.get_tag("X_inner_mtype")
+        y : array-like, shape = [n_instances] - the class labels
+
+        Returns
+        -------
+        self : reference to self.
+
+        State change
+        ------------
+        creates fitted model (attributes ending in "_")
+        """
+        Xt = self.transformers_.fit_transform(X)
+        self.regressor_.fit(Xt, y)
+
+        return self
+
+    def _predict(self, X) -> np.ndarray:
+        """Predict labels for sequences in X.
+
+        core logic
+
+        Parameters
+        ----------
+        X : data not used in training, of type self.get_tag("X_inner_mtype")
+
+        Returns
+        -------
+        y : predictions of labels for X, np.ndarray
+        """
+        Xt = self.transformers_.transform(X)
+        return self.regressor_.predict(Xt)
+
+    def get_params(self, deep=True):
+        """Get parameters of estimator in `transformers`.
+
+        Parameters
+        ----------
+        deep : boolean, optional, default=True
+            If True, will return the parameters for this estimator and
+            contained sub-objects that are estimators.
+
+        Returns
+        -------
+        params : mapping of string to any
+            Parameter names mapped to their values.
+        """
+        params = dict()
+        trafo_params = self._get_params("_transformers", deep=deep)
+        params.update(trafo_params)
+
+        return params
+
+    def set_params(self, **kwargs):
+        """Set the parameters of estimator in `transformers`.
+
+        Valid parameter keys can be listed with ``get_params()``.
+
+        Returns
+        -------
+        self : returns an instance of self.
+        """
+        if "regressor" in kwargs.keys():
+            if not isinstance(kwargs["regressor"], BaseRegressor):
+                raise TypeError('"regressor" arg must be an sktime regressor')
+        trafo_keys = self._get_params("_transformers", deep=True).keys()
+        classif_keys = self.regressor.get_params(deep=True).keys()
+        trafo_args = self._subset_dict_keys(dict_to_subset=kwargs, keys=trafo_keys)
+        classif_args = self._subset_dict_keys(dict_to_subset=kwargs, keys=classif_keys)
+        if len(classif_args) > 0:
+            self.regressor.set_params(**classif_args)
+        if len(trafo_args) > 0:
+            self._set_params("_transformers", **trafo_args)
+        return self
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            For regressors, a "default" set of parameters should be provided for
+            general testing, and a "results_comparison" set for comparing against
+            previously recorded results if the general set does not produce suitable
+            probabilities to compare against.
+
+        Returns
+        -------
+        params : dict or list of dict, default={}
+            Parameters to create testing instances of the class.
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`.
+        """
+        # imports
+        from sktime.classification.distance_based import KNeighborsTimeSeriesRegressor
+        from sktime.transformations.series.exponent import ExponentTransformer
+
+        t1 = ExponentTransformer(power=2)
+        t2 = ExponentTransformer(power=0.5)
+        c = KNeighborsTimeSeriesRegressor()
+
+        # construct without names
+        return {"transformers": [t1, t2], "regressor": c}
+
+
+class SklearnRegressorPipeline(RegressorPipeline):
+    """Pipeline of transformers and a regressor.
+
+    The `SklearnRegressorPipeline` chains transformers and an single regressor.
+        Similar to `RegressorPipeline`, but uses a tabular `sklearn` regressor.
+    The pipeline is constructed with a list of sktime transformers, plus a regressor,
+        i.e., transformers following the BaseTransformer interface,
+        regressor follows the `scikit-learn` regressor interface.
+    The transformer list can be unnamed - a simple list of transformers -
+        or string named - a list of pairs of string, estimator.
+
+    For a list of transformers `trafo1`, `trafo2`, ..., `trafoN` and a regressor `reg`,
+        the pipeline behaves as follows:
+    `fit(X, y)` - changes styte by running `trafo1.fit_transform` on `X`,
+        them `trafo2.fit_transform` on the output of `trafo1.fit_transform`, etc
+        sequentially, with `trafo[i]` receiving the output of `trafo[i-1]`,
+        and then running `reg.fit` with `X` the output of `trafo[N]` converted to numpy,
+        and `y` identical with the input to `self.fit`.
+        `X` is converted to `numpyflat` mtype if `X` is of `Panel` scitype;
+        `X` is converted to `numpy2D` mtype if `X` is of `Table` scitype.
+    `predict(X)` - result is of executing `trafo1.transform`, `trafo2.transform`, etc
+        with `trafo[i].transform` input = output of `trafo[i-1].transform`,
+        then running `reg.predict` on the numpy converted output of `trafoN.transform`,
+        and returning the output of `reg.predict`.
+        Output of `trasfoN.transform` is converted to numpy, as in `fit`.
+
+    `get_params`, `set_params` uses `sklearn` compatible nesting interface
+        if list is unnamed, names are generated as names of classes
+        if names are non-unique, `f"_{str(i)}"` is appended to each name string
+            where `i` is the total count of occurrence of a non-unique string
+            inside the list of names leading up to it (inclusive)
+
+    `SklearnRegressorPipeline` can also be created by using the magic multiplication
+        between `sktime` transformers and `sklearn` regressors,
+            and `my_trafo1`, `my_trafo2` inherit from `BaseTransformer`, then,
+            for instance, `my_trafo1 * my_trafo2 * my_reg`
+            will result in the same object as  obtained from the constructor
+            `SklearnRegressorPipeline(regressor=my_reg, transformers=[t1, t2])`
+        magic multiplication can also be used with (str, transformer) pairs,
+            as long as one element in the chain is a transformer
+
+    Parameters
+    ----------
+    regressor : sklearn regressor, i.e., inheriting from sklearn RegressorMixin
+        this is a "blueprint" regressor, state does not change when `fit` is called
+    transformers : list of sktime transformers, or
+        list of tuples (str, transformer) of sktime transformers
+        these are "blueprint" transformers, states do not change when `fit` is called
+
+    Attributes
+    ----------
+    regressor_ : sklearn regressor, clone of regressor in `regressor`
+        this clone is fitted in the pipeline when `fit` is called
+    transformers_ : list of tuples (str, transformer) of sktime transformers
+        clones of transformers in `transformers` which are fitted in the pipeline
+        is always in (str, transformer) format, even if transformers is just a list
+        strings not passed in transformers are unique generated strings
+        i-th transformer in `transformers_` is clone of i-th in `transformers`
+
+    Examples
+    --------
+    >>> from sklearn.neighbors import KNeighborsRegressor
+    >>> from sktime.transformations.series.exponent import ExponentTransformer
+    >>> from sktime.transformations.series.summarize import SummaryTransformer
+    >>> from sktime.datasets import load_unit_test
+    >>> from sktime.classification.compose import SklearnRegressorPipeline
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
+    >>> t1 = ExponentTransformer()
+    >>> t2 = SummaryTransformer()
+    >>> pipeline = SklearnRegressorPipeline(KNeighborsRegressor(), [t1, t2])
+    >>> pipeline = pipeline.fit(X_train, y_train)
+    >>> y_pred = pipeline.predict(X_test)
+
+    Alternative construction via dunder method:
+    >>> pipeline = t1 * t2 * KNeighborsRegressor()
+    """
+
+    _tags = {
+        "X_inner_mtype": "pd-multiindex",  # which type do _fit/_predict accept
+        "capability:multivariate": False,
+        "capability:unequal_length": False,
+        "capability:missing_values": True,
+        "capability:train_estimate": False,
+        "capability:contractable": False,
+        "capability:multithreading": False,
+    }
+
+    _required_parameters = ["regressor"]
+
+    # no default tag values - these are set dynamically below
+
+    def __init__(self, regressor, transformers):
+
+        from sklearn.base import clone
+
+        self.regressor = regressor
+        self.regressor_ = clone(regressor)
+        self.transformers = transformers
+        self.transformers_ = TransformerPipeline(transformers)
+
+        super(RegressorPipeline, self).__init__()
+
+        # can handle multivariate iff all transformers can
+        # sklearn transformers always support multivariate
+        multivariate = not self.transformers_.get_tag("univariate-only", True)
+        # can handle missing values iff transformer chain removes missing data
+        # sklearn regressors might be able to handle missing data (but no tag there)
+        # so better set the tag liberally
+        missing = self.transformers_.get_tag("handles-missing-data", False)
+        missing = missing or self.transformers_.get_tag(
+            "capability:missing_values:removes", False
+        )
+        # can handle unequal length iff transformer chain renders series equal length
+        # because sklearn regressors require equal length (number of variables) input
+        unequal = self.transformers_.get_tag("capability:unequal_length:removes", False)
+        # last three tags are always False, since not supported by transformers
+        tags_to_set = {
+            "capability:multivariate": multivariate,
+            "capability:missing_values": missing,
+            "capability:unequal_length": unequal,
+            "capability:contractable": False,
+            "capability:train_estimate": False,
+            "capability:multithreading": False,
+        }
+        self.set_tags(**tags_to_set)
+
+    def __rmul__(self, other):
+        """Magic * method, return concatenated RegressorPipeline, transformers on left.
+
+        Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
+
+        Parameters
+        ----------
+        other: `sktime` transformer, must inherit from BaseTransformer
+            otherwise, `NotImplemented` is returned
+
+        Returns
+        -------
+        RegressorPipeline object, concatenation of `other` (first) with `self` (last).
+        """
+        if isinstance(other, BaseTransformer):
+            # use the transformers dunder to get a TransformerPipeline
+            trafo_pipeline = other * self.transformers_
+            # then stick the expanded pipeline in a SklearnRegressorPipeline
+            new_pipeline = SklearnRegressorPipeline(
+                regressor=self.regressor,
+                transformers=trafo_pipeline.steps,
+            )
+            return new_pipeline
+        else:
+            return NotImplemented
+
+    def _convert_X_to_sklearn(self, X):
+        """Convert a Table or Panel X to 2D numpy required by sklearn."""
+        X_scitype = self.transformers_.get_tag("scitype:transform-output")
+        # if X_scitype is Primitives, output is Table, convert to 2D numpy array
+        if X_scitype == "Primitives":
+            Xt = convert_to(X, to_type="numpy2D", as_scitype="Table")
+        # if X_scitype is Series, output is Panel, convert to 2D numpy array (numpyflat)
+        elif X_scitype == "Series":
+            Xt = convert_to(X, to_type="numpyflat", as_scitype="Panel")
+        else:
+            raise TypeError(
+                f"unexpected X output type in {type(self.regressor).__name__}, "
+                f'in tag "scitype:transform-output", found "{X_scitype}", '
+                'expected one of "Primitives" or "Series"'
+            )
+
+        return Xt
+
+    def _fit(self, X, y):
+        """Fit time series regressor to training data.
+
+        core logic
+
+        Parameters
+        ----------
+        X : Training data of type self.get_tag("X_inner_mtype")
+        y : array-like, shape = [n_instances] - the class labels
+
+        Returns
+        -------
+        self : reference to self.
+
+        State change
+        ------------
+        creates fitted model (attributes ending in "_")
+        """
+        Xt = self.transformers_.fit_transform(X)
+        Xt_sklearn = self._convert_X_to_sklearn(Xt)
+        self.regressor_.fit(Xt_sklearn, y)
+
+        return self
+
+    def _predict(self, X) -> np.ndarray:
+        """Predict labels for sequences in X.
+
+        core logic
+
+        Parameters
+        ----------
+        X : data not used in training, of type self.get_tag("X_inner_mtype")
+
+        Returns
+        -------
+        y : predictions of labels for X, np.ndarray
+        """
+        Xt = self.transformers_.transform(X)
+        Xt_sklearn = self._convert_X_to_sklearn(Xt)
+        return self.regressor_.predict(Xt_sklearn)
+
+    def set_params(self, **kwargs):
+        """Set the parameters of estimator in `transformers`.
+
+        Valid parameter keys can be listed with ``get_params()``.
+
+        Returns
+        -------
+        self : returns an instance of self.
+        """
+        if "regressor" in kwargs.keys():
+            if not is_sklearn_regressor(kwargs["regressor"]):
+                raise TypeError('"regressor" arg must be an sklearn regressor')
+        trafo_keys = self._get_params("_transformers", deep=True).keys()
+        classif_keys = self.regressor.get_params(deep=True).keys()
+        trafo_args = self._subset_dict_keys(dict_to_subset=kwargs, keys=trafo_keys)
+        classif_args = self._subset_dict_keys(dict_to_subset=kwargs, keys=classif_keys)
+        if len(classif_args) > 0:
+            self.regressor.set_params(**classif_args)
+        if len(trafo_args) > 0:
+            self._set_params("_transformers", **trafo_args)
+        return self
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            For regressors, a "default" set of parameters should be provided for
+            general testing, and a "results_comparison" set for comparing against
+            previously recorded results if the general set does not produce suitable
+            probabilities to compare against.
+
+        Returns
+        -------
+        params : dict or list of dict, default={}
+            Parameters to create testing instances of the class.
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`.
+        """
+        from sklearn.neighbors import KNeighborsRegressor
+
+        from sktime.transformations.series.exponent import ExponentTransformer
+        from sktime.transformations.series.summarize import SummaryTransformer
+
+        # example with series-to-series transformer before sklearn regressor
+        t1 = ExponentTransformer(power=2)
+        t2 = ExponentTransformer(power=0.5)
+        c = KNeighborsRegressor()
+        params1 = {"transformers": [t1, t2], "regressor": c}
+
+        # example with series-to-primitive transformer before sklearn regressor
+        t1 = ExponentTransformer(power=2)
+        t2 = SummaryTransformer()
+        c = KNeighborsRegressor()
+        params2 = {"transformers": [t1, t2], "regressor": c}
+
+        # construct without names
+        return [params1, params2]

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -280,7 +280,7 @@ class RegressorPipeline(BaseRegressor, _HeterogenousMetaEstimator):
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
         # imports
-        from sktime.classification.distance_based import KNeighborsTimeSeriesRegressor
+        from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
         from sktime.transformations.series.exponent import ExponentTransformer
 
         t1 = ExponentTransformer(power=2)

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -71,9 +71,9 @@ class RegressorPipeline(BaseRegressor, _HeterogenousMetaEstimator):
     Examples
     --------
     >>> from sktime.transformations.panel.pca import PCATransformer
-    >>> from sktime.classification.distance_based import KNeighborsTimeSeriesRegressor
     >>> from sktime.datasets import load_unit_test
-    >>> from sktime.classification.compose import RegressorPipeline
+    >>> from sktime.regression.compose import RegressorPipeline
+    >>> from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
     >>> X_train, y_train = load_unit_test(split="train")
     >>> X_test, y_test = load_unit_test(split="test")
     >>> pipeline = RegressorPipeline(
@@ -353,10 +353,10 @@ class SklearnRegressorPipeline(RegressorPipeline):
     Examples
     --------
     >>> from sklearn.neighbors import KNeighborsRegressor
+    >>> from sktime.datasets import load_unit_test
+    >>> from sktime.regression.compose import SklearnRegressorPipeline
     >>> from sktime.transformations.series.exponent import ExponentTransformer
     >>> from sktime.transformations.series.summarize import SummaryTransformer
-    >>> from sktime.datasets import load_unit_test
-    >>> from sktime.classification.compose import SklearnRegressorPipeline
     >>> X_train, y_train = load_unit_test(split="train")
     >>> X_test, y_test = load_unit_test(split="test")
     >>> t1 = ExponentTransformer()

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -194,8 +194,8 @@ class RegressorPipeline(BaseRegressor, _HeterogenousMetaEstimator):
         ------------
         creates fitted model (attributes ending in "_")
         """
-        Xt = self.transformers_.fit_transform(X)
-        self.regressor_.fit(Xt, y)
+        Xt = self.transformers_.fit_transform(X=X, y=y)
+        self.regressor_.fit(X=Xt, y=y)
 
         return self
 
@@ -212,8 +212,8 @@ class RegressorPipeline(BaseRegressor, _HeterogenousMetaEstimator):
         -------
         y : predictions of labels for X, np.ndarray
         """
-        Xt = self.transformers_.transform(X)
-        return self.regressor_.predict(Xt)
+        Xt = self.transformers_.transform(X=X)
+        return self.regressor_.predict(X=Xt)
 
     def get_params(self, deep=True):
         """Get parameters of estimator in `transformers`.
@@ -480,7 +480,7 @@ class SklearnRegressorPipeline(RegressorPipeline):
         ------------
         creates fitted model (attributes ending in "_")
         """
-        Xt = self.transformers_.fit_transform(X)
+        Xt = self.transformers_.fit_transform(X=X, y=y)
         Xt_sklearn = self._convert_X_to_sklearn(Xt)
         self.regressor_.fit(Xt_sklearn, y)
 
@@ -499,7 +499,7 @@ class SklearnRegressorPipeline(RegressorPipeline):
         -------
         y : predictions of labels for X, np.ndarray
         """
-        Xt = self.transformers_.transform(X)
+        Xt = self.transformers_.transform(X=X)
         Xt_sklearn = self._convert_X_to_sklearn(Xt)
         return self.regressor_.predict(Xt_sklearn)
 

--- a/sktime/regression/kernel_based/__init__.py
+++ b/sktime/regression/kernel_based/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+"""Kernel based time series regressors."""
+__all__ = ["RocketRegressor"]
+
+from sktime.regression.kernel_based._rocket_regressor import RocketRegressor

--- a/sktime/regression/kernel_based/_rocket_regressor.py
+++ b/sktime/regression/kernel_based/_rocket_regressor.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""RandOm Convolutional KErnel Transform (Rocket) regressor.
+
+Pipeline classifier using the ROCKET transformer and RidgeCV estimator.
+"""
+
+__author__ = ["fkiraly"]
+__all__ = ["RocketRegressor"]
+
+import numpy as np
+from sklearn.linear_model import RidgeCV
+from sklearn.preprocessing import StandardScaler
+
+from sktime.classification.kernel_based import RocketClassifier
+from sktime.regression._delegate import _DelegatedRegressor
+from sktime.pipeline import make_pipeline
+from sktime.transformations.panel.rocket import (
+    MiniRocket,
+    MiniRocketMultivariate,
+    MultiRocket,
+    MultiRocketMultivariate,
+    Rocket,
+)
+
+
+class RocketRegressor(_DelegatedRegressor, RocketClassifier):
+    """Regressor wrapped for the Rocket transformer using RidgeCV regressor.
+
+    This classifier simply transforms the input data using the Rocket [1]_
+    transformer and builds a RidgeCV estimator using the transformed data.
+
+    Shorthand for the pipeline
+    `rocket * StandardScaler(with_mean=False) * RidgeCV(alphas)`
+    where `alphas = np.logspace(-3, 3, 10)`, and
+    where `rocket` depends on params `rocket_transform`, `use_multivariate` as follows:
+
+        | rocket_transform | `use_multivariate` | rocket (class)          |
+        |------------------|--------------------|-------------------------|
+        | "rocket"         | any                | Rocket                  |
+        | "minirocket"     | "yes               | MiniRocketMultivariate  |
+        | "minirocket"     | "no"               | MiniRocket              |
+        | "multirocket"    | "yes"              | MultiRocketMultivariate |
+        | "multirocket"    | "no"               | MultiRocket             |
+
+    classes are sktime classes, other parameters are passed on to the rocket class.
+
+    To build other regressors with rocket transformers, use `make_pipeline` or the
+    pipeline dunder `*`, and different transformers/regressors in combination.
+
+    Parameters
+    ----------
+    num_kernels : int, optional, default=10,000
+        The number of kernels the for Rocket transform.
+    rocket_transform : str, optional, default="rocket"
+        The type of Rocket transformer to use.
+        Valid inputs = ["rocket", "minirocket", "multirocket"]
+    max_dilations_per_kernel : int, optional, default=32
+        MiniRocket and MultiRocket only. The maximum number of dilations per kernel.
+    n_features_per_kernel : int, optional, default=4
+        MultiRocket only. The number of features per kernel.
+    use_multivariate : str, ["auto", "yes", "no"], optional, default="auto"
+        whether to use multivariate rocket transforms or univariate ones
+        "auto" = multivariate iff data seen in fit is multivariate, otherwise univariate
+        "yes" = always uses multivariate transformers, native multi/univariate
+        "no" = always univariate transformers, multivariate by framework vectorization
+    n_jobs : int, default=1
+        The number of jobs to run in parallel for both `fit` and `predict`.
+        ``-1`` means using all processors.
+    random_state : int or None, default=None
+        Seed for random number generation.
+
+    Attributes
+    ----------
+    n_classes : int
+        The number of classes.
+    classes_ : list
+        The classes labels.
+    estimator_ : RegressorPipeline
+        RocketRegressor as a RegressorPipeline, fitted to data internally
+
+    See Also
+    --------
+    Rocket
+
+    Notes
+    -----
+    For the Java version, see
+    `TSML <https://github.com/uea-machine-learning/tsml/blob/master/src/main/java/
+    tsml/classifiers/shapelet_based/ROCKETClassifier.java>`_.
+
+    References
+    ----------
+    .. [1] Dempster, Angus, François Petitjean, and Geoffrey I. Webb. "Rocket:
+       exceptionally fast and accurate time series classification using random
+       convolutional kernels." Data Mining and Knowledge Discovery 34.5 (2020)
+
+    Examples
+    --------
+    >>> from sktime.regression.kernel_based import RocketRegressor
+    >>> from sktime.datasets import load_unit_test
+    >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
+    >>> reg = RocketRegressor(num_kernels=500)
+    >>> reg.fit(X_train, y_train)
+    RocketRegressor(...)
+    >>> y_pred = reg.predict(X_test)
+    """
+
+    _tags = {
+        "capability:multivariate": True,
+        "capability:multithreading": True,
+        "classifier_type": "kernel",
+    }
+
+    def __init__(
+        self,
+        num_kernels=10000,
+        rocket_transform="rocket",
+        max_dilations_per_kernel=32,
+        n_features_per_kernel=4,
+        use_multivariate="auto",
+        n_jobs=1,
+        random_state=None,
+    ):
+        self.num_kernels = num_kernels
+        self.rocket_transform = rocket_transform
+        self.max_dilations_per_kernel = max_dilations_per_kernel
+        self.n_features_per_kernel = n_features_per_kernel
+        self.use_multivariate = use_multivariate
+
+        self.n_jobs = n_jobs
+        self.random_state = random_state
+
+        super(RocketRegressor, self).__init__()
+
+        if use_multivariate not in self.VALID_MULTIVAR_VALUES:
+            raise ValueError(
+                f"Invalid use_multivariate value, must be one of "
+                f"{self.VALID_MULTIVAR_VALUES}, but found {use_multivariate}"
+            )
+
+        common_params = {
+            "num_kernels": self.num_kernels,
+            "random_state": self.random_state,
+            "max_dilations_per_kernel": self.max_dilations_per_kernel,
+            "n_jobs": self._threads_to_use,
+        }
+
+        if rocket_transform == "rocket":
+            del common_params["max_dilations_per_kernel"]
+            univar_rocket = Rocket(**common_params)
+            multivar_rocket = univar_rocket
+
+        elif rocket_transform == "minirocket":
+            multivar_rocket = MiniRocketMultivariate(**common_params)
+            univar_rocket = MiniRocket(**common_params)
+
+        elif self.rocket_transform == "multirocket":
+            common_params["n_features_per_kernel"] = self.n_features_per_kernel
+            multivar_rocket = MultiRocketMultivariate(**common_params)
+            univar_rocket = MultiRocket(**common_params)
+
+        else:
+            raise ValueError(
+                f"Invalid rocket_transform string, must be one of "
+                f"{self.VALID_ROCKET_STRINGS}, but found {rocket_transform}"
+            )
+
+        self.multivar_rocket_ = make_pipeline(
+            multivar_rocket,
+            StandardScaler(with_mean=False),
+            RidgeCV(alphas=np.logspace(-3, 3, 10)),
+        )
+        self.univar_rocket_ = make_pipeline(
+            univar_rocket,
+            StandardScaler(with_mean=False),
+            RidgeCV(alphas=np.logspace(-3, 3, 10)),
+        )
+
+        if not use_multivariate:
+            self.set_tags(**{"capability:multivariate": False})

--- a/sktime/regression/kernel_based/_rocket_regressor.py
+++ b/sktime/regression/kernel_based/_rocket_regressor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """RandOm Convolutional KErnel Transform (Rocket) regressor.
 
-Pipeline classifier using the ROCKET transformer and RidgeCV estimator.
+Pipeline regressor using the ROCKET transformer and RidgeCV estimator.
 """
 
 __author__ = ["fkiraly"]
@@ -26,7 +26,7 @@ from sktime.transformations.panel.rocket import (
 class RocketRegressor(_DelegatedRegressor, RocketClassifier):
     """Regressor wrapped for the Rocket transformer using RidgeCV regressor.
 
-    This classifier simply transforms the input data using the Rocket [1]_
+    This regressor simply transforms the input data using the Rocket [1]_
     transformer and builds a RidgeCV estimator using the transformed data.
 
     Shorthand for the pipeline
@@ -80,13 +80,7 @@ class RocketRegressor(_DelegatedRegressor, RocketClassifier):
 
     See Also
     --------
-    Rocket
-
-    Notes
-    -----
-    For the Java version, see
-    `TSML <https://github.com/uea-machine-learning/tsml/blob/master/src/main/java/
-    tsml/classifiers/shapelet_based/ROCKETClassifier.java>`_.
+    Rocket, RocketClassifier
 
     References
     ----------
@@ -109,7 +103,7 @@ class RocketRegressor(_DelegatedRegressor, RocketClassifier):
     _tags = {
         "capability:multivariate": True,
         "capability:multithreading": True,
-        "classifier_type": "kernel",
+        "regressor_type": "kernel",
     }
 
     def __init__(

--- a/sktime/regression/kernel_based/_rocket_regressor.py
+++ b/sktime/regression/kernel_based/_rocket_regressor.py
@@ -103,8 +103,11 @@ class RocketRegressor(_DelegatedRegressor, BaseRegressor):
     _tags = {
         "capability:multivariate": True,
         "capability:multithreading": True,
-        "regressor_type": "kernel",
     }
+
+    # valid rocket strings for input validity checking
+    VALID_ROCKET_STRINGS = ["rocket", "minirocket", "multirocket"]
+    VALID_MULTIVAR_VALUES = ["auto", "yes", "no"]
 
     def __init__(
         self,

--- a/sktime/regression/kernel_based/_rocket_regressor.py
+++ b/sktime/regression/kernel_based/_rocket_regressor.py
@@ -11,9 +11,9 @@ import numpy as np
 from sklearn.linear_model import RidgeCV
 from sklearn.preprocessing import StandardScaler
 
+from sktime.pipeline import make_pipeline
 from sktime.regression._delegate import _DelegatedRegressor
 from sktime.regression.base import BaseRegressor
-from sktime.pipeline import make_pipeline
 from sktime.transformations.panel.rocket import (
     MiniRocket,
     MiniRocketMultivariate,

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -64,7 +64,11 @@ from sktime.datatypes import (
     mtype_to_scitype,
 )
 from sktime.datatypes._series_as_panel import convert_to_scitype
-from sktime.utils.sklearn import is_sklearn_classifier, is_sklearn_transformer
+from sktime.utils.sklearn import (
+    is_sklearn_classifier,
+    is_sklearn_regressor,
+    is_sklearn_transformer,
+)
 from sktime.utils.validation._dependencies import _check_estimator_deps
 
 # single/multiple primitives
@@ -170,6 +174,7 @@ class BaseTransformer(BaseEstimator):
         if (
             isinstance(other, BaseTransformer)
             or is_sklearn_classifier(other)
+            or is_sklearn_regressor(other)
             or is_sklearn_transformer(other)
         ):
             self_as_pipeline = TransformerPipeline(steps=[self])

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -9,7 +9,11 @@ from sktime.base import _HeterogenousMetaEstimator
 from sktime.transformations._delegate import _DelegatedTransformer
 from sktime.transformations.base import BaseTransformer
 from sktime.utils.multiindex import flatten_multiindex
-from sktime.utils.sklearn import is_sklearn_classifier, is_sklearn_transformer
+from sktime.utils.sklearn import (
+    is_sklearn_classifier,
+    is_sklearn_regressor,
+    is_sklearn_transformer,
+)
 
 __author__ = ["fkiraly", "mloning", "miraep8"]
 __all__ = [
@@ -213,12 +217,17 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
             not nested, contains only non-TransformerPipeline `sktime` transformers
         """
         from sktime.classification.compose import SklearnClassifierPipeline
+        from sktime.regression.compose import SklearnRegressorPipeline
 
         other = _coerce_to_sktime(other)
 
         # if sklearn classifier, use sklearn classifier pipeline
         if is_sklearn_classifier(other):
             return SklearnClassifierPipeline(classifier=other, transformers=self.steps)
+
+        # if sklearn regressor, use sklearn regressor pipeline
+        if is_sklearn_regressor(other):
+            return SklearnRegressorPipeline(regressor=other, transformers=self.steps)
 
         return self._dunder_concat(
             other=other,


### PR DESCRIPTION
This PR reprises the old PR https://github.com/alan-turing-institute/sktime/pull/767 and attempts to solve it with abstract composition functionality instead of a rocket specific refactor.

This PR introduces compositors for regressors similar to those of classifiers:

* two regressor pipelines, an sktime one and an sklearn one, with dunders
* a delegator for regressors

With the above, the intended translation of classifier to regressor in #767 is as simple as taking the rocket classifier, and changing every string "classifier" in the code to "regressor".

There is a lot of copy-paste, so a common parent such as in #767 could be attempted based on this.