### PR TITLE
[ENH] isolate soft dependency in `MLPClassifier` doctest

### DIFF
--- a/sktime/classification/deep_learning/mlp.py
+++ b/sktime/classification/deep_learning/mlp.py
@@ -58,8 +58,8 @@ class MLPClassifier(BaseDeepClassifier):
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
     >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
-    >>> mlp = MLPClassifier()
-    >>> mlp.fit(X_train, y_train)
+    >>> mlp = MLPClassifier() # doctest: +SKIP
+    >>> mlp.fit(X_train, y_train) # doctest: +SKIP
     MLPClassifier(...)
     """
 

--- a/sktime/classification/deep_learning/mlp.py
+++ b/sktime/classification/deep_learning/mlp.py
@@ -57,9 +57,8 @@ class MLPClassifier(BaseDeepClassifier):
     >>> from sktime.classification.deep_learning.mlp import MLPClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
-    >>> mlp = MLPClassifier() # doctest: +SKIP
-    >>> mlp.fit(X_train, y_train) # doctest: +SKIP
+    >>> mlp = MLPClassifier()  # doctest: +SKIP
+    >>> mlp.fit(X_train, y_train)  # doctest: +SKIP
     MLPClassifier(...)
     """
 


### PR DESCRIPTION
This isolates the soft dependency in the `MLPClassifier` doctest by skipping it.

Coverage is not reduced as fitting is already tested by the test suite.