### PR TITLE
[ENH] robustify `BaseObject.set_tags` against forgotten `__init__`

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -347,7 +347,11 @@ class BaseObject(_BaseEstimator):
         Changes object state by settting tag values in tag_dict as dynamic tags
         in self.
         """
-        self._tags_dynamic.update(deepcopy(tag_dict))
+        tag_update = deepcopy(tag_dict)
+        if hasattr(self, "_tags_dynamic"):
+            self._tags_dynamic.update(tag_update)
+        else:
+            self._tags_dynamic = tag_update
 
         return self
 


### PR DESCRIPTION
This PR robustifies `BaseObject.set_tags` against forgotten `__init__`, e.g., if a child object forgets to `super.__init__` (or intentionally does not call `super.__init__`).

Without this, an unexpected exception can occur if a developer implements a class that inherits from `BaseObject`, does not directly or indirectly call `BaseObject.__init__` before calling `set_tags`. Likely failure mode is a sub-base-class, as has previously happened in https://github.com/alan-turing-institute/sktime/pull/3225