### PR TITLE
[ENH] treat non nested cols in conversion `nested_univ` to `pd-multiindex`

### DIFF
--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -794,7 +794,7 @@ def from_nested_to_multi_index(X, instance_index=None, time_index=None):
     for c in non_nested_cols:
         for ix in X.index:
             X_mi.loc[ix, c] = X[[c]].loc[ix].iloc[0]
-        X_mi[[c]] = X_mi[[c]].astype(X[[c]].dtypes[0])
+        X_mi[[c]] = X_mi[[c]].convert_dtypes()
 
     return X_mi
 


### PR DESCRIPTION
This PR extends the converter `nested_univ` to `pd-multiindex` to allow it to deal with non-nested columns.

See discussion in https://github.com/alan-turing-institute/sktime/issues/3169

Bit clunky (double loop), but I currently have no better idea, and there is no compute overhead if all the columns are nested.