### PR TITLE
[BUG] fixes missing `super.__init__` call in `MLPNetwork`

### DIFF
--- a/sktime/networks/mlp.py
+++ b/sktime/networks/mlp.py
@@ -42,6 +42,7 @@ class MLPNetwork(BaseDeepNetwork):
     ):
         _check_dl_dependencies(severity="error")
         self.random_state = random_state
+        super(MLPNetwork, self).__init__()
 
     def build_network(self, input_shape, **kwargs):
         """Construct a network and return its input and output layers.


### PR DESCRIPTION
Fixes a bug that was introduced to main in https://github.com/alan-turing-institute/sktime/pull/3232.

The tests passed before merge, but the branch was not up to date, missing some newer tests.

@AurumnPegasus, please make sure your branch is up to date with the latest release, for any future PR.