### PR TITLE
[BUG] removes superfluous `UserWarning` in `AutoETS.fit` if `auto=True` and `additive_only=True` #3311

### DIFF
--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -242,14 +242,17 @@ class AutoETS(_StatsModelsAdapter):
         # Select model automatically
         if self.auto:
             # Initialise parameter ranges
-            if (y > 0).all():
-                error_range = ["add", "mul"]
-            else:
-                warnings.warn(
-                    "Warning: time series is not strictly positive,"
-                    "multiplicative components are ommitted"
-                )
+            if self.additive_only:
                 error_range = ["add"]
+            else:
+                if (y > 0).all():
+                    error_range = ["add", "mul"]
+                else:
+                    warnings.warn(
+                        "Warning: time series is not strictly positive, "
+                        "multiplicative components are ommitted"
+                    )
+                    error_range = ["add"]
 
             if self.allow_multiplicative_trend and (y > 0).all():
                 trend_range = ["add", "mul", None]


### PR DESCRIPTION
Removes unnecessary warning from ETS estimator

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Bug #3311 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
This removes a warning about multiplicative components when self.additive_only == True 
#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?
Open to any feedback, this is my first open source PR
<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
I also added a space in the warning string so it will be formatted slightly better when printed. I will add myself to the list of contributors and add unit tests if necessary.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

<!--
Thanks for contributing!
-->
