### PR TITLE
[BUG] apply per-series backfill in WindowSummarizer for MultiIndex data

### DIFF
--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -483,8 +483,8 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
 
     # Handle backfill
     if bfill is True:
-        if isinstance(Z.index, pd.MultiIndex):
-            feat = feat.groupby(level=list(range(Z.index.nlevels - 1))).bfill()
+        if isinstance(Z, pd.core.groupby.GroupBy):
+            feat = feat.groupby(level=list(range(feat.index.nlevels - 1))).bfill()
         else:
             feat = feat.bfill()
 


### PR DESCRIPTION
Fixes #8456 
 
When using `WindowSummarizer` with `truncate="bfill"` on hierarchical (MultiIndex) data, 
the current implementation applied `.bfill()` at the global DataFrame level.  
This caused values from one series to "leak" into another when filling missing lagged values.

Updated `_window_feature` to apply `bfill` **per series** when the input has a MultiIndex.