### PR TITLE
DIAGNOSTIC - DO NOT MERGE - testing by estimator to measure time by estimator

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ addopts =
     --cov-report xml
     --cov-report html
     --showlocals
-    --matrixdesign True
     -n auto
 filterwarnings =
     ignore::UserWarning

--- a/sktime/classification/early_classification/tests/test_all_early_classifiers.py
+++ b/sktime/classification/early_classification/tests/test_all_early_classifiers.py
@@ -6,7 +6,7 @@ __author__ = ["mloning", "TonyBagnall", "fkiraly", "MatthewMiddlehurst"]
 import numpy as np
 
 from sktime.classification.tests.test_all_classifiers import (
-    TestAllClassifiers as ClassifierTests,
+    _TestAllClassifiers as ClassifierTests,
 )
 from sktime.tests.test_all_estimators import BaseFixtureGenerator, QuickTester
 
@@ -25,14 +25,14 @@ class EarlyClassifierFixtureGenerator(BaseFixtureGenerator):
         ranges over all scenarios returned by retrieve_scenarios
     """
 
-    # note: this should be separate from TestAllEarlyClassifiers
+    # note: this should be separate from _TestAllEarlyClassifiers
     #   additional fixtures, parameters, etc should be added here
-    #   TestAllEarlyClassifiers should contain the tests only
+    #   _TestAllEarlyClassifiers should contain the tests only
 
     estimator_type_filter = "early_classifier"
 
 
-class TestAllEarlyClassifiers(EarlyClassifierFixtureGenerator, QuickTester):
+class _TestAllEarlyClassifiers(EarlyClassifierFixtureGenerator, QuickTester):
     """Module level tests for all sktime classifiers."""
 
     def test_multivariate_input_exception(self, estimator_instance):

--- a/sktime/classification/tests/test_all_classifiers.py
+++ b/sktime/classification/tests/test_all_classifiers.py
@@ -37,14 +37,14 @@ class ClassifierFixtureGenerator(BaseFixtureGenerator):
         ranges over all scenarios returned by retrieve_scenarios
     """
 
-    # note: this should be separate from TestAllClassifiers
+    # note: this should be separate from _TestAllClassifiers
     #   additional fixtures, parameters, etc should be added here
     #   Classifiers should contain the tests only
 
     estimator_type_filter = "classifier"
 
 
-class TestAllClassifiers(ClassifierFixtureGenerator, QuickTester):
+class _TestAllClassifiers(ClassifierFixtureGenerator, QuickTester):
     """Module level tests for all sktime classifiers."""
 
     def test_multivariate_input_exception(self, estimator_instance):

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -72,9 +72,9 @@ class ForecasterFixtureGenerator(BaseFixtureGenerator):
         ranges over all scenarios returned by retrieve_scenarios
     """
 
-    # note: this should be separate from TestAllForecasters
+    # note: this should be separate from _TestAllForecasters
     #   additional fixtures, parameters, etc should be added here
-    #   TestAllForecasters should contain the tests only
+    #   _TestAllForecasters should contain the tests only
 
     estimator_type_filter = "forecaster"
 
@@ -137,7 +137,7 @@ class ForecasterFixtureGenerator(BaseFixtureGenerator):
             return TEST_STEP_LENGTHS_INT, [f"step={a}" for a in TEST_STEP_LENGTHS_INT]
 
 
-class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
+class _TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
     """Module level tests for all sktime forecasters."""
 
     def test_get_fitted_params(self, estimator_instance, scenario):

--- a/sktime/regression/tests/test_all_regressors.py
+++ b/sktime/regression/tests/test_all_regressors.py
@@ -28,14 +28,14 @@ class RegressorFixtureGenerator(BaseFixtureGenerator):
         ranges over all scenarios returned by retrieve_scenarios
     """
 
-    # note: this should be separate from TestAllRegressors
+    # note: this should be separate from _TestAllRegressors
     #   additional fixtures, parameters, etc should be added here
-    #   TestAllRegressors should contain the tests only
+    #   _TestAllRegressors should contain the tests only
 
     estimator_type_filter = "regressor"
 
 
-class TestAllRegressors(RegressorFixtureGenerator, QuickTester):
+class _TestAllRegressors(RegressorFixtureGenerator, QuickTester):
     """Module level tests for all sktime regressors."""
 
     def test_multivariate_input_exception(self, estimator_instance):

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -91,6 +91,22 @@ def subsample_by_version_os(x):
     return res
 
 
