### PR TITLE
[BUG] fix bug where default forecaster `_update` empties converter store

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1776,14 +1776,16 @@ class BaseForecaster(BaseEstimator):
                 f"{self.__class__.__name__} will be refit each time "
                 f"`update` is called with update_params=True."
             )
-            # we need to overwrite the mtype last seen, since the _y
+            # we need to overwrite the mtype last seen and converter store, since the _y
             #    may have been converted
             mtype_last_seen = self._y_mtype_last_seen
+            _converter_store_y = self._converter_store_y
             # refit with updated data, not only passed data
             self.fit(y=self._y, X=self._X, fh=self._fh)
             # todo: should probably be self._fit, not self.fit
             # but looping to self.fit for now to avoid interface break
             self._y_mtype_last_seen = mtype_last_seen
+            self._converter_store_y = _converter_store_y
 
         # if update_params=False, and there are no components, do nothing
         # if update_params=False, and there are components, we update cutoffs


### PR DESCRIPTION
This fixes an unreported bug where call to default `_update` would empty the converter store, due to a call to `self.fit`.

This has unintended side effects such as returning wrong column names when the mtype passed is not the internal mtype supported.