### PR TITLE
[MNT] Refactor _reduce.py: Simplify boolean logic and type checks

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -555,7 +555,7 @@ class _DirectReducer(_Reducer):
                 "Transformers currently cannot be provided"
                 + "for models that run locally"
             )
-        pd_format = isinstance(y, pd.Series) or isinstance(y, pd.DataFrame)
+        pd_format = isinstance(y, (pd.Series, pd.DataFrame))
         if self.pooling == "local":
             if pd_format is True and isinstance(y, pd.MultiIndex):
                 warn(
@@ -668,7 +668,7 @@ class _DirectReducer(_Reducer):
         if self.pooling == "global":
             y_last, X_last = self._get_shifted_window(X_update=X)
             ys = np.array(y_last)
-            if not np.sum(np.isnan(ys)) == 0 and np.sum(np.isinf(ys)) == 0:
+            if np.sum(np.isnan(ys)) != 0 and np.sum(np.isinf(ys)) == 0:
                 return self._predict_nan(fh, method=method, **kwargs)
         else:
             y_last, X_last = self._get_last_window()
@@ -1695,7 +1695,7 @@ def _get_forecaster(scitype, strategy):
         raise ValueError(
             "Error in make_reduction, no reduction strategies defined for "
             f"specified or inferred scitype of estimator: {scitype}. "
-            f"Valid scitypes are: {list(registry.keys())}."
+            f"Valid scitypes are: {list(registry)}."
         )
     if strategy not in registry[scitype]:
         raise ValueError(


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9099

#### What does this implement/fix? Explain your changes.
This PR applies safe `ruff` linter suggestions to `sktime/forecasting/compose/_reduce.py` to improve code readability and modernization.

**Specific changes:**
- **SIM101:** Merged redundant `isinstance` checks into single tuples (Line ~558).
- **SIM201:** Simplified boolean math logic (`!= 0` instead of `not ... == 0`) (Line ~671).
- **SIM118:** Removed redundant `.keys()` calls in dictionary iteration.

**Note on Stability:**
This refactor is strictly scoped to safe syntax changes. I have explicitly **excluded** the nested `if` statement refactor (SIM102) to avoid regressions in hierarchical indexing logic (which caused CI issues in a previous attempt).

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
Verifying that the logic flow remains identical to the original implementation.

#### Did you add any tests for the change?
No, this is a refactor of existing logic. I verified locally that `test_hierarchical_with_exogeneous` passes.

#### PR checklist
##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) (will do post-merge)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].