### PR TITLE
[MNT] CI: change `macos-13` runners to `macos-latest`, of arm64 Architecture

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -358,7 +358,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.9
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
@@ -458,11 +458,6 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-22.04-arm]
-        exclude:
-          - os: macos-latest
-            python-version: "3.9"
-          - os: macos-latest
-            python-version: "3.10"
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -36,11 +36,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-22.04-arm
           - windows-latest
-        exclude:
-          - operating-system: macos-latest
-            python-version: "3.9"
-          - operating-system: macos-latest
-            python-version: "3.10"
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: checkout pull request branch
@@ -79,11 +74,6 @@ jobs:
           - param_est
           - regression
           - transformations
-        exclude:
-          - operating-system: macos-latest
-            python-version: "3.9"
-          - operating-system: macos-latest
-            python-version: "3.10"
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: checkout pull request branch
@@ -113,11 +103,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-22.04-arm
           - windows-latest
-        exclude:
-          - operating-system: macos-latest
-            python-version: "3.9"
-          - operating-system: macos-latest
-            python-version: "3.10"
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: checkout pull request branch

--- a/.github/workflows/test_base.yml
+++ b/.github/workflows/test_base.yml
@@ -36,11 +36,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-22.04-arm
           - windows-latest
-        exclude:
-          - operating-system: macos-latest
-            python-version: "3.9"
-          - operating-system: macos-latest
-            python-version: "3.10"
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: checkout pull request branch

--- a/.github/workflows/test_datasets.yml
+++ b/.github/workflows/test_datasets.yml
@@ -21,11 +21,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-22.04-arm
           - windows-latest
-        exclude:
-          - operating-system: macos-latest
-            python-version: "3.9"
-          - operating-system: macos-latest
-            python-version: "3.10"
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: repository checkout step
@@ -63,11 +58,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-22.04-arm
           - windows-latest
-        exclude:
-          - operating-system: macos-latest
-            python-version: "3.9"
-          - operating-system: macos-latest
-            python-version: "3.10"
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: repository checkout step

--- a/.github/workflows/test_module.yml
+++ b/.github/workflows/test_module.yml
@@ -69,11 +69,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-22.04-arm
           - windows-latest
-        exclude:
-          - operating-system: macos-latest
-            python-version: "3.9"
-          - operating-system: macos-latest
-            python-version: "3.10"
         sktime-component: ${{ fromJSON(needs.detect.outputs.module_changes) }}
     runs-on: ${{ matrix.operating-system }}
     steps:

--- a/.github/workflows/test_other.yml
+++ b/.github/workflows/test_other.yml
@@ -49,11 +49,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-22.04-arm
           - windows-latest
-        exclude:
-          - operating-system: macos-latest
-            python-version: "3.9"
-          - operating-system: macos-latest
-            python-version: "3.10"
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: checkout pull request branch

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,11 +36,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        exclude:
-          - os: macos-latest
-            python-version: "3.9"
-          - os: macos-latest
-            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
This PR implements ARM64 architecture macos support across all GitHub Actions workflow files by adding macos-latest runners. The change enables testing on ARM-based macos infrastructure providing comprehensive platform coverage for sktime's CI pipeline.

Note: Python 3.9 and 3.10 need to disable for macos-latest as stated in https://github.com/actions/runner-images/issues/10812

Also we can see image of macos-latest arm64 is not avilable for python 3.9 and 3.10 in [Github Runner wheel images](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json)

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->

cc @fkiraly @yarnabrina 