### PR TITLE
[ENH] set default `ignores-exogeneous-X` to `False`

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -88,7 +88,7 @@ class BaseForecaster(BaseEstimator):
     # default tag values - these typically make the "safest" assumption
     _tags = {
         "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
-        "ignores-exogeneous-X": True,  # does estimator ignore the exogeneous X?
+        "ignores-exogeneous-X": False,  # does estimator ignore the exogeneous X?
         "capability:pred_int": False,  # can the estimator produce prediction intervals?
         "handles-missing-data": False,  # can estimator handle missing data?
         "y_inner_mtype": "pd.Series",  # which types do _fit/_predict, support for y?


### PR DESCRIPTION
This PR sets the default for the forecaster tag `ignores-exogeneous-X` to `False`.

This is the safer default, or otherwise exogeneous `X` will be inored under the default setting, and this might be accidental and unexpected for an implementer.

See bug here:
https://github.com/alan-turing-institute/sktime/pull/3257