### PR TITLE
[DOC] cleaning up the user docs

### DIFF
--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -3,8 +3,9 @@
 Tutorials
 =========
 
-We have a number of tutorial notebooks. If you like to run them interactively, you can launch them on Binder without
-having to install anything.
+We have a number of tutorial notebooks. If you like to run them interactively, you can
+`launch them on binder <https://mybinder.org/v2/gh/alan-turing-institute/sktime/main?filepath=examples>`_
+without having to install anything.
 
 We assume basic familiarity with `scikit-learn`_. If you haven’t worked with scikit-learn before, check out their
 `getting-started guide`_.
@@ -17,4 +18,4 @@ The notebook files can be found `here <https://github.com/alan-turing-institute/
 .. nbgallery::
     :glob:
 
-    examples/*
+    https://github.com/alan-turing-institute/sktime/blob/main/examples


### PR DESCRIPTION
Small changes to improve the documentation by pointing towards the example notebooks, removing outdated notebooks from the sphinx docs.

Goes towards https://github.com/alan-turing-institute/sktime/issues/2127