### PR TITLE
[MNT] gate `test-full` behind smaller CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,7 +271,7 @@ jobs:
         uses: codecov/codecov-action@v4
 
   test-unix-pandas1:
-    needs: test-nosoftdeps
+    needs: [test-base, test-module, test-other]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,7 +232,7 @@ jobs:
     uses: ./.github/workflows/test_datasets.yml
 
   test-full:
-    needs: test-nosoftdeps
+    needs: [test-base, test-module, test-other]
     strategy:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:


### PR DESCRIPTION
This PR aims to reduce expected runtime of the current CI setup by gating the longer `test-full` and `test-unix-pandas1` behind the shorter jobs from the new CI.

Expected runtime is reduced, as the new CI almost reaches coverage of old CI, and has substantially shorter "runtime until error" for failing runs - while failing CI runs are common.

This may well be a temporary measure until the design discussion in #5706 is resolved.