### PR TITLE
[BUG] Fixing test failure test_deep_estimator_full regressor [object-adamax]

### DIFF
--- a/sktime/regression/tests/test_base.py
+++ b/sktime/regression/tests/test_base.py
@@ -386,9 +386,7 @@ def test_deep_estimator_full(optimizer):
         assert serialize(full_dummy.optimizer) == serialize(deserialized_full.optimizer)
 
         # assert weights of optimizers are same
-        assert (
-            full_dummy.optimizer.variables == deserialized_full.optimizer.variables
-        )
+        assert full_dummy.optimizer.variables == deserialized_full.optimizer.variables
 
         # remove optimizers from both to do full dict check,
         # since two different objects


### PR DESCRIPTION
#### Reference Issues/PRs

#6153 



#### What does this implement/fix? Explain your changes.

n/a


#### Does your contribution introduce a new dependency? If yes, which one?

no


#### What should a reviewer concentrate their feedback on?

 check
<img width="1030" height="978" alt="Screenshot 2025-08-26 211405" src="https://github.com/user-attachments/assets/65d1c793-78fa-4d4a-8f85-8c4ab087261b" />
<img width="1901" height="955" alt="Screenshot 2025-08-26 211739" src="https://github.com/user-attachments/assets/4d62d441-4532-4644-a9dd-f2a2c0bf4616" />
<img width="1896" height="947" alt="Screenshot 2025-08-26 211800" src="https://github.com/user-attachments/assets/680d8fac-0da3-4472-8179-633101b2dbe2" />
<img width="1754" height="161" alt="Screenshot 2025-08-26 211811" src="https://github.com/user-attachments/assets/264942b5-4530-40b0-bf2b-59281e5cd2cc" />

[object-adamax] has an error where full_dummy.optimizer.variables cannot be callable as a list, when is supposed to be called as a method.
 

#### Did you add any tests for the change?


 No tests added.


#### Any other comments?

Any help to try to solve this could be helpful. I used WSL, Python 3.12.3, tensorflow 2.20.0, uv  0.8.13.

commands used (by order): 
--pytest sktime/regression/tests/test_base.py -v
-- pytest sktime/regression/tests/test_base.py::test_deep_estimator_full[object-adamax] -v --tb=long -s --runxfail (to see the real error and what causes)









