### PR TITLE
[ENH] CI element to print names of all changed classes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,7 @@ jobs:
 
   test-est:
     needs: detect-changed-classes
-    if: ${{ needs.detect-changed-classes.outputs.obj_list != '[]' }}
+    if: ${{ needs.detect-changed-classes.outputs.CLS_CH_VM != '[]' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This PR adds a CI step in the `test.yml` jobs that lists the classes that are directly changed, or for which tests are triggered by the conditional tests logic (e.g., core classes and framework changes).

The list separates the classes that require their own VM, and classes that are tested in the standard CI.

For classes in the standard CI, the printout is for information only; the list of classes that require their own VM is used later to spin up said VM.

Also simplifies the `detect-changed-classes` step and removes deprecated logic in environment variable assignment.