### PR TITLE
[ENH] second param sets for selected estimators

### DIFF
--- a/sktime/classification/feature_based/_catch22_classifier.py
+++ b/sktime/classification/feature_based/_catch22_classifier.py
@@ -146,5 +146,15 @@ class Catch22Classifier(_DelegatedClassifier):
                 "estimator": RandomForestClassifier(n_estimators=10),
                 "outlier_norm": True,
             }
-        else:
-            return {"estimator": RandomForestClassifier(n_estimators=2)}
+
+        from sklearn.dummy import DummyClassifier
+
+        param1 = {"estimator": RandomForestClassifier(n_estimators=2)}
+        param2 = {
+            "estimator": DummyClassifier(),
+            "outlier_norm": True,
+            "replace_nans": False,
+            "random_state": 42,
+        }
+
+        return [param1, param2]

--- a/sktime/transformations/series/exponent.py
+++ b/sktime/transformations/series/exponent.py
@@ -6,6 +6,8 @@
 __author__ = ["Ryan Kuhns"]
 __all__ = ["ExponentTransformer", "SqrtTransformer"]
 
+from warnings import warn
+
 import numpy as np
 import pandas as pd
 
@@ -101,6 +103,14 @@ class ExponentTransformer(BaseTransformer):
 
         super(ExponentTransformer, self).__init__()
 
+        if abs(power) < 1e-6:
+            warn(
+                "power close to zero passed to ExponentTransformer, "
+                "inverse_transform will default to identity "
+                "if called, in order to avoid division by zero"
+            )
+            self.set_tags({"skip-inverse-transform": True})
+
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.
 
@@ -176,7 +186,7 @@ class ExponentTransformer(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        return [{"power": 2.5}, {"power": 0}]
+        return [{"power": 2.5, "offset": 1}, {"power": 0}]
 
 
 class SqrtTransformer(ExponentTransformer):

--- a/sktime/transformations/series/exponent.py
+++ b/sktime/transformations/series/exponent.py
@@ -157,6 +157,27 @@ class ExponentTransformer(BaseTransformer):
 
         return offset
 
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        return [{"power": 2.5}, {"power": 0}]
+
 
 class SqrtTransformer(ExponentTransformer):
     """Apply element-sise square root transformation to a time series.

--- a/sktime/transformations/series/exponent.py
+++ b/sktime/transformations/series/exponent.py
@@ -109,7 +109,7 @@ class ExponentTransformer(BaseTransformer):
                 "inverse_transform will default to identity "
                 "if called, in order to avoid division by zero"
             )
-            self.set_tags({"skip-inverse-transform": True})
+            self.set_tags(**{"skip-inverse-transform": True})
 
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.

--- a/sktime/transformations/series/exponent.py
+++ b/sktime/transformations/series/exponent.py
@@ -241,3 +241,24 @@ class SqrtTransformer(ExponentTransformer):
 
     def __init__(self, offset="auto"):
         super().__init__(power=0.5, offset=offset)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        return [{}, {"offset": 4.2}]

--- a/sktime/transformations/tests/test_all_transformers.py
+++ b/sktime/transformations/tests/test_all_transformers.py
@@ -164,6 +164,10 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
         if not estimator_instance.get_class_tag("capability:inverse_transform", False):
             return None
 
+        # skip this test if the estimator skips inverse_transform
+        if estimator_instance.get_tag("skip-inverse-transform", False):
+            return None
+
         X = scenario.args["transform"]["X"]
         Xt = scenario.run(estimator_instance, method_sequence=["fit", "transform"])
         Xit = estimator_instance.inverse_transform(Xt)

--- a/sktime/utils/estimators/_forecasters.py
+++ b/sktime/utils/estimators/_forecasters.py
@@ -367,3 +367,23 @@ class MockForecaster(BaseForecaster):
             )
 
         return pred_quantiles
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        return [{"prediction_constant": 42}, {"prediction_constant": -4.2}]


### PR DESCRIPTION
Towards #3429. This adds a second parameter set for all estimators checked via `check_estimator` in the `no-softdeps` CI element.

This is generally useful, and also allows https://github.com/alan-turing-institute/sktime/pull/2862 to pass that CI element.

... and we already discovered a bug, which I suppose proves that #3429 is generally a good idea.
The bug is `ExponentTransformer.inverse_transform` breaking if `power` is close to zero. This is now dealt with by a skip and a warning.