### PR TITLE
[ENH] `BaseTransformer` data memory - enabled by tag

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -321,6 +321,8 @@ UPDATE_DATA_INTERNAL_MTYPES = [
 def update_data(X, X_new=None):
     """Update time series container with another one.
 
+    Coerces X, X_new to one of the assumed mtypes, if not already of that type.
+
     Parameters
     ----------
     X : None, or sktime data container, in one of the following mtype formats

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -313,7 +313,7 @@ def update_data(X, X_new=None):
 
     Parameters
     ----------
-    X : sktime data container, in one of the following mtype formats
+    X : None, or sktime data container, in one of the following mtype formats
         pd.DataFrame, pd.Series, np.ndarray, pd-multiindex, numpy3D,
         pd_multiindex_hier
     X_new : None, or sktime data container, should be same mtype as X,
@@ -324,6 +324,7 @@ def update_data(X, X_new=None):
     X updated with X_new, with rows/indices in X_new added
         entries in X_new overwrite X if at same index
         numpy based containers will always be interpreted as having new row index
+        if one of X, X_new is None, returns the other; if both are None, returns None
     """
     from sktime.datatypes._convert import convert_to
     from sktime.datatypes._vectorize import VectorizedDF
@@ -331,6 +332,10 @@ def update_data(X, X_new=None):
     # we only need to modify _X if X is not None
     if X_new is None:
         return X
+
+    # if X is None, but X_new is not, return N_new
+    if X is None:
+        return X_new
 
     # if X or X_new is vectorized, unwrap it first
     if isinstance(X, VectorizedDF):

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -327,7 +327,7 @@ def update_data(X, X_new=None):
     ----------
     X : None, or sktime data container, in one of the following mtype formats
         pd.DataFrame, pd.Series, np.ndarray, pd-multiindex, numpy3D,
-        pd_multiindex_hier
+        pd_multiindex_hier. If not of that format, coerced.
     X_new : None, or sktime data container, should be same mtype as X,
         or convert to same format when converting to format list via convert_to
 

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -346,6 +346,12 @@ ESTIMATOR_TAG_REGISTER = [
         ("list", "str"),
         "python dependencies of estimator as str or list of str",
     ),
+    (
+        "remember_data",
+        ["forecaster", "transformer"],
+        "bool",
+        "whether estimator remembers all data seen as self._X, self._y, etc",
+    ),
 ]
 
 ESTIMATOR_TAG_TABLE = pd.DataFrame(ESTIMATOR_TAG_REGISTER)

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -129,6 +129,7 @@ class BaseTransformer(BaseEstimator):
         "capability:missing_values:removes": False,
         # is transform result always guaranteed to contain no missing values?
         "python_version": None,  # PEP 440 python version specifier to limit versions
+        "remember_data": False,  # whether all data seen is remembered as self._X
     }
 
     # allowed mtypes for transformers - Series and Panel
@@ -332,7 +333,8 @@ class BaseTransformer(BaseEstimator):
 
         Writes to self:
         _is_fitted : flag is set to True.
-        _X : X, possibly coerced to inner type or update_data compatible type
+        _X : X, coerced copy of X, if remember_data tag is True
+            possibly coerced to inner type or update_data compatible type
             by reference, when possible
         model attributes (ending in "_") : dependent on estimator
 
@@ -362,8 +364,9 @@ class BaseTransformer(BaseEstimator):
         # check and convert X/y
         X_inner, y_inner = self._check_X_y(X=X, y=y)
 
-        # memorize X as self._X
-        self._X = update_data(None, X_new=X_inner)
+        # memorize X as self._X, if remember_data tag is set to True
+        if self.get_tag("remember_data", False):
+            self._X = update_data(None, X_new=X_inner)
 
         # skip everything if fit_is_empty is True
         if self.get_tag("fit_is_empty"):
@@ -393,7 +396,7 @@ class BaseTransformer(BaseEstimator):
 
         Accesses in self:
         _is_fitted : must be True
-        _X : optionally accessed
+        _X : optionally accessed, only available if remember_data tag is True
         fitted model attributes (ending in "_") : must be set, accessed by _transform
 
         Parameters
@@ -465,7 +468,8 @@ class BaseTransformer(BaseEstimator):
 
         Writes to self:
         _is_fitted : flag is set to True.
-        _X : X, possibly coerced to inner type or update_data compatible type
+        _X : X, coerced copy of X, if remember_data tag is True
+            possibly coerced to inner type or update_data compatible type
             by reference, when possible
         model attributes (ending in "_") : dependent on estimator
 
