### PR TITLE
[ENH] skip failures of exogenous forecast tests from issue #8787 until resolved

### DIFF
--- a/sktime/forecasting/ardl.py
+++ b/sktime/forecasting/ardl.py
@@ -214,6 +214,10 @@ class ARDL(_StatsModelsAdapter):
         "X-y-must-have-same-index": True,  # can estimator handle different X/y index?
         "enforce_index_type": None,  # index type that needs to be enforced in X/y
         "capability:pred_int": False,  # does forecaster implement proba forecasts?
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_predict_time_index_with_X"],
+        # known failure in case of non-contiguous X, see issue #8787
     }
 
     def __init__(

--- a/sktime/forecasting/arima/_statsmodels.py
+++ b/sktime/forecasting/arima/_statsmodels.py
@@ -172,6 +172,10 @@ class StatsModelsARIMA(_StatsModelsAdapter):
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
         "python_dependencies": ["statsmodels"],
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_predict_time_index_with_X"],
+        # known failure in case of non-contiguous X, see issue #8787
     }
 
     def __init__(

--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -141,6 +141,10 @@ class DynamicFactor(_StatsModelsAdapter):
         "capability:insample": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_predict_time_index_with_X"],
+        # known failure in case of non-contiguous X, see issue #8787
     }
 
     def __init__(

--- a/sktime/forecasting/statsforecast.py
+++ b/sktime/forecasting/statsforecast.py
@@ -194,6 +194,8 @@ class StatsForecastAutoARIMA(_GeneralisedStatsForecastAdapter):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
+        "tests:skip_by_name": ["test_predict_time_index_with_X"],
+        # known failure in case of non-contiguous X, see issue #8787
     }
 
     def __init__(

--- a/sktime/forecasting/structural.py
+++ b/sktime/forecasting/structural.py
@@ -213,6 +213,10 @@ class UnobservedComponents(_StatsModelsAdapter):
         "capability:pred_int:insample": True,
         "capability:missing_values": False,
         "ignores-exogeneous-X": False,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_predict_time_index_with_X"],
+        # known failure in case of non-contiguous X, see issue #8787
     }
 
     def __init__(


### PR DESCRIPTION
Adds a temporary skip to the failures in issue #8787 until they are resolved, so only unknown failures appear in the CI as failures.