### PR TITLE
[ENH] Allow lists to be `cutoff` argument in `CutoffSplitter`

### DIFF
--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -684,7 +684,7 @@ class CutoffSplitter(BaseSplitter):
 
     Parameters
     ----------
-    cutoffs : np.array or pd.Index
+    cutoffs : list or np.array or pd.Index
         Cutoff points, positive and integer- or datetime-index like.
         Type should match the type of `fh` input.
     fh : int, timedelta, list or np.ndarray of ints or timedeltas

--- a/sktime/forecasting/tests/_config.py
+++ b/sktime/forecasting/tests/_config.py
@@ -27,14 +27,15 @@ import pandas as pd
 from sktime.utils._testing.series import _make_series
 
 # We here define the parameter values for unit testing.
-TEST_CUTOFFS_INT = [np.array([21, 22]), np.array([3, 7, 10])]
+TEST_CUTOFFS_INT_LIST = [[21, 22], [3, 7, 10]]
+TEST_CUTOFFS_INT_ARR = [np.array([21, 22]), np.array([3, 7, 10])]
 # The following timestamps correspond
 # to the above integers for `_make_series(all_positive=True)`
 TEST_CUTOFFS_TIMESTAMP = [
     pd.to_datetime(["2000-01-22", "2000-01-23"]),
     pd.to_datetime(["2000-01-04", "2000-01-08", "2000-01-11"]),
 ]
-TEST_CUTOFFS = [*TEST_CUTOFFS_INT, *TEST_CUTOFFS_TIMESTAMP]
+TEST_CUTOFFS = [*TEST_CUTOFFS_INT_LIST, *TEST_CUTOFFS_INT_ARR, *TEST_CUTOFFS_TIMESTAMP]
 
 TEST_WINDOW_LENGTHS_INT = [1, 5]
 TEST_WINDOW_LENGTHS_TIMEDELTA = [pd.Timedelta(1, unit="D"), pd.Timedelta(5, unit="D")]

--- a/sktime/utils/validation/forecasting.py
+++ b/sktime/utils/validation/forecasting.py
@@ -34,7 +34,7 @@ from sktime.utils.validation import (
 )
 from sktime.utils.validation.series import check_equal_time_index, check_series
 
-ACCEPTED_CUTOFF_TYPES = np.ndarray, pd.Index
+ACCEPTED_CUTOFF_TYPES = list, np.ndarray, pd.Index
 VALID_CUTOFF_TYPES = Union[ACCEPTED_CUTOFF_TYPES]
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Closes #3082 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Allow lists to be `cutoff` argument in `sktime.forecasting.model_selection._split.CutoffSplitter`.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [X] I've added unit tests and made sure they pass locally.
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.