### PR TITLE
[BUG] bound `pmdarima < 2.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ all_extras = [
     "gluonts>=0.9.0",
     "matplotlib>=3.3.2",
     "mne",
-    "pmdarima>=1.8.0,!=1.8.1",
+    "pmdarima>=1.8.0,!=1.8.1,<2.0.0",
     "prophet>=1.1",
     "pykalman>=0.9.5",
     "pyod>=0.8.0",


### PR DESCRIPTION
Temporary maintenance fix for https://github.com/alan-turing-institute/sktime/issues/3300, until bugs are resolved.