### PR TITLE
[BUG] fixed concat dunder for `ParamFitterPipeline`

### DIFF
--- a/sktime/param_est/compose.py
+++ b/sktime/param_est/compose.py
@@ -150,9 +150,9 @@ class ParamFitterPipeline(BaseParamFitter, _HeterogenousMetaEstimator):
         if isinstance(other, BaseTransformer):
             # use the transformers dunder to get a TransformerPipeline
             trafo_pipeline = other * self.transformers_
-            # then stick the expanded pipeline in a ClassifierPipeline
+            # then stick the expanded pipeline in a ParamFitterPipeline
             new_pipeline = ParamFitterPipeline(
-                classifier=self.classifier,
+                param_est=self.param_est,
                 transformers=trafo_pipeline.steps,
             )
             return new_pipeline

--- a/sktime/param_est/compose.py
+++ b/sktime/param_est/compose.py
@@ -45,7 +45,7 @@ class ParamFitterPipeline(BaseParamFitter, _HeterogenousMetaEstimator):
             and `my_trafo1`, `my_trafo2` inherit from `BaseTransformer`, then,
             for instance, `my_trafo1 * my_trafo2 * est`
             will result in the same object as  obtained from the constructor
-            `ParamFitterPipeline(classifier=est, transformers=[my_trafo1, my_trafo2])`
+            `ParamFitterPipeline(param_est=est, transformers=[my_trafo1, my_trafo2])`
         magic multiplication can also be used with (str, transformer) pairs,
             as long as one element in the chain is a transformer
 
@@ -105,12 +105,12 @@ class ParamFitterPipeline(BaseParamFitter, _HeterogenousMetaEstimator):
 
         super(ParamFitterPipeline, self).__init__()
 
-        # can handle multivariate iff: both classifier and all transformers can
+        # can handle multivariate iff: both estimator and all transformers can
         multivariate = param_est.get_tag("capability:multivariate", False)
         multivariate = multivariate and not self.transformers_.get_tag(
             "univariate-only", True
         )
-        # can handle missing values iff: both classifier and all transformers can,
+        # can handle missing values iff: both estimator and all transformers can,
         #   *or* transformer chain removes missing data
         missing = param_est.get_tag("capability:missing_values", False)
         missing = missing and self.transformers_.get_tag("handles-missing-data", False)
@@ -272,10 +272,6 @@ class ParamFitterPipeline(BaseParamFitter, _HeterogenousMetaEstimator):
         parameter_set : str, default="default"
             Name of the set of test parameters to return, for use in tests. If no
             special parameters are defined for a value, will return `"default"` set.
-            For classifiers, a "default" set of parameters should be provided for
-            general testing, and a "results_comparison" set for comparing against
-            previously recorded results if the general set does not produce suitable
-            probabilities to compare against.
 
         Returns
         -------

--- a/sktime/param_est/compose.py
+++ b/sktime/param_est/compose.py
@@ -25,11 +25,11 @@ class ParamFitterPipeline(BaseParamFitter, _HeterogenousMetaEstimator):
 
     For a list of transformers `trafo1`, `trafo2`, ..., `trafoN` and an estimator `est`,
         the pipeline behaves as follows:
-    `fit(X)` - changes styte by running `trafo1.fit_transform` on `X`,
+    `fit(X)` - changes state by running `trafo1.fit_transform` on `X`,
         them `trafo2.fit_transform` on the output of `trafo1.fit_transform`, etc
         sequentially, with `trafo[i]` receiving the output of `trafo[i-1]`,
         and then running `est.fit` with `X` being the output of `trafo[N]`
-    `update(X)` - changes styte by running `trafo1.update.transform` on `X`,
+    `update(X)` - changes state by running `trafo1.update.transform` on `X`,
         them `trafo2.update.transform` on the output of `trafo1.update.transform`, etc
         sequentially, with `trafo[i]` receiving the output of `trafo[i-1]`,
         and then running `est.update` with `X` being the output of `trafo[N]`
@@ -250,7 +250,7 @@ class ParamFitterPipeline(BaseParamFitter, _HeterogenousMetaEstimator):
         -------
         self : returns an instance of self.
         """
-        if "classifier" in kwargs.keys():
+        if "param_est" in kwargs.keys():
             if not isinstance(kwargs["param_est"], BaseParamFitter):
                 raise TypeError('"param_est" arg must be an sktime parameter fitter')
         trafo_keys = self._get_params("_transformers", deep=True).keys()


### PR DESCRIPTION
This fixes the concatenation dunder `*` for the `ParamFitterPipeline`, when concatenated with another transformer.

Also fixes some docstring issues due to copy-paste from classifier pipeline.