### PR TITLE
[ENH] `**` dunder for applying transformers to exogeneous data in forecasters

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -147,7 +147,7 @@ class BaseForecaster(BaseEstimator):
             return NotImplemented
 
     def __rmul__(self, other):
-        """Magic * method, return (left) concatenated TransformerPipeline.
+        """Magic * method, return (left) concatenated TransformedTargetForecaster.
 
         Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
 
@@ -171,6 +171,37 @@ class BaseForecaster(BaseEstimator):
         #   the TransformedTargetForecaster does the rest, e.g., dispatch on other
         if isinstance(other, BaseTransformer):
             self_as_pipeline = TransformedTargetForecaster(steps=[self])
+            return other * self_as_pipeline
+        elif is_sklearn_transformer(other):
+            return TabularToSeriesAdaptor(other) * self
+        else:
+            return NotImplemented
+
+    def __rpow__(self, other):
+        """Magic ** method, return (left) concatenated ForecastingPipeline.
+
+        Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
+
+        Parameters
+        ----------
+        other: `sktime` transformer, must inherit from BaseTransformer
+            otherwise, `NotImplemented` is returned
+
+        Returns
+        -------
+        TransformedTargetForecaster object,
+            concatenation of `other` (first) with `self` (last).
+            not nested, contains only non-TransformerPipeline `sktime` steps
+        """
+        from sktime.forecasting.compose import ForecastingPipeline
+        from sktime.transformations.base import BaseTransformer
+        from sktime.transformations.series.adapt import TabularToSeriesAdaptor
+        from sktime.utils.sklearn import is_sklearn_transformer
+
+        # we wrap self in a pipeline, and concatenate with the other
+        #   the TransformedTargetForecaster does the rest, e.g., dispatch on other
+        if isinstance(other, BaseTransformer):
+            self_as_pipeline = ForecastingPipeline(steps=[self])
             return other * self_as_pipeline
         elif is_sklearn_transformer(other):
             return TabularToSeriesAdaptor(other) * self

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -199,12 +199,12 @@ class BaseForecaster(BaseEstimator):
         from sktime.utils.sklearn import is_sklearn_transformer
 
         # we wrap self in a pipeline, and concatenate with the other
-        #   the TransformedTargetForecaster does the rest, e.g., dispatch on other
+        #   the ForecastingPipeline does the rest, e.g., dispatch on other
         if isinstance(other, BaseTransformer):
             self_as_pipeline = ForecastingPipeline(steps=[self])
-            return other * self_as_pipeline
+            return other ** self_as_pipeline
         elif is_sklearn_transformer(other):
-            return TabularToSeriesAdaptor(other) * self
+            return TabularToSeriesAdaptor(other) ** self
         else:
             return NotImplemented
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -202,7 +202,7 @@ class BaseForecaster(BaseEstimator):
         #   the ForecastingPipeline does the rest, e.g., dispatch on other
         if isinstance(other, BaseTransformer):
             self_as_pipeline = ForecastingPipeline(steps=[self])
-            return other ** self_as_pipeline
+            return other**self_as_pipeline
         elif is_sklearn_transformer(other):
             return TabularToSeriesAdaptor(other) ** self
         else:

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -324,7 +324,7 @@ class ForecastingPipeline(_Pipeline):
         """Return reference to the forecaster in the pipeline. Valid after _fit."""
         return self.steps_[-1][1]
 
