### PR TITLE
[ENH] test `super.__init__` call in objects and estimators

### DIFF
--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -236,6 +236,7 @@ class ComposableTimeSeriesForestClassifier(BaseTimeSeriesForest, BaseClassifier)
             class_weight=class_weight,
             max_samples=max_samples,
         )
+        BaseClassifier.__init__(self)
 
         # We need to add is-fitted state when inheriting from scikit-learn
         self._is_fitted = False

--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -85,6 +85,21 @@ class TimeSeriesForestClassifier(
 
     _base_estimator = DecisionTreeClassifier(criterion="entropy")
 
+    def __init__(
+        self,
+        min_interval=3,
+        n_estimators=200,
+        n_jobs=1,
+        random_state=None,
+    ):
+        super(TimeSeriesForestClassifier, self).__init__(
+            min_interval=min_interval,
+            n_estimators=n_estimators,
+            n_jobs=n_jobs,
+            random_state=random_state,
+        )
+        BaseClassifier.__init__(self)
+
     def fit(self, X, y, **kwargs):
         """Wrap fit to call BaseClassifier.fit.
 

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -345,6 +345,8 @@ class BaseSplitter(BaseObject):
         self.window_length = window_length
         self.fh = fh
 
+        super(BaseSplitter, self).__init__()
+
     def split(self, y: ACCEPTED_Y_TYPES) -> SPLIT_GENERATOR_TYPE:
         """Get iloc references to train/test slits of `y`.
 

--- a/sktime/networks/cnn.py
+++ b/sktime/networks/cnn.py
@@ -57,6 +57,8 @@ class CNNNetwork(BaseDeepNetwork):
         self.filter_sizes = [6, 12]
         self.activation = activation
 
+        super.__init__(CNNNetwork, self)
+
     def build_network(self, input_shape, **kwargs):
         """Construct a network and return its input and output layers.
 

--- a/sktime/networks/cnn.py
+++ b/sktime/networks/cnn.py
@@ -57,7 +57,7 @@ class CNNNetwork(BaseDeepNetwork):
         self.filter_sizes = [6, 12]
         self.activation = activation
 
-        super.__init__(CNNNetwork, self)
+        super(CNNNetwork, self).__init__()
 
     def build_network(self, input_shape, **kwargs):
         """Construct a network and return its input and output layers.

--- a/sktime/regression/interval_based/_tsf.py
+++ b/sktime/regression/interval_based/_tsf.py
@@ -73,6 +73,21 @@ class TimeSeriesForestRegressor(BaseTimeSeriesForest, ForestRegressor, BaseRegre
 
     _base_estimator = DecisionTreeRegressor()
 
+    def __init__(
+        self,
+        min_interval=3,
+        n_estimators=200,
+        n_jobs=1,
+        random_state=None,
+    ):
+        super(TimeSeriesForestRegressor, self).__init__(
+            min_interval=min_interval,
+            n_estimators=n_estimators,
+            n_jobs=n_jobs,
+            random_state=random_state,
+        )
+        BaseRegressor.__init__(self)
+
     def fit(self, X, y):
         """Override sklearn forest fit with BaseRegressor fit."""
         return BaseRegressor.fit(self, X, y)

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -682,6 +682,14 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             f"found {type(estimator)}"
         )
 
+        msg = (
+            f"{estimator_class.__name__}.__init__ should call "
+            f"super({estimator_class.__name__}, self).__init__, "
+            "but that does not seem to be the case. Please ensure to call the "
+            f"parent class's constructor in {estimator_class.__name__}.__init__"
+        )
+        assert hasattr(estimator, "_tags_dynamic"), msg
+
     def test_create_test_instances_and_names(self, estimator_class):
         """Check that create_test_instances_and_names works."""
         estimators, names = estimator_class.create_test_instances_and_names()
@@ -951,10 +959,15 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         attrs = ["_is_fitted", "is_fitted"]
 
         estimator = estimator_instance
+        estimator_class = type(estimator_instance)
 
-        assert hasattr(
-            estimator, "_is_fitted"
-        ), f"Estimator: {estimator.__name__} does not set_is_fitted in construction"
+        msg = (
+            f"{estimator_class.__name__}.__init__ should call "
+            f"super({estimator_class.__name__}, self).__init__, "
+            "but that does not seem to be the case. Please ensure to call the "
+            f"parent class's constructor in {estimator_class.__name__}.__init__"
+        )
+        assert hasattr(estimator, "_is_fitted"), msg
 
         # Check is_fitted attribute is set correctly to False before fit, at init
         for attr in attrs:

--- a/sktime/transformations/panel/compose.py
+++ b/sktime/transformations/panel/compose.py
@@ -135,6 +135,7 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
             n_jobs=n_jobs,
             transformer_weights=transformer_weights,
         )
+        BaseTransformer.__init__(self)
         self.preserve_dataframe = preserve_dataframe
         self._is_fitted = False
 


### PR DESCRIPTION
This adds checks and user friendly messages in the test suite, to ensure that all objects and estimators call their respective parent constructor in `__init__`.

Also adds missing `__init__` calls (to `super`'s `__init__`) in the following classes:

* `ComposableTimeSeriesForest`
* `ColumnTransformer`
* `BaseSplitter`
* `CNNNetwork`
* `TimeSeriesForestClassifier` and `TimeSeriesForestRegressor`

(all discovered by the new test 😄 )