### PR TITLE
[ENH] `is_module_changed` to return `True` if path cannot be found instead of exception raised

### DIFF
--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -59,12 +59,18 @@ def is_module_changed(module_str):
 
     If a child module has changed, the parent module is considered changed as well.
 
+    If the module cannot be found, it is considered changed.
+
     Parameters
     ----------
     module_str : str
         module string, e.g., sktime.forecasting.naive
     """
-    module_file_path = get_path_from_module(module_str)
+    try:
+        module_file_path = get_path_from_module(module_str)
+    except ImportError:
+        # if the file cannot be found, we consider it changed
+        return True
     cmd = f"git diff remotes/origin/main -- {module_file_path}"
     try:
         output = subprocess.check_output(cmd, shell=True, text=True, encoding="utf-8")


### PR DESCRIPTION
The `is_module_changed` currently crashes if the path passed to it does not exist.

This results in test collection failure currently if one of the `"tests:libs"` paths has a typo or does otherwise not exist.

This PR changes `is_module`changed` to return `True` if path cannot be found instead of exception raised, ensuring tests collects also for badly specified `"tests:libs"`.

Not a bug but makes the test system more robust.