### PR TITLE
Revert "[BUG] Fix HIVE-COTE2 sporadic test failure"

### DIFF
--- a/sktime/classification/interval_based/_drcif.py
+++ b/sktime/classification/interval_based/_drcif.py
@@ -571,11 +571,6 @@ class DrCIF(BaseClassifier):
 
         indices = range(self.n_instances_)
         subsample = rng.choice(self.n_instances_, size=self.n_instances_)
-
-        # subsample must have at least 2 unique classes
-        while len(np.unique(y[subsample])) == 1:
-            subsample = rng.choice(self.n_instances_, size=self.n_instances_)
-
         oob = [n for n in indices if n not in subsample]
 
         results = np.zeros((self.n_instances_, self.n_classes_))

--- a/sktime/classification/kernel_based/_arsenal.py
+++ b/sktime/classification/kernel_based/_arsenal.py
@@ -390,11 +390,6 @@ class Arsenal(BaseClassifier):
 
         indices = range(self.n_instances_)
         subsample = rng.choice(self.n_instances_, size=self.n_instances_)
-
-        # subsample must have at least 2 unique classes
-        while len(np.unique(y[subsample])) == 1:
-            subsample = rng.choice(self.n_instances_, size=self.n_instances_)
-
         oob = [n for n in indices if n not in subsample]
 
         results = np.zeros((self.n_instances_, self.n_classes_))

--- a/sktime/classification/sklearn/_rotation_forest.py
+++ b/sktime/classification/sklearn/_rotation_forest.py
@@ -451,11 +451,6 @@ class RotationForest(BaseEstimator):
 
         indices = range(self.n_instances_)
         subsample = rng.choice(self.n_instances_, size=self.n_instances_)
-
-        # subsample must have at least 2 unique classes
-        while len(np.unique(y[subsample])) == 1:
-            subsample = rng.choice(self.n_instances_, size=self.n_instances_)
-
         oob = [n for n in indices if n not in subsample]
 
         results = np.zeros((self.n_instances_, self.n_classes_))


### PR DESCRIPTION
Reverts alan-turing-institute/sktime#3094

Problem with #3094 is possibly infinite loop if data passed has only one class.

See discussion in https://github.com/alan-turing-institute/sktime/pull/3110 which tries to address secondary bugs caused by #3094.