### PR TITLE
[DOC] updated extension templates - tags explained, soft dependencies

### DIFF
--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -40,6 +40,13 @@ from sktime.classification.base import BaseClassifier
 
 # todo: add any necessary imports here
 
+# todo: if any imports are sktime soft dependencies:
+#  * make sure to fill in the "python_dependencies" tag with the package import name
+#  * add a _check_soft_dependencies warning here, example:
+#
+# from sktime.utils.validation._dependencies import check_soft_dependencies
+# _check_soft_dependencies("soft_dependency_name", severity="warning")
+
 
 class MyTimeSeriesClassifier(BaseClassifier):
     """Custom time series classifier. todo: write docstring.

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -28,6 +28,13 @@ from sktime.dists_kernels import BasePairwiseTransformerPanel
 
 # todo: add any necessary imports here
 
+# todo: if any imports are sktime soft dependencies:
+#  * make sure to fill in the "python_dependencies" tag with the package import name
+#  * add a _check_soft_dependencies warning here, example:
+#
+# from sktime.utils.validation._dependencies import check_soft_dependencies
+# _check_soft_dependencies("soft_dependency_name", severity="warning")
+
 
 class MyTrafoPwPanel(BasePairwiseTransformerPanel):
     """Custom time series distance/kernel. todo: write docstring.

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -28,6 +28,13 @@ from sktime.dists_kernels import BasePairwiseTransformer
 
 # todo: add any necessary imports here
 
+# todo: if any imports are sktime soft dependencies:
+#  * make sure to fill in the "python_dependencies" tag with the package import name
+#  * add a _check_soft_dependencies warning here, example:
+#
+# from sktime.utils.validation._dependencies import check_soft_dependencies
+# _check_soft_dependencies("soft_dependency_name", severity="warning")
+
 
 class MyTrafoPw(BasePairwiseTransformer):
     """Custom distance/kernel (on data frame rows). todo: write docstring.

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -49,6 +49,13 @@ from sktime.forecasting.base import BaseForecaster
 
 # todo: add any necessary imports here
 
+# todo: if any imports are sktime soft dependencies:
+#  * make sure to fill in the "python_dependencies" tag with the package import name
+#  * add a _check_soft_dependencies warning here, example:
+#
+# from sktime.utils.validation._dependencies import check_soft_dependencies
+# _check_soft_dependencies("soft_dependency_name", severity="warning")
+
 
 class MyForecaster(BaseForecaster):
     """Custom forecaster. todo: write docstring.
@@ -80,16 +87,78 @@ class MyForecaster(BaseForecaster):
     #   y_inner_mtype should be changed to pd.DataFrame
     # other tags are "safe defaults" which can usually be left as-is
     _tags = {
-        "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
-        "ignores-exogeneous-X": True,  # does estimator ignore the exogeneous X?
-        "handles-missing-data": False,  # can estimator handle missing data?
-        "y_inner_mtype": "pd.Series",  # which types do _fit, _predict, assume for y?
-        "X_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for X?
-        "requires-fh-in-fit": True,  # is forecasting horizon already required in fit?
-        "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
-        "enforce_index_type": None,  # index type that needs to be enforced in X/y
-        "capability:pred_int": False,  # does forecaster implement proba forecasts?
-        "python_version": None,  # PEP 440 python version specifier to limit versions
+        # to list all valid tags with description, use sktime.registry.all_tags
+        #   all_tags(estimator_types="forecaster", as_dataframe=True)
+        #
+        # behavioural tags: internal type
+        # -------------------------------
+        #
+        # y_inner_mtype, X_inner_mtype control which format X/y appears in
+        # in the inner functions _fit, _predict, etc
+        "y_inner_mtype": "pd.Series",
+        "X_inner_mtype": "pd.DataFrame",
+        # valid values: str and list of str
+        # if str, must be a valid mtype str, in sktime.datatypes.MTYPE_REGISTER
+        #   of scitype Series, Panel (panel data) or Hierarchical (hierarchical series)
+        #   in that case, all inputs are converted to that one type
+        # if list of str, must be a list of valid str specifiers
+        #   in that case, X/y are passed through without conversion if on the list
+        #   if not on the list, converted to the first entry of the same scitype
+        #
+        # scitype:y controls whether internal y can be univariate/multivariate
+        # if multivariate is not valid, applies vectorization over variables
+        "scitype:y": "univariate",
+        # valid values: "univariate", "multivariate", "both"
+        #   "univariate": inner _fit, _predict, etc, receive only univariate series
+        #   "multivariate": inner methods receive only series with 2 or more variables
+        #   "both": inner methods can see series with any number of variables
+        #
+        # capability tags: properties of the estimator
+        # --------------------------------------------
+        #
+        # ignores-exogeneous-X = does estimator ignore the exogeneous X?
+        "ignores-exogeneous-X": False,
+        # valid values: boolean True (ignores X), False (uses X in non-trivial manner)
+        # CAVEAT: if tag is set to True, inner methods always see X=None
+        #
+        # requires-fh-in-fit = is forecasting horizon always required in fit?
+        "requires-fh-in-fit": True,
+        # valid values: boolean True (yes), False (no)
+        # if True, raises exception in fit if fh has not been passed
+        #
+        # X-y-must-have-same-index = can estimator handle different X/y index?
+        "X-y-must-have-same-index": True,
+        # valid values: boolean True (yes), False (no)
+        # if True, raises exception if X.index is not contained in y.index
+        #
+        # enforce_index_type = index type that needs to be enforced in X/y
+        "enforce_index_type": None,
+        # valid values: pd.Index subtype, or list of pd.Index subtype
+        # if not None, raises exception if X.index, y.index level -1 is not of that type
+        #
+        # handles-missing-data = can estimator handle missing data?
+        "handles-missing-data": False,
+        # valid values: boolean True (yes), False (no)
+        # no boilerplate effect, for inspection
+        #
+        # capability:pred_int = does forecaster implement probabilistic forecasts?
+        "capability:pred_int": False,
+        # valid values: boolean True (yes), False (no)
+        # if False, exception raised if proba methods are called (predict_interval etc)
+        #
+        #
+        # dependency tags: python version and soft dependencies
+        # -----------------------------------------------------
+        #
+        # python version requirement
+        "python_version": None,
+        # valid values: str, PEP 440 valid python version specifiers
+        # raises exception at construction if local python veresion is incompatible
+        #
+        # soft dependency requirement
+        "python_dependencies": None
+        # valid values: str or list of str
+        # raises exception at construction if modules at strings cannot be imported
     }
     #  in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)
