### PR TITLE
[MNT] revert to `pip` on failing `test_external_data`

### DIFF
--- a/.github/workflows/test_datasets.yml
+++ b/.github/workflows/test_datasets.yml
@@ -93,6 +93,9 @@ jobs:
         run: python3 -m pip install .[tests,datasets]
         shell: bash
 
+      - name: Show dependencies
+        run: python -m pip list
+
       - name: unit test step
         run: python3 -m pytest -m "datadownload" sktime/datasets
         shell: bash


### PR DESCRIPTION
This PR reverts the recent change to `uv` installation on `test_external_data` CI job back to `pip`.

This is a temporary fix for the failure https://github.com/sktime/sktime/issues/8984.