### PR TITLE
[ENH] address deprecation and raise error in `test_differencer_cutoff`

### DIFF
--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -131,8 +131,6 @@ def test_differencer_cutoff():
     fh = [1, 2]
     train_model, _ = temporal_train_test_split(y, fh=fh)
     X_train = X[X.index.isin(train_model.index)]
-    train_model.index = train_model.index.to_timestamp(freq="Y")
-    X_train.index = X_train.index.to_timestamp(freq="Y")
 
     # pipeline
     pipe = TransformedTargetForecaster(


### PR DESCRIPTION
* ensures that exceptions from the grid search are raised if occurring in `test_differencer_cutoff`.
* removes use of ` `pandas` `freq` `"A"` - this will need to be investigated in #6487