@@ -139,7 +208,8 @@ class MyForecaster(BaseForecaster):
 
         Parameters
         ----------
-        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+        y : sktime time series object
+            guaranteed to be of an mtype in self.get_tag("y_inner_mtype")
             Time series to which to fit the forecaster.
             if self.get_tag("scitype:y")=="univariate":
                 guaranteed to have a single column/variable
@@ -150,8 +220,8 @@ class MyForecaster(BaseForecaster):
             The forecasting horizon with the steps ahead to to predict.
             Required (non-optional) here if self.get_tag("requires-fh-in-fit")==True
             Otherwise, if not passed in _fit, guaranteed to be passed in _predict
-        X : optional (default=None)
-            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
             Exogeneous time series to fit to.
 
         Returns
@@ -191,13 +261,14 @@ class MyForecaster(BaseForecaster):
         fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
             The forecasting horizon with the steps ahead to to predict.
             If not passed in _fit, guaranteed to be passed here
-        X : optional (default=None)
-            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+        X : sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
             Exogeneous time series for the forecast
 
         Returns
         -------
-        y_pred : pd.Series
+        y_pred : sktime time series object
+            should be of the same type as seen in _fit, as in "y_inner_mtype" tag
             Point predictions
         """
 
@@ -224,15 +295,16 @@ class MyForecaster(BaseForecaster):
 
         Parameters
         ----------
-        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+        y : sktime time series object
+            guaranteed to be of an mtype in self.get_tag("y_inner_mtype")
             Time series with which to update the forecaster.
             if self.get_tag("scitype:y")=="univariate":
                 guaranteed to have a single column/variable
             if self.get_tag("scitype:y")=="multivariate":
                 guaranteed to have 2 or more columns
             if self.get_tag("scitype:y")=="both": no restrictions apply
-        X : optional (default=None)
-            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
             Exogeneous time series for the forecast
         update_params : bool, optional (default=True)
             whether model parameters should be updated
@@ -286,8 +358,8 @@ class MyForecaster(BaseForecaster):
         ----------
         fh : guaranteed to be ForecastingHorizon
             The forecasting horizon with the steps ahead to to predict.
-        X : optional (default=None)
-            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
             Exogeneous time series for the forecast
         alpha : list of float (guaranteed not None and floats in [0,1] interval)
             A list of probabilities at which quantile forecasts are computed.
@@ -329,8 +401,8 @@ class MyForecaster(BaseForecaster):
         ----------
         fh : guaranteed to be ForecastingHorizon
             The forecasting horizon with the steps ahead to to predict.
-        X : optional (default=None)
-            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
             Exogeneous time series for the forecast
         coverage : list of float (guaranteed not None and floats in [0,1] interval)
            nominal coverage(s) of predictive interval(s)
@@ -372,8 +444,8 @@ class MyForecaster(BaseForecaster):
         fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
             The forecasting horizon with the steps ahead to to predict.
             If not passed in _fit, guaranteed to be passed here
-        X : optional (default=None)
-            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
             Exogeneous time series for the forecast
         cov : bool, optional (default=False)
             if True, computes covariance matrix forecast.
@@ -418,7 +490,7 @@ class MyForecaster(BaseForecaster):
         fh : int, list, np.array or ForecastingHorizon (not optional)
             The forecasting horizon encoding the time stamps to forecast at.
             if has not been passed in fit, must be passed, not optional
-        X : time series in sktime compatible format, optional (default=None)
+        X : sktime time series object, optional (default=None)
                 Exogeneous time series for the forecast
             Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
             if self.get_tag("X-y-must-have-same-index"),

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -70,15 +70,44 @@ class MyForecaster(BaseForecaster):
     #   scitype:y - the expected input scitype of y - univariate or multivariate or both
     # tag values are "safe defaults" which can usually be left as-is
     _tags = {
-        "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
-        "ignores-exogeneous-X": True,  # does estimator ignore the exogeneous X?
-        "handles-missing-data": False,  # can estimator handle missing data?
-        "y_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for y?
-        "X_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for X?
-        "requires-fh-in-fit": True,  # is forecasting horizon already required in fit?
-        "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
-        "enforce_index_type": None,  # index type that needs to be enforced in X/y
-        "capability:pred_int": False,  # does forecaster implement predict_quantiles?
+        # to list all valid tags with description, use sktime.registry.all_tags
+        #   all_tags(estimator_types="forecaster", as_dataframe=True)
+        #
+        # behavioural tags: internal type
+        # -------------------------------
+        #
+        # y_inner_mtype, X_inner_mtype control which format X/y appears in
+        # in the inner functions _fit, _predict, etc
+        "y_inner_mtype": "pd.Series",
+        "X_inner_mtype": "pd.DataFrame",
+        # valid values: str and list of str
+        # if str, must be a valid mtype str, in sktime.datatypes.MTYPE_REGISTER
+        #   of scitype Series, Panel (panel data) or Hierarchical (hierarchical series)
+        #   in that case, all inputs are converted to that one type
+        # if list of str, must be a list of valid str specifiers
+        #   in that case, X/y are passed through without conversion if on the list
+        #   if not on the list, converted to the first entry of the same scitype
+        #
+        # scitype:y controls whether internal y can be univariate/multivariate
+        # if multivariate is not valid, applies vectorization over variables
+        "scitype:y": "univariate",
+        # valid values: "univariate", "multivariate", "both"
+        #   "univariate": inner _fit, _predict, etc, receive only univariate series
+        #   "multivariate": inner methods receive only series with 2 or more variables
+        #   "both": inner methods can see series with any number of variables
+        #
+        # capability tags: properties of the estimator
+        # --------------------------------------------
+        #
+        # ignores-exogeneous-X = does estimator ignore the exogeneous X?
+        "ignores-exogeneous-X": False,
+        # valid values: boolean True (ignores X), False (uses X in non-trivial manner)
+        # CAVEAT: if tag is set to True, inner methods always see X=None
+        #
+        # requires-fh-in-fit = is forecasting horizon always required in fit?
+        "requires-fh-in-fit": True,
+        # valid values: boolean True (yes), False (no)
+        # if True, raises exception in fit if fh has not been passed
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -47,6 +47,13 @@ from sktime.transformations.base import BaseTransformer
 
 # todo: add any necessary sktime internal imports here
 
+# todo: if any imports are sktime soft dependencies:
+#  * make sure to fill in the "python_dependencies" tag with the package import name
+#  * add a _check_soft_dependencies warning here, example:
+#
+# from sktime.utils.validation._dependencies import check_soft_dependencies
+# _check_soft_dependencies("soft_dependency_name", severity="warning")
+
 
 class MyTransformer(BaseTransformer):
     """Custom transformer. todo: write docstring.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -86,6 +86,7 @@ class BaseForecaster(BaseEstimator):
     """
 
     # default tag values - these typically make the "safest" assumption
+    # for more extensive documentation, see forecasting extension template
     _tags = {
         "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
         "ignores-exogeneous-X": False,  # does estimator ignore the exogeneous X?
@@ -98,7 +99,7 @@ class BaseForecaster(BaseEstimator):
         "enforce_index_type": None,  # index type that needs to be enforced in X/y
         "fit_is_empty": False,  # is fit empty and can be skipped?
         "python_version": None,  # PEP 440 python version specifier to limit versions
-        "python_dependencies": None  # str or list of str, package soft dependencies
+        "python_dependencies": None,  # str or list of str, package soft dependencies
     }
 
     def __init__(self):

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -86,7 +86,7 @@ class BaseForecaster(BaseEstimator):
     """
 
     # default tag values - these typically make the "safest" assumption
-    # for more extensive documentation, see forecasting extension template
+    # for more extensive documentation, see extension_templates/forecasting.py
     _tags = {
         "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
         "ignores-exogeneous-X": False,  # does estimator ignore the exogeneous X?

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -98,6 +98,7 @@ class BaseForecaster(BaseEstimator):
         "enforce_index_type": None,  # index type that needs to be enforced in X/y
         "fit_is_empty": False,  # is fit empty and can be skipped?
         "python_version": None,  # PEP 440 python version specifier to limit versions
+        "python_dependencies": None  # str or list of str, package soft dependencies
     }
 
     def __init__(self):


### PR DESCRIPTION
This updates the extension templates:

* tags are explained in the forecaster template (for review, is this good for other templates?). Towards https://github.com/alan-turing-institute/sktime/issues/3280
* paragraph on soft dependencies is added to all (non-simple, non-experimental) templates, replacing https://github.com/alan-turing-institute/sktime/pull/1900