### PR TITLE
[BUG] prevent circular imports in `all_estimators`

### DIFF
--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -182,6 +182,7 @@ def all_estimators(
             that do not contain any of the strings on the `exclude` list
             string is prefixed by the string `prefix`
         """
+
         def _is_ignored_module(module):
             if exclude is None:
                 return False
@@ -193,7 +194,8 @@ def all_estimators(
                 yield f"{prefix}{module_name}"
                 if is_pgk:
                     yield from (
-                        f"{prefix}{module_name}.{x}" for x in _walk(f"{root}/{module_name}", exclude=exclude)
+                        f"{prefix}{module_name}.{x}"
+                        for x in _walk(f"{root}/{module_name}", exclude=exclude)
                     )
 
     # Ignore deprecation warnings triggered at import time and from walking

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -133,7 +133,7 @@ def all_estimators(
     import sys
     import warnings
 
-    MODULES_TO_IGNORE = ("tests", "setup", "contrib", "benchmarking", "utils")
+    MODULES_TO_IGNORE = ("tests", "setup", "contrib", "benchmarking", "utils", "all")
 
     all_estimators = []
     ROOT = str(Path(__file__).parent.parent)  # sktime package root directory
@@ -148,10 +148,6 @@ def all_estimators(
     def _is_private_module(module):
         return "._" in module
 
-    def _is_ignored_module(module):
-        module_parts = module.split(".")
-        return any(part in MODULES_TO_IGNORE for part in module_parts)
-
     def _is_base_class(name):
         return name.startswith("_") or name.startswith("Base")
 
@@ -165,6 +161,41 @@ def all_estimators(
             and not _is_base_class(name)
         )
 
+    def _walk(root, exclude=None, prefix=""):
+        """Return all modules contained as sub-modules (recursive) as string list.
+
+        Unlike pkgutil.walk_packages, does not import modules on exclusion list.
+
+        Parameters
+        ----------
+        root : Path
+            root path in which to look for submodules
+        exclude : tuple of str or None, optional, default = None
+            list of sub-modules to ignore in the return, including sub-modules
+        prefix: str, optional, default = ""
+            this str is appended to all strings in the return
+
+        Yields
+        ------
+        str : sub-module strings
+            iterates over all sub-modules of root
+            that do not contain any of the strings on the `exclude` list
+            string is prefixed by the string `prefix`
+        """
+        def _is_ignored_module(module):
+            if exclude is None:
+                return False
+            module_parts = module.split(".")
+            return any(part in exclude for part in module_parts)
+
+        for _, module_name, is_pgk in pkgutil.iter_modules(path=[root]):
+            if not _is_ignored_module(module_name):
+                yield f"{prefix}{module_name}"
+                if is_pgk:
+                    yield from (
+                        f"{prefix}{module_name}.{x}" for x in _walk(f"{root}/{module_name}", exclude=exclude)
+                    )
+
     # Ignore deprecation warnings triggered at import time and from walking
     # packages
     with warnings.catch_warnings():
@@ -173,10 +204,12 @@ def all_estimators(
         warnings.filterwarnings(
             "ignore", category=UserWarning, message=".*has been moved to.*"
         )
-        for _, module_name, _ in pkgutil.walk_packages(path=[ROOT], prefix="sktime."):
+        for module_name in _walk(
+            root=ROOT, exclude=MODULES_TO_IGNORE, prefix="sktime."
+        ):
 
             # Filter modules
-            if _is_ignored_module(module_name) or _is_private_module(module_name):
+            if _is_private_module(module_name):
                 continue
 
             try:


### PR DESCRIPTION
Addresses #3166.

The use of `pkgutils.walk_package` in `all_estimators` could lead to circular imports if a sub-module also used `all_estimators` to load exports (e.g., the `all` modules).

In theory, this should be prevented by putting these sub-modules on the exclusion list, but is not, because `pkgutils.walk_package` imports all sub-modules, and `all_estimators` not preventing the import of modules on the exclusion list.

The issue is addressed by:
* replacing `walk_package` by a custom utility `_walk`, based on `pgkutil.iter_modules` that does not import sub-modules on the exclusion list
* putting the `all` sub-modules, which use `all_estimators`, on the exclusion list in `all_estimators`