### PR TITLE
[BUG] Fix conversion of ForecastingHorizon

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -10,7 +10,7 @@ from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
-from pandas.tseries.frequencies import to_offset
+from pandas.tseries.frequencies import to_offset, get_period_alias, freq_to_period_freqstr
 
 from sktime.utils.datetime import _coerce_duration_to_int
 from sktime.utils.validation import (
@@ -898,7 +898,7 @@ def _to_absolute(fh: ForecastingHorizon, cutoff) -> ForecastingHorizon:
 
         if is_timestamp:
             # coerce back to DatetimeIndex after operation
-            absolute = absolute.to_timestamp(fh.freq)
+            absolute = absolute.to_timestamp(to_offset(fh.freq))
 
         if old_tz is not None:
             absolute = absolute.tz_localize(old_tz)
@@ -956,7 +956,9 @@ def _coerce_to_period(x, freq=None):
             "_coerce_to_period requires freq argument to be passed if x is pd.Timestamp"
         )
     try:
-        return x.to_period(freq)
+        offset = to_offset(freq)
+        period_alias = get_period_alias(offset.name)
+        return x.to_period(period_alias)
     except (ValueError, AttributeError) as e:
         msg = str(e)
         if "Invalid frequency" in msg or "_period_dtype_code" in msg:


### PR DESCRIPTION
 Fix by ensuring that a periodicity alias is used when converting forecasting horizons.

Note, depends probably also on a downstream bug in pandas. Reported in [pandas-dev/pandas#58902](https://github.com/pandas-dev/pandas/issues/58092)


#### Reference Issues/PRs
fixes #6241 fixes #5131 

alternative to #5133

#### What does this implement/fix? Explain your changes.

It tries to extract the periodicity alias from the datetime frequency

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?



#### Did you add any tests for the change?



#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.


<!--
Thanks for contributing!
-->
