### PR TITLE
[ENH] classifier single class handling

### DIFF
--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -152,11 +152,13 @@ class BaseClassifier(BaseEstimator, ABC):
         start = int(round(time.time() * 1000))
         # convenience conversions to allow user flexibility:
         # if X is 2D array, convert to 3D, if y is Series, convert to numpy
-        X, y = _internal_convert(X, y)
-        X_metadata = _check_classifier_input(X, y)
+        X, y = self._internal_convert(X, y)
+        X_metadata = self._check_classifier_input(X, y)
         missing = X_metadata["has_nans"]
         multivariate = not X_metadata["is_univariate"]
         unequal = not X_metadata["is_equal_length"]
+        self._X_metadata = X_metadata
+
         # Check this classifier can handle characteristics
         self._check_capabilities(missing, multivariate, unequal)
         # Convert data as dictated by the classifier tags
@@ -170,14 +172,17 @@ class BaseClassifier(BaseEstimator, ABC):
                     "self.n_jobs must be set if capability:multithreading is True"
                 )
 
+        # remember class labels
         self.classes_ = np.unique(y)
         self.n_classes_ = self.classes_.shape[0]
-        self._X_metadata = X_metadata
         self._class_dictionary = {}
         for index, class_val in enumerate(self.classes_):
             self._class_dictionary[class_val] = index
+
+        # pass coerced and checked data to inner _fit
         self._fit(X, y)
         self.fit_time_ = int(round(time.time() * 1000)) - start
+
         # this should happen last
         self._is_fitted = True
         return self
@@ -318,8 +323,8 @@ class BaseClassifier(BaseEstimator, ABC):
             self.fit(X, y)
 
         # we now know that cv is an sklearn splitter
-        X, y = _internal_convert(X, y)
-        X_metadata = _check_classifier_input(X, y)
+        X, y = self._internal_convert(X, y)
+        X_metadata = self._check_classifier_input(X, y)
         missing = X_metadata["has_nans"]
         multivariate = not X_metadata["is_univariate"]
         unequal = not X_metadata["is_equal_length"]
@@ -575,8 +580,8 @@ class BaseClassifier(BaseEstimator, ABC):
         ValueError if X is of invalid input data type, or there is not enough data
         ValueError if the capabilities in self._tags do not handle the data.
         """
-        X = _internal_convert(X)
-        X_metadata = _check_classifier_input(X)
+        X = self._internal_convert(X)
+        X_metadata = self._check_classifier_input(X)
         missing = X_metadata["has_nans"]
         multivariate = not X_metadata["is_univariate"]
         unequal = not X_metadata["is_equal_length"]
@@ -656,94 +661,98 @@ class BaseClassifier(BaseEstimator, ABC):
         )
         return X
 
+    def _check_classifier_input(self, X, y=None, enforce_min_instances=1):
+        """Check whether input X and y are valid formats with minimum data.
 
