### PR TITLE
[ENH] avoid metadata computation in `scitype` utility

### DIFF
--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -472,12 +472,31 @@ def scitype(obj, candidate_scitypes=SCITYPE_LIST, exclude_mtypes=AMBIGUOUS_MTYPE
     ------
     TypeError if no type can be identified, or more than one type is identified
     """
-    _, _, metadata = check_is_scitype(
-        obj,
-        scitype=candidate_scitypes,
-        return_metadata=True,
-        exclude_mtypes=exclude_mtypes,
+    candidate_scitypes = _coerce_list_of_str(
+        candidate_scitypes,
+        var_name="candidate_scitypes"
     )
-    scitype = metadata["scitype"]
+
+    valid_scitypes = []
+
+    for scitype in candidate_scitypes:
+        valid = check_is_scitype(
+            obj,
+            scitype=candidate_scitypes,
+            return_metadata=False,
+            exclude_mtypes=exclude_mtypes,
+        )
+        if valid:
+            valid_scitypes += [scitype]
+
+    if len(valid_scitypes) > 1:
+        raise TypeError(
+            "Error in function scitype, more than one valid scitype identified:"
+            f"{ valid_scitypes}"
+        )
+    if len(valid_scitypes) == 0:
+        raise TypeError(
+            "Error in function scitype, no valid scitype could be identified."
+        )
 
     return scitype

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -473,8 +473,7 @@ def scitype(obj, candidate_scitypes=SCITYPE_LIST, exclude_mtypes=AMBIGUOUS_MTYPE
     TypeError if no type can be identified, or more than one type is identified
     """
     candidate_scitypes = _coerce_list_of_str(
-        candidate_scitypes,
-        var_name="candidate_scitypes"
+        candidate_scitypes, var_name="candidate_scitypes"
     )
 
     valid_scitypes = []

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -498,4 +498,4 @@ def scitype(obj, candidate_scitypes=SCITYPE_LIST, exclude_mtypes=AMBIGUOUS_MTYPE
             "Error in function scitype, no valid scitype could be identified."
         )
 
-    return scitype
+    return valid_scitypes[0]

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -482,7 +482,7 @@ def scitype(obj, candidate_scitypes=SCITYPE_LIST, exclude_mtypes=AMBIGUOUS_MTYPE
     for scitype in candidate_scitypes:
         valid = check_is_scitype(
             obj,
-            scitype=candidate_scitypes,
+            scitype=scitype,
             return_metadata=False,
             exclude_mtypes=exclude_mtypes,
         )


### PR DESCRIPTION
This PR makes the utility `scitype` (infer scitype) more efficient by avoiding calls to `check_is_scitype` with the `return_metadata=True` flag.

The internal logic is changed to call `check_is_scitype` with the `return_metadata=False` flag, which avoids the more expensive metadata related calculations (e.g., in a `nested_univ` frame, check all indices of all series for equal length, etc).