### PR TITLE
[ENH] `SktimeForecastingExperiment` for CV experiments of `sktime` Forecasters

### DIFF
--- a/sktime/benchmarking/base.py
+++ b/sktime/benchmarking/base.py
@@ -9,6 +9,8 @@ from warnings import warn
 
 import numpy as np
 
+from sktime.base import BaseObject
+
 
 class BaseDataset:
     """Base dataset class."""
@@ -230,3 +232,89 @@ class BaseMetric:
     @abstractmethod
     def compute(self, y_true, y_pred):
         """Compute mean and standard error of metric."""
+
+
+class BaseExperiment(BaseObject):
+    """Base class for experiment.
+
+    Copied and adapted from hyperactive's BaseExperiment.
+    """
+
+    _tags = {
+        "object_type": "experiment",
+        "python_dependencies": None,
+        "property:randomness": "random",  # random or deterministic
+        # if deterministic, two calls of score will result in the same value
+        # random = two calls may result in different values; same as "stochastic"
+    }
+
+    def __init__(self):
+        super().__init__()
+
+    def __call__(self, **kwargs):
+        """Score parameters, with kwargs call."""
+        score, _ = self.score(kwargs)
+        return score
+
+    @property
+    def __name__(self):
+        return type(self).__name__
+
+    def paramnames(self):
+        """Return the parameter names of the search.
+
+        Returns
+        -------
+        list of str
+            The parameter names of the search parameters.
+        """
+        return self._paramnames()
+
+    def _paramnames(self):
+        """Return the parameter names of the search.
+
+        Returns
+        -------
+        list of str
+            The parameter names of the search parameters.
+        """
+        raise NotImplementedError
+
+    def score(self, params):
+        """Score the parameters.
+
+        Parameters
+        ----------
+        params : dict with string keys
+            Parameters to score.
+
+        Returns
+        -------
+        float
+            The score of the parameters.
+        dict
+            Additional metadata about the search.
+        """
+        paramnames = self.paramnames()
+        if not set(params.keys()) <= set(paramnames):
+            raise ValueError("Parameters do not match.")
+        res, metadata = self._score(params)
+        res = np.float64(res)
+        return res, metadata
+
+    def _score(self, params):
+        """Score the parameters.
+
+        Parameters
+        ----------
+        params : dict with string keys
+            Parameters to score.
+
+        Returns
+        -------
+        float
+            The score of the parameters.
+        dict
+            Additional metadata about the search.
+        """
+        raise NotImplementedError

--- a/sktime/benchmarking/forecasting_experiment.py
+++ b/sktime/benchmarking/forecasting_experiment.py
@@ -1,0 +1,12 @@
+"""Experiment adaptor for forecasting cv experiments."""
+
+from sktime.benchmarking.base import BaseExperiment
+
+
+class SktimeForecastingExperiment(BaseExperiment):
+    """Experiment adaptor for forecasting cross-validation experiments.
+
+    This class is used to perform cross-validation experiments using a given
+    sktime forecaster. It allows for hyperparamter tuning and evaluation of the
+    forecaster's performance using cross-validation.
+    """


### PR DESCRIPTION
In progress - refactoring of `ForecastingBenchmark`.

This PR creates `SktimeForecastingExperiment` in sktime for cross-validation of sktime forecasters. `BaseExperiment` is copied and adapted from the [Hyperactive](https://github.com/SimonBlanke/Hyperactive) package. 

The goal is to encapsulate evaluation logic for forecasting experiments in a more modular way, wrapping `evaluate` internally and returning benchmark tables as metadata. 