@@ -526,7 +530,7 @@ class BaseTransformer(BaseEstimator):
 
         Accesses in self:
         _is_fitted : must be True
-        _X : optionally accessed
+        _X : optionally accessed, only available if remember_data tag is True
         fitted model attributes (ending in "_") : accessed by _inverse_transform
 
         Parameters
@@ -579,11 +583,11 @@ class BaseTransformer(BaseEstimator):
 
         Accesses in self:
         _is_fitted : must be True
-        _X : accessed by _update and by update_data
+        _X : accessed by _update and by update_data, if remember_data tag is True
         fitted model attributes (ending in "_") : must be set, accessed by _update
 
         Writes to self:
-        _X : updated by values in X, via update_data
+        _X : updated by values in X, via update_data, if remember_data tag is True
         fitted model attributes (ending in "_") : only if update_params=True
             type and nature of update are dependent on estimator
 
@@ -616,8 +620,9 @@ class BaseTransformer(BaseEstimator):
         # check and convert X/y
         X_inner, y_inner = self._check_X_y(X=X, y=y)
 
-        # update memory of X
-        self._X = update_data(self._X, X_new=X_inner)
+        # update memory of X, if remember_data tag is set to True
+        if self.get_tag("remember_data", False):
+            self._X = update_data(None, X_new=X_inner)
 
         # skip everything if update_params is False
         # skip everything if fit_is_empty is True

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -357,6 +357,11 @@ class BaseTransformer(BaseEstimator):
         # if fit is called, estimator is reset, including fitted state
         self.reset()
 
+        # skip everything if fit_is_empty is True and we do not need to remember data
+        if self.get_tag("fit_is_empty") and not self.get_tag("remember_data", False):
+            self._is_fitted = True
+            return self
+
         # if requires_y is set, y is required in fit and update
         if self.get_tag("requires_y") and y is None:
             raise ValueError(f"{self.__class__.__name__} requires `y` in `fit`.")
@@ -368,7 +373,7 @@ class BaseTransformer(BaseEstimator):
         if self.get_tag("remember_data", False):
             self._X = update_data(None, X_new=X_inner)
 
-        # skip everything if fit_is_empty is True
+        # skip the rest if fit_is_empty is True
         if self.get_tag("fit_is_empty"):
             self._is_fitted = True
             return self

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -355,12 +355,6 @@ class BaseTransformer(BaseEstimator):
         # if fit is called, estimator is reset, including fitted state
         self.reset()
 
-        # skip everything if fit_is_empty is True
-        if self.get_tag("fit_is_empty"):
-            self._is_fitted = True
-            self._X = update_data(None, X_new=X)
-            return self
-
         # if requires_y is set, y is required in fit and update
         if self.get_tag("requires_y") and y is None:
             raise ValueError(f"{self.__class__.__name__} requires `y` in `fit`.")
@@ -370,6 +364,11 @@ class BaseTransformer(BaseEstimator):
 
         # memorize X as self._X
         self._X = update_data(None, X_new=X_inner)
+
+        # skip everything if fit_is_empty is True
+        if self.get_tag("fit_is_empty"):
+            self._is_fitted = True
+            return self
 
         # checks and conversions complete, pass to inner fit
         #####################################################
@@ -610,12 +609,6 @@ class BaseTransformer(BaseEstimator):
         # check whether is fitted
         self.check_is_fitted()
 
-        # skip everything if update_params is False
-        # skip everything if fit_is_empty is True
-        if not update_params or self.get_tag("fit_is_empty", False):
-            self._X = update_data(self._X, X_new=X)  # update memory of X
-            return self
-
         # if requires_y is set, y is required in fit and update
         if self.get_tag("requires_y") and y is None:
             raise ValueError(f"{self.__class__.__name__} requires `y` in `update`.")
@@ -625,6 +618,11 @@ class BaseTransformer(BaseEstimator):
 
         # update memory of X
         self._X = update_data(self._X, X_new=X_inner)
+
+        # skip everything if update_params is False
+        # skip everything if fit_is_empty is True
+        if not update_params or self.get_tag("fit_is_empty", False):
+            return self
 
         # checks and conversions complete, pass to inner fit
         #####################################################

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -139,6 +139,7 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
             "pd_multiindex_hier",
         ],
         "univariate-only": False,
+        "fit_is_empty": False,  # never skip fit, since self._X may have to be written
     }
 
     # no further default tag values - these are set dynamically below
@@ -171,7 +172,6 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
         self._anytag_notnone_set("scitype:transform-labels", ests)
 
         self._anytagis_then_set("scitype:instancewise", False, True, ests)
