### PR TITLE
& achieveordie [BUG] fix recurring instances of forgotten list comprehension brackets inside `np.all`

### DIFF
--- a/sktime/datatypes/_convert.py
+++ b/sktime/datatypes/_convert.py
@@ -306,7 +306,7 @@ def _conversions_defined(scitype: str):
 def _check_str_or_list_of_str(obj, obj_name="obj"):
     """Check whether obj is str or list of str; coerces to list of str."""
     if isinstance(obj, list):
-        if not np.all(isinstance(x, str) for x in obj):
+        if not np.all([isinstance(x, str) for x in obj]):
             raise TypeError(f"{obj} must be a str or list of str")
         else:
             return obj

--- a/sktime/datatypes/_table/_check.py
+++ b/sktime/datatypes/_table/_check.py
@@ -174,7 +174,7 @@ def check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
         msg = f"{var_name} must be a list of dict, found {type(obj)}"
         return _ret(False, msg, None, return_metadata)
 
-    if not np.all(isinstance(x, dict) for x in obj):
+    if not np.all([isinstance(x, dict) for x in obj]):
         msg = (
             f"{var_name} must be a list of dict, but elements at following "
             f"indices are not dict: {np.where(not isinstance(x, dict) for x in obj)}"

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -590,7 +590,7 @@ class QuickTester:
                 obj = [obj]
             if not isinstance(obj, list):
                 raise ValueError(msg)
-            if not np.all(isinstance(x, str) for x in obj):
+            if not np.all([isinstance(x, str) for x in obj]):
                 raise ValueError(msg)
         return obj
 
@@ -695,12 +695,12 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             f"found {type(names)}"
         )
 
-        assert np.all(isinstance(est, estimator_class) for est in estimators), (
+        assert np.all([isinstance(est, estimator_class) for est in estimators]), (
             "list elements of first return returned by create_test_instances_and_names "
             "all must be an instance of the class"
         )
 
-        assert np.all(isinstance(name, names) for name in names), (
+        assert np.all([isinstance(name, names) for name in names]), (
             "list elements of second return returned by create_test_instances_and_names"
             " all must be strings"
         )

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -700,7 +700,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             "all must be an instance of the class"
         )
 
-        assert np.all([isinstance(name, names) for name in names]), (
+        assert np.all([isinstance(name, str) for name in names]), (
             "list elements of second return returned by create_test_instances_and_names"
             " all must be strings"
         )

--- a/sktime/utils/_testing/_conditional_fixtures.py
+++ b/sktime/utils/_testing/_conditional_fixtures.py
@@ -226,7 +226,7 @@ def _check_list_of_str(obj, name="obj"):
     ------
     TypeError if obj is not list of str
     """
-    if not isinstance(obj, list) or not np.all(isinstance(x, str) for x in obj):
+    if not isinstance(obj, list) or not np.all([isinstance(x, str) for x in obj]):
         raise TypeError(f"{name} must be a list of str")
     return obj
 

--- a/sktime/utils/_testing/scenarios.py
+++ b/sktime/utils/_testing/scenarios.py
@@ -242,7 +242,7 @@ def _check_list_of_str(obj, name="obj"):
     ------
     TypeError if obj is not list of str
     """
-    if not isinstance(obj, list) or not np.all(isinstance(x, str) for x in obj):
+    if not isinstance(obj, list) or not np.all([isinstance(x, str) for x in obj]):
         raise TypeError(f"{obj} must be a list of str")
     return obj
 
@@ -266,8 +266,8 @@ def _check_dict_of_dict(obj, name="obj"):
     msg = f"{obj} must be a dict of dict, with str keys"
     if not isinstance(obj, dict):
         raise TypeError(msg)
-    if not np.all(isinstance(x, dict) for x in obj.values()):
+    if not np.all([isinstance(x, dict) for x in obj.values()]):
         raise TypeError(msg)
-    if not np.all(isinstance(x, str) for x in obj.keys()):
+    if not np.all([isinstance(x, str) for x in obj.keys()]):
         raise TypeError(msg)
     return obj


### PR DESCRIPTION
This fixes recurring instances of the issue identified by @achieveordie, where instead of a condition

`np.all([sth for sth in sthelse])`

a condition

`np.all(sth for sth in sthelse)`

would be carried out. The latter is more often true, and the condition was used in checks, making the checks weaker (and erroneous) in consequence, letting wrong input pass instead of catching it.

This was also not caught in tests, as it would require to pass very specific failure cases (lists with first element complying, but not all elements complying).

This PR fixes all occurrences of the bug that a code base search for `np.all(isinstance` found.
An exhaustive search for `np.all(` did not find more of this (list comprehension with forgotten brackets).
