### PR TITLE
[BUG] Fix `write_ndarray_to_tsfile` for `classLabel = False`

### DIFF
--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -1572,9 +1572,9 @@ def write_ndarray_to_tsfile(
     # write class label line
     if class_label is not None:
         space_separated_class_label = " ".join(str(label) for label in class_label)
-        file.write(f"@classLabel true {space_separated_class_label}\n")
+        file.write(f"@classlabel true {space_separated_class_label}\n")
     else:
-        file.write("@class_label false\n")
+        file.write("@classlabel false\n")
     # begin writing the core data for each case
     # which are the series and the class value list if there is any
     file.write("@data\n")


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes the following issue when reading a tsfile written with `write_ndarray_to_tsfile`

```
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
/tmp/ipykernel_1092/2889448795.py in <module>
----> 1 df = load_from_tsfile_to_dataframe("./amex_train_1.ts/AMEX-Data/AMEX-Data.ts", replace_missing_vals_with='NaN', return_separate_X_and_y=False)

/tmp/ipykernel_1092/3989994789.py in load_from_tsfile_to_dataframe(full_file_path_and_name, return_separate_X_and_y, replace_missing_vals_with)
    159                         print(has_data_tag)
    160                         raise IOError(
--> 161                             "a full set of metadata has not been provided "
    162                             "before the data"
    163                         )

OSError: a full set of metadata has not been provided before the data
```


#### What does this implement/fix? Explain your changes.
The issue in `load_from_tsfile_to_dataframe` happend because `has_class_labels_tag = False`. This is because the line 

```python
elif line.startswith("@classlabel"):
     ....
     has_class_labels_tag = True
```
is never  executed since the `line.startswith("@classlabel")` is `False`

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

How should the tag "@classlabel" be named,  `write_ndarray_to_tsfile` and `load_from_tsfile_to_dataframe` depend on each other here. Another solution would be to allow multiple way of writing this tag in `load_from_tsfile_to_dataframe`


##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.