+ALL_ESTIMATOR_LIST = all_estimators(
+    return_names=False,
+    exclude_estimators=EXCLUDE_ESTIMATORS,
+)
+
+
+@pytest.mark.parametrize("estimator_class", ALL_ESTIMATOR_LIST)
+def test_estimator(estimator_class):
+    """Universal test for an estimator. Used to measure time per estimator."""
+    from sktime.utils.estimator_checks import check_estimator
+
+    excluded = EXCLUDED_TESTS[estimator_class.__name__]
+
+    check_estimator(estimator_class, return_exceptions=False, tests_to_exclude=excluded)
+
+
 class BaseFixtureGenerator:
     """Fixture generator for base testing functionality in sktime.
 
@@ -435,13 +451,13 @@ class QuickTester:
         Examples
         --------
         >>> from sktime.forecasting.naive import NaiveForecaster
-        >>> from sktime.tests.test_all_estimators import TestAllObjects
-        >>> TestAllObjects().run_tests(
+        >>> from sktime.tests.test_all_estimators import _TestAllObjects
+        >>> _TestAllObjects().run_tests(
         ...     NaiveForecaster,
         ...     tests_to_run="test_required_params"
         ... )
         {'test_required_params[NaiveForecaster]': 'PASSED'}
-        >>> TestAllObjects().run_tests(
+        >>> _TestAllObjects().run_tests(
         ...     NaiveForecaster, fixtures_to_run="test_repr[NaiveForecaster-2]"
         ... )
         {'test_repr[NaiveForecaster-2]': 'PASSED'}
@@ -667,7 +683,7 @@ class QuickTester:
         return fixture_vars_return, fixture_prod_return, fixture_names_return
 
 
-class TestAllObjects(BaseFixtureGenerator, QuickTester):
+class _TestAllObjects(BaseFixtureGenerator, QuickTester):
     """Package level tests for all sktime objects."""
 
     estimator_type_filter = "object"
@@ -982,7 +998,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             assert tag in VALID_ESTIMATOR_TAGS
 
 
-class TestAllEstimators(BaseFixtureGenerator, QuickTester):
+class _TestAllEstimators(BaseFixtureGenerator, QuickTester):
     """Package level tests for all sktime estimators, i.e., objects with fit."""
 
     def test_fit_updates_state(self, estimator_instance, scenario):

--- a/sktime/transformations/tests/test_all_transformers.py
+++ b/sktime/transformations/tests/test_all_transformers.py
@@ -24,14 +24,14 @@ class TransformerFixtureGenerator(BaseFixtureGenerator):
         ranges over all scenarios returned by retrieve_scenarios
     """
 
-    # note: this should be separate from TestAllTransformers
+    # note: this should be separate from _TestAllTransformers
     #   additional fixtures, parameters, etc should be added here
-    #   TestAllTransformers should contain the tests only
+    #   _TestAllTransformers should contain the tests only
 
     estimator_type_filter = "transformer"
 
 
-class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
+class _TestAllTransformers(TransformerFixtureGenerator, QuickTester):
     """Module level tests for all sktime transformers."""
 
     def test_capability_inverse_tag_is_correct(self, estimator_instance):

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -71,23 +71,23 @@ def check_estimator(
     """
     from sktime.base import BaseEstimator
     from sktime.classification.early_classification.tests.test_all_early_classifiers import (  # noqa E501
-        TestAllEarlyClassifiers,
+        _TestAllEarlyClassifiers,
     )
-    from sktime.classification.tests.test_all_classifiers import TestAllClassifiers
-    from sktime.forecasting.tests.test_all_forecasters import TestAllForecasters
+    from sktime.classification.tests.test_all_classifiers import _TestAllClassifiers
+    from sktime.forecasting.tests.test_all_forecasters import _TestAllForecasters
     from sktime.registry import scitype
-    from sktime.regression.tests.test_all_regressors import TestAllRegressors
-    from sktime.tests.test_all_estimators import TestAllEstimators, TestAllObjects
-    from sktime.transformations.tests.test_all_transformers import TestAllTransformers
+    from sktime.regression.tests.test_all_regressors import _TestAllRegressors
+    from sktime.tests.test_all_estimators import _TestAllEstimators, _TestAllObjects
+    from sktime.transformations.tests.test_all_transformers import _TestAllTransformers
 
     testclass_dict = dict()
-    testclass_dict["classifier"] = TestAllClassifiers
-    testclass_dict["early_classifier"] = TestAllEarlyClassifiers
-    testclass_dict["forecaster"] = TestAllForecasters
-    testclass_dict["regressor"] = TestAllRegressors
-    testclass_dict["transformer"] = TestAllTransformers
+    testclass_dict["classifier"] = _TestAllClassifiers
+    testclass_dict["early_classifier"] = _TestAllEarlyClassifiers
+    testclass_dict["forecaster"] = _TestAllForecasters
+    testclass_dict["regressor"] = _TestAllRegressors
+    testclass_dict["transformer"] = _TestAllTransformers
 
-    results = TestAllObjects().run_tests(
+    results = _TestAllObjects().run_tests(
         estimator=estimator,
         return_exceptions=return_exceptions,
         tests_to_run=tests_to_run,
@@ -97,7 +97,7 @@ def check_estimator(
     )
 
     if isinstance(estimator, BaseEstimator) or issubclass(estimator, BaseEstimator):
-        results_estimator = TestAllEstimators().run_tests(
+        results_estimator = _TestAllEstimators().run_tests(
             estimator=estimator,
             return_exceptions=return_exceptions,
             tests_to_run=tests_to_run,


### PR DESCRIPTION
This PR contains a modified version of the test suite that runs a single test per estimator (via `check_estimator`).

This enables `pytest` to measure the time per estimator, and appropriately list the highest ranking estimators by time, to identify test time reduction targets - also see https://github.com/alan-turing-institute/sktime/issues/2890 on discussion regarding overall test time.

The `--matrixdesign` flag is deactivated, so all estimators are tested on all os/version combinations.