-def _check_classifier_input(
-    X,
-    y=None,
-    enforce_min_instances=1,
-):
-    """Check whether input X and y are valid formats with minimum data.
+        Raises a ValueError if the input is not valid.
 
-    Raises a ValueError if the input is not valid.
+        Parameters
+        ----------
+        X : check whether conformant with any sktime Panel mtype specification
+        y : check whether a pd.Series or np.array
+        enforce_min_instances : int, optional (default=1)
+            check there are a minimum number of instances.
 
-    Parameters
-    ----------
-    X : check whether conformant with any sktime Panel mtype specification
-    y : check whether a pd.Series or np.array
-    enforce_min_instances : int, optional (default=1)
-        check there are a minimum number of instances.
+        Returns
+        -------
+        metadata : dict with metadata for X returned by datatypes.check_is_scitype
 
-    Returns
-    -------
-    metadata : dict with metadata for X returned by datatypes.check_is_scitype
-
-    Raises
-    ------
-    ValueError
-        If y or X is invalid input data type, or there is not enough data
-    """
-    # Check X is valid input type and recover the data characteristics
-    X_valid, _, X_metadata = check_is_scitype(X, scitype="Panel", return_metadata=True)
-    if not X_valid:
-        raise TypeError(
-            f"X is not of a supported input data type."
-            f"X must be in a supported mtype format for Panel, found {type(X)}"
-            f"Use datatypes.check_is_mtype to check conformance with specifications."
+        Raises
+        ------
+        ValueError
+            If y or X is invalid input data type, or there is not enough data
+        """
+        # Check X is valid input type and recover the data characteristics
+        X_valid, _, X_metadata = check_is_scitype(
+            X, scitype="Panel", return_metadata=True
         )
-    n_cases = X_metadata["n_instances"]
-    if n_cases < enforce_min_instances:
-        raise ValueError(
-            f"Minimum number of cases required is {enforce_min_instances} but X "
-            f"has : {n_cases}"
-        )
+        if not X_valid:
+            raise TypeError(
+                f"X is not of a supported input data type."
+                f"X must be in a supported mtype format for Panel, found {type(X)}"
+                f"Use datatypes.check_is_mtype to check conformance "
+                "with specifications."
+            )
+        n_cases = X_metadata["n_instances"]
+        if n_cases < enforce_min_instances:
+            raise ValueError(
+                f"Minimum number of cases required is {enforce_min_instances} but X "
+                f"has : {n_cases}"
+            )
 
-    # Check y if passed
-    if y is not None:
-        # Check y valid input
-        if not isinstance(y, (pd.Series, np.ndarray)):
-            raise ValueError(
-                f"y must be a np.array or a pd.Series, but found type: {type(y)}"
-            )
-        # Check matching number of labels
-        n_labels = y.shape[0]
-        if n_cases != n_labels:
-            raise ValueError(
-                f"Mismatch in number of cases. Number in X = {n_cases} nos in y = "
-                f"{n_labels}"
-            )
-        if isinstance(y, np.ndarray):
-            if y.ndim > 1:
+        # Check y if passed
+        if y is not None:
+            # Check y valid input
+            if not isinstance(y, (pd.Series, np.ndarray)):
                 raise ValueError(
-                    f"y must be 1-dimensional but is in fact " f"{y.ndim} dimensional"
+                    f"y must be a np.array or a pd.Series, but found type: {type(y)}"
                 )
-    return X_metadata
+            # Check matching number of labels
+            n_labels = y.shape[0]
+            if n_cases != n_labels:
+                raise ValueError(
+                    f"Mismatch in number of cases. Number in X = {n_cases} nos in y = "
+                    f"{n_labels}"
+                )
+            if isinstance(y, np.ndarray):
+                if y.ndim > 1:
+                    raise ValueError(
+                        f"np.ndarray y must be 1-dimensional, "
+                        f"but found " f"{y.ndim} dimensions"
+                    )
+            if len(np.unique(y)) == 1:
+                warn(
+                    "only single label seen in y passed to "
+                    f"fit of classifier {type(self).__name__}"
+                )
 
+        return X_metadata
 
-def _internal_convert(X, y=None):
-    """Convert X and y if necessary as a user convenience.
+    def _internal_convert(self, X, y=None):
+        """Convert X and y if necessary as a user convenience.
 
-    Convert X to a 3D numpy array if already a 2D and convert y into an 1D numpy
-    array if passed as a Series.
+        Convert X to a 3D numpy array if already a 2D and convert y into an 1D numpy
+        array if passed as a Series.
 
-    Parameters
-    ----------
-    X : an object of a supported Panel mtype, or 2D numpy.ndarray
-    y : np.ndarray or pd.Series
+        Parameters
+        ----------
+        X : an object of a supported Panel mtype, or 2D numpy.ndarray
+        y : np.ndarray or pd.Series
 
-    Returns
-    -------
-    X: an object of a supported Panel mtype, numpy3D if X was a 2D numpy.ndarray
-    y: np.ndarray
-    """
-    if isinstance(X, np.ndarray):
-        # Temporary fix to insist on 3D numpy. For univariate problems,
-        # most classifiers simply convert back to 2D. This squeezing should be
-        # done here, but touches a lot of files, so will get this to work first.
-        if X.ndim == 2:
-            X = X.reshape(X.shape[0], 1, X.shape[1])
-    if y is not None and isinstance(y, pd.Series):
-        # y should be a numpy array, although we allow Series for user convenience
-        y = pd.Series.to_numpy(y)
-    if y is None:
-        return X
-    return X, y
+        Returns
+        -------
+        X: an object of a supported Panel mtype, numpy3D if X was a 2D numpy.ndarray
+        y: np.ndarray
+        """
+        if isinstance(X, np.ndarray):
+            # Temporary fix to insist on 3D numpy. For univariate problems,
+            # most classifiers simply convert back to 2D. This squeezing should be
+            # done here, but touches a lot of files, so will get this to work first.
+            if X.ndim == 2:
+                X = X.reshape(X.shape[0], 1, X.shape[1])
+        if y is not None and isinstance(y, pd.Series):
+            # y should be a numpy array, although we allow Series for user convenience
+            y = pd.Series.to_numpy(y)
+        if y is None:
+            return X
+        return X, y

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -161,6 +161,21 @@ class BaseClassifier(BaseEstimator, ABC):
 
         # Check this classifier can handle characteristics
         self._check_capabilities(missing, multivariate, unequal)
+
+        # remember class labels
+        self.classes_ = np.unique(y)
+        self.n_classes_ = self.classes_.shape[0]
+        self._class_dictionary = {}
+        for index, class_val in enumerate(self.classes_):
+            self._class_dictionary[class_val] = index
+
+        # escape early and do not fit if only one class label has been seen
+        #   in this case, we later predict the single class label seen
+        if len(self.classes_) == 1:
+            self.fit_time_ = int(round(time.time() * 1000)) - start
+            self._is_fitted = True
+            return self
+
         # Convert data as dictated by the classifier tags
         X = self._convert_X(X)
         multithread = self.get_tag("capability:multithreading")
@@ -171,13 +186,6 @@ class BaseClassifier(BaseEstimator, ABC):
                 raise AttributeError(
                     "self.n_jobs must be set if capability:multithreading is True"
                 )
-
-        # remember class labels
-        self.classes_ = np.unique(y)
-        self.n_classes_ = self.classes_.shape[0]
-        self._class_dictionary = {}
-        for index, class_val in enumerate(self.classes_):
-            self._class_dictionary[class_val] = index
 
         # pass coerced and checked data to inner _fit
         self._fit(X, y)

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -718,7 +718,7 @@ class BaseClassifier(BaseEstimator, ABC):
                 if y.ndim > 1:
                     raise ValueError(
                         f"np.ndarray y must be 1-dimensional, "
-                        f"but found " f"{y.ndim} dimensions"
+                        f"but found {y.ndim} dimensions"
                     )
             # warn if only a single class label is seen
             # this should not raise exception since this can occur by train subsampling

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -720,9 +720,11 @@ class BaseClassifier(BaseEstimator, ABC):
                         f"np.ndarray y must be 1-dimensional, "
                         f"but found " f"{y.ndim} dimensions"
                     )
+            # warn if only a single class label is seen
+            # this should not raise exception since this can occur by train subsampling
             if len(np.unique(y)) == 1:
                 warn(
-                    "only single label seen in y passed to "
+                    "only single class label seen in y passed to "
                     f"fit of classifier {type(self).__name__}"
                 )
 

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -204,13 +204,14 @@ class BaseClassifier(BaseEstimator, ABC):
         """
         self.check_is_fitted()
 
+        # boilerplate input checks for predict-like methods
+        X = self._check_convert_X_for_predict(X)
+
         # handle the single-class-label case
         if len(self._class_dictionary) == 1:
             return self._single_class_y_pred(X, method="predict")
 
-        # boilerplate input checks for predict-like methods
-        X = self._check_convert_X_for_predict(X)
-
+        # call internal _predict_proba
         return self._predict(X)
 
     def predict_proba(self, X) -> np.ndarray:
@@ -237,13 +238,14 @@ class BaseClassifier(BaseEstimator, ABC):
         """
         self.check_is_fitted()
 
+        # boilerplate input checks for predict-like methods
+        X = self._check_convert_X_for_predict(X)
+
         # handle the single-class-label case
         if len(self._class_dictionary) == 1:
             return self._single_class_y_pred(X, method="predict_proba")
 
-        # boilerplate input checks for predict-like methods
-        X = self._check_convert_X_for_predict(X)
-
+        # call internal _predict_proba
         return self._predict_proba(X)
 
     def fit_predict(self, X, y, cv=None, change_state=True) -> np.ndarray:
@@ -315,10 +317,6 @@ class BaseClassifier(BaseEstimator, ABC):
         elif change_state:
             self.fit(X, y)
 
-        # handle single class case
-        if len(self._class_dictionary) == 1:
-            return self._single_class_y_pred(X)
-
         # we now know that cv is an sklearn splitter
         X, y = _internal_convert(X, y)
         X_metadata = _check_classifier_input(X, y)
@@ -327,6 +325,10 @@ class BaseClassifier(BaseEstimator, ABC):
         unequal = not X_metadata["is_equal_length"]
         # Check this classifier can handle characteristics
         self._check_capabilities(missing, multivariate, unequal)
+
+        # handle single class case
+        if len(self._class_dictionary) == 1:
+            return self._single_class_y_pred(X)
 
         # Convert data to format easily useable for applying cv
         if isinstance(X, np.ndarray):

--- a/sktime/classification/early_classification/base.py
+++ b/sktime/classification/early_classification/base.py
@@ -611,3 +611,46 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
         """
         _convert_X = BaseClassifier._convert_X
         return _convert_X(self, X)
+
+    def _check_classifier_input(self, X, y=None, enforce_min_instances=1):
+        """Check whether input X and y are valid formats with minimum data.
+
+        Raises a ValueError if the input is not valid.
+
+        Parameters
+        ----------
+        X : check whether conformant with any sktime Panel mtype specification
+        y : check whether a pd.Series or np.array
+        enforce_min_instances : int, optional (default=1)
+            check there are a minimum number of instances.
+
+        Returns
+        -------
+        metadata : dict with metadata for X returned by datatypes.check_is_scitype
+
+        Raises
+        ------
+        ValueError
+            If y or X is invalid input data type, or there is not enough data
+        """
+        _check_classifier_input = BaseClassifier._check_classifier_input
+        return _check_classifier_input(self, X, y, enforce_min_instances)
+
+    def _internal_convert(self, X, y=None):
+        """Convert X and y if necessary as a user convenience.
+
+        Convert X to a 3D numpy array if already a 2D and convert y into an 1D numpy
+        array if passed as a Series.
+
+        Parameters
+        ----------
+        X : an object of a supported Panel mtype, or 2D numpy.ndarray
+        y : np.ndarray or pd.Series
+
+        Returns
+        -------
+        X: an object of a supported Panel mtype, numpy3D if X was a 2D numpy.ndarray
+        y: np.ndarray
+        """
+        _internal_convert = BaseClassifier._internal_convert
+        return _internal_convert(self, X, y)

--- a/sktime/classification/interval_based/_drcif.py
+++ b/sktime/classification/interval_based/_drcif.py
@@ -403,6 +403,10 @@ class DrCIF(BaseClassifier):
         self.check_is_fitted()
         X, y = check_X_y(X, y, coerce_to_numpy=True)
 
+        # handle the single-class-label case
+        if len(self._class_dictionary) == 1:
+            return self._single_class_y_pred(X, method="predict_proba")
+
         n_instances, n_dims, series_length = X.shape
 
         if (

--- a/sktime/classification/kernel_based/_arsenal.py
+++ b/sktime/classification/kernel_based/_arsenal.py
@@ -321,6 +321,10 @@ class Arsenal(BaseClassifier):
         self.check_is_fitted()
         X, y = check_X_y(X, y, coerce_to_numpy=True)
 
+        # handle the single-class-label case
+        if len(self._class_dictionary) == 1:
+            return self._single_class_y_pred(X, method="predict_proba")
+
         n_instances, n_dims, series_length = X.shape
 
         if (

--- a/sktime/classification/sklearn/_rotation_forest.py
+++ b/sktime/classification/sklearn/_rotation_forest.py
@@ -330,6 +330,10 @@ class RotationForest(BaseEstimator):
             )
         X = self._validate_data(X=X, reset=False)
 
+        # handle the single-class-label case
+        if len(self._class_dictionary) == 1:
+            return np.repeat([[1]], len(X), axis=0)
+
         n_instances, n_atts = X.shape
 
         if n_instances != self.n_instances_ or n_atts != self.n_atts_:

--- a/sktime/classification/tests/test_all_classifiers.py
+++ b/sktime/classification/tests/test_all_classifiers.py
@@ -190,6 +190,6 @@ class TestAllClassifiers(ClassifierFixtureGenerator, QuickTester):
         y[:] = 42
 
         error_msg = "single class label"
-    
+
         with pytest.warns(UserWarning, match=error_msg):
             estimator_instance.fit(X, y)

--- a/sktime/classification/tests/test_all_classifiers.py
+++ b/sktime/classification/tests/test_all_classifiers.py
@@ -14,7 +14,10 @@ from sktime.classification.tests._expected_outputs import (
 from sktime.datasets import load_basic_motions, load_unit_test
 from sktime.datatypes import check_is_scitype
 from sktime.tests.test_all_estimators import BaseFixtureGenerator, QuickTester
-from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
+from sktime.utils._testing.estimator_checks import (
+    _assert_array_almost_equal,
+    make_classification_problem,
+)
 from sktime.utils._testing.scenarios_classification import (
     ClassifierFitPredictMultivariate,
 )
@@ -176,3 +179,17 @@ class TestAllClassifiers(ClassifierFixtureGenerator, QuickTester):
 
         # assert probabilities are the same
         _assert_array_almost_equal(y_proba, expected_probas, decimal=2)
+
+    def test_handles_single_class(self, estimator_instance):
+        """Test that estimator handles fit when only single class label is seen.
+
+        This is important for compatibility with ensembles that sub-sample,
+        as sub-sampling stochastically produces training sets with single class label.
+        """
+        X, y = make_classification_problem()
+        y[:] = 42
+
+        error_msg = "single class label"
+    
+        with pytest.warns(UserWarning, match=error_msg):
+            estimator_instance.fit(X, y)

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -8,11 +8,7 @@ import pandas as pd
 import pytest
 from sklearn.model_selection import KFold
 
-from sktime.classification.base import (
-    BaseClassifier,
-    _check_classifier_input,
-    _internal_convert,
-)
+from sktime.classification.base import BaseClassifier
 from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
 from sktime.classification.feature_based import Catch22Classifier
 from sktime.utils._testing.estimator_checks import (
@@ -189,6 +185,10 @@ def test_convert_input():
     4. Pass a pd.Series y, get a pd.Series back
     5. Pass a np.ndarray y, get a pd.Series back
     """
+
+    def _internal_convert(X, y):
+        return BaseClassifier._internal_convert(None, X, y)
+
     cases = 5
     length = 10
     test_X1 = np.random.uniform(-1, 1, size=(cases, length))
@@ -227,6 +227,10 @@ def test__check_classifier_input():
     4. Test incorrect: y as a list
     5. Test incorrect: too few cases or too short a series
     """
+
+    def _check_classifier_input(X, y):
+        return BaseClassifier._check_classifier_input(None, X, y)
+
     # 1. Test correct: X: np.array of 2 and 3 dimensions vs y:np.array and np.Series
     test_X1 = np.random.uniform(-1, 1, size=(5, 10))
     test_X2 = np.random.uniform(-1, 1, size=(5, 2, 10))

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -8,11 +8,7 @@ import pandas as pd
 import pytest
 from sklearn.model_selection import KFold
 
-from sktime.classification.base import (
-    BaseClassifier,
-    _check_classifier_input,
-    _internal_convert,
-)
+from sktime.classification.base import BaseClassifier
 from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
 from sktime.classification.feature_based import Catch22Classifier
 from sktime.utils._testing.estimator_checks import (
@@ -189,6 +185,9 @@ def test_convert_input():
     4. Pass a pd.Series y, get a pd.Series back
     5. Pass a np.ndarray y, get a pd.Series back
     """
+    def _internal_convert(X, y):
+        return BaseClassifier._internal_convert(None, X, y)
+
     cases = 5
     length = 10
     test_X1 = np.random.uniform(-1, 1, size=(cases, length))
@@ -227,6 +226,9 @@ def test__check_classifier_input():
     4. Test incorrect: y as a list
     5. Test incorrect: too few cases or too short a series
     """
+    def _check_classifier_input(X, y):
+        return BaseClassifier._check_classifier_input(None, X, y)
+
     # 1. Test correct: X: np.array of 2 and 3 dimensions vs y:np.array and np.Series
     test_X1 = np.random.uniform(-1, 1, size=(5, 10))
     test_X2 = np.random.uniform(-1, 1, size=(5, 2, 10))

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -228,7 +228,7 @@ def test__check_classifier_input():
     5. Test incorrect: too few cases or too short a series
     """
 
-    def _check_classifier_input(X, y=None, enforce_min_instances=None):
+    def _check_classifier_input(X, y=None, enforce_min_instances=1):
         return BaseClassifier._check_classifier_input(None, X, y, enforce_min_instances)
 
     # 1. Test correct: X: np.array of 2 and 3 dimensions vs y:np.array and np.Series

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -186,7 +186,7 @@ def test_convert_input():
     5. Pass a np.ndarray y, get a pd.Series back
     """
 
-    def _internal_convert(X, y):
+    def _internal_convert(X, y=None):
         return BaseClassifier._internal_convert(None, X, y)
 
     cases = 5
@@ -228,7 +228,7 @@ def test__check_classifier_input():
     5. Test incorrect: too few cases or too short a series
     """
 
-    def _check_classifier_input(X, y):
+    def _check_classifier_input(X, y=None):
         return BaseClassifier._check_classifier_input(None, X, y)
 
     # 1. Test correct: X: np.array of 2 and 3 dimensions vs y:np.array and np.Series

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -228,8 +228,8 @@ def test__check_classifier_input():
     5. Test incorrect: too few cases or too short a series
     """
 
-    def _check_classifier_input(X, y=None):
-        return BaseClassifier._check_classifier_input(None, X, y)
+    def _check_classifier_input(X, y=None, enforce_min_instances=None):
+        return BaseClassifier._check_classifier_input(None, X, y, enforce_min_instances)
 
     # 1. Test correct: X: np.array of 2 and 3 dimensions vs y:np.array and np.Series
     test_X1 = np.random.uniform(-1, 1, size=(5, 10))

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -185,6 +185,7 @@ def test_convert_input():
     4. Pass a pd.Series y, get a pd.Series back
     5. Pass a np.ndarray y, get a pd.Series back
     """
+
     def _internal_convert(X, y):
         return BaseClassifier._internal_convert(None, X, y)
 
@@ -226,6 +227,7 @@ def test__check_classifier_input():
     4. Test incorrect: y as a list
     5. Test incorrect: too few cases or too short a series
     """
+
     def _check_classifier_input(X, y):
         return BaseClassifier._check_classifier_input(None, X, y)
 

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -6,7 +6,6 @@ __author__ = ["mloning", "fkiraly", "TonyBagnall", "MatthewMiddlehurst"]
 import numpy as np
 import pandas as pd
 import pytest
-
 from sklearn.model_selection import KFold
 
 from sktime.classification.base import (

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -8,7 +8,11 @@ import pandas as pd
 import pytest
 from sklearn.model_selection import KFold
 
-from sktime.classification.base import BaseClassifier
+from sktime.classification.base import (
+    BaseClassifier,
+    _check_classifier_input,
+    _internal_convert,
+)
 from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
 from sktime.classification.feature_based import Catch22Classifier
 from sktime.utils._testing.estimator_checks import (
@@ -185,10 +189,6 @@ def test_convert_input():
     4. Pass a pd.Series y, get a pd.Series back
     5. Pass a np.ndarray y, get a pd.Series back
     """
-
-    def _internal_convert(X, y):
-        return BaseClassifier._internal_convert(None, X, y)
-
     cases = 5
     length = 10
     test_X1 = np.random.uniform(-1, 1, size=(cases, length))
@@ -227,10 +227,6 @@ def test__check_classifier_input():
     4. Test incorrect: y as a list
     5. Test incorrect: too few cases or too short a series
     """
-
-    def _check_classifier_input(X, y):
-        return BaseClassifier._check_classifier_input(None, X, y)
-
     # 1. Test correct: X: np.array of 2 and 3 dimensions vs y:np.array and np.Series
     test_X1 = np.random.uniform(-1, 1, size=(5, 10))
     test_X2 = np.random.uniform(-1, 1, size=(5, 2, 10))

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -386,7 +386,8 @@ def _check_regressor_input(
         if isinstance(y, np.ndarray):
             if y.ndim > 1:
                 raise ValueError(
-                    f"y must be 1-dimensional but is in fact " f"{y.ndim} dimensional"
+                    f"np.ndarray y must be 1-dimensional, "
+                    f"but found {y.ndim} dimensions"
                 )
     return X_metadata
 


### PR DESCRIPTION
Handles "single class seen in `fit`" scenario that can lead to infinite loops according to unreported bug discussed in PR #3110.

Alternative solution which simply returns "that class" predicted every time, instead of erroring out. Includes tests.