### PR TITLE
[DOC] API reference for `dists_kernels` module

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -17,13 +17,14 @@ For a scientific manual, see the :ref:`user_guide`.
 
     api_reference/base
     api_reference/forecasting
-    api_reference/annotation
+    api_reference/transformations
     api_reference/classification
     api_reference/regression
     api_reference/clustering
-    api_reference/series_as_features
-    api_reference/transformations
+    api_reference/dists_kernels
     api_reference/performance_metrics
+    api_reference/series_as_features
+    api_reference/annotation
     api_reference/datasets
     api_reference/utils
     api_reference/exceptions

--- a/docs/source/api_reference/dists_kernels.rst
+++ b/docs/source/api_reference/dists_kernels.rst
@@ -4,7 +4,7 @@ Time series distances/kernels
 =============================
 
 The :mod:`sktime.dists_kernels` module contains pairwise transformers, such as
-distances and kernel functions on time series data. It also containe some distances/kernel functions for tabular data.
+distances and kernel functions on time series data. It also contains some distances/kernel functions for tabular data.
 
 Distances and kernel functions are treated the same, as they have the same formal signature - that of a "pairwise transformer".
 

--- a/docs/source/api_reference/dists_kernels.rst
+++ b/docs/source/api_reference/dists_kernels.rst
@@ -1,0 +1,87 @@
+.. _transformations_ref:
+
+Time series distances/kernels
+=============================
+
+The :mod:`sktime.dists_kernels` module contains pairwise transformers, such as
+distances and kernel functions on time series data. It also containe some distances/kernel functions for tabular data.
+
+Distances and kernel functions are treated the same, as they have the same formal signature - that of a "pairwise transformer".
+
+Below, we list separately pairwise transformers for time series, and pairwise transformers for tabular data.
+
+.. automodule:: sktime.dists_kernels
+   :no-members:
+   :no-inherited-members:
+
+Time series distances/kernels
+-----------------------------
+
+Composition
+~~~~~~~~~~~
+
+.. currentmodule:: sktime.dists_kernels.compose
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    PwTrafoPanelPipeline
+
+.. currentmodule:: sktime.dists_kernels.algebra
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    CombinedDistance
+
+.. currentmodule:: sktime.dists_kernels.compose_tab_to_panel
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    AggrDist
+    FlatDist
+
+.. currentmodule:: sktime.dists_kernels.compose_from_align
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    DistFromAligner
+
+Dynamic Time Warping Distances
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.dists_kernels.dtw
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    DtwDist
+
+Edit Distances
+~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.dists_kernels.edit_dist
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    EditDist
+
+Tabular distances/kernels
+-------------------------
+
+.. currentmodule:: sktime.dists_kernels.scipy_dist
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ScipyDist


### PR DESCRIPTION
This PR adds an API reference for `dists_kernels` module to the docs.