### PR TITLE
[ENH] Test param sets for LogTransformer

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -255,7 +255,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "IndividualBOSS",
         "IndividualTDE",
         "InformationGainSegmentation",
-        "LogTransformer",
         "M5Dataset",
         "MCDCNNClassifier",
         "MCDCNNNetwork",

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -450,6 +450,34 @@ class LogTransformer(BaseTransformer):
         Xt = (np.exp(X) / scale) - offset
         return Xt
 
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+            There are currently no reserved values for transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
+            instance.
+            ``create_test_instance`` uses the first (or only) dictionary in ``params``
+        """
+        return [
+            {"offset": 0, "scale": 1},
+            {"offset": 0, "scale": 10},
+            {"offset": 0.5, "scale": 0.5},
+            {"offset": 1, "scale": 2},
+            {"offset": 10, "scale": 10},
+        ]
+
 
 def _make_boxcox_optimizer(bounds=None, brack=(-2.0, 2.0)):
     from scipy import optimize


### PR DESCRIPTION
Reference Issues/PRs
References: https://github.com/sktime/sktime/issues/3429

What does this implement/fix? Explain your changes.
Implementing get_test_params method for LogTransformer

PR checklist
For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.