### PR TITLE
[ENH] `OptionalPassthrough` wrapping via `neg` dunder

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -278,6 +278,20 @@ class BaseTransformer(BaseEstimator):
         else:
             return NotImplemented
 
+    def __neg__(self):
+        """Magic unary - method, return OptionalPassthrough of self.
+
+        Intuition: `OptionalPassthrough` is "not having transformer", as an option.
+
+        Returns
+        -------
+        `OptionalPassthrough` object, containing `self`, with `passthrough=False`.
+            The `passthrough` parameter can be set via `set_params`.
+        """
+        from sktime.transformations.series.compose import OptionalPassthrough
+
+        return OptionalPassthrough(self, passthrough=False)
+
     def __getitem__(self, key):
         """Magic [...] method, return column subsetted transformer.
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -279,7 +279,7 @@ class BaseTransformer(BaseEstimator):
             return NotImplemented
 
     def __neg__(self):
-        """Magic unary - method, return OptionalPassthrough of self.
+        """Magic unary - (negation) method, return OptionalPassthrough of self.
 
         Intuition: `OptionalPassthrough` is "not having transformer", as an option.
 

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -13,6 +13,7 @@ from sktime.datatypes import get_examples
 from sktime.transformations.compose import FeatureUnion, TransformerPipeline
 from sktime.transformations.panel.padder import PaddingTransformer
 from sktime.transformations.series.boxcox import LogTransformer
+from sktime.transformations.series.compose import OptionalPassthrough
 from sktime.transformations.series.exponent import ExponentTransformer
 from sktime.transformations.series.impute import Imputer
 from sktime.transformations.series.subset import ColumnSelect
@@ -224,3 +225,18 @@ def test_subset_getitem():
     )
     _assert_array_almost_equal(t_both.fit_transform(X), X_theta[["b__0", "b__2"]])
     _assert_array_almost_equal(t_none.fit_transform(X), X_theta)
+
+
+def test_dunder_neg():
+    """Test the neg dunder method, for wrapping in OptionalPassthrough."""
+    X = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+
+    t = ExponentTransformer(power=2)
+
+    tp = -t
+
+    assert isinstance(tp, OptionalPassthrough)
+    assert not tp.get_params()["passthrough"]
+    assert isinstance(tp.get_params()["transformer"], ExponentTransformer)
+
+    _assert_array_almost_equal(tp.fit_transform(X), X)


### PR DESCRIPTION
This PR adds a shortcut for wrapping in `OptionalPassthrough` via the `__neg__` dunder of transformers.

This seems very natural, since "negation" is intuitively very close to "not having the transformer", which is added as a parameter configurable condition via the composition.

Inversion (e.g., switching `transform` and `inverse_transform`) is more natural in the `__invert__` dunder, which would have been the other, "obvious" option.

Also adds a test for ensuring the dunder works as intended.