### PR TITLE
[ENH] pandas 1.5.0 compatibility fix: use `infer_freq` in `Lag` if no `freq` passed or specified

### DIFF
--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -226,6 +226,8 @@ class Lag(BaseTransformer):
                 Xt.index = X.index + lag
                 X_orig_idx_shifted = X_orig_idx + lag
             else:
+                if hasattr(X.index, "freq") and X.index.freq is None and freq is None:
+                    freq = X.index.infer_freq()
                 X_orig_idx_shifted = X_orig_idx.shift(periods=lag, freq=freq)
                 if isinstance(lag, int) and freq is None:
                     freq = "infer"

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -227,7 +227,7 @@ class Lag(BaseTransformer):
                 X_orig_idx_shifted = X_orig_idx + lag
             else:
                 if hasattr(X.index, "freq") and X.index.freq is None and freq is None:
-                    freq = X.index.infer_freq()
+                    freq = pd.infer_freq(X.index)
                 X_orig_idx_shifted = X_orig_idx.shift(periods=lag, freq=freq)
                 if isinstance(lag, int) and freq is None:
                     freq = "infer"


### PR DESCRIPTION
Attempted fix for failure in https://github.com/alan-turing-institute/sktime/pull/3450 after update to pandas 1.5.0.

This ensures that `Lag` uses `infer_freq` if no `freq` passed or specified.