### PR TITLE
[BUG] ensure `nested_univ` metadata inference passes for scalar columns present

### DIFF
--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -278,9 +278,12 @@ def _nested_dataframe_has_nans(X: pd.DataFrame) -> bool:
     for i in range(cases):
         for j in range(dimensions):
             s = X.iloc[i, j]
-            for k in range(s.size):
-                if pd.isna(s.iloc[k]):
-                    return True
+            if hasattr(s, "size"):
+                for k in range(s.size):
+                    if pd.isna(s.iloc[k]):
+                        return True
+            elif pd.isna(s):
+                return True
     return False
 
 


### PR DESCRIPTION
One of the previous `sktime` versions extended the `nested_univ` mtype to allow for scalar valued columns.

The check for that worked fine, but the metadata extraction would break if such a column was present.
This was not directly or indirectly tested as the example fixtures did not cover this case.

With the data loaders being tested, the case is covered and uncovers the bug.

This PR ensures that the `nested_univ` metadata inference does not break in the case where scalar columns are present.