### PR TITLE
[ENH] Add efficient implementation of _evaluate_by_index for mean relative absolute error

### DIFF
--- a/sktime/performance_metrics/forecasting/_mrelae.py
+++ b/sktime/performance_metrics/forecasting/_mrelae.py
@@ -10,9 +10,11 @@ the lower the better.
 import pandas as pd
 
 from sktime.performance_metrics.forecasting._base import BaseForecastingErrorMetric
+from sktime.performance_metrics.forecasting._common import (
+    _relative_error,
+)
 from sktime.performance_metrics.forecasting._functions import (
     _get_kwarg,
-    _relative_error,
     mean_relative_absolute_error,
 )
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes one part of #4304 (Mean Relative Absolute Error)

#### What does this implement/fix? Explain your changes.
Previously, the metric was implemented via a jackknife pseudo‐sample trick: one would compute two aggregate (mean‐based) errors on the full series and on series with one point omitted, then back out the per‐point contributions by subtraction.  While generic, that method requires multiple passes over the data and extra bookkeeping.  Our new `_evaluate_by_index` computes each time‐point’s relative error directly in a single vectorized pass, no sub‐sequence means, no subtraction chains, yielding much lower overhead and clearer code. 

#### What should a reviewer concentrate their feedback on?
Check whether it is a correct and efficient implementation. 