### PR TITLE
[BUG] Documentation conf.py is missing mandatory extensions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,8 @@ addopts =
     --durations 20
     --timeout 600
     --showlocals
-    #--matrixdesign True
-    #--only_changed_modules True
+    --matrixdesign True
+    --only_changed_modules True
     -n auto
 filterwarnings =
     ignore::UserWarning


### PR DESCRIPTION

#### Reference Issues/PRs
Closes #8434 

#### What does this implement/fix? Explain your changes.
Re-add some extensions to conf.py

