### PR TITLE
[BUG] fix stray args in one `from_multi_index_to_3d_numpy` call

### DIFF
--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -847,9 +847,7 @@ def from_nested_to_3d_numpy(X):
     # Then the multi-indexed DataFrame can be converted to 3d NumPy array
     else:
         X_mi = from_nested_to_multi_index(X)
-        X_3d = from_multi_index_to_3d_numpy(
-            X_mi, instance_index="instance", time_index="timepoints"
-        )
+        X_3d = from_multi_index_to_3d_numpy(X_mi)
 
     return X_3d
 


### PR DESCRIPTION
Removes stray args in `from_multi_index_to_3d_numpy` that remained after earlier removal of index name args, in a piece of code not covered by tests (apparently), but covered by new tests here: https://github.com/alan-turing-institute/sktime/issues/3169