### PR TITLE
[ENH] consistent `sp` handling in parameter estimators and `AutoARIMA`

### DIFF
--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -376,6 +376,8 @@ class AutoARIMA(_PmdArimaAdapter):
 
         super(AutoARIMA, self).__init__()
 
+        self._sp = sp if sp else 1
+
     def _instantiate_model(self):
         # import inside method to avoid hard dependency
         from pmdarima.arima import AutoARIMA as _AutoARIMA  # type: ignore
@@ -396,7 +398,7 @@ class AutoARIMA(_PmdArimaAdapter):
             max_D=self.max_D,
             max_Q=self.max_Q,
             max_order=self.max_order,
-            m=self.sp,
+            m=self._sp,
             seasonal=self.seasonal,
             stationary=self.stationary,
             information_criterion=self.information_criterion,

--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -50,6 +50,13 @@ class SeasonalityACF(BaseParamFitter):
             estimate the autocovariance. When using "conservative",
             n is set to the number of non-missing observations.
 
+    Attributes
+    ----------
+    sp_ : int, seasonality period at lowest p-level, if any sub-threshold, else 1
+        if `candidate_sp` is passed, will be in `candidate_sp` or 1
+    sp_significant_ : list of int, seasonality periods with sub-threshold p-levels
+        ordered increasingly by p-level. Empty list, not [1], if none are sub-threshold
+
     Examples
     --------
     >>> from sktime.datasets import load_airline
@@ -162,8 +169,8 @@ class SeasonalityACF(BaseParamFitter):
             self.sp_ = sp_significant[0]
             self.sp_significant_ = sp_significant
         else:
-            self.sp_ = None
-            self.sp_significant_ = None
+            self.sp_ = 1
+            self.sp_significant_ = []
 
         return self
 
@@ -239,6 +246,13 @@ class SeasonalityACFqstat(BaseParamFitter):
             removed when computing the mean and cross-products that are used to
             estimate the autocovariance. When using "conservative",
             n is set to the number of non-missing observations.
+
+    Attributes
+    ----------
+    sp_ : int, seasonality period at lowest p-level, if any sub-threshold, else 1
+        if `candidate_sp` is passed, will be in `candidate_sp` or 1
+    sp_significant_ : list of int, seasonality periods with sub-threshold p-levels
+        ordered increasingly by p-level. Empty list, not [1], if none are sub-threshold
 
     Examples
     --------
@@ -358,8 +372,8 @@ class SeasonalityACFqstat(BaseParamFitter):
             self.sp_ = sp_significant[0]
             self.sp_significant_ = sp_significant
         else:
-            self.sp_ = None
-            self.sp_significant_ = None
+            self.sp_ = 1
+            self.sp_significant_ = []
 
         return self
 


### PR DESCRIPTION
This PR has some additions to make `sp` handling consistent in case no `sp` is present:

* `AutoARIMA` now also accepts `sp=None`, interpreting this as `sp=1`
* the two seasonality estimators in `param_est` will produce `sp_=1` and `sp_significant_ = []` if no seasonality is significant, instead of both being `None`. This ensures type consistency (`int` and `list`).