### PR TITLE
[ENH] add helpful error message to `check_estimator` if estimator dependencies are not present

### DIFF
--- a/sktime/transformations/panel/truncation.py
+++ b/sktime/transformations/panel/truncation.py
@@ -16,11 +16,11 @@ class TruncationTransformer(BaseTransformer):
     Parameters
     ----------
     lower : int, optional (default=None) minimum length, inclusive
-                Cannot be less than the length of the shortest series in the panel.
-                If None, will find the length of the shortest series and use instead.
+        Cannot be less than the length of the shortest series in the panel.
+        If None, will find the length of the shortest series and use instead.
     upper : int, optional (default=None) maximum length, exclusive
-                This is used to calculate the range between.
-                If None, will truncate to the lower bound.
+        This is used to calculate the range between.
+        If None, will truncate to the lower bound.
 
     Examples
     --------

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -127,7 +127,10 @@ def check_estimator(
     All tests PASSED!
     {'test_clone[ExponentTransformer-1]': 'PASSED'}
     """
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from sktime.utils.dependencies import (
+        _check_estimator_deps,
+        _check_soft_dependencies,
+    )
 
     msg = (
         "check_estimator is a testing utility for developers, and "
@@ -140,6 +143,17 @@ def check_estimator(
         " `pip install sktime[dev]`"
     )
     _check_soft_dependencies("pytest", msg=msg)
+
+    try:
+        _check_estimator_deps(estimator)
+    except ModuleNotFoundError as e:
+        msg = (
+            "check_estimator requires all dependencies of the tested object "
+            "to be present in the python environment, "
+            "but some were not found. "
+            f"Details: {e}"
+        )
+        raise ModuleNotFoundError(msg) from e
 
     from sktime.tests.test_class_register import get_test_classes_for_obj
 


### PR DESCRIPTION
This PR adds a helpful error message to `check_estimator` if estimator dependencies are not present, prompting the user to install estimator dependencies.

Otherwise, lack of installed dependencies can confuse power users who add new estimators, or developers who work on estimators, see, e.g., https://github.com/sktime/sktime/pull/8842#discussion_r2420410206