### PR TITLE
[ENH] test `pd.Series` with name attribute in forecasters

### DIFF
--- a/sktime/utils/_testing/scenarios_forecasting.py
+++ b/sktime/utils/_testing/scenarios_forecasting.py
@@ -173,17 +173,17 @@ class ForecasterFitPredictUnivariateWithX(ForecasterTestScenario):
     default_method_sequence = ["fit", "predict"]
 
 
+y_with_name = _make_series(n_timepoints=20, random_state=RAND_SEED)
+y_with_name.name = "foo"
+
+
 class ForecasterFitPredictUnivariateWithXLongFh(ForecasterTestScenario):
     """Fit/predict only, univariate y, with X, and longer fh, passed early in fit."""
 
     _tags = {"univariate_y": True, "fh_passed_in_fit": True}
 
     args = {
-        "fit": {
-            "y": _make_series(n_timepoints=20, random_state=RAND_SEED),
-            "X": X.copy(),
-            "fh": [1, 2, 3],
-        },
+        "fit": {"y": y_with_name, "X": X.copy(), "fh": [1, 2, 3]},
         "predict": {"X": X_test.copy()},
     }
     default_method_sequence = ["fit", "predict"]


### PR DESCRIPTION
This changes one of the univariate `pd.Series` `y` fixtures in the scenarios for forecasters to have a `name` attribute.

Relies on https://github.com/alan-turing-institute/sktime/pull/3290. Combined with that, this change additionally tests that the `name` is preserved and is handled without exceptions.