### PR TITLE
[ENH] Add rolling_mean strategy to NaiveForecaster

### DIFF
--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -209,9 +209,11 @@ class NaiveForecaster(_BaseWindowForecaster):
                     f"the `window_length`: {self.window_length} "
                     f"value must be greater than one."
                 )
-
+        elif self.strategy == "rolling_mean":
+            if self.window_length_ is None:
+                self.window_length_ = self.window_length
         else:
-            allowed_strategies = ("last", "mean", "drift")
+            allowed_strategies = ("last", "mean", "drift", "rolling_mean")
             raise ValueError(
                 f"Unknown strategy: {self.strategy}. Expected "
                 f"one of: {allowed_strategies}."
@@ -274,6 +276,25 @@ class NaiveForecaster(_BaseWindowForecaster):
 
                 # tile prediction according to seasonal periodicity
                 y_pred = self._tile_seasonal_prediction(y_pred, fh)
+
+
+        elif strategy == "rolling_mean":
+            if sp == 1:
+                current_window = last_window.copy()
+                preds = []
+                for _ in range(len(fh)):
+                    pred = np.nanmean(current_window)
+                    preds.append(pred)
+                    # update the current window
+                    current_window = np.append(current_window[1:], pred)
+                return np.array(preds)
+            else:
+                raise NotImplementedError("rolling_mean currently only supports sp=1")
+
+
+
+
+
 
         elif strategy == "drift":
             if self.window_length_ != 1:


### PR DESCRIPTION
## Description
This PR implements the requested rolling_mean strategy for the NaiveForecaster (resolves #9101).

Previously, NaiveForecaster supported mean (constant average of the window) but did not support a rolling update where predictions feed back into the window for subsequent steps.

## Changes
- Updated _naive.py to include rolling_mean in allowed_strategies.
- Implemented the recursive prediction loop in _predict_last_window.
- Added safety check in _fit to ensure window_length_ is set correctly for this strategy.

## Testing
- Verified locally with a test script using pd.period_range.
- Confirmed that predictions change over the forecasting horizon (unlike the flat line produced by the standard mean strategy).
-
