### PR TITLE
[ENH] in `Lag`, make column naming consistent between single-lag and multi-lag case

### DIFF
--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -260,14 +260,9 @@ class Lag(BaseTransformer):
             Xt_list.append(Xt)
 
         lag_names = self._yield_shift_param_names()
-        if len(Xt_list) == 1:
-            Xt = Xt_list[0]
-            lag_name = next(lag_names, None)
-            Xt = Xt.add_prefix(lag_name + "__")
-        else:
-            Xt = pd.concat(Xt_list, axis=1, keys=lag_names, names=["lag", "variable"])
-            if self.flatten_transform_index:
-                Xt.columns = flatten_multiindex(Xt.columns)
+        Xt = pd.concat(Xt_list, axis=1, keys=lag_names, names=["lag", "variable"])
+        if self.flatten_transform_index:
+            Xt.columns = flatten_multiindex(Xt.columns)
 
         # some pandas versions do not sort index automatically after concat
         # so removing will break specific pandas versions

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -259,10 +259,12 @@ class Lag(BaseTransformer):
 
             Xt_list.append(Xt)
 
+        lag_names = self._yield_shift_param_names()
         if len(Xt_list) == 1:
             Xt = Xt_list[0]
+            lag_name = next(lag_names, None)
+            Xt = Xt.add_prefix(lag_name + "__")
         else:
-            lag_names = self._yield_shift_param_names()
             Xt = pd.concat(Xt_list, axis=1, keys=lag_names, names=["lag", "variable"])
             if self.flatten_transform_index:
                 Xt.columns = flatten_multiindex(Xt.columns)

--- a/sktime/transformations/series/tests/test_featureizer.py
+++ b/sktime/transformations/series/tests/test_featureizer.py
@@ -28,4 +28,4 @@ def test_featurized_values():
     exp_transformer = ExponentTransformer()
     expected_len = lags + len(y_test)
     y_hat = exp_transformer.fit_transform(y[-expected_len:])
-    assert_array_equal(X_hat["TOTEMP"].values, y_hat.values)
+    assert_array_equal(X_hat[f"lag_{lags}__TOTEMP"].values, y_hat.values)

--- a/sktime/transformations/series/tests/test_lag.py
+++ b/sktime/transformations/series/tests/test_lag.py
@@ -4,6 +4,8 @@
 
 __author__ = ["fkiraly"]
 
+import itertools
+
 import pandas as pd
 import pytest
 
@@ -63,3 +65,31 @@ def test_lag_fit_transform_columns(X, index_out, lag):
             return 1
 
     assert ncols(Xt) == ncols(X) * len_lag
+
+
+@pytest.mark.parametrize("X", X_fixtures)
+@pytest.mark.parametrize("index_out", index_outs)
+@pytest.mark.parametrize("lags", [2, [2, 4]])
+def test_lag_fit_transform_column_names(X, index_out, lags):
+    """Test expected column names."""
+    t = Lag(lags=lags, index_out=index_out)
+    Xt = t.fit_transform(X)
+
+    if isinstance(Xt, pd.DataFrame):
+        lag_col_names = set(Xt.columns)
+
+        if isinstance(X, pd.DataFrame):
+            col_names = X.columns
+        elif isinstance(X, pd.Series):
+            col_names = [X.name if X.name else 0]
+        else:
+            pass
+
+        lags = [lags] if isinstance(lags, int) else lags
+        expected = {
+            f"lag_{lag}__{col}" for lag, col in itertools.product(lags, col_names)
+        }
+        assert lag_col_names == expected
+
+    elif isinstance(Xt, pd.Series):
+        assert Xt.name is None


### PR DESCRIPTION
Problem:
`Lag` outputs column names prefixed with "lag_x__" when using multiple lags. If a single lag is specified then the output column name is the same as the original column name (if the input is a `pd.DataFrame` rather than a `pd.Series`) without "lag_x__" prefixed to the original column name. It would be desirable for the output column names to be consistent, irrespective if a single lag or multiple lags is specified.

Fix implemented:
`Lag` now outputs the same column name irrespective of whether a single lag or multiple lags is specified.