### PR TITLE
[MNT] temporarily exclude `RandomShapeletTransform` from tests

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -35,6 +35,8 @@ EXCLUDE_ESTIMATORS = [
     "TSFreshRelevantFeatureExtractor",
     # PlateauFinder seems to be broken, see #2259
     "PlateauFinder",
+    # RandomShapeletTransform is breaking with empty lists, see #3138
+    "RandomShapeletTransform",
 ]
 
 


### PR DESCRIPTION
Excludes the failing `RandomShapeletTransform` from tests until we know what is going on.

See #3138 for the failure.