### PR TITLE
[MNT] ensure release depends on `check_tag`

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,6 +32,7 @@ jobs:
           fi
 
   build_wheels:
+    needs: check_tag
     name: Build wheels
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
ensure release depends on `check_tag`.

This builds on https://github.com/sktime/sktime/pull/8718 and ensures no release happens if the tag is not valid.

FYI @szepeviktor