### PR TITLE
[ENH] remove hierarchical datatypes from recursive reduction forecasters

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -933,8 +933,11 @@ class RecursiveTabularRegressionForecaster(_RecursiveReducer):
 
     _tags = {
         "requires-fh-in-fit": False,  # is the forecasting horizon required in fit?
-        "y_inner_mtype": ["pd.Series", "pd-multiindex", "pd_multiindex_hier"],
-        "X_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
+        "y_inner_mtype": "pd.Series",
+        "X_inner_mtype": "pd.DataFrame",
+        # hierarchical data types are commented out until #3316 is fixed
+        # "y_inner_mtype": ["pd.Series", "pd-multiindex", "pd_multiindex_hier"],
+        # "X_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
     }
 
     _estimator_scitype = "tabular-regressor"


### PR DESCRIPTION
This PR removes hierarchical datatypes from recursive reduction forecasters as a temporary measure to address #3316.

Until #3316 is addressed at the root, this will allow the recursive forecasters to be applied to hierarchical data without raising an exception - what happens is simply naive vectorization, i.e., one model is fitted per unit/instance.