### PR TITLE
[MNT] skip known failure case for `VARMAX`

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -87,7 +87,9 @@ EXCLUDED_TESTS = {
         "test_fit_idempotent",
         "test_persistence_via_pickle",
     ],
-    "VARMAX": "test_update_predict_single",  # see 2997, sporadic failure, unknown cause
+    "VARMAX": [
+        "test_update_predict_single",  # see 2997, sporadic failure, unknown cause
+        "test__y_when_refitting",  # see 3176
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -90,6 +90,7 @@ EXCLUDED_TESTS = {
     "VARMAX": [
         "test_update_predict_single",  # see 2997, sporadic failure, unknown cause
         "test__y_when_refitting",  # see 3176
+    ],
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish


### PR DESCRIPTION
One specific test for `VARMAX` on windows terminates with an exception:
https://github.com/alan-turing-institute/sktime/issues/3176

Since this happens frequently, removing the test until we understand what is going on.