### PR TITLE
[ENH] `check_is_scitype` error message return changed to `dict`

### DIFF
--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -356,9 +356,9 @@ def check_is_scitype(
     Returns
     -------
     valid: bool - whether obj is a valid object of mtype/scitype
-    msg: str or list of str - error messages if object is not valid, otherwise None
-            str if mtype is str; list of len(mtype) with message per mtype if list
-            returned only if return_metadata is True
+    msg: dict[str, str] or None - error messages if object is not valid, otherwise None
+        keys are all mtypes tested, value for key is error message for that key
+        returned only if return_metadata is True
     metadata: dict - metadata about obj if valid, otherwise None
             returned only if return_metadata is True
         Fields depend on scitpe.
@@ -401,7 +401,7 @@ def check_is_scitype(
     keys = [x for x in valid_keys if x[1] in scitype and x[0] not in exclude_mtypes]
 
     # storing the msg retursn
-    msg = []
+    msg = {}
     found_mtype = []
     found_scitype = []
 
@@ -418,7 +418,7 @@ def check_is_scitype(
             found_mtype.append(key[0])
             found_scitype.append(key[1])
         elif return_metadata:
-            msg.append(res[1])
+            msg[key[0]] = res[1]
 
     # there are three options on the result of check_is_mtype:
     # a. two or more mtypes are found - this is unexpected and an error with checks
@@ -439,9 +439,6 @@ def check_is_scitype(
             return True
     # c. no mtype is found - then return False and all error messages if requested
     else:
-        if len(msg) == 1:
-            msg = msg[0]
-
         return _ret(False, msg, None, return_metadata)
 
 

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -25,6 +25,7 @@ __all__ = [
 ]
 
 from typing import List, Union
+from warnings import warn
 
 import numpy as np
 
@@ -332,12 +333,15 @@ def mtype(
     return mtypes_positive[0]
 
 
+# todo 0.15.0: change msg_legacy_interface default to False
+# todo 0.16.0: remove msg_legacy_interface arg, and remove msg_legacy variable inside
 def check_is_scitype(
     obj,
     scitype: Union[str, List[str]],
     return_metadata=False,
     var_name="obj",
     exclude_mtypes=AMBIGUOUS_MTYPES,
+    msg_legacy_interface=True,
 ):
     """Check object for compliance with scitype specification, return metadata.
 
@@ -352,12 +356,20 @@ def check_is_scitype(
     var_name: str, optional, default="obj" - name of input in error messages
     exclude_mtypes : list of str, default = AMBIGUOUS_MTYPES
         which mtypes to ignore in inferring mtype, default = ambiguous ones
+    msg_legacy_interface : bool, default = True
+        whether the deprecated interface for msg return is used (True) or not (False)
+        False = msg is returned as dict; True = msg is returned as list (values only)
 
     Returns
     -------
     valid: bool - whether obj is a valid object of mtype/scitype
-    msg: dict[str, str] or None - error messages if object is not valid, otherwise None
+    msg:
+        if legacy_interface=False:
+        dict[str, str] or None - error messages if object is not valid, otherwise None
         keys are all mtypes tested, value for key is error message for that key
+        if legacy_interface=True:
+        str or list of str - error messages if object is not valid, otherwise None
+        str if mtype is str; list of len(mtype) with message per mtype if list
         returned only if return_metadata is True
     metadata: dict - metadata about obj if valid, otherwise None
             returned only if return_metadata is True
@@ -402,6 +414,7 @@ def check_is_scitype(
 
     # storing the msg retursn
     msg = {}
+    msg_legacy = []
     found_mtype = []
     found_scitype = []
 
@@ -419,6 +432,7 @@ def check_is_scitype(
             found_scitype.append(key[1])
         elif return_metadata:
             msg[key[0]] = res[1]
+            msg_legacy.append(res[1])
 
     # there are three options on the result of check_is_mtype:
     # a. two or more mtypes are found - this is unexpected and an error with checks
@@ -439,6 +453,20 @@ def check_is_scitype(
             return True
     # c. no mtype is found - then return False and all error messages if requested
     else:
+        if len(msg_legacy) == 1:
+            msg_legacy = msg_legacy[0]
+
+        if msg_legacy_interface:
+            msg = msg_legacy
+            warn(
+                "return msg (2nd argument) of check_is_scitype will change to "
+                "dict from list type. Set msg_legacy_interface=False for "
+                "post-deprecation behaviour. Default msg_legacy_interface "
+                "will change to True in 0.15.0. Argument msg_legacy_interface "
+                "will be removed in 0.16.0.",
+                DeprecationWarning,
+            )
+
         return _ret(False, msg, None, return_metadata)
 
 

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -92,7 +92,9 @@ def check_pdmultiindex_hierarchical(obj, return_metadata=False, var_name="obj"):
     # check that there are 3 or more index levels
     nlevels = obj.index.nlevels
     if not nlevels > 2:
-        msg = f"{var_name} have a MultiIndex with 3 or more levels, found {nlevels}"
+        msg = (
+            f"{var_name} must have a MultiIndex with 3 or more levels, found {nlevels}"
+        )
         return _ret(False, msg, None, return_metadata)
 
     inst_inds = obj.index.droplevel(-1).unique()

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -157,7 +157,7 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     if not isinstance(obj.index, pd.MultiIndex):
-        msg = f"{var_name} have a MultiIndex, found {type(obj.index)}"
+        msg = f"{var_name} must have a MultiIndex, found {type(obj.index)}"
         return _ret(False, msg, None, return_metadata)
 
     # check that columns are unique
@@ -167,7 +167,7 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj"):
     # check that there are precisely two index levels
     nlevels = obj.index.nlevels
     if not nlevels == 2:
-        msg = f"{var_name} have a MultiIndex with 2 levels, found {nlevels}"
+        msg = f"{var_name} must have a MultiIndex with 2 levels, found {nlevels}"
         return _ret(False, msg, None, return_metadata)
 
     # check instance index being integer or range index

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -831,9 +831,9 @@ class BaseTransformer(BaseEstimator):
             f"where mtype is the string of the type specification you want. "
             f"Error message for checked mtypes, in format mtype:message, as follows:"
         )
-        for mtype, err in msg.items():
-            msg_invalid_input += f" {mtype}: {err}"
         if not X_valid:
+            for mtype, err in msg.items():
+                msg_invalid_input += f" {mtype}: {err}"
             raise TypeError("X " + msg_invalid_input)
 
         X_scitype = X_metadata["scitype"]

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -823,17 +823,17 @@ class BaseTransformer(BaseEstimator):
             f"of scitype Series, Panel or Hierarchical, "
             f"for instance a pandas.DataFrame with sktime compatible time indices, "
             f"or with MultiIndex and last(-1) level an sktime compatible time index. "
-            f"Allowed compatible mtype format specifications are: {ALLOWED_MTYPES}"
+            f"Allowed compatible mtype format specifications are: {ALLOWED_MTYPES} ."
             # f"See the transformers tutorial examples/05_transformers.ipynb, or"
-            f" See the data format tutorial examples/AA_datatypes_and_datasets.ipynb, "
+            f" See the data format tutorial examples/AA_datatypes_and_datasets.ipynb. "
             f"If you think the data is already in an sktime supported input format, "
             f"run sktime.datatypes.check_raise(data, mtype) to diagnose the error, "
             f"where mtype is the string of the type specification you want. "
-            f"Error message for checked mtypes, in format mtype:message, as follows:"
+            f"Error message for checked mtypes, in format [mtype: message], as follows:"
         )
         if not X_valid:
             for mtype, err in msg.items():
-                msg_invalid_input += f" {mtype}: {err}"
+                msg_invalid_input += f" [{mtype}: {err}] "
             raise TypeError("X " + msg_invalid_input)
 
         X_scitype = X_metadata["scitype"]

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -810,8 +810,12 @@ class BaseTransformer(BaseEstimator):
         ALLOWED_MTYPES = self.ALLOWED_INPUT_MTYPES
 
         # checking X
-        X_valid, _, X_metadata = check_is_scitype(
-            X, scitype=ALLOWED_SCITYPES, return_metadata=True, var_name="X"
+        X_valid, msg, X_metadata = check_is_scitype(
+            X,
+            scitype=ALLOWED_SCITYPES,
+            return_metadata=True,
+            var_name="X",
+            msg_legacy_interface=False,
         )
 
         msg_invalid_input = (
@@ -825,7 +829,10 @@ class BaseTransformer(BaseEstimator):
             f"If you think the data is already in an sktime supported input format, "
             f"run sktime.datatypes.check_raise(data, mtype) to diagnose the error, "
             f"where mtype is the string of the type specification you want. "
+            f"Error message for checked mtypes, in format mtype:message, as follows:"
         )
+        for mtype, err in msg.items():
+            msg_invalid_input += f" {mtype}: {err}"
         if not X_valid:
             raise TypeError("X " + msg_invalid_input)
 


### PR DESCRIPTION
This PR changes `check_is_scitype`'s second return to a `dict`, so the error message is indexed by the corresponding mtype.

The old return was not very useful, as it was not possible to easily or clearly match the message with its mtype.

Includes:
* deprecation mechanism to change the return type
* improved input check feedback for transformers
* cleanup of formatting and grammar in some check error messages