### PR TITLE
[ENH] simplify `convert_to_scitype` logic, fix export and docstring omissions in scitype converter module

### DIFF
--- a/sktime/datatypes/_series_as_panel/_convert.py
+++ b/sktime/datatypes/_series_as_panel/_convert.py
@@ -11,12 +11,10 @@ convert_Panel_to_Series(obj, store=None)
 
 __author__ = ["fkiraly"]
 
-__all__ = ["convert_Series_to_Panel", "convert_Panel_to_Series"]
-
 import numpy as np
 import pandas as pd
 
-from sktime.datatypes import convert_to, mtype, mtype_to_scitype
+from sktime.datatypes import convert_to, scitype
 
 
 def convert_Series_to_Panel(obj, store=None):
@@ -227,8 +225,9 @@ def convert_to_scitype(obj, to_scitype, from_scitype=None, store=None):
             if not possible, will be one of the mtypes with pd.DataFrame python type
     """
     if from_scitype is None:
-        obj_mtype = mtype(obj, as_scitype=["Series", "Panel", "Hierarchical"])
-        from_scitype = mtype_to_scitype(obj_mtype)
+        from_scitype = scitype(
+            obj, candidate_scitypes=["Series", "Panel", "Hierarchical"]
+        )
 
     if to_scitype == from_scitype:
         return obj

--- a/sktime/datatypes/_series_as_panel/_convert.py
+++ b/sktime/datatypes/_series_as_panel/_convert.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 """Machine type converters for Series to Panel.
 
-Exports conversion functions for conversions between Series and Panel:
+Exports conversion functions for conversions between series scitypes:
 
 convert_Series_to_Panel(obj, store=None)
     converts obj of Series mtype to "adjacent" Panel mtype (e.g., numpy to numpy)
 convert_Panel_to_Series(obj, store=None)
     converts obj of Panel mtype to "adjacent" Series mtype (e.g., numpy to numpy)
+convert_Series_to_Hierarchical(obj, store=None)
+convert_Hierarchical_to_series(obj, store=None)
+convert_Panel_to_Hierarchical(obj, store=None)
+convert_Hierarchical_to_Panel(obj, store=None)
+    converts to pd.DataFrame based data container in the target scitype
 """
 
 __author__ = ["fkiraly"]


### PR DESCRIPTION
This PR makes minor improvements to the between-scitype converter module:
* simplifies `convert_to_scitype` logic by direct call to `scitype`, instead of daisy chain of mtype related functions
* fixes omissions in exports and docstrings