### PR TITLE
[BUG] Fix `ConvTimeNetForecaster` test configuration paths

### DIFF
--- a/sktime/forecasting/convtimenet.py
+++ b/sktime/forecasting/convtimenet.py
@@ -161,6 +161,7 @@ class ConvTimeNetForecaster(_pytorch.BaseDeepNetworkPyTorch):
             "sktime.networks.convtimenet.forecaster._patch_layers",
             "sktime.networks.convtimenet.forecaster._revin",
         ],
+        "tests:vm": True,
     }
 
     def __init__(


### PR DESCRIPTION
The `ConvTimeNetForecaster` test configuration paths had typos, this PR fixes that.