### PR TITLE
[ENH] Move `RandomIntervals` test skip from `_config.py` to estimator tags

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -35,7 +35,6 @@ EXCLUDE_ESTIMATORS = [
     "HIVECOTEV1",
     "HIVECOTEV2",
     "RandomIntervalSpectralEnsemble",
-    "RandomInvervals",
     "RandomIntervalSegmenter",
     "RandomIntervalFeatureExtractor",
     # tapnet based estimators fail stochastically for unknown reasons, see #3525
@@ -286,7 +285,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "RandomIntervalFeatureExtractor",
         "RandomIntervalSegmenter",
         "RandomIntervalSpectralEnsemble",
-        "RandomIntervals",
         "RandomSamplesAugmenter",
         "RandomShapeletTransform",
         "RecursiveTabularRegressionForecaster",

--- a/sktime/transformations/panel/random_intervals.py
+++ b/sktime/transformations/panel/random_intervals.py
@@ -61,6 +61,7 @@ class RandomIntervals(BaseTransformer):
         # CI and test flags
         # -----------------
         "tests:skip_by_name": ["test_categorical_X_passes"],
+        "tests:skip_all": True,
         # categoricals can be passed, but depending on transformers passed
     }
 


### PR DESCRIPTION
This PR moves the test skip configuration for RandomIntervals from sktime/tests/_config.py to the estimator's _tags.

This fix is in accordance with the issue #8515 