-        self._anytagis_then_set("fit_is_empty", False, True, ests)
         self._anytagis_then_set("transform-returns-same-time-index", False, True, ests)
         self._anytagis_then_set("skip-inverse-transform", False, True, ests)
 

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -139,7 +139,6 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
             "pd_multiindex_hier",
         ],
         "univariate-only": False,
-        "fit_is_empty": False,  # never skip fit, since self._X may have to be written
     }
 
     # no further default tag values - these are set dynamically below
@@ -172,6 +171,7 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
         self._anytag_notnone_set("scitype:transform-labels", ests)
 
         self._anytagis_then_set("scitype:instancewise", False, True, ests)
+        self._anytagis_then_set("fit_is_empty", False, True, ests)
         self._anytagis_then_set("transform-returns-same-time-index", False, True, ests)
         self._anytagis_then_set("skip-inverse-transform", False, True, ests)
 

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -268,7 +268,7 @@ class PandasTransformAdaptor(BaseTransformer):
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
         "univariate-only": False,
         "transform-returns-same-time-index": False,
-        "fit_is_empty": False,
+        "fit_is_empty": True,
         "capability:inverse_transform": False,
     }
 
@@ -294,26 +294,6 @@ class PandasTransformAdaptor(BaseTransformer):
 
         if apply_to == "call":
             self.set_tags(**{"fit_is_empty": True})
-
-    def _fit(self, X, y=None):
-        """Fit transformer to X and y.
-
-        private _fit containing the core logic, called from fit
-
-        Parameters
-        ----------
-        X : pd.DataFrame
-            Data to fit transform to
-        y : ignored argument for interface compatibility
-            Additional data, e.g., labels for transformation
-
-        Returns
-        -------
-        self: a fitted instance of the estimator
-        """
-        if self.apply_to in ["all", "all_subset"]:
-            self._X = X
-        return self
 
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.
@@ -350,26 +330,6 @@ class PandasTransformAdaptor(BaseTransformer):
             Xt = Xt.loc[X.index]
 
         return Xt
-
-    def _update(self, X, y=None):
-        """Fit transformer to X and y.
-
-        private _fit containing the core logic, called from fit
-
-        Parameters
-        ----------
-        X : pd.DataFrame
-            Data to fit transform to
-        y : ignored argument for interface compatibility
-            Additional data, e.g., labels for transformation
-
-        Returns
-        -------
-        self: a fitted instance of the estimator
-        """
-        if self.apply_to in ["all", "all_subset"]:
-            self._X = X.combine_first(self._X)
-        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -270,7 +270,7 @@ class PandasTransformAdaptor(BaseTransformer):
         "transform-returns-same-time-index": False,
         "fit_is_empty": False,
         "capability:inverse_transform": False,
-        "remember_data": True,  # remember all data seen as _X
+        "remember_data": False,  # remember all data seen as _X
     }
 
     def __init__(self, method, kwargs=None, apply_to="call"):
@@ -289,6 +289,9 @@ class PandasTransformAdaptor(BaseTransformer):
             )
 
         super(PandasTransformAdaptor, self).__init__()
+
+        if apply_to in ["all", "all_subset"]:
+            self.set_tags(**{"remember_data": True})
 
         if apply_to == "all_subset":
             self.set_tags(**{"transform-returns-same-time-index": True})

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -268,7 +268,7 @@ class PandasTransformAdaptor(BaseTransformer):
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
         "univariate-only": False,
         "transform-returns-same-time-index": False,
-        "fit_is_empty": True,
+        "fit_is_empty": False,
         "capability:inverse_transform": False,
         "remember_data": True,  # remember all data seen as _X
     }

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -270,6 +270,7 @@ class PandasTransformAdaptor(BaseTransformer):
         "transform-returns-same-time-index": False,
         "fit_is_empty": True,
         "capability:inverse_transform": False,
+        "remember_data": True,  # remember all data seen as _X
     }
 
     def __init__(self, method, kwargs=None, apply_to="call"):

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -95,7 +95,7 @@ class Imputer(BaseTransformer):
         "univariate-only": False,
         "capability:missing_values:removes": True,
         # is transform result always guaranteed to contain no missing values?
