### PR TITLE
[ENH] test for transformer `update`

### DIFF
--- a/sktime/transformations/tests/test_all_transformers.py
+++ b/sktime/transformations/tests/test_all_transformers.py
@@ -5,6 +5,7 @@
 __author__ = ["mloning", "fkiraly"]
 __all__ = []
 
+from sktime.datasets import load_airline
 from sktime.datatypes import check_is_scitype
 from sktime.tests.test_all_estimators import BaseFixtureGenerator, QuickTester
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
@@ -157,6 +158,18 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
         else:
             _assert_array_almost_equal(X.loc[Xit.index], Xit)
 
+    def test_update(self, estimator_instance):
+        """Test transformer update functionality."""
+        y = load_airline()
+        y_fit = y[0:36]
+        y_update1 = y[36:48]
+        y_update2 = y[48:60]
+
+        estimator_instance.fit(y_fit)
+        estimator_instance.update(y_update1, update_params=True)
+        estimator_instance.transform(y_update1)
+        estimator_instance.update(y_update2, update_params=False)
+        estimator_instance.transform(y_update2)
 
 # todo: add testing of inverse_transform
 # todo: refactor the below, equivalent index check


### PR DESCRIPTION
The tests for transformers did not cover the `update` functionality, leaving potential bugs such as https://github.com/alan-turing-institute/sktime/issues/3267 uncovered.

This PR adds a test for `update` of transformers.

It should pick up bug #3267.
