### PR TITLE
[MNT] add `mlflow<3.0` bound until breaking changes are addressed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,12 +304,12 @@ dl = [
   'hydra-core; python_version < "3.13"',
 ]
 mlflow = [
-  "mlflow",
+  "mlflow<3.0",
 ]
 mlflow_tests = [
   "boto3",
   "botocore",
-  "mlflow",
+  "mlflow<3.0",
   "moto",
 ]
 numpy1 = [


### PR DESCRIPTION
`mlflow 3.0` has been released recently. This PR adds an `mlflow<3.0` bound until breaking changes are addressed in the `sktime` / `mlflow` integration.