### PR TITLE
[DOC] improved docstrings for forecasting performance metrics

### DIFF
--- a/sktime/performance_metrics/forecasting/_mae.py
+++ b/sktime/performance_metrics/forecasting/_mae.py
@@ -13,6 +13,10 @@ from sktime.performance_metrics.forecasting._base import BaseForecastingErrorMet
 class MeanAbsoluteError(BaseForecastingErrorMetric):
     r"""Mean absolute error (MAE).
 
+    MAE output is non-negative floating point.
+    MAE is of the same unit as the input data.
+    Lower is better, and the lowest possible value is 0.0.
+
     For a univariate, non-hierarchical sample
     of true values :math:`y_1, \dots, y_n` and
     predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n` (in :math:`mathbb{R}`),

--- a/sktime/performance_metrics/forecasting/_mape.py
+++ b/sktime/performance_metrics/forecasting/_mape.py
@@ -14,6 +14,10 @@ from sktime.performance_metrics.forecasting._common import _percentage_error
 class MeanAbsolutePercentageError(BaseForecastingErrorMetric):
     r"""Mean absolute percentage error (MAPE) or symmetric MAPE.
 
+    Both MAPE and sMAPE are non-negative floating point,
+    is in fractional units relative to a specified denominator.
+    Lower is better, and the lowest possible value is 0.0.
+
     For a univariate, non-hierarchical sample
     of true values :math:`y_1, \dots, y_n` and
     predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
@@ -27,8 +31,9 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetric):
     :math:`\frac{2}{n} \sum_{i=1}^n \frac{|y_i - \widehat{y}_i|}
     {|y_i| + |\widehat{y}_i|}`.
 
-    Both MAPE and sMAPE output non-negative floating point which is in fractional units
-    rather than percentage. The best value is 0.0.
+    To avoid division by zero, any denominator above is replaced by ``eps``
+    if it is smaller than ``eps``; the value of ``eps`` defaults to
+    ``np.finfo(np.float64).eps`` if not specified.
 
     sMAPE is measured in percentage error relative to the test data. Because it
     takes the absolute value rather than square the percentage forecast

--- a/sktime/performance_metrics/forecasting/_mase.py
+++ b/sktime/performance_metrics/forecasting/_mase.py
@@ -18,6 +18,10 @@ from sktime.performance_metrics.forecasting._base import (
 class MeanAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetric):
     r"""Mean absolute scaled error (MASE).
 
+    MASE output is non-negative floating point, in fractional units
+    relative to a specified denominator.
+    Lower is better, and the lowest possible value is 0.0.
+
     For a univariate, non-hierarchical sample of
     true values :math:`y_1, \dots, y_n`,
     pred values :math:`\widehat{y}_1, \dots, \widehat{y}_n` (in :math:`\mathbb{R}`),
@@ -34,7 +38,9 @@ class MeanAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetric):
     where :math:`s` is the seasonal periodicity (`sp`), and
     the denominator is the in-sample mean absolute error of the seasonal naive forecast.
 
-    MASE output is non-negative floating point. The best value is 0.0.
+    To avoid division by zero, the denominator above is replaced by ``eps``
+    if it is smaller than ``eps``; the value of ``eps`` defaults to
+    ``np.finfo(np.float64).eps`` if not specified.
 
     Like other scaled performance metrics, this scale-free error metric can be
     used to compare forecast methods on a single series and also to compare

--- a/sktime/performance_metrics/forecasting/_mse.py
+++ b/sktime/performance_metrics/forecasting/_mse.py
@@ -13,6 +13,10 @@ from sktime.performance_metrics.forecasting._base import BaseForecastingErrorMet
 class MeanSquaredError(BaseForecastingErrorMetric):
     r"""Mean squared error (MSE) or root mean squared error (RMSE).
 
+    MSE and RMSE output is non-negative floating point.
+    MSE has units of the input data squared, while RMSE is of the same unit as
+    the input data. Lower is better, and the lowest possible value is 0.0.
+
     For a univariate, non-hierarchical sample
     of true values :math:`y_1, \dots, y_n` and
     predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n` (in :math:`mathbb{R}`),


### PR DESCRIPTION
This PR makes improvements to the currently complete/reworked docstrings of forecasting performance metrics:

* preamble summarizes the type and whether lower/higher is better
* clear explanation of `eps`