### PR TITLE
[GOV] provisions for asynchronous decision making by CC

### DIFF
--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -472,6 +472,9 @@ corresponding decision making process is described in more detail below.
    * - Changes to sktime's governance (including this document and the CoC)
      - Proposal, reading, vote, via council meeting (or equivalent async process);
        Directly starts with CC decision making (stage 3)
+   * - Operational, non-technical decision making, e.g., budgets & expenditures
+     - Proposal, reading, vote, via council meeting (or equivalent async process);
+       Directly starts with CC decision making (stage 3)
    * - Appointment
      - Directly starts with core developer voting (stage 2)
 


### PR DESCRIPTION
Towards my action on "update doc on gov & decision making to include new discord channels".

A draft which updates the use of discord channels for asynchronous decision making by the CC.

Previously, the decision making by CC was lacking details. 

The action was is to adapt the standing policy in https://github.com/sktime/community-org/issues/49 (which was adopted) to the governance provisions - filling in the missing details in the "CC decision making".

For discussion.

The gaps in the governance document this addresses:

* "CC reserves the right to overrule decisions" - from the original, imprecise as to procedure. Replaced with more precise procedure and clear remit definitions.
* CC votes - replaced with procedure along the lines of https://github.com/sktime/community-org/issues/49