### PR TITLE
DIAGNOSTIC [MNT] run test suite with `numpy 1.25`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ all_extras_pandas2 = [
     "pmdarima>=1.8.0,!=1.8.1,<3.0.0",
     "prophet>=1.1",
     "pykalman>=0.9.5; python_version < '3.11'",
-    "pyod>=0.8.0; python_version < '3.11'",
     "scikit_posthocs>=0.6.5",
     "seaborn>=0.11.0",
     "statsmodels>=0.12.1",


### PR DESCRIPTION
Removes `numba` from the test dep set to ensure it runs with `numpy 1.25`

This is done by removing packages that imply `numba` from the `all_extras_pandas2` dependency set:

* `numba` itself
* `pyod`
* `tsfresh`

Related: https://github.com/sktime/sktime/issues/4837