### PR TITLE
[ENH] rework / fix forecaster `update_predict`

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -887,6 +887,7 @@ class BaseForecaster(BaseEstimator):
             "overwrite" : output is in of same type format as y,
                 forecasts from later folds overwrite forecasts from earlier folds
             "multiindex" : output is pd.DataFrame, indexed by (cutoff, horizon)
+            "col_multiindex" : output is pd.DataFrame, column-indexed by cutoff
             "auto" : as "overwrite" if collection of absolute horizon points is unique
                 as "multiindex" if collection of absolute horizon points is not unique
         fh_priority : str, optional (default="cv")
@@ -903,7 +904,7 @@ class BaseForecaster(BaseEstimator):
                 cutoff is suppressed in output
                 has same type as the y that has been passed most recently:
                 Series, Panel, Hierarchical scitype, same format (see above)
-            output_format="multiindex", or "auto" and duplicate absolute horizon points:
+            output_format="col_multiindex", or "auto" and duplicate horizon points:
                 type is a pandas DataFrame, with row and col index being time stamps
                 row index corresponds to cutoffs that are predicted from
                 column index corresponds to absolut horizons that are predicted
@@ -938,27 +939,89 @@ class BaseForecaster(BaseEstimator):
         y_first_index = get_cutoff(y, return_index=True, reverse_order=True)
         self_copy._set_cutoff(_shift(y_first_index, by=-1, return_index=True))
 
+        ALLOWED_SCITYPES = ["Series", "Panel", "Hierarchical"]
+        y_valid, _, y_metadata = check_is_scitype(
+            y, scitype=ALLOWED_SCITYPES, return_metadata=True, var_name="y"
+        )
+        msg = (
+            "y must be in an sktime compatible format, "
+            "of scitype Series, Panel or Hierarchical, "
+            "for instance a pandas.DataFrame with sktime compatible time indices, "
+            "or with MultiIndex and last(-1) level an sktime compatible time index."
+            " See the forecasting tutorial examples/01_forecasting.ipynb, or"
+            " the data format tutorial examples/AA_datatypes_and_datasets.ipynb,"
+            "If you think y is already in an sktime supported input format, "
+            "run sktime.datatypes.check_raise(y, mtype) to diagnose the error, "
+            "where mtype is the string of the type specification you want for y. "
+        )
+        if not y_valid:
+            raise TypeError(msg)
+
+        # convert to data frame to avoid complicated special case treatment
+        y_store = {}
+        y_mtype = y_metadata["mtype"]
+        y_df = convert_to(
+            y,
+            ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
+            store=y_store,
+        )
+
         # iterate over data
-        for y_new, _ in cv.split_series(y):
+        for y_new, _ in cv.split_series(y_df):
             # we use `update_predict_single` here
             #  this updates the forecasting horizon
-            y_pred = self_copy.update_predict_single(
+            y_pred = self_copy._update_predict_single(
                 y=y_new,
                 fh=fh,
                 X=X,
                 update_params=update_params,
             )
+            # y_preds is now guaranteed list of pandas.DataFrame
             y_preds.append(y_pred)
             cutoffs.append(self_copy.cutoff)
 
-            for i in range(len(y_preds)):
-                y_preds[i] = convert_to(
-                    y_preds[i],
-                    self._y_mtype_last_seen,
-                    store=self._converter_store_y,
-                    store_behaviour="freeze",
-                )
-        return _format_moving_cutoff_predictions(y_preds, cutoffs)
+        y_mi = y_preds[0]
+
+        for y_upd in y_preds[1:]:
+            y_mi = update_data(y_mi, y_upd)
+
+        # index_duplicated = is there a duplicate absolute horizon index
+        index_duplicated = len(y_mi) < sum([len(y) for y in y_preds])
+
+        # resolve "auto" output_format depending
+        if output_format == "auto":
+            if index_duplicated:
+                output_format = "col_multiindex"
+            else:
+                output_format = "overwrite"
+
+        if output_format == "overwrite":
+            # return series for single step ahead predictions
+            y_pred = pd.concat(y_preds)
+        elif output_format == "col_multiindex":
+            y_pred = pd.concat(y_preds, axis=1, keys=cutoffs)
+            y_pred_col_names = list(y_pred.columns.names)
+            y_pred_col_names[0] = "cutoff"
+            y_pred.columns.names = y_pred_col_names
+        elif output_format == "multiindex":
+            y_pred = pd.concat(y_preds, axis=0, keys=cutoffs)
+            y_pred = y_pred.swaplevel(0, -1)
+            y_pred_index_names = list(y_pred.index.names)
+            y_pred_index_names[-1] = "cutoff"
+            y_pred.index.names = y_pred_index_names
+        else:
+            raise ValueError(
+                f"invalid output_format found in update_predict: {output_format}"
+            )
+
+        if output_format == "overwrite":
+            y_pred = convert_to(
+                y_pred,
+                y_mtype,
+                store=y_store,
+            )
+
+        return y_pred
 
     def update_predict_single(
         self,

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -820,6 +820,7 @@ class BaseForecaster(BaseEstimator):
         X=None,
         update_params=True,
         reset_forecaster=True,
+        output_format="auto",
     ):
         """Make predictions and update model iteratively over the test set.
 


### PR DESCRIPTION
Draft PR in which I am reworking and fixing issues with `update_predict`.

For `pandas` containers this should be ok, but there were some issue with `numpy`.
Also compare https://github.com/alan-turing-institute/sktime/issues/3177.

FYI @benHeid, one problem that I still have and do not fully know how to resolve:

Let's suppose we pass a `numpy` container and overlapping folds as `cv` to `update_predict`.

Currently, `sktime` interprets `numpy` passed to `update` as non-overlapping.

`update_predict`, at current `main`, simply cuts and passed to `update`, which would result in `sktime` interpreting the folds as non-overlapping, leading to inflated training time span.

How should we deal with that, logically?
My intuition is conversion to `pandas` with overlapping integer index, but - unlike in the other methods where a simple conversion is sufficient - this seems to incur substantial amoutns of extra logic which is specific to `numpy`, which I do not like.

Any ideas, @benHeid?