### PR TITLE
functools-wrapper-in-make_mock_estimator

### DIFF
--- a/sktime/utils/estimators/_base.py
+++ b/sktime/utils/estimators/_base.py
@@ -5,6 +5,7 @@ __author__ = ["ltsaprounis"]
 
 import re
 from copy import deepcopy
+from functools import wraps
 from inspect import getcallargs, getfullargspec
 
 from sktime.base import BaseEstimator
@@ -40,6 +41,7 @@ class _MockEstimatorMixin:
 def _method_logger(method):
     """Log the method and it's arguments."""
 
+    @wraps(wrapped=method)
     def wrapper(self, *args, **kwargs):
         args_dict = getcallargs(method, self, *args, **kwargs)
         if not isinstance(self, _MockEstimatorMixin):


### PR DESCRIPTION
Added the `functools.wrap` decorator in `make_mock_estimator` to make sure that things like `help(mock_estimator.fit)` return the docstring of the mocked estimator and not something meaningless.