### PR TITLE
[BUG] fix merge accident that deleted `DtwDist` export

### DIFF
--- a/sktime/dists_kernels/__init__.py
+++ b/sktime/dists_kernels/__init__.py
@@ -6,6 +6,7 @@ from sktime.dists_kernels._base import (
     BasePairwiseTransformerPanel,
 )
 from sktime.dists_kernels.compose_tab_to_panel import AggrDist, FlatDist
+from sktime.dists_kernels.dtw import DtwDist
 from sktime.dists_kernels.edit_dist import EditDist
 from sktime.dists_kernels.scipy_dist import ScipyDist
 
@@ -13,6 +14,7 @@ __all__ = [
     "BasePairwiseTransformer",
     "BasePairwiseTransformerPanel",
     "AggrDist",
+    "DtwDist",
     "EditDist",
     "FlatDist",
     "ScipyDist",


### PR DESCRIPTION
maintenance PR that fixes a recent merge accident that deleted `DtwDist` export in the `dists_kernels` module.

Will emergency merge once tests pass, as this got accidentally removed by my confusion over multiple merges in the `dists_kernels` module.