### PR TITLE
[BUG] Fix tag in DirectReductionForecaster

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1315,6 +1315,7 @@ class DirectReductionForecaster(BaseForecaster):
 
     _tags = {
         "requires-fh-in-fit": True,  # is the forecasting horizon required in fit?
+        "ignores-exogeneous-X": False,
         "X_inner_mtype": "pd.DataFrame",
         "y_inner_mtype": "pd.DataFrame",
     }


### PR DESCRIPTION
`DirectReductionForecaster` is meant to allow for exogenous variables. However, because it inherits from `BaseForecaster` the default tag for exogenous variables was: ` "ignores-exogeneous-X": True`. This meant that any instance of `DirectReductionForecaster` was ignoring any exogenous variables passed to it during training and prediction. This PR fixes the tag so that `DirectReductionForecaster` uses `X`. 