### PR TITLE
[ENH] Move SimpleRNNRegressor test skip config from tests._config to estimator tags.

### DIFF
--- a/sktime/regression/deep_learning/rnn.py
+++ b/sktime/regression/deep_learning/rnn.py
@@ -64,6 +64,11 @@ class SimpleRNNRegressor(BaseDeepRegressor):
         "authors": ["mloning"],
         "python_dependencies": "tensorflow",
         # estimator type handled by parent class
+        "tests:skip_by_name": [
+            "test_fit_idempotent",
+            "test_persistence_via_pickle",
+            "test_save_estimators_to_file",
+        ],
     }
 
     def __init__(

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -106,11 +106,6 @@ EXCLUDED_TESTS = {
         "test_multioutput",  # see 6201
         "test_classifier_on_unit_test_data",  # see 6201
     ],
-    "SimpleRNNRegressor": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
     # sth is not quite right with the RowTransformer-s changing state,
     #   but these are anyway on their path to deprecation, see #2370
     "SeriesToPrimitivesRowTransformer": ["test_methods_do_not_change_state"],


### PR DESCRIPTION
Reference Issues/PRs

* https://github.com/sktime/sktime/issues/8515

What does this implement/fix? Explain your changes.

This PR implements part of issue https://github.com/sktime/sktime/issues/8515 by migrating SimpleRNNRegressor test skip configurations from the central tests._config.py file to the estimator's own tags.