### PR TITLE
[ENH] fix `_enforce_infer_freq` private utility for short time series

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -383,5 +383,6 @@ def _enforce_index_freq(item: pd.Series) -> pd.Series:
         it will stay None
     """
     if hasattr(item.index, "freq") and item.index.freq is None:
-        item.index.freq = pd.infer_freq(item.index)
+        if len(item.index) > 2:  # pandas.infer_freq errors out for length 1 or 2
+            item.index.freq = pd.infer_freq(item.index)
     return item


### PR DESCRIPTION
Vectorization could break for short time series with a `freq` index attribute, since `pandas.infer_freq`, called from within `_enforce_infer_freq` in the vectorization modeule breaks on time series of length 1 or 2.

Example: https://github.com/alan-turing-institute/sktime/pull/3270

Completely unintuitive imo (it could just infer `None` or not break), but that is what happens.

Also FYI @ltsaprounis.