-    def __rmul__(self, other):
+    def __rpow__(self, other):
         """Magic ** method, return (left) concatenated ForecastingPipeline.
 
         Implemented for `other` being a transformer, otherwise returns `NotImplemented`.

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -269,7 +269,8 @@ class ForecastingPipeline(_Pipeline):
     >>> pipe = ForecastingPipeline(steps=[
     ...     ("imputer", Imputer(method="mean")),
     ...     ("minmaxscaler", TabularToSeriesAdaptor(MinMaxScaler())),
-    ...     ("forecaster", NaiveForecaster(strategy="drift"))]),
+    ...     ("forecaster", NaiveForecaster(strategy="drift")),
+    ... ])
     >>> pipe.fit(y_train, X_train)
     ForecastingPipeline(...)
     >>> y_pred = pipe.predict(fh=fh, X=X_test)

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -262,20 +262,36 @@ class ForecastingPipeline(_Pipeline):
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.forecasting.compose import ForecastingPipeline
     >>> from sktime.transformations.series.impute import Imputer
-    >>> from sktime.transformations.series.adapt import TabularToSeriesAdaptor
     >>> from sktime.forecasting.base import ForecastingHorizon
     >>> from sktime.forecasting.model_selection import temporal_train_test_split
     >>> from sklearn.preprocessing import MinMaxScaler
     >>> y, X = load_longley()
     >>> y_train, _, X_train, X_test = temporal_train_test_split(y, X)
     >>> fh = ForecastingHorizon(X_test.index, is_relative=False)
+
+        Example 1: string/estimator pairs
     >>> pipe = ForecastingPipeline(steps=[
     ...     ("imputer", Imputer(method="mean")),
-    ...     ("minmaxscaler", TabularToSeriesAdaptor(MinMaxScaler())),
-    ...     ("forecaster", NaiveForecaster(strategy="drift"))])
+    ...     ("minmaxscaler", MinMaxScaler()),
+    ...     ("forecaster", NaiveForecaster(strategy="drift"))]),
     >>> pipe.fit(y_train, X_train)
     ForecastingPipeline(...)
     >>> y_pred = pipe.predict(fh=fh, X=X_test)
+
+        Example 2: without strings
+    >>> pipe = ForecastingPipeline([
+    ...     Imputer(method="mean"),
+    ...     MinMaxScaler(),
+    ...     NaiveForecaster(strategy="drift"),
+    ... ])
+
+        Example 3: using the dunder method
+    >>> forecaster = NaiveForecaster(strategy="drift")
+    >>> imputer = Imputer(method="mean")
+    >>> pipe = (imputer * MinMaxScaler()) ** forecaster
+
+        Example 3b: using the dunder method, alternative
+    >>> pipe = imputer ** MinMaxScaler() ** forecaster
     """
 
     _tags = {
@@ -309,6 +325,49 @@ class ForecastingPipeline(_Pipeline):
     def forecaster_(self):
         """Return reference to the forecaster in the pipeline. Valid after _fit."""
         return self.steps_[-1][1]
+
+    def __rmul__(self, other):
+        """Magic ** method, return (left) concatenated ForecastingPipeline.
+
+        Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
+
+        Parameters
+        ----------
+        other: `sktime` transformer, must inherit from BaseTransformer
+            otherwise, `NotImplemented` is returned
+
+        Returns
+        -------
+        ForecastingPipeline object,
+            concatenation of `other` (first) with `self` (last).
+            not nested, contains only non-TransformerPipeline `sktime` steps
+        """
+        from sktime.transformations.base import BaseTransformer
+        from sktime.transformations.compose import TransformerPipeline
+
+        _, ests = zip(*self.steps_)
+        names = tuple(self._get_estimator_names(self.steps))
+        if isinstance(other, TransformerPipeline):
+            _, trafos_o = zip(*other.steps_)
+            names_o = tuple(other._get_estimator_names(other.steps))
+            new_names = names_o + names
+            new_ests = trafos_o + ests
+        elif isinstance(other, BaseTransformer):
+            new_names = (type(other).__name__,) + names
+            new_ests = (other,) + ests
+        elif self._is_name_and_est(other, BaseTransformer):
+            other_name = other[0]
+            other_trafo = other[1]
+            new_names = (other_name,) + names
+            new_ests = (other_trafo,) + ests
+        else:
+            return NotImplemented
+
+        # if all the names are equal to class names, we eat them away
+        if all(type(x[1]).__name__ == x[0] for x in zip(new_names, new_ests)):
+            return ForecastingPipeline(steps=list(new_ests))
+        else:
+            return ForecastingPipeline(steps=list(zip(new_names, new_ests)))
 
     def _fit(self, y, X=None, fh=None):
         """Fit to training data.

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -283,12 +283,13 @@ class ForecastingPipeline(_Pipeline):
     ... ])
 
         Example 3: using the dunder method
+        Note: * (= apply to `y`) has precedence over ** (= apply to `X`)
     >>> forecaster = NaiveForecaster(strategy="drift")
     >>> imputer = Imputer(method="mean")
-    >>> pipe = (imputer * TabularToSeriesAdaptor(MinMaxScaler())) ** forecaster
+    >>> pipe = (imputer * MinMaxScaler()) ** forecaster
 
         Example 3b: using the dunder method, alternative
-    >>> pipe = imputer ** TabularToSeriesAdaptor(MinMaxScaler()) ** forecaster
+    >>> pipe = imputer ** MinMaxScaler() ** forecaster
     """
 
     _tags = {

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -215,7 +215,6 @@ class _Pipeline(
         from sktime.forecasting.sarimax import SARIMAX
         from sktime.transformations.series.adapt import TabularToSeriesAdaptor
         from sktime.transformations.series.exponent import ExponentTransformer
-        from sktime.utils.validation._dependencies import _check_estimator_deps
 
         # StandardScaler does not skip fit, NaiveForecaster is not probabilistic
         STEPS1 = [

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -211,8 +211,8 @@ class _Pipeline(
         """
         from sklearn.preprocessing import StandardScaler
 
-        from sktime.forecasting.arima import ARIMA
         from sktime.forecasting.naive import NaiveForecaster
+        from sktime.forecasting.sarimax import SARIMAX
         from sktime.transformations.series.adapt import TabularToSeriesAdaptor
         from sktime.transformations.series.exponent import ExponentTransformer
         from sktime.utils.validation._dependencies import _check_estimator_deps
@@ -224,20 +224,16 @@ class _Pipeline(
         ]
         params1 = {"steps": STEPS1}
 
-        if _check_estimator_deps(ARIMA, severity="none"):
-            # ARIMA has probabilistic methods, ExponentTransformer skips fit
-            STEPS2 = [
-                ("transformer", ExponentTransformer()),
-                ("forecaster", ARIMA()),
-            ]
-            params2 = {"steps": STEPS2}
+        # ARIMA has probabilistic methods, ExponentTransformer skips fit
+        STEPS2 = [
+            ("transformer", ExponentTransformer()),
+            ("forecaster", SARIMAX()),
+        ]
+        params2 = {"steps": STEPS2}
 
-            params3 = {"steps": [ExponentTransformer(), ARIMA()]}
+        params3 = {"steps": [ExponentTransformer(), SARIMAX()]}
 
-            return [params1, params2, params3]
-
-        else:
-            return params1
+        return [params1, params2, params3]
 
 
 # we ensure that internally we convert to pd.DataFrame for now

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -256,6 +256,7 @@ class ForecastingPipeline(_Pipeline):
     >>> from sktime.datasets import load_longley
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.forecasting.compose import ForecastingPipeline
+    >>> from sktime.transformations.series.adapt import TabularToSeriesAdaptor
     >>> from sktime.transformations.series.impute import Imputer
     >>> from sktime.forecasting.base import ForecastingHorizon
     >>> from sktime.forecasting.model_selection import temporal_train_test_split
@@ -267,7 +268,7 @@ class ForecastingPipeline(_Pipeline):
         Example 1: string/estimator pairs
     >>> pipe = ForecastingPipeline(steps=[
     ...     ("imputer", Imputer(method="mean")),
-    ...     ("minmaxscaler", MinMaxScaler()),
+    ...     ("minmaxscaler", TabularToSeriesAdaptor(MinMaxScaler())),
     ...     ("forecaster", NaiveForecaster(strategy="drift"))]),
     >>> pipe.fit(y_train, X_train)
     ForecastingPipeline(...)
@@ -276,17 +277,17 @@ class ForecastingPipeline(_Pipeline):
         Example 2: without strings
     >>> pipe = ForecastingPipeline([
     ...     Imputer(method="mean"),
-    ...     MinMaxScaler(),
+    ...     TabularToSeriesAdaptor(MinMaxScaler()),
     ...     NaiveForecaster(strategy="drift"),
     ... ])
 
         Example 3: using the dunder method
     >>> forecaster = NaiveForecaster(strategy="drift")
     >>> imputer = Imputer(method="mean")
-    >>> pipe = (imputer * MinMaxScaler()) ** forecaster
+    >>> pipe = (imputer * TabularToSeriesAdaptor(MinMaxScaler())) ** forecaster
 
         Example 3b: using the dunder method, alternative
-    >>> pipe = imputer ** MinMaxScaler() ** forecaster
+    >>> pipe = imputer ** TabularToSeriesAdaptor(MinMaxScaler()) ** forecaster
     """
 
     _tags = {

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -187,6 +187,11 @@ def test_forecasting_pipeline_dunder_endog():
 
     forecaster = ExponentTransformer() * MinMaxScaler() * NaiveForecaster()
 
+    assert isinstance(forecaster, TransformedTargetForecaster)
+    assert isinstance(forecaster.steps[0], ExponentTransformer)
+    assert isinstance(forecaster.steps[1], TabularToSeriesAdaptor)
+    assert isinstance(forecaster.steps[2], NaiveForecaster)
+
     fh = np.arange(len(y_test)) + 1
     forecaster.fit(y_train, fh=fh)
     actual = forecaster.predict()
@@ -220,6 +225,15 @@ def test_forecasting_pipeline_dunder_exog():
 
     forecaster = ExponentTransformer() ** MinMaxScaler() ** SARIMAX(random_state=3)
     forecaster_alt = (ExponentTransformer() * MinMaxScaler()) ** SARIMAX(random_state=3)
+
+    assert isinstance(forecaster, ForecastingPipeline)
+    assert isinstance(forecaster.steps[0], ExponentTransformer)
+    assert isinstance(forecaster.steps[1], TabularToSeriesAdaptor)
+    assert isinstance(forecaster.steps[2], SARIMAX)
+    assert isinstance(forecaster_alt, ForecastingPipeline)
+    assert isinstance(forecaster_alt.steps[0], ExponentTransformer)
+    assert isinstance(forecaster_alt.steps[1], TabularToSeriesAdaptor)
+    assert isinstance(forecaster_alt.steps[2], SARIMAX)
 
     fh = np.arange(len(y_test)) + 1
     forecaster.fit(y_train, fh=fh, X=X_train)

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -218,9 +218,8 @@ def test_forecasting_pipeline_dunder_exog():
     X = _make_series(n_columns=2)
     X_train, X_test = temporal_train_test_split(X)
 
-    scaler = TabularToSeriesAdaptor(MinMaxScaler())
-    forecaster = ExponentTransformer() ** scaler ** SARIMAX(random_state=42)
-    forecaster_alt = (ExponentTransformer() * scaler) ** SARIMAX(random_state=42)
+    forecaster = ExponentTransformer() ** MinMaxScaler() ** SARIMAX(random_state=3)
+    forecaster_alt = (ExponentTransformer() * MinMaxScaler()) ** SARIMAX(random_state=3)
 
     fh = np.arange(len(y_test)) + 1
     forecaster.fit(y_train, fh=fh, X=X_train)
@@ -237,7 +236,7 @@ def test_forecasting_pipeline_dunder_exog():
         Xt = t1.fit_transform(Xt)
         t2 = TabularToSeriesAdaptor(MinMaxScaler())
         Xt = t2.fit_transform(Xt)
-        forecaster = SARIMAX(random_state=42)
+        forecaster = SARIMAX(random_state=3)
         forecaster.fit(yt, fh=fh, X=Xt)
 
         # predicting
@@ -248,5 +247,5 @@ def test_forecasting_pipeline_dunder_exog():
         return y_pred
 
     expected = compute_expected_y_pred(y_train, X_train, X_test, fh)
-    _assert_array_almost_equal(actual, expected)
-    _assert_array_almost_equal(actual_alt, expected)
+    _assert_array_almost_equal(actual, expected, decimal=2)
+    _assert_array_almost_equal(actual_alt, expected, decimal=2)

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -211,7 +211,7 @@ def test_forecasting_pipeline_dunder_endog():
     np.testing.assert_array_equal(actual, expected)
 
 
-def test_forecasting_pipeline_dunder_exSog():
+def test_forecasting_pipeline_dunder_exog():
     """Test forecasting pipeline dunder for exogeneous transformation."""
     y = _make_series()
     y_train, y_test = temporal_train_test_split(y)

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -8,16 +8,15 @@ __all__ = []
 
 import numpy as np
 import pandas as pd
-import pytest
 from sklearn.preprocessing import MinMaxScaler
 
 from sktime.datasets import load_airline
 from sktime.datatypes import get_examples
 from sktime.datatypes._utilities import get_window
-from sktime.forecasting.arima import ARIMA
 from sktime.forecasting.compose import ForecastingPipeline, TransformedTargetForecaster
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.forecasting.naive import NaiveForecaster
+from sktime.forecasting.sarimax import SARIMAX
 from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.transformations.series.adapt import TabularToSeriesAdaptor
@@ -25,7 +24,7 @@ from sktime.transformations.series.detrend import Detrender
 from sktime.transformations.series.exponent import ExponentTransformer
 from sktime.transformations.series.impute import Imputer
 from sktime.transformations.series.outlier_detection import HampelFilter
-from sktime.utils.validation._dependencies import _check_estimator_deps
+from sktime.utils._testing.series import _make_series
 
 
 def test_pipeline():
@@ -130,10 +129,6 @@ def test_pipeline_with_detrender():
     trans_fc.predict(1)
 
 
-@pytest.mark.skipif(
-    not _check_estimator_deps(ARIMA, severity="none"),
-    reason="skip test if required soft dependencies not available",
-)
 def test_nested_pipeline_with_index_creation_y_before_X():
     """Tests a nested pipeline where y indices are created before X indices.
 
@@ -148,7 +143,7 @@ def test_nested_pipeline_with_index_creation_y_before_X():
     X_test = get_window(X, window_length=1)
 
     # Aggregator creates indices for y (via *), then for X (via ForecastingPipeline)
-    f = Aggregator() * ForecastingPipeline([Aggregator(), ARIMA()])
+    f = Aggregator() * ForecastingPipeline([Aggregator(), SARIMAX()])
 
     f.fit(y=y_train, X=X_train, fh=1)
     y_pred = f.predict(X=X_test)
@@ -159,10 +154,6 @@ def test_nested_pipeline_with_index_creation_y_before_X():
     assert len(y_pred) == 9
 
 
-@pytest.mark.skipif(
-    not _check_estimator_deps(ARIMA, severity="none"),
-    reason="skip test if required soft dependencies not available",
-)
 def test_nested_pipeline_with_index_creation_X_before_y():
     """Tests a nested pipeline where X indices are created before y indices.
 
@@ -177,7 +168,7 @@ def test_nested_pipeline_with_index_creation_X_before_y():
     X_test = get_window(X, window_length=1)
 
     # Aggregator creates indices for X (via ForecastingPipeline), then for y (via *)
-    f = ForecastingPipeline([Aggregator(), Aggregator() * ARIMA()])
+    f = ForecastingPipeline([Aggregator(), Aggregator() * SARIMAX()])
 
     f.fit(y=y_train, X=X_train, fh=1)
     y_pred = f.predict(X=X_test)
@@ -186,3 +177,71 @@ def test_nested_pipeline_with_index_creation_X_before_y():
     assert isinstance(y_pred, pd.DataFrame)
     assert isinstance(y_pred.index, pd.MultiIndex)
     assert len(y_pred) == 9
+
+
+def test_forecasting_pipeline_dunder_endog():
+    """Test forecasting pipeline dunder for endogeneous transformation."""
+    y = load_airline()
+    y_train, y_test = temporal_train_test_split(y)
+
+    forecaster = ExponentTransformer() * MinMaxScaler() * NaiveForecaster()
+
+    fh = np.arange(len(y_test)) + 1
+    forecaster.fit(y_train, fh=fh)
+    actual = forecaster.predict()
+
+    def compute_expected_y_pred(y_train, fh):
+        # fitting
+        yt = y_train.copy()
+        t1 = ExponentTransformer()
+        yt = t1.fit_transform(yt)
+        t2 = TabularToSeriesAdaptor(MinMaxScaler())
+        yt = t2.fit_transform(yt)
+        forecaster = NaiveForecaster()
+        forecaster.fit(yt, fh=fh)
+
+        # predicting
+        y_pred = forecaster.predict()
+        y_pred = t2.inverse_transform(y_pred)
+        y_pred = t1.inverse_transform(y_pred)
+        return y_pred
+
+    expected = compute_expected_y_pred(y_train, fh)
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_forecasting_pipeline_dunder_exSog():
+    """Test forecasting pipeline dunder for exogeneous transformation."""
+    y = _make_series()
+    y_train, y_test = temporal_train_test_split(y)
+    X = _make_series(n_columns=2)
+    X_train, X_test = temporal_train_test_split(X)
+
+    forecaster = ExponentTransformer() ** MinMaxScaler() ** SARIMAX()
+    forecaster_alt = (ExponentTransformer() * MinMaxScaler()) ** SARIMAX()
+
+    fh = np.arange(len(y_test)) + 1
+    forecaster.fit(y_train, fh=fh, X=X_train)
+    actual = forecaster.predict(X=X_test)
+
+    forecaster_alt.fit(y_train, fh=fh, X=X_train)
+    actual_alt = forecaster_alt.predict(X=X_test)
+
+    def compute_expected_y_pred(y_train, X_train, X_test, fh):
+        # fitting
+        yt = y_train.copy()
+        Xt = X_train.copy()
+        t1 = ExponentTransformer()
+        Xt = t1.fit_transform(Xt)
+        t2 = TabularToSeriesAdaptor(MinMaxScaler())
+        Xt = t2.fit_transform(Xt)
+        forecaster = SARIMAX()
+        forecaster.fit(yt, fh=fh, X=Xt)
+
+        # predicting
+        y_pred = forecaster.predict(X=X_test)
+        return y_pred
+
+    expected = compute_expected_y_pred(y_train, X_train, X_test, fh)
+    np.testing.assert_array_equal(actual, expected)
+    np.testing.assert_array_equal(actual_alt, expected)

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -184,7 +184,8 @@ def test_forecasting_pipeline_dunder_endog():
     y = load_airline()
     y_train, y_test = temporal_train_test_split(y)
 
-    forecaster = ExponentTransformer() * MinMaxScaler() * NaiveForecaster()
+    scaler = TabularToSeriesAdaptor(MinMaxScaler())
+    forecaster = ExponentTransformer() * scaler * NaiveForecaster()
 
     fh = np.arange(len(y_test)) + 1
     forecaster.fit(y_train, fh=fh)
@@ -217,8 +218,9 @@ def test_forecasting_pipeline_dunder_exSog():
     X = _make_series(n_columns=2)
     X_train, X_test = temporal_train_test_split(X)
 
-    forecaster = ExponentTransformer() ** MinMaxScaler() ** SARIMAX()
-    forecaster_alt = (ExponentTransformer() * MinMaxScaler()) ** SARIMAX()
+    scaler = TabularToSeriesAdaptor(MinMaxScaler())
+    forecaster = ExponentTransformer() ** scaler ** SARIMAX()
+    forecaster_alt = (ExponentTransformer() * scaler) ** SARIMAX()
 
     fh = np.arange(len(y_test)) + 1
     forecaster.fit(y_train, fh=fh, X=X_train)


### PR DESCRIPTION
This PR adds a shorthand `**` dunder to apply transformers to exogeneous data in forecasters.
Under the hood, a `ForecastingPipeline` is constructed.

This complements the existing dunders `*`, `+`, and `[ ]`, allowing quick construction of the most common linear forecasting pipelines.

In addition, this PR:

* adds dedicated tests for the forecasting pipeline dunders
* removes `pmdarima` dependency from a number of pipeline tests by replacing `ARIMA` with `SARIMAX` (from core dependency `statsmodels`)
* fixes some docstring typos