### PR TITLE
[ENH] deprecate `transformations.series.compose` in favour of `transformations.compose`

### DIFF
--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -20,7 +20,7 @@ from sktime.utils.sklearn import (
     is_sklearn_transformer,
 )
 
-__author__ = ["fkiraly", "mloning", "miraep8"]
+__author__ = ["fkiraly", "mloning", "miraep8", "aiwalter", "SveaMeyer13"]
 __all__ = [
     "ColumnwiseTransformer",
     "FeatureUnion",

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -8,6 +8,11 @@ from sklearn import clone
 from sktime.base import _HeterogenousMetaEstimator
 from sktime.transformations._delegate import _DelegatedTransformer
 from sktime.transformations.base import BaseTransformer
+from sktime.transformations.series.compose import (
+    ColumnwiseTransformer,
+    OptionalPassthrough,
+    YtoX,
+)
 from sktime.utils.multiindex import flatten_multiindex
 from sktime.utils.sklearn import (
     is_sklearn_classifier,
@@ -17,11 +22,28 @@ from sktime.utils.sklearn import (
 
 __author__ = ["fkiraly", "mloning", "miraep8"]
 __all__ = [
-    "TransformerPipeline",
+    "ColumnwiseTransformer",
     "FeatureUnion",
     "FitInTransform",
     "MultiplexTransformer",
+    "OptionalPassthrough",
+    "TransformerPipeline",
+    "YtoX",
 ]
+
+
+# mtypes for Series, Panel, Hierarchical,
+# with exception of some ambiguous and discouraged mtypes
+CORE_MTYPES = [
+            "pd.DataFrame",
+            "np.ndarray",
+            "pd.Series",
+            "pd-multiindex",
+            "df-list",
+            "nested_univ",
+            "numpy3D",
+            "pd_multiindex_hier",
+        ]
 
 
 def _coerce_to_sktime(other):
@@ -128,16 +150,7 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
 
     _tags = {
         # we let all X inputs through to be handled by first transformer
-        "X_inner_mtype": [
-            "pd.DataFrame",
-            "np.ndarray",
-            "pd.Series",
-            "pd-multiindex",
-            "df-list",
-            "nested_univ",
-            "numpy3D",
-            "pd_multiindex_hier",
-        ],
+        "X_inner_mtype": CORE_MTYPES,
         "univariate-only": False,
     }
 

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -35,15 +35,15 @@ __all__ = [
 # mtypes for Series, Panel, Hierarchical,
 # with exception of some ambiguous and discouraged mtypes
 CORE_MTYPES = [
-            "pd.DataFrame",
-            "np.ndarray",
-            "pd.Series",
-            "pd-multiindex",
-            "df-list",
-            "nested_univ",
-            "numpy3D",
-            "pd_multiindex_hier",
-        ]
+    "pd.DataFrame",
+    "np.ndarray",
+    "pd.Series",
+    "pd-multiindex",
+    "df-list",
+    "nested_univ",
+    "numpy3D",
+    "pd_multiindex_hier",
+]
 
 
 def _coerce_to_sktime(other):

--- a/sktime/transformations/series/compose.py
+++ b/sktime/transformations/series/compose.py
@@ -6,11 +6,35 @@
 __author__ = ["aiwalter", "SveaMeyer13", "fkiraly"]
 __all__ = ["OptionalPassthrough", "ColumnwiseTransformer", "YtoX"]
 
+from warnings import warn
+
 import pandas as pd
 from sklearn.utils.metaestimators import if_delegate_has_method
 
 from sktime.transformations.base import BaseTransformer
 from sktime.utils.validation.series import check_series
+
+
+warn(
+    "transformations.series.compose is deprecated and will be removed in"
+    " version 0.15.0. All estimators in it will be moved to transformations.compose. "
+    "Please change imports to transformations.compose to avoid breakage.",
+    DeprecationWarning,
+)
+
+
+# mtypes for Series, Panel, Hierarchical,
+# with exception of some ambiguous and discouraged mtypes
+CORE_MTYPES = [
+            "pd.DataFrame",
+            "np.ndarray",
+            "pd.Series",
+            "pd-multiindex",
+            "df-list",
+            "nested_univ",
+            "numpy3D",
+            "pd_multiindex_hier",
+        ]
 
 
 class OptionalPassthrough(BaseTransformer):
@@ -73,7 +97,7 @@ class OptionalPassthrough(BaseTransformer):
         "scitype:transform-output": "Series",
         # what scitype is returned: Primitives, Series, Panel
         "scitype:instancewise": True,  # is this an instance-wise transform?
-        "X_inner_mtype": ["pd.DataFrame", "pd.Series"],
+        "X_inner_mtype": ALL_MTYPES,
         # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
         "univariate-only": False,

--- a/sktime/transformations/series/compose.py
+++ b/sktime/transformations/series/compose.py
@@ -96,7 +96,7 @@ class OptionalPassthrough(BaseTransformer):
         "scitype:transform-output": "Series",
         # what scitype is returned: Primitives, Series, Panel
         "scitype:instancewise": True,  # is this an instance-wise transform?
-        "X_inner_mtype": ALL_MTYPES,
+        "X_inner_mtype": CORE_MTYPES,
         # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
         "univariate-only": False,

--- a/sktime/transformations/series/compose.py
+++ b/sktime/transformations/series/compose.py
@@ -14,7 +14,6 @@ from sklearn.utils.metaestimators import if_delegate_has_method
 from sktime.transformations.base import BaseTransformer
 from sktime.utils.validation.series import check_series
 
-
 warn(
     "transformations.series.compose is deprecated and will be removed in"
     " version 0.15.0. All estimators in it will be moved to transformations.compose. "
@@ -26,15 +25,15 @@ warn(
 # mtypes for Series, Panel, Hierarchical,
 # with exception of some ambiguous and discouraged mtypes
 CORE_MTYPES = [
-            "pd.DataFrame",
-            "np.ndarray",
-            "pd.Series",
-            "pd-multiindex",
-            "df-list",
-            "nested_univ",
-            "numpy3D",
-            "pd_multiindex_hier",
-        ]
+    "pd.DataFrame",
+    "np.ndarray",
+    "pd.Series",
+    "pd-multiindex",
+    "df-list",
+    "nested_univ",
+    "numpy3D",
+    "pd_multiindex_hier",
+]
 
 
 class OptionalPassthrough(BaseTransformer):


### PR DESCRIPTION
This PR deprecates `transformations.series.compose` in favour of `transformations.compose`, with estimators to be moved in 0.15.0.

The `compose` module in `transformations.panel` will be deprecated separately:
* row transformers here: https://github.com/alan-turing-institute/sktime/pull/2370
* `ColumnTransformer` should be merged with `ColumnwiseTransformer`
* `ColumnConcatenator` should move to a "multivariate" module or similar.

The estimators still remain in the deprecated module, to make refactor in separate PR easier.