### PR TITLE
[ENH] Add a GitHub Action script to Automate Issue Assignment to Contributors

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -1,0 +1,25 @@
+name: Auto Assign Issue
+
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+
+permissions: read-all
+
+jobs:
+  take-issue:
+    name: Auto Assign Issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    timeout-minutes: 10
+    steps:
+      - name: take an issue
+        uses: bdougie/take-action@v1.6.1
+        with:
+          message: Thank you for assigning yourself this issue, please let us know if you have any questions.
+          issueCurrentlyAssignedMessage: It seems like this issue is already assigned to a contributor.
+          trigger: .take
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
Fixes #7528 


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
This adds a YAML file in `.github/workflows` which interacts with the GitHub's API and assigns issues to user based on a trigger command, the script is taken from [https://github.com/bdougie/take-action/blob/main/action.yml](https://github.com/bdougie/take-action/blob/main/action.yml)

