### PR TITLE
[MNT] remove `freia` soft dependency from `dl` depset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,7 +261,6 @@ datasets = [
   "requests",
 ]
 dl = [
-  'FrEIA; python_version < "3.12"',
   'neuralforecast<1.8.0,>=1.6.4; python_version < "3.11"',
   'peft>=0.10.0,<0.14.0; python_version < "3.12"',
   'tensorflow<2.20,>=2.15; python_version < "3.13"',

--- a/sktime/forecasting/conditional_invertible_neural_network.py
+++ b/sktime/forecasting/conditional_invertible_neural_network.py
@@ -130,6 +130,9 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
         "enforce_index_type": None,
         "capability:missing_values": False,
         "capability:pred_int": False,
+        # CI and test flags
+        # -----------------
+        "tests:vm": True,  # run tests on vm in GHA
     }
 
     def __init__(


### PR DESCRIPTION
removes `freia` soft dependency from `dl` depset - this is not a well maintained package currently, and is used by only a single estimator.

Adds that single estimator to VM-based per-estimator testing instead, to ensure test coverage is maintained.