### PR TITLE
[ENH] allow transformer instance as deseasonalizer in `ThetaForecaster`, fix test cases

### DIFF
--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -84,8 +84,6 @@ class ProbabilityThresholdEarlyClassifier(BaseClassifier):
     _tags = {
         "capability:multivariate": True,
         "capability:multithreading": True,
-        "capability:random_state": True,
-        "property:randomness": "derandomized",
     }
 
     def __init__(


### PR DESCRIPTION
This PR adds the capability to pass a transformer instance to `ThetaForecaster` as deseasonalizer.

It also fixes the test cases which use multiplicative trend, which triggers an exception on the test data scenarios on newer `statsmodels` versions, due to negative values.

As side effect, fixes some current failures on `main`.