### PR TITLE
 [ENH] Optimize `from_3d_numpy_to_nested` converter function

### DIFF
--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -910,7 +910,12 @@ def from_3d_numpy_to_nested(X, column_names=None, cells_as_numpy=False):
 
     column_list = []
     for j, column in enumerate(column_names):
-        nested_column = pd.DataFrame(X[:, j, :]).apply(lambda x: [container(x)], axis=1).str[0].rename(column)
+        nested_column = (
+            pd.DataFrame(X[:, j, :])
+            .apply(lambda x: [container(x)], axis=1)
+            .str[0]
+            .rename(column)
+        )
         column_list.append(nested_column)
     df = pd.concat(column_list, axis=1)
     return df

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -892,6 +892,7 @@ def from_3d_numpy_to_nested(X, column_names=None, cells_as_numpy=False):
     df : pd.DataFrame
     """
     n_instances, n_columns, n_timepoints = X.shape
+    array_type = X.dtype
 
     container = np.array if cells_as_numpy else pd.Series
 
@@ -912,7 +913,7 @@ def from_3d_numpy_to_nested(X, column_names=None, cells_as_numpy=False):
     for j, column in enumerate(column_names):
         nested_column = (
             pd.DataFrame(X[:, j, :])
-            .apply(lambda x: [container(x)], axis=1)
+            .apply(lambda x: [container(x, dtype=array_type)], axis=1)
             .str[0]
             .rename(column)
         )

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -891,8 +891,6 @@ def from_3d_numpy_to_nested(X, column_names=None, cells_as_numpy=False):
     -------
     df : pd.DataFrame
     """
-    df = pd.DataFrame()
-    # n_instances, n_variables, _ = X.shape
     n_instances, n_columns, n_timepoints = X.shape
 
     container = np.array if cells_as_numpy else pd.Series
@@ -910,8 +908,11 @@ def from_3d_numpy_to_nested(X, column_names=None, cells_as_numpy=False):
             )
             raise ValueError(msg)
 
+    column_list = []
     for j, column in enumerate(column_names):
-        df[column] = [container(X[instance, j, :]) for instance in range(n_instances)]
+        nested_column = pd.DataFrame(X[:, j, :]).apply(lambda x: [container(x)], axis=1).str[0].rename(column)
+        column_list.append(nested_column)
+    df = pd.concat(column_list, axis=1)
     return df
 
 


### PR DESCRIPTION
Building a nested column with all instances at once trough pd.DataFrame instead of interating over every instance improves performance by factor 3.

#### What does this implement/fix? Explain your changes.

I was doing some inference on a big dataset 500k observations using a numpy array. The inference on big datasets is very slow. In this case one of the issues is that the numpy array was converted to a nested dataframe with `from_3d_numpy_to_nested`. And the function is very slow for bigger Dataframe sizes.

Have a look at this example:
<img width="1102" alt="grafik" src="https://user-images.githubusercontent.com/20282916/186608127-33c19ffa-3836-4701-931d-1fe2f87a3119.png">

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

The changes are rather small. You can test how the performance improves for bigger Dataframes, see my example provided above.

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.