### PR TITLE
[BUG] fix parallelization and pickling in TSC `evaluate`

### DIFF
--- a/sktime/classification/model_evaluation/_functions.py
+++ b/sktime/classification/model_evaluation/_functions.py
@@ -258,7 +258,7 @@ def _evaluate_fold(x, meta):
     column_order = _get_column_order_and_datatype(scoring, return_data)
     result = result.reindex(columns=column_order.keys())
 
-    return result, classifier
+    return result
 
 
 def evaluate(


### PR DESCRIPTION
This PR fixes an unreported bug: some parallelization backends in the TSC `evaluate` would fail (at pickling) since a function was defined in a local scope, `_evaluate_fold_wrapper`.

However, it appears this function is entirely unnecessary, since all it does is wrapping a function in a global scope. This PR fixes the bug by removing the unnecessary wrapper, and point to the function in the global scope.