### PR TITLE
[DOC] Expired slack link under "Where to ask questions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Questions and feedback are extremely welcome! Please understand that we won't be
 [github discussions]: https://github.com/alan-turing-institute/sktime/discussions
 [stack overflow]: https://stackoverflow.com/questions/tagged/sktime
 [discord]: https://discord.com/invite/gqSab2K
-[slack]: https://join.slack.com/t/sktime-group/shared_invite/zt-62i7aejn-vXc3nOWF26S_P3VXFPWisQ
+[slack]: https://join.slack.com/t/sktime-group/shared_invite/zt-1cghagwee-sqLJ~eHWGYgzWbqUX937ig
 
 ## :dizzy: Features
 Our aim is to make the time series analysis ecosystem more interoperable and usable as a whole. sktime provides a __unified interface for distinct but related time series learning tasks__. It features [__dedicated time series algorithms__](https://www.sktime.org/en/stable/estimator_overview.html) and __tools for composite model building__ including pipelining, ensembling, tuning and reduction that enables users to apply an algorithm for one task to another.


### PR DESCRIPTION
Fixes expired link to Slack under the "Where to ask questions" section of the README.

Related to #3014 