-        "remember_data": True,  # remember all data seen as _X
+        "remember_data": False,  # remember all data seen as _X
     }
 
     def __init__(
@@ -113,6 +113,10 @@ class Imputer(BaseTransformer):
         self.forecaster = forecaster
         self.random_state = random_state
         super(Imputer, self).__init__()
+
+        # these methods require self._X remembered in _fit and _update
+        if method in ["drift", "forecaster", "random"]:
+            self.set_tags(**{"remember_data": True})
 
     def _fit(self, X, y=None):
         """Fit transformer to X and y.

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -135,8 +135,6 @@ class Imputer(BaseTransformer):
         # implemented here. Some methods dont need fit, so they are just
         # impleented in _transform
         if self.method in ["drift", "forecaster"]:
-            # save train data as needed for multivariate fitting int _fit()
-            self._X = X.copy()
             self._y = y.copy() if y is not None else None
             if self.method == "drift":
                 self._forecaster = PolynomialTrendForecaster(degree=1)
@@ -147,8 +145,7 @@ class Imputer(BaseTransformer):
         elif self.method == "median":
             self._median = X.median()
         elif self.method == "random":
-            # save train data to get min() and max() in transform() for each column
-            self._X = X.copy()
+            pass
 
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -95,6 +95,7 @@ class Imputer(BaseTransformer):
         "univariate-only": False,
         "capability:missing_values:removes": True,
         # is transform result always guaranteed to contain no missing values?
+        "remember_data": True,  # remember all data seen as _X
     }
 
     def __init__(

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -120,6 +120,7 @@ class Lag(BaseTransformer):
         "capability:unequal_length:removes": False,
         "handles-missing-data": True,  # can estimator handle missing data?
         "capability:missing_values:removes": False,
+        "remember_data": True,  # remember all data seen as _X
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -112,7 +112,7 @@ class Lag(BaseTransformer):
         "univariate-only": False,  # can the transformer handle multivariate X?
         "X_inner_mtype": "pd.DataFrame",  # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
-        "fit_is_empty": True,  # is fit empty and can be skipped? Yes = True
+        "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
         "transform-returns-same-time-index": False,
         # does transform return have the same time index as input X
         "skip-inverse-transform": True,  # is inverse-transform skipped when called?

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -112,7 +112,7 @@ class Lag(BaseTransformer):
         "univariate-only": False,  # can the transformer handle multivariate X?
         "X_inner_mtype": "pd.DataFrame",  # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
-        "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
+        "fit_is_empty": True,  # is fit empty and can be skipped? Yes = True
         "transform-returns-same-time-index": False,
         # does transform return have the same time index as input X
         "skip-inverse-transform": True,  # is inverse-transform skipped when called?
@@ -185,24 +185,6 @@ class Lag(BaseTransformer):
                 name = f"{lag}{freq}"
             name = "lag_" + name
             yield name
-
-    def _fit(self, X, y=None):
-        """Fit transformer to X and y.
-
-        private _fit containing the core logic, called from fit
-
-        Parameters
-        ----------
-        X : pd.DataFrame
-            Data to fit transform to
-        y : ignored, passed for interface compatibility
-
-        Returns
-        -------
-        self: reference to self
-        """
-        # remember X for lagging across past data indices
-        self._X = X
 
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.
@@ -319,7 +301,7 @@ class Lag(BaseTransformer):
         -------
         self: reference to self
         """
-        self._X = X.combine_first(self._X)
+        return self
 
     # todo: return default parameters, so that a test instance can be created
     #   required for automated unit and integration testing of estimator

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -45,7 +45,7 @@ class IndexSubset(BaseTransformer):
         "X_inner_mtype": ["pd.DataFrame", "pd.Series"],
         "y_inner_mtype": ["pd.DataFrame", "pd.Series"],
         "transform-returns-same-time-index": False,
-        "fit_is_empty": False,
+        "fit_is_empty": True,
         "univariate-only": False,
         "capability:inverse_transform": False,
     }
@@ -53,25 +53,6 @@ class IndexSubset(BaseTransformer):
     def __init__(self, index_treatment="keep"):
         self.index_treatment = index_treatment
         super(IndexSubset, self).__init__()
-
-    def _fit(self, X, y=None):
-        """Fit transformer to X and y.
-
-        private _fit containing the core logic, called from fit
-
-        Parameters
-        ----------
-        X : pd.DataFrame or pd.Series
-            Data the transformer is fitted to
-        y : ignored argument for interface compatibility
-            Additional data, e.g., labels for transformation
-
-        Returns
-        -------
-        self: a fitted instance of the estimator
-        """
-        self._X = X
-        return self
 
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.
@@ -110,25 +91,6 @@ class IndexSubset(BaseTransformer):
                 f' "{index_treatment}"'
             )
         return Xt
