### PR TITLE
[MNT] skip `CNNClassifier` doctest

### DIFF
--- a/sktime/classification/deep_learning/cnn.py
+++ b/sktime/classification/deep_learning/cnn.py
@@ -62,8 +62,8 @@ class CNNClassifier(BaseDeepClassifier):
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
     >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
-    >>> cnn = CNNClassifier()
-    >>> cnn.fit(X_train, y_train)
+    >>> cnn = CNNClassifier()  # doctest: +SKIP
+    >>> cnn.fit(X_train, y_train)  # doctest: +SKIP
     CNNClassifier(...)
     """
 


### PR DESCRIPTION
This skips the `CNNClassifier` doctest in order to isolate the `tensorflow` soft dependency.

Test coverage is not reduced, sinfe `fit` is tested in `TestAllClassifiers` already.