### PR TITLE
[BUG] allowing single class case in sklearn classifiers (trees/forests)

### DIFF
--- a/sktime/classification/sklearn/_continuous_interval_tree.py
+++ b/sktime/classification/sklearn/_continuous_interval_tree.py
@@ -126,8 +126,10 @@ class ContinuousIntervalTree(BaseEstimator):
         for index, classVal in enumerate(self.classes_):
             self._class_dictionary[classVal] = index
 
+        # escape if only one class seen
         if self.n_classes_ == 1:
-            raise ValueError("fit input y must contain more than one class")
+            self._is_fitted = True
+            return self
 
         le = preprocessing.LabelEncoder()
         y = le.fit_transform(y)
@@ -196,6 +198,12 @@ class ContinuousIntervalTree(BaseEstimator):
                 f"This instance of {self.__class__.__name__} has not "
                 f"been fitted yet; please call `fit` first."
             )
+
+        # treat case of single class seen in fit
+        if self.n_classes_ == 1:
+            n_instances = len(X)
+            return np.repeat([[1]], n_instances, axis=0)
+
         if isinstance(X, np.ndarray) and len(X.shape) == 3 and X.shape[1] == 1:
             X = np.reshape(X, (X.shape[0], -1))
         elif not isinstance(X, np.ndarray) or len(X.shape) > 2:

--- a/sktime/classification/sklearn/_rotation_forest.py
+++ b/sktime/classification/sklearn/_rotation_forest.py
@@ -170,8 +170,10 @@ class RotationForest(BaseEstimator):
         for index, classVal in enumerate(self.classes_):
             self._class_dictionary[classVal] = index
 
+        # escape if only one class seen
         if self.n_classes_ == 1:
-            raise ValueError("fit input y must contain more than one class")
+            self._is_fitted = True
+            return self
 
         time_limit = self.time_limit_in_minutes * 60
         start_time = time.time()
@@ -279,6 +281,12 @@ class RotationForest(BaseEstimator):
                 f"This instance of {self.__class__.__name__} has not "
                 f"been fitted yet; please call `fit` first."
             )
+
+        # treat case of single class seen in fit
+        if self.n_classes_ == 1:
+            n_instances = len(X)
+            return np.repeat([[1]], n_instances, axis=0)
+
         if isinstance(X, np.ndarray) and len(X.shape) == 3 and X.shape[1] == 1:
             X = np.reshape(X, (X.shape[0], -1))
         elif isinstance(X, pd.DataFrame) and len(X.shape) == 2:


### PR DESCRIPTION
This allows single class in training set in the sklearn classifiers `RotationForest` and `ContinuousIntervalTree`.

Fixes #3202.