### PR TITLE
[ENH] `BaseTransformer` data memory - always enabled

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -321,6 +321,8 @@ UPDATE_DATA_INTERNAL_MTYPES = [
 def update_data(X, X_new=None):
     """Update time series container with another one.
 
+    Coerces X, X_new to one of the assumed mtypes, if not already of that type.
+
     Parameters
     ----------
     X : None, or sktime data container, in one of the following mtype formats

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -313,7 +313,7 @@ def update_data(X, X_new=None):
 
     Parameters
     ----------
-    X : sktime data container, in one of the following mtype formats
+    X : None, or sktime data container, in one of the following mtype formats
         pd.DataFrame, pd.Series, np.ndarray, pd-multiindex, numpy3D,
         pd_multiindex_hier
     X_new : None, or sktime data container, should be same mtype as X,
@@ -324,6 +324,7 @@ def update_data(X, X_new=None):
     X updated with X_new, with rows/indices in X_new added
         entries in X_new overwrite X if at same index
         numpy based containers will always be interpreted as having new row index
+        if one of X, X_new is None, returns the other; if both are None, returns None
     """
     from sktime.datatypes._convert import convert_to
     from sktime.datatypes._vectorize import VectorizedDF
@@ -331,6 +332,10 @@ def update_data(X, X_new=None):
     # we only need to modify _X if X is not None
     if X_new is None:
         return X
+
+    # if X is None, but X_new is not, return N_new
+    if X is None:
+        return X_new
 
     # if X or X_new is vectorized, unwrap it first
     if isinstance(X, VectorizedDF):

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -327,7 +327,7 @@ def update_data(X, X_new=None):
     ----------
     X : None, or sktime data container, in one of the following mtype formats
         pd.DataFrame, pd.Series, np.ndarray, pd-multiindex, numpy3D,
-        pd_multiindex_hier
+        pd_multiindex_hier. If not of that format, coerced.
     X_new : None, or sktime data container, should be same mtype as X,
         or convert to same format when converting to format list via convert_to
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -355,12 +355,6 @@ class BaseTransformer(BaseEstimator):
         # if fit is called, estimator is reset, including fitted state
         self.reset()
 
-        # skip everything if fit_is_empty is True
-        if self.get_tag("fit_is_empty"):
-            self._is_fitted = True
-            self._X = update_data(None, X_new=X)
-            return self
-
         # if requires_y is set, y is required in fit and update
         if self.get_tag("requires_y") and y is None:
             raise ValueError(f"{self.__class__.__name__} requires `y` in `fit`.")
@@ -370,6 +364,11 @@ class BaseTransformer(BaseEstimator):
 
         # memorize X as self._X
         self._X = update_data(None, X_new=X_inner)
+
+        # skip everything if fit_is_empty is True
+        if self.get_tag("fit_is_empty"):
+            self._is_fitted = True
+            return self
 
         # checks and conversions complete, pass to inner fit
         #####################################################
@@ -610,12 +609,6 @@ class BaseTransformer(BaseEstimator):
         # check whether is fitted
         self.check_is_fitted()
 
-        # skip everything if update_params is False
-        # skip everything if fit_is_empty is True
-        if not update_params or self.get_tag("fit_is_empty", False):
-            self._X = update_data(self._X, X_new=X)  # update memory of X
-            return self
-
         # if requires_y is set, y is required in fit and update
         if self.get_tag("requires_y") and y is None:
             raise ValueError(f"{self.__class__.__name__} requires `y` in `update`.")
@@ -625,6 +618,11 @@ class BaseTransformer(BaseEstimator):
 
         # update memory of X
         self._X = update_data(self._X, X_new=X_inner)
+
+        # skip everything if update_params is False
+        # skip everything if fit_is_empty is True
+        if not update_params or self.get_tag("fit_is_empty", False):
+            return self
 
         # checks and conversions complete, pass to inner fit
         #####################################################

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -268,7 +268,7 @@ class PandasTransformAdaptor(BaseTransformer):
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
         "univariate-only": False,
         "transform-returns-same-time-index": False,
-        "fit_is_empty": False,
+        "fit_is_empty": True,
         "capability:inverse_transform": False,
     }
 
@@ -294,26 +294,6 @@ class PandasTransformAdaptor(BaseTransformer):
 
         if apply_to == "call":
             self.set_tags(**{"fit_is_empty": True})
-
-    def _fit(self, X, y=None):
-        """Fit transformer to X and y.
-
-        private _fit containing the core logic, called from fit
-
-        Parameters
-        ----------
-        X : pd.DataFrame
-            Data to fit transform to
-        y : ignored argument for interface compatibility
-            Additional data, e.g., labels for transformation
-
-        Returns
-        -------
-        self: a fitted instance of the estimator
-        """
-        if self.apply_to in ["all", "all_subset"]:
-            self._X = X
-        return self
 
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.
@@ -350,26 +330,6 @@ class PandasTransformAdaptor(BaseTransformer):
             Xt = Xt.loc[X.index]
 
         return Xt
-
-    def _update(self, X, y=None):
-        """Fit transformer to X and y.
-
-        private _fit containing the core logic, called from fit
-
-        Parameters
-        ----------
-        X : pd.DataFrame
-            Data to fit transform to
-        y : ignored argument for interface compatibility
-            Additional data, e.g., labels for transformation
-
-        Returns
-        -------
-        self: a fitted instance of the estimator
-        """
-        if self.apply_to in ["all", "all_subset"]:
-            self._X = X.combine_first(self._X)
-        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -135,8 +135,6 @@ class Imputer(BaseTransformer):
         # implemented here. Some methods dont need fit, so they are just
         # impleented in _transform
         if self.method in ["drift", "forecaster"]:
