### PR TITLE
 [BUG] Fix `AutoEnsembleForecaster` inverse variance bug

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1739,6 +1739,14 @@
       "contributions": [
         "code",
       ]
+    },
+    {
+      "login": "AnH0ang",
+      "name": "An Hoang",
+      "profile": "https://github.com/AnH0ang",
+      "contributions": [
+        "bug"
+      ]
     }
   ],
   "projectName": "sktime",

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -187,7 +187,7 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
             inv_var = np.array(
                 [
                     1 / np.var(y_test - y_pred_test)
-                    for y_pred_test in self._predict_forecasters(fh_test, X)
+                    for y_pred_test in self._predict_forecasters(fh_test, X_test)
                 ]
             )
             # standardize the inverse variance

--- a/sktime/forecasting/compose/tests/test_autoensemble.py
+++ b/sktime/forecasting/compose/tests/test_autoensemble.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3 -u
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
+"""Unit tests of AutoEnsembleForecaster functionality."""
+
+__author__ = ["mloning", "GuzalBulatova", "aiwalter", "RNKuhns", "AnH0ang"]
+
+import pandas as pd
+import pytest
+from sklearn.linear_model import LinearRegression
+from sklearn.tree import DecisionTreeRegressor
+
+from sktime.datasets import load_longley
+from sktime.forecasting.base import ForecastingHorizon
+from sktime.forecasting.compose import (
+    AutoEnsembleForecaster,
+    RecursiveTabularRegressionForecaster,
+)
+from sktime.forecasting.model_selection import temporal_train_test_split
+
+
+@pytest.mark.parametrize(
+    "forecasters",
+    [
+        [
+            (
+                "dt",
+                RecursiveTabularRegressionForecaster(
+                    DecisionTreeRegressor(random_state=42), window_length=3
+                ),
+            ),
+            (
+                "lr",
+                RecursiveTabularRegressionForecaster(
+                    LinearRegression(), window_length=3
+                ),
+            ),
+        ],
+    ],
+)
+@pytest.mark.parametrize(
+    "method",
+    ["inverse-variance", "feature-importance"],
+)
+def test_autoensembler(forecasters, method):
+    """Check that the prediction is a weighted mean of the individual predictions."""
+    y, X = load_longley()
+    y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
+
+    fh_test = ForecastingHorizon(y_test.index, is_relative=False)
+
+    ensemble_forecaster = AutoEnsembleForecaster(forecasters=forecasters, method=method)
+    ensemble_forecaster.fit(y_train, X_train)
+    y_pred = ensemble_forecaster.predict(fh=fh_test, X=X_test)
+
+    predictions = []
+    for _, forecaster in forecasters:
+        f = forecaster
+        f.fit(y_train, X_train)
+        f_pred = f.predict(fh=fh_test, X=X_test)
+        predictions.append(f_pred)
+    predictions = pd.DataFrame(predictions).T
+
+    assert (predictions.min(axis=1) <= y_pred).all()
+    assert (predictions.max(axis=1) >= y_pred).all()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #3199
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fix the error described in #3199 that occurred in `AutoEnsembleForecaster` when `method="inverse-variance"` was used. This was caused by passing `X` instead of `X_test` to the internal forecasters when making predictions in `fit` method. This has been fixed. In addition, tests for the `AutoEnsembleForecaster` have been added.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?
<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
No
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [x] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [x] I've added the estimator to the online documentation.
- [x] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
