### PR TITLE
[DOC] add GC.OS donation mechanism to `FUNDING.yml`

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -9,4 +9,4 @@ community_bridge: # replace with username
 liberapay: # replace with username
 issuehunt: # replace with username
 otechie: # replace with username
-custom: # replace with custom URLs e.g., ['link1', 'link2']
+custom: https://gc-os-ai.github.io/donate


### PR DESCRIPTION
adds a link to the GC.OS donations page to `FUNDING.yml`, this will cause the donation info to be linked via a new "sponsoring" buttin at the right of the GH web page.