### PR TITLE
[ENH] skip sporadic failure in testing `HMM`

### DIFF
--- a/sktime/annotation/tests/test_all_annotators.py
+++ b/sktime/annotation/tests/test_all_annotators.py
@@ -9,7 +9,11 @@ from sktime.registry import all_estimators
 from sktime.utils._testing.annotation import make_annotation_problem
 from sktime.utils.validation._dependencies import _check_estimator_deps
 
-ALL_ANNOTATORS = all_estimators(estimator_types="series-annotator", return_names=False)
+EXCLUDE = "HMM"
+
+ALL_ANNOTATORS = all_estimators(
+    estimator_types="series-annotator", return_names=False, exclude_estimators=EXCLUDE
+)
 
 
 @pytest.mark.parametrize("Estimator", ALL_ANNOTATORS)

--- a/sktime/annotation/tests/test_all_annotators.py
+++ b/sktime/annotation/tests/test_all_annotators.py
@@ -9,6 +9,7 @@ from sktime.registry import all_estimators
 from sktime.utils._testing.annotation import make_annotation_problem
 from sktime.utils.validation._dependencies import _check_estimator_deps
 
+# todo: sporadic failure needs to be fixed, see issue #3394
 EXCLUDE = "HMM"
 
 ALL_ANNOTATORS = all_estimators(


### PR DESCRIPTION
Temporarily addresses sporadic failure on `main`
https://github.com/alan-turing-institute/sktime/issues/3394
by skipping the affected test.