### PR TITLE
[MNT] remove `pykan` soft dependency from `dl` depset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,7 +267,6 @@ dl = [
   'tensorflow<2.20,>=2.15; python_version < "3.13"',
   "torch; (sys_platform != 'darwin' or python_version != '3.13')",
   'transformers[torch]<4.41.0; python_version < "3.12"',
-  'pykan>=0.2.1,<0.2.9; python_version > "3.9.7"',
   "pytorch-forecasting>=1.0.0,<1.6.0; (sys_platform != 'darwin' or python_version != '3.13')",
   'lightning>=2.0; python_version < "3.12"',
   'gluonts>=0.14.3; python_version < "3.12"',

--- a/sktime/forecasting/pykan_forecaster.py
+++ b/sktime/forecasting/pykan_forecaster.py
@@ -76,6 +76,7 @@ class PyKANForecaster(BaseForecaster):
         # CI and test flags
         # -----------------
         "tests:vm": True,  # run tests on vm in GHA
+        "tests:skip_by_name": ["test_predict_time_index_in_sample_full"],
     }
 
     def __init__(

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -138,7 +138,6 @@ EXCLUDED_TESTS = {
     "Pipeline": ["test_inheritance"],  # does not inherit from intermediate base classes
     # networks do not support negative fh
     "HFTransformersForecaster": ["test_predict_time_index_in_sample_full"],
-    "PyKANForecaster": ["test_predict_time_index_in_sample_full"],
     "WEASEL": ["test_multiprocessing_idempotent"],  # see 5658
     # StatsForecastMSTL is failing in probabistic forecasts, see #5703, #5920
     "StatsForecastMSTL": ["test_pred_int_tag"],


### PR DESCRIPTION
removes `pykan` soft dependency from `dl` depset - this is not a well maintained package currently, and is used by only a single estimator.

Adds that single estimator to VM-based per-estimator testing instead, to ensure test coverage is maintained.