### PR TITLE
[ENH] global/local setting for `DirectReductionForecaster`

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1291,7 +1291,7 @@ class _ReducerMixin:
         Returns
         -------
         fh_idx : pd.Index, expected index of y_pred returned by _predict
-            CAVEAT: sorted by index level -1, since reduction is applied by fh        
+            CAVEAT: sorted by index level -1, since reduction is applied by fh
         """
         fh_idx = pd.Index(fh.to_absolute(self.cutoff))
         y_index = self._y.index

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1621,12 +1621,12 @@ class DirectReductionForecaster(BaseForecaster):
             "estimator": est,
             "window_length": 3,
             "X_treatment": "shifted",
-            "pooling": "global"  # all internal mtypes are tested across scenarios
+            "pooling": "global",  # all internal mtypes are tested across scenarios
         }
         params2 = {
             "estimator": est,
             "window_length": 3,
             "X_treatment": "concurrent",
-            "pooling": "global"
+            "pooling": "global",
         }
         return [params1, params2]

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1278,7 +1278,35 @@ def slice_at_ix(df, ix):
         return df.loc[[ix]]
 
 
-class DirectReductionForecaster(BaseForecaster):
+class _ReducerMixin:
+    """Common utilities for reducers."""
+
+    def _get_expected_pred_idx(self, fh):
+        """Construct DataFrame Index expected in y_pred, return of _predict.
+
+        Parameters
+        ----------
+        fh : ForecastingHorizon, fh of self
+
+        Returns
+        -------
+        fh_idx : pd.Index, expected index of y_pred returned by _predict
+            CAVEAT: sorted by index level -1, since reduction is applied by fh        
+        """
+        fh_idx = pd.Index(fh.to_absolute(self.cutoff))
+        y_index = self._y.index
+
+        if isinstance(y_index, pd.MultiIndex):
+            y_inst_idx = y_index.droplevel(-1).unique()
+            if isinstance(y_inst_idx, pd.MultiIndex):
+                fh_idx = pd.Index([x + (y,) for y in fh_idx for x in y_inst_idx])
+            else:
+                fh_idx = pd.Index([(x, y) for y in fh_idx for x in y_inst_idx])
+
+        return fh_idx
+
+
+class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
     """Direct reduction forecaster, incl single-output, multi-output, exogeneous Dir.
 
     Implements direct reduction, of forecasting to tabular regression.
@@ -1395,30 +1423,6 @@ class DirectReductionForecaster(BaseForecaster):
         """Predict dispatcher based on X_treatment."""
         methodname = f"_predict_{self.X_treatment}"
         return getattr(self, methodname)(X=X, fh=fh)
-
-    def _get_expected_pred_idx(self, fh):
-        """Construct DataFrame Index expected in y_pred, return of _predict.
-
-        Parameters
-        ----------
-        fh : ForecastingHorizon, fh of self
-
-        Returns
-        -------
-        fh_idx : pd.Index, expected index of y_pred returned by _predict
-            CAVEAT: sorted by index level -1, since reduction is applied by fh        
-        """
-        fh_idx = pd.Index(fh.to_absolute(self.cutoff))
-        y_index = self._y.index
-
-        if isinstance(y_index, pd.MultiIndex):
-            y_inst_idx = y_index.droplevel(-1).unique()
-            if isinstance(y_inst_idx, pd.MultiIndex):
-                fh_idx = pd.Index([x + (y,) for y in fh_idx for x in y_inst_idx])
-            else:
-                fh_idx = pd.Index([(x, y) for y in fh_idx for x in y_inst_idx])
-
-        return fh_idx
 
     def _fit_shifted(self, y, X=None, fh=None):
         """Fit to training data."""


### PR DESCRIPTION
This introduces a parameter `pooling` to `DirectReductionForecaster`, which can be set to `"global"` for global pooling, `"local"` for per-instance pooling, and `"panel"` for panel-wise pooling. Pooling refers to the `X` and `y` passed to the supervised sklearn regressors, which could be constructed from single instances, or the entire panel/hierarchy, in case there are more than one instances.

Giving the user a choice is the way to go here imo, as all settings can make sense.

The logic of `DirectReductionForecaster` also had to be extended to also accommodate for potential multi-indexed `pandas.DataFrame` appearing in the `fit`/`predict` parts. Unfortunately this is a bit fiddly, since it seems `pandas` interfaces are quite discrepant between the 1-level case and the 2- and multi-level case.

Testing was done locally using the full panel/hierarchical suite introduced in https://github.com/alan-turing-institute/sktime/pull/3321, but that is *not* included in this PR, to minimize size of PR and interdependencies. #3321 should be merged first, therefore.

---

Update: #3321 is merged now, so test passing pass with full hierarchical test suite in #3321.