### PR TITLE
[DOC] Fix Install Command

### DIFF
--- a/docs/source/developer_guide/continuous_integration.rst
+++ b/docs/source/developer_guide/continuous_integration.rst
@@ -48,7 +48,7 @@ To install, if not already installed:
 
    .. code:: bash
 
-      pip install -e .[dev]
+      pip install -e ".[dev]"
 
    This installs an editable `development
    version <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`__


### PR DESCRIPTION
This PR corrects the installation command in the documentation.

Previously: [`pip install -e .[dev]`](https://www.sktime.net/en/stable/developer_guide/continuous_integration.html#:~:text=pip%20install%20%2De%20.%5Bdev%5D)

This above command doesn't work in shells like `zsh` due to globbing of square brackets.

Now: `pip install -e ".[dev]"`

Using quotes makes the command work consistently across different shells. And this is the way it is used in other places in `sktime` docs as well.