-
-    def _update(self, X, y=None):
-        """Update transformer with X and y.
-
-        private _update containing the core logic, called from update
-
-        Parameters
-        ----------
-        X : pd.DataFrame or pd.Series
-            Data the transform is fitted to
-        y : ignored argument for interface compatibility
-            Additional data, e.g., labels for transformation
-
-        Returns
-        -------
-        self: a fitted instance of the estimator
-        """
-        self._X = X.combine_first(self._X)
-        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -48,6 +48,7 @@ class IndexSubset(BaseTransformer):
         "fit_is_empty": True,
         "univariate-only": False,
         "capability:inverse_transform": False,
+        "remember_data": True,  # remember all data seen as _X
     }
 
     def __init__(self, index_treatment="keep"):

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -45,7 +45,7 @@ class IndexSubset(BaseTransformer):
         "X_inner_mtype": ["pd.DataFrame", "pd.Series"],
         "y_inner_mtype": ["pd.DataFrame", "pd.Series"],
         "transform-returns-same-time-index": False,
-        "fit_is_empty": True,
+        "fit_is_empty": False,
         "univariate-only": False,
         "capability:inverse_transform": False,
         "remember_data": True,  # remember all data seen as _X

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -297,7 +297,7 @@ class WindowSummarizer(BaseTransformer):
         transformed version of X
         """
         idx = X.index
-        X = self._X
+        X = X.combine_first(self._X)
 
         func_dict = self._func_dict
         target_cols = self._target_cols

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -330,20 +330,6 @@ class WindowSummarizer(BaseTransformer):
         Xt_return = Xt_return.loc[idx]
         return Xt_return
 
-    def _update(self, X, y=None):
-        """Update X and return a transformed version.
-
-        Parameters
-        ----------
-        X : pd.DataFrame
-        y : None
-
-        Returns
-        -------
-        transformed version of X
-        """
-        return self
-
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -199,6 +199,7 @@ class WindowSummarizer(BaseTransformer):
         "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
         "transform-returns-same-time-index": False,
         # does transform return have the same time index as input X
+        "remember_data": True,  # remember all data seen as _X
     }
 
     def __init__(

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -238,8 +238,6 @@ class WindowSummarizer(BaseTransformer):
             The raw inputs to transformed columns will be dropped.
         self: reference to self
         """
-        self._X_memory = X
-
         X_name = get_name_list(X)
 
         if self.target_cols is not None:
@@ -299,7 +297,7 @@ class WindowSummarizer(BaseTransformer):
         transformed version of X
         """
         idx = X.index
-        X = X.combine_first(self._X_memory)
+        X = self._X
 
         func_dict = self._func_dict
         target_cols = self._target_cols
@@ -344,7 +342,7 @@ class WindowSummarizer(BaseTransformer):
         -------
         transformed version of X
         """
-        self._X_memory = X.combine_first(self._X_memory)
+        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/transformations/tests/test_all_transformers.py
+++ b/sktime/transformations/tests/test_all_transformers.py
@@ -41,6 +41,19 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
         if capability_tag and not skip_tag:
             assert estimator_instance._has_implementation_of("_inverse_transform")
 
+    def test_remember_data_tag_is_correct(self, estimator_instance):
+        """Test that the remember_data tag is set correctly."""
+        fit_empty_tag = estimator_instance.get_tag("fit_is_empty", True)
+        remember_data_tag = estimator_instance.get_tag("remember_data", False)
+        msg = (
+            'if the "remember_data" tag is set to True, then the "fit_is_empty" tag '
+            "must be set to False, even if _fit is not implemented or empty. "
+            "This is due to boilerplate that write to self.X in fit. "
+            f"Please check these two tags in {type(estimator_instance)}."
+        )
+        if fit_empty_tag and remember_data_tag:
+            raise AssertionError(msg)
+
     def _expected_trafo_output_scitype(self, X_scitype, trafo_input, trafo_output):
         """Return expected output scitype, given X scitype and input/output.
 


### PR DESCRIPTION
Variant of https://github.com/alan-turing-institute/sktime/pull/3306 which introduces a `remember_data` tag. Data is only remembered and stored to `self._X` if the `remember_data` tag is set.

This PR adds a data memory to transformers, similar to forecasters.

If enabled by the tag, all data seen are stored in an attribute `self._X`, as a reference if possible (due to coercions, storing a reference may not be possible).

This allows to refactor some transformers which already to that internally, and remove a layer of boilerplate:

* `Imputer`
* `Lag`
* `IndexSubset`
* `PandasTransformAdaptor`
* `WindowSummarizer`

The tag is set to `False` by default, and to `True` only in estimators that currently use `self._X` already (the refactored transformers listed in #3306).

Because `self._X` may now have to be written, we need to check that `fit_is_empty` is `False` whenever `remember_data` is `True`. This is checked by an added transformer test.