### PR TITLE
[BUG] remove `KNeighborsTimeSeriesRegressor` spurious `numba` dependency tag

### DIFF
--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -144,7 +144,6 @@ class KNeighborsTimeSeriesRegressor(_BaseKnnTimeSeriesEstimator, BaseRegressor):
         # packaging info
         # --------------
         "authors": ["fkiraly"],
-        "python_dependencies": "numba",
         # estimator type
         # --------------
         "capability:multivariate": True,


### PR DESCRIPTION
Fixes #9020 - removes from `KNeighborsTimeSeriesRegressor` a spurious `numba` dependency tag - like for the `KNeighborsTimeSeriesClassifier`, `numba` is not needed