### PR TITLE
[ENH] enable univariate mode for `DynamicFactor` forecaster

### DIFF
--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -330,25 +330,12 @@ class DynamicFactor(_StatsModelsAdapter):
         ]
 
         predictions_df = predictions_df[final_ord]
-        cols = [col_name.split(" ") for col_name in predictions_df.columns]
 
-        predictions_df_2 = pd.DataFrame(
-            predictions_df.values, columns=pd.MultiIndex.from_tuples(cols)
-        )
+        final_columns = self._get_columns("predict_interval", coverage=coverage_list)
+        predictions_df = pd.DataFrame(predictions_df.values, columns=final_columns)
+        predictions_df.index = fh.to_absolute_index(self.cutoff)
 
-        final_columns = [
-            [col_name, float(coverage), bound]
-            for col_name in ynames
-            for coverage in predictions_df_2.columns.get_level_values(1).unique()
-            for bound in predictions_df_2.columns.get_level_values(2).unique()
-        ]
-
-        predictions_df_3 = pd.DataFrame(
-            predictions_df_2.values, columns=pd.MultiIndex.from_tuples(final_columns)
-        )
-        predictions_df_3.index = fh.to_absolute_index(self.cutoff)
-
-        return predictions_df_3
+        return predictions_df
 
     def _fit_forecaster(self, y, X=None):
         """Fit to training data.


### PR DESCRIPTION
This PR adds a univariate mode for the `DynamicFactor` forecaster. While it is degenerate in the sense of being full rank, this results in a non-trivial smoothing model determined by the parameters.

The "trick" is to duplicate a univariate dataframe to one that is bivariate. This will result in singular matrices but the algorithm still produces valid output.

This is somewhat questionable in the modeling sense, but it simplifies the interface by removing one of a very few number of forecasters that do not have a univariate mode.

Reviewers should check whether this makes sense or whether this feels too problematic.