-            # save train data as needed for multivariate fitting int _fit()
-            self._X = X.copy()
             self._y = y.copy() if y is not None else None
             if self.method == "drift":
                 self._forecaster = PolynomialTrendForecaster(degree=1)
@@ -147,8 +145,7 @@ class Imputer(BaseTransformer):
         elif self.method == "median":
             self._median = X.median()
         elif self.method == "random":
-            # save train data to get min() and max() in transform() for each column
-            self._X = X.copy()
+            pass
 
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -112,7 +112,7 @@ class Lag(BaseTransformer):
         "univariate-only": False,  # can the transformer handle multivariate X?
         "X_inner_mtype": "pd.DataFrame",  # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
-        "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
+        "fit_is_empty": True,  # is fit empty and can be skipped? Yes = True
         "transform-returns-same-time-index": False,
         # does transform return have the same time index as input X
         "skip-inverse-transform": True,  # is inverse-transform skipped when called?
@@ -185,24 +185,6 @@ class Lag(BaseTransformer):
                 name = f"{lag}{freq}"
             name = "lag_" + name
             yield name
-
-    def _fit(self, X, y=None):
-        """Fit transformer to X and y.
-
-        private _fit containing the core logic, called from fit
-
-        Parameters
-        ----------
-        X : pd.DataFrame
-            Data to fit transform to
-        y : ignored, passed for interface compatibility
-
-        Returns
-        -------
-        self: reference to self
-        """
-        # remember X for lagging across past data indices
-        self._X = X
 
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.
@@ -319,7 +301,7 @@ class Lag(BaseTransformer):
         -------
         self: reference to self
         """
-        self._X = X.combine_first(self._X)
+        return self
 
     # todo: return default parameters, so that a test instance can be created
     #   required for automated unit and integration testing of estimator

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -45,7 +45,7 @@ class IndexSubset(BaseTransformer):
         "X_inner_mtype": ["pd.DataFrame", "pd.Series"],
         "y_inner_mtype": ["pd.DataFrame", "pd.Series"],
         "transform-returns-same-time-index": False,
-        "fit_is_empty": False,
+        "fit_is_empty": True,
         "univariate-only": False,
         "capability:inverse_transform": False,
     }
@@ -53,25 +53,6 @@ class IndexSubset(BaseTransformer):
     def __init__(self, index_treatment="keep"):
         self.index_treatment = index_treatment
         super(IndexSubset, self).__init__()
-
-    def _fit(self, X, y=None):
-        """Fit transformer to X and y.
-
-        private _fit containing the core logic, called from fit
-
-        Parameters
-        ----------
-        X : pd.DataFrame or pd.Series
-            Data the transformer is fitted to
-        y : ignored argument for interface compatibility
-            Additional data, e.g., labels for transformation
-
-        Returns
-        -------
-        self: a fitted instance of the estimator
-        """
-        self._X = X
-        return self
 
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.
@@ -110,25 +91,6 @@ class IndexSubset(BaseTransformer):
                 f' "{index_treatment}"'
             )
         return Xt
-
-    def _update(self, X, y=None):
-        """Update transformer with X and y.
-
-        private _update containing the core logic, called from update
-
-        Parameters
-        ----------
-        X : pd.DataFrame or pd.Series
-            Data the transform is fitted to
-        y : ignored argument for interface compatibility
-            Additional data, e.g., labels for transformation
-
-        Returns
-        -------
-        self: a fitted instance of the estimator
-        """
-        self._X = X.combine_first(self._X)
-        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -297,7 +297,7 @@ class WindowSummarizer(BaseTransformer):
         transformed version of X
         """
         idx = X.index
-        X = self._X
+        X = X.combine_first(self._X)
 
         func_dict = self._func_dict
         target_cols = self._target_cols

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -330,20 +330,6 @@ class WindowSummarizer(BaseTransformer):
         Xt_return = Xt_return.loc[idx]
         return Xt_return
 
-    def _update(self, X, y=None):
-        """Update X and return a transformed version.
-
-        Parameters
-        ----------
-        X : pd.DataFrame
-        y : None
-
-        Returns
-        -------
-        transformed version of X
-        """
-        return self
-
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -238,8 +238,6 @@ class WindowSummarizer(BaseTransformer):
             The raw inputs to transformed columns will be dropped.
         self: reference to self
         """
-        self._X_memory = X
-
         X_name = get_name_list(X)
 
         if self.target_cols is not None:
@@ -299,7 +297,7 @@ class WindowSummarizer(BaseTransformer):
         transformed version of X
         """
         idx = X.index
-        X = X.combine_first(self._X_memory)
+        X = self._X
 
         func_dict = self._func_dict
         target_cols = self._target_cols
@@ -344,7 +342,7 @@ class WindowSummarizer(BaseTransformer):
         -------
         transformed version of X
         """
-        self._X_memory = X.combine_first(self._X_memory)
+        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
This adds a data memory to transformers, similar to forecasters.

It stores all data seen in an attribute `self._X`, as a reference if possible (due to coercions, storing a reference may not be possible).

This allows to refactor some transformers which already to that internally, and remove a layer of boilerplate:

* `Imputer`
* `Lag`
* `IndexSubset`
* `PandasTransformAdaptor`
* `WindowSummarizer`

While convenient, this may cause some memory overhead, especially in pipelines with many transformers, so reviewers should also put that to consideration.

An alternative may be turning this off in transformers that do not need it, say, via a tag, or a base class init argument. The option with a tag is carrie out in https://github.com/alan-turing-institute/sktime/pull/3307, perhaps that is preferable to minimize effect on memory in transformers that do not need the memory.