### PR TITLE
[DOC] Added detailed examples to NaiveForecaster

### DIFF
--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -103,8 +103,17 @@ class NaiveForecaster(_BaseWindowForecaster):
     >>> y = load_airline()
     >>> forecaster = NaiveForecaster(strategy="drift")
     >>> forecaster.fit(y)
-    NaiveForecaster(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])
+    NaiveForecaster(strategy='drift')
+    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> print(y_pred)  # doctest: +SKIP
+
+    >>> # Example with explicit train/test split
+    >>> forecaster = NaiveForecaster(strategy="last")
+    >>> forecaster.fit(y[:-12])  # Train excluding last 12 points
+    NaiveForecaster(strategy='last')
+    >>> y_pred = forecaster.predict(fh=[1,2,3])  # Predict next 3 steps
+    >>> len(y_pred)  # Should return 3
+    3
     """
 
     _tags = {


### PR DESCRIPTION
## What does this implement/fix?
Adds two clear usage examples to NaiveForecaster:
- Basic drift strategy example
- Detailed train/test split example demonstrating:
  - Proper train/test splitting
  - Prediction length verification
  - Docstring-compatible formatting

## References
Related to #4264 (documentation improvements)

## Does your contribution introduce a new dependency?
No

## PR checklist
- [x] I've added myself to the list of contributors (with 'doc' badge)
- [x] The PR title starts with [DOC]
- [x] Added illustrative examples to the docstring