### PR TITLE
[ENH] skip `ClearSky` doctest to avoid `load_solar` crash

### DIFF
--- a/sktime/transformations/series/clear_sky.py
+++ b/sktime/transformations/series/clear_sky.py
@@ -59,12 +59,12 @@ class ClearSky(BaseTransformer):
 
     Examples
     --------
-    >>> from sktime.transformations.series.clear_sky import ClearSky
-    >>> from sktime.datasets import load_solar
-    >>> y = load_solar()
-    >>> transformer = ClearSky()
+    >>> from sktime.transformations.series.clear_sky import ClearSky  # doctest: +SKIP
+    >>> from sktime.datasets import load_solar  # doctest: +SKIP
+    >>> y = load_solar()  # doctest: +SKIP
+    >>> transformer = ClearSky()  # doctest: +SKIP
     >>> # takes ~1min
-    >>> y_trafo = transformer.fit_transform(y)
+    >>> y_trafo = transformer.fit_transform(y)  # doctest: +SKIP
     """
 
     _tags = {


### PR DESCRIPTION
This PR skips the `ClearSky` doctest to avoid `load_solar` crashing upon intermittent connection to the data repository.

The problem has already been addressed by using the `backoff` library in `load_solar` itself and testing, and test coverage is not reduced as `ClearSky` is still subject to the full transformer test suite, and `load_solar` is tested separately.