### PR TITLE
[BUG] fixing bugs in metrics base classes and custom performance metric

### DIFF
--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -533,8 +533,7 @@ class _DynamicForecastingErrorMetric(BaseForecastingErrorMetricFunc):
         self.name = name
         super().__init__()
 
-        if not lower_is_better:
-            self.set_tags(**{"lower_is_better": False})
+        self.set_tags(**{"lower_is_better": lower_is_better})
 
 
 class _ScaledMetricTags:

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -576,6 +576,7 @@ class _DynamicForecastingErrorMetric(BaseForecastingErrorMetricFunc):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+
         def custom_mape(y_true, y_pred) -> float:
 
             eps = np.finfo(np.float64).eps
@@ -584,9 +585,7 @@ class _DynamicForecastingErrorMetric(BaseForecastingErrorMetricFunc):
 
             return float(result)
 
-        params = {
-            "func": custom_mape, "name": "custom_mape", "lower_is_better": False
-        }
+        params = {"func": custom_mape, "name": "custom_mape", "lower_is_better": False}
         return params
 
 

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -8,7 +8,7 @@ Classes named as ``*Error`` or ``*Loss`` return a value to minimize:
 the lower the better.
 """
 from copy import deepcopy
-from inspect import isfunction, getfullargspec, signature
+from inspect import getfullargspec, isfunction, signature
 from warnings import warn
 
 import numpy as np

--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -54,7 +54,7 @@ def _get_kwarg(kwarg, metric_name="Metric", **kwargs):
     if kwarg_ is None:
         msg = "".join(
             [
-                f"{metric_name} requires `{kwarg}`.",
+                f"{metric_name} requires `{kwarg}`. ",
                 f"Pass `{kwarg}` as a keyword argument when calling the metric.",
             ]
         )

--- a/sktime/performance_metrics/tests/test_metrics_classes.py
+++ b/sktime/performance_metrics/tests/test_metrics_classes.py
@@ -108,7 +108,7 @@ def test_custom_metric(greater_is_better):
     """Test custom metric constructor, integration _DynamicForecastingErrorMetric."""
     y = load_airline()
 
-    def custom_mape(y_true , y_pred) -> float:
+    def custom_mape(y_true, y_pred) -> float:
 
         eps = np.finfo(np.float64).eps
 

--- a/sktime/performance_metrics/tests/test_metrics_classes.py
+++ b/sktime/performance_metrics/tests/test_metrics_classes.py
@@ -6,7 +6,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from sktime.performance_metrics.forecasting import MeanSquaredError, _classes
+from sktime.datasets import load_airline
+from sktime.performance_metrics.forecasting import (
+    MeanSquaredError,
+    _classes,
+    make_forecasting_scorer,
+)
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.series import _make_series
 
@@ -96,3 +101,28 @@ def test_metric_hierarchical(multioutput, multilevel, n_columns):
             assert isinstance(res, np.ndarray)
             assert res.ndim == 1
             assert len(res) == len(y_true.columns)
+
+
+@pytest.mark.parametrize("greater_is_better", [True, False])
+def test_custom_metric(greater_is_better):
+    """Test custom metric constructor, integration _DynamicForecastingErrorMetric."""
+    y = load_airline()
+
+    def custom_mape(y_true , y_pred) -> float:
+
+        eps = np.finfo(np.float64).eps
+
+        result = np.mean(np.abs(y_true - y_pred) / np.maximum(np.abs(y_true), eps))
+
+        return float(result)
+
+    fc_scorer = make_forecasting_scorer(
+        func=custom_mape,
+        name="custom_mape",
+        greater_is_better=False,
+    )
+
+    assert isinstance(fc_scorer, _classes._DynamicForecastingErrorMetric)
+
+    score = fc_scorer(y, y)
+    assert isinstance(score, float)

--- a/sktime/performance_metrics/tests/test_metrics_classes.py
+++ b/sktime/performance_metrics/tests/test_metrics_classes.py
@@ -106,6 +106,8 @@ def test_metric_hierarchical(multioutput, multilevel, n_columns):
 @pytest.mark.parametrize("greater_is_better", [True, False])
 def test_custom_metric(greater_is_better):
     """Test custom metric constructor, integration _DynamicForecastingErrorMetric."""
+    from sktime.utils.estimator_checks import check_estimator
+
     y = load_airline()
 
     def custom_mape(y_true, y_pred) -> float:
@@ -126,3 +128,5 @@ def test_custom_metric(greater_is_better):
 
     score = fc_scorer(y, y)
     assert isinstance(score, float)
+
+    check_estimator(fc_scorer, return_exceptions=False)

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -4,6 +4,8 @@
 __author__ = ["fkiraly"]
 __all__ = ["check_estimator"]
 
+from inspect import isclass
+
 
 def check_estimator(
     estimator,
@@ -96,7 +98,14 @@ def check_estimator(
         fixtures_to_exclude=fixtures_to_exclude,
     )
 
-    if isinstance(estimator, BaseEstimator) or issubclass(estimator, BaseEstimator):
+    def is_estimator(obj):
+        """Return whether obj is an estimator class or estimator object."""
+        if isclass(obj):
+            return issubclass(obj, BaseEstimator)
+        else:
+            return isinstance(obj, BaseEstimator)
+
+    if is_estimator(estimator):
         results_estimator = TestAllEstimators().run_tests(
             estimator=estimator,
             return_exceptions=return_exceptions,


### PR DESCRIPTION
Fixes #3221.

There were two problems with the dynamic metric after refactoring:

* `lower_is_better` tag was only set if false
* `func` attribute was not properly written or invoked

Further bugs in the metrics base classes were discovered in the process of fixing:

* the `BaseForecastingMetric` did not call `super.__init__` in its `__init__`, breaking dynamic tag functionality
* the `BaseForecastingMetric` would overwrite `self.name` even if it was set by a child class already, leading to potential `sklearn` incompatibility (parameter get/set)

The bug was also not caught since the dynamic metric started with an underscore, so was not collected in tests.
This has been remedied by adding to tests:

* a version of the example in #3221
* the custom metric from #3221 as test parameters for the dynamic metric
* a full run of `check_estimator` on the resulting metric