### PR TITLE
[BUG] ensure that forecasters do not add `pd.Series.name` attribute

### DIFF
--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -85,7 +85,11 @@ class _StatsModelsAdapter(BaseForecaster):
 
         # statsmodels forecasts all periods from start to end of forecasting
         # horizon, but only return given time points in forecasting horizon
-        return y_pred.loc[fh.to_absolute(self.cutoff).to_pandas()]
+        y_pred = y_pred.loc[fh.to_absolute(self.cutoff).to_pandas()]
+        # ensure that name is not added nor removed
+        # otherwise this may upset conversion to pd.DataFrame
+        y_pred.name = self._y.name
+        return y_pred
 
     def get_fitted_params(self):
         """Get fitted parameters.

--- a/sktime/forecasting/tests/test_structural.py
+++ b/sktime/forecasting/tests/test_structural.py
@@ -223,6 +223,7 @@ def test_result_consistency_exog(level_sample_data_split):
     result = model.fit(disp=0)
     n_test = X_test.shape[0]
     y_pred_base = result.forecast(steps=n_test, exog=X_test)
+    y_pred_base.name = y_train.name
     assert_series_equal(left=y_pred_forecaster, right=y_pred_base)
     assert len(fh) == y_pred_forecaster.shape[0]
 

--- a/sktime/forecasting/tests/test_structural.py
+++ b/sktime/forecasting/tests/test_structural.py
@@ -196,6 +196,7 @@ def test_results_consistency(level, fh_length, y_airlines):
     model = _UnobservedComponents(level=level, endog=y_airlines)
     result = model.fit(disp=0)
     y_pred_base = result.forecast(steps=fh_length)
+    y_pred_base.name = y_airlines.name
     assert_series_equal(left=y_pred_forecaster, right=y_pred_base)
     assert len(fh) == y_pred_forecaster.shape[0]
 

--- a/sktime/utils/_testing/forecasting.py
+++ b/sktime/utils/_testing/forecasting.py
@@ -140,10 +140,17 @@ def _assert_correct_columns(y_pred, y_train):
     """Check that forecast object has right column names."""
     if isinstance(y_pred, pd.DataFrame) and isinstance(y_train, pd.DataFrame):
         msg = (
-            "forecast must have same columns index as past data, "
+            "forecast pd.DataFrame must have same column index as past data, "
             f"expected {y_train.columns} but found {y_pred.columns}"
         )
         assert (y_pred.columns == y_train.columns).all(), msg
+
+    if isinstance(y_pred, pd.Series) and isinstance(y_train, pd.Series):
+        msg = (
+            "forecast pd.Series must have same name as past data, "
+            f"expected {y_train.name} but found {y_pred.name}"
+        )
+        assert y_pred.name == y_train.name, msg
 
 
 def _make_fh(cutoff, steps, fh_type, is_relative):


### PR DESCRIPTION
This adds a test to ensure that forecasters do not add a `name` attribute to `pd.Series`.

This prevents edge cases in conversion to `pd.DataFrame` where the `name` becomes a column name, and can lead to inconsistency between train series column name and test series column name.

It also fixes an issue with the `statsmodels` adapter which could create a `predicted_mean` name on resulting series.