### PR TITLE
[MNT] revert docs to pre-8385 state

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,6 +4,7 @@
 import datetime
 import os
 import sys
+import warnings
 
 import sktime
 
@@ -108,7 +109,9 @@ numpydoc_show_class_members = True
 # see https://github.com/numpy/numpydoc/issues/69
 numpydoc_class_members_toctree = False
 
-numpydoc_validation_checks = {"all"}
+# https://numpydoc.readthedocs.io/en/latest/validation.html#built-in-validation-checks
+# Let's turn of the check for building but keep it in pre-commit hooks
+numpydoc_validation_checks = set()
 
 # generate autosummary even if no references
 autosummary_generate = True
@@ -132,7 +135,17 @@ add_function_parentheses = False
 # configuration. This ensures that MathJax processes only math, identified by the
 # dollarmath and amsmath extensions, or specified in math directives. We here silence
 # the corresponding warning that this override happens.
-suppress_warnings = ["myst.mathjax"]
+suppress_warnings = [
+    "myst.mathjax",
+    "docutils",
+    "toc.not_included",
+    "autodoc.import_object",
+    "autosectionlabel",
+    "ref",
+]
+# FIXME: Temporary solution until numpydoc issues are fixed
+warnings.filterwarnings("ignore", category=UserWarning, module="numpydoc.docscrape")
+show_warning_types = True
 
 # Link to GitHub repo for github_issues extension
 issues_github_path = "sktime/sktime"
@@ -202,13 +215,6 @@ html_theme_options = {
             "url": "https://www.linkedin.com/company/scikit-time/",
             "icon": "fab fa-linkedin",
         },
-    ],
-    "favicons": [
-        {
-            "rel": "icon",
-            "sizes": "16x16",
-            "href": "images/sktime-favicon.ico",
-        }
     ],
     "show_prev_next": False,
     "use_edit_page_button": False,
@@ -414,6 +420,7 @@ def _make_estimator_overview(app):
         ],
         "classifier": [
             "capability:multivariate",
+            "capability:predict_proba",
             "capability:multioutput",
             "capability:unequal_length",
             "capability:missing_values",
@@ -518,14 +525,11 @@ def _make_estimator_overview(app):
         modpath = str(obj_class)[8:-2]
         path_parts = modpath.split(".")
         del path_parts[-2]
-        clean_path = ".".join(path_parts)
         import_path = ".".join(path_parts[:-1])
+        # includes part of class string
+        url = obj_class._generate_doc_link()
         # adds html link reference
-        obj_name = (
-            """<a href='#'"""
-            f"""onclick="go2URL('api_reference/auto_generated/{clean_path}.html',"""
-            f"""'api_reference/auto_generated/{modpath}.html', event)">{obj_name}</a>"""
-        )
+        obj_name = f"""<a href={url}>{obj_name}</a>"""
 
         # determine the "main" object type
         # this is the first in the list that also appears in the dropdown menu


### PR DESCRIPTION
https://github.com/sktime/sktime/pull/8442 reverted documentation to the state of the 0.37.0 release.

This PR moves the state of `conf.py` to directly prior to 8385.