### PR TITLE
[ENH] missing data input check in forecasters

### DIFF
--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -139,7 +139,7 @@ class MyForecaster(BaseForecaster):
         # handles-missing-data = can estimator handle missing data?
         "handles-missing-data": False,
         # valid values: boolean True (yes), False (no)
-        # no boilerplate effect, for inspection
+        # if False, raises exception if y or X passed contain missing data (nans)
         #
         # capability:pred_int = does forecaster implement probabilistic forecasts?
         "capability:pred_int": False,

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1203,6 +1203,22 @@ class BaseForecaster(BaseEstimator):
             else:
                 raise ValueError("no series scitypes supported, bug in estimator")
 
+        def _check_missing(metadata, obj_name):
+            """Check input metadata against self's missing capability tag."""
+            if not self.get_tag("handles-missing-data"):
+                msg = (
+                    f"{type(self).__name} cannot handle missing data (nans), "
+                    f"but {obj_name} passed contained missing data."
+                )
+                if self.get_class_tag("handles-missing-data"):
+                    msg = msg + (
+                        f" Whether instances of {type(self).__name} can handle "
+                        "missing data is depends on parameters of the instance, "
+                        "e.g., estimator components."
+                    )
+                if metadata["has_nans"]:
+                    raise ValueError(msg)
+
         # retrieve supported mtypes
         y_inner_mtype = _coerce_to_list(self.get_tag("y_inner_mtype"))
         X_inner_mtype = _coerce_to_list(self.get_tag("X_inner_mtype"))
@@ -1254,6 +1270,9 @@ class BaseForecaster(BaseEstimator):
                 raise ValueError(
                     "y must have two or more variables, but found only one"
                 )
+
+            _check_missing(y_metadata, "y")
+
         else:
             # y_scitype is used below - set to None if y is None
             y_scitype = None
@@ -1284,6 +1303,9 @@ class BaseForecaster(BaseEstimator):
             X_scitype = X_metadata["scitype"]
             X_requires_vectorization = X_scitype not in X_inner_scitype
             requires_vectorization = requires_vectorization or X_requires_vectorization
+
+            _check_missing(X_metadata, "X")
+
         else:
             # X_scitype is used below - set to None if X is None
             X_scitype = None

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1207,13 +1207,13 @@ class BaseForecaster(BaseEstimator):
             """Check input metadata against self's missing capability tag."""
             if not self.get_tag("handles-missing-data"):
                 msg = (
-                    f"{type(self).__name} cannot handle missing data (nans), "
+                    f"{type(self).__name__} cannot handle missing data (nans), "
                     f"but {obj_name} passed contained missing data."
                 )
                 if self.get_class_tag("handles-missing-data"):
                     msg = msg + (
-                        f" Whether instances of {type(self).__name} can handle "
-                        "missing data is depends on parameters of the instance, "
+                        f" Whether instances of {type(self).__name__} can handle "
+                        "missing data depends on parameters of the instance, "
                         "e.g., estimator components."
                     )
                 if metadata["has_nans"]:

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -183,6 +183,8 @@ class _Reducer(_BaseWindowForecaster):
         self.estimator = estimator
         self._cv = None
 
+        self.set_tags(**{"handles-missing-data": estimator._get_tags()["allow_nan"]})
+
     def _is_predictable(self, last_window):
         """Check if we can make predictions from last window."""
         return (
@@ -1418,6 +1420,7 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
             )
         self.set_tags(**{"X_inner_mtype": mtypes})
         self.set_tags(**{"y_inner_mtype": mtypes})
+        self.set_tags(**{"handles-missing-data": estimator._get_tags()["allow_nan"]})
 
     def _fit(self, y, X=None, fh=None):
         """Fit dispatcher based on X_treatment."""

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -186,7 +186,10 @@ class _Reducer(_BaseWindowForecaster):
         self.estimator = estimator
         self._cv = None
 
-        self.set_tags(**{"handles-missing-data": estimator._get_tags()["allow_nan"]})
+        # it seems that the sklearn tags are not fully reliable
+        # see discussion in PR #3405 and issue #3402
+        # therefore this is commented out until sktime and sklearn are better aligned
+        # self.set_tags(**{"handles-missing-data": estimator._get_tags()["allow_nan"]})
 
     def _is_predictable(self, last_window):
         """Check if we can make predictions from last window."""
@@ -1423,7 +1426,11 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
             )
         self.set_tags(**{"X_inner_mtype": mtypes})
         self.set_tags(**{"y_inner_mtype": mtypes})
-        self.set_tags(**{"handles-missing-data": estimator._get_tags()["allow_nan"]})
+
+        # it seems that the sklearn tags are not fully reliable
+        # see discussion in PR #3405 and issue #3402
+        # therefore this is commented out until sktime and sklearn are better aligned
+        # self.set_tags(**{"handles-missing-data": estimator._get_tags()["allow_nan"]})
 
     def _fit(self, y, X=None, fh=None):
         """Fit dispatcher based on X_treatment."""

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -174,7 +174,10 @@ def _sliding_window_transform(
 class _Reducer(_BaseWindowForecaster):
     """Base class for reducing forecasting to regression."""
 
-    _tags = {"ignores-exogeneous-X": False}  # reduction uses X in non-trivial way
+    _tags = {
+        "ignores-exogeneous-X": False,  # reduction uses X in non-trivial way
+        "handles-missing-data": True,
+    }
 
     def __init__(self, estimator, window_length=10, transformers=None):
         super(_Reducer, self).__init__(window_length=window_length)

--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -172,7 +172,7 @@ class AutoETS(_StatsModelsAdapter):
         "ignores-exogeneous-X": True,
         "capability:pred_int": True,
         "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "handles-missing-data": True,
     }
 
     def __init__(


### PR DESCRIPTION
This PR introduces missing data input checks to forecasters and fixes #3402.

Changes:
* `_check_X_y` in forecasters now raises an informative exception if input contains missing data and the forecaster does not support it
* the forecaster extension template is updated accordingly
* reducers are updated so missing value handling tags mirror the wrapped sklearn estimator's tag
* switched the tag to `True` in some estimators causing issues: `AutoETS`