### PR TITLE
[BUG] Fix `_safe_import` import error in `ConvTimeNetForecaster`

### DIFF
--- a/sktime/forecasting/convtimenet.py
+++ b/sktime/forecasting/convtimenet.py
@@ -5,9 +5,8 @@ __all__ = ["ConvTimeNetForecaster"]
 
 import warnings
 
-from skbase.utils.dependencies import _safe_import
-
 from sktime.forecasting.base.adapters import _pytorch
+from sktime.utils.dependencies import _safe_import
 
 torch = _safe_import("torch")
 

--- a/sktime/networks/convtimenet/_convtimenet.py
+++ b/sktime/networks/convtimenet/_convtimenet.py
@@ -2,7 +2,7 @@
 
 __author__ = ["Tanuj-Taneja1"]
 
-from skbase.utils.dependencies import _safe_import
+from sktime.utils.dependencies import _safe_import
 
 torch = _safe_import("torch")
 nn = _safe_import("torch.nn")

--- a/sktime/networks/convtimenet/_convtimenet_backbone.py
+++ b/sktime/networks/convtimenet/_convtimenet_backbone.py
@@ -3,7 +3,7 @@ __author__ = ["Tanuj-Taneja1"]
 
 import copy
 
-from skbase.utils.dependencies import _safe_import
+from sktime.utils.dependencies import _safe_import
 
 torch = _safe_import("torch")
 nn = _safe_import("torch.nn")

--- a/sktime/networks/convtimenet/_dlutils.py
+++ b/sktime/networks/convtimenet/_dlutils.py
@@ -2,7 +2,7 @@ __author__ = ["Tanuj-Taneja1"]
 
 import math
 
-from skbase.utils.dependencies import _safe_import
+from sktime.utils.dependencies import _safe_import
 
 torch = _safe_import("torch")
 nn = _safe_import("torch.nn")

--- a/sktime/networks/convtimenet/forecaster/_convtimenet.py
+++ b/sktime/networks/convtimenet/forecaster/_convtimenet.py
@@ -1,7 +1,8 @@
 __all__ = ["Model"]
 
 import numpy as np
-from skbase.utils.dependencies import _safe_import
+
+from sktime.utils.dependencies import _safe_import
 
 torch = _safe_import("torch")
 nn = _safe_import("torch.nn")

--- a/sktime/networks/convtimenet/forecaster/_convtimenet_backbone.py
+++ b/sktime/networks/convtimenet/forecaster/_convtimenet_backbone.py
@@ -3,7 +3,7 @@ __all__ = ["ConvTimeNet_backbone"]
 # Cell
 import copy
 
-from skbase.utils.dependencies import _safe_import
+from sktime.utils.dependencies import _safe_import
 
 torch = _safe_import("torch")
 nn = _safe_import("torch.nn")

--- a/sktime/networks/convtimenet/forecaster/_patch_layers.py
+++ b/sktime/networks/convtimenet/forecaster/_patch_layers.py
@@ -1,5 +1,6 @@
 __all__ = ["DepatchSampling"]
-from skbase.utils.dependencies import _safe_import
+
+from sktime.utils.dependencies import _safe_import
 
 torch = _safe_import("torch")
 nn = _safe_import("torch.nn")

--- a/sktime/networks/convtimenet/forecaster/_revin.py
+++ b/sktime/networks/convtimenet/forecaster/_revin.py
@@ -1,6 +1,6 @@
 __all__ = ["RevIN"]
 
-from skbase.utils.dependencies import _safe_import
+from sktime.utils.dependencies import _safe_import
 
 torch = _safe_import("torch")
 nn = _safe_import("torch.nn")


### PR DESCRIPTION
This PR fixes import error in `ConvTimeNetForecaster` and its associated files. `_safe_import` is not a part of `skbase` rn, it is included in `sktime`. The wrong import was leading to errors in running `all_estimators` and related workflows.