### PR TITLE
[MNT] split tests in by-estimator VM CI into separate tests via `parametrize_with_checks`

### DIFF
--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -204,7 +204,7 @@ def parametrize_with_checks(objs, obj_varname="obj", check_varname="test_name"):
 
     See Also
     --------
-    check_estimator : Check if estimator adheres to sktime APi contracts.
+    check_estimator : Check if estimator adheres to sktime API contracts.
 
     Examples
     --------


### PR DESCRIPTION
Currently, the `test-est` job runs a single test which contains `check_estimator`.

This is hard to debug, and requires a rerun if multiple failures have to be fixed.

This PR changes the CI from a single `check_estimator` calls to multiple tests via `parametrize_with_checks`.