### PR TITLE
Reduced calls

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -71,6 +71,7 @@ Data sets and data loaders
 
 * [ENH] only run ``test_load_fpp3_public`` when ``rdata`` is installed (:pr:`8891`) :user:`noxthot`
 * [ENH] More Dataset Classes for Existing Loaders (:pr:`8894`) :user:`jgyasu`
+* [ENH] Optionally download entire HuggingFace dataset repos in one snapshot to cut benchmark API calls (:issue:`9124`) :user:`jgyasu`
 
 Forecasting
 ^^^^^^^^^^^

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -70,7 +70,14 @@ def _list_available_datasets(extract_path, origin_repo=None):
     return datasets
 
 
-def _cache_dataset(url, name, extract_path=None, repeats=1, verbose=False):
+def _cache_dataset(
+    url,
+    name,
+    extract_path=None,
+    repeats=1,
+    verbose=False,
+    download_entire_repo=False,
+):
     """Download and unzip datasets from multiple mirrors or fallback sources.
 
     If url is string, will attempt to download and unzip from url, to extract_path.
@@ -89,6 +96,10 @@ def _cache_dataset(url, name, extract_path=None, repeats=1, verbose=False):
         number of times to try downloading from each url
     verbose : bool, optional (default: False)
         whether to print progress
+    download_entire_repo : bool, optional (default=False)
+        If True, download the full HuggingFace dataset repository snapshot in a single
+        call instead of filtering for ``name``. This significantly reduces API calls
+        when downloading many datasets from the same repository.
 
     Returns
     -------
@@ -116,6 +127,7 @@ def _cache_dataset(url, name, extract_path=None, repeats=1, verbose=False):
                 hf_repo_name="sktime/tsc-datasets",
                 folder_name=name,
                 fallback_urls=[name_url],
+                download_entire_repo=download_entire_repo,
             )
 
             downloader.download(download_path=extract_path)
@@ -142,7 +154,13 @@ def _mkdir_if_not_exist(*path):
 
 
 def _load_dataset(
-    name, split, return_X_y, return_type=None, extract_path=None, y_dtype="str"
+    name,
+    split,
+    return_X_y,
+    return_type=None,
+    extract_path=None,
+    y_dtype="str",
+    download_entire_repo=False,
 ):
     """Load time series classification datasets (helper function).
 
@@ -172,6 +190,10 @@ def _load_dataset(
         defaults to sktime/datasets/local_data and downloads data there
     y_dtype : str, optional(default: 'str')
         dtype of the target variable
+    download_entire_repo : bool, optional (default=False)
+        If True, download a full HuggingFace snapshot for the repository that contains
+        ``name`` the first time any dataset is requested. Subsequent dataset loads use
+        the locally cached repository without extra API calls.
 
     Returns
     -------
@@ -216,7 +238,12 @@ def _load_dataset(
     # download the dataset from CLASSIF_URLS
     # will try multiple mirrors if necessary
     # if fails, will raise a RuntimeError
-    _cache_dataset(CLASSIF_URLS, name, extract_path=extract_path)
+    _cache_dataset(
+        CLASSIF_URLS,
+        name,
+        extract_path=extract_path,
+        download_entire_repo=download_entire_repo,
+    )
 
     # if we reach this, the data has been downloaded, now we can load it
     return _get_data_from(extract_path)

--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -71,6 +71,7 @@ def load_UCR_UEA_dataset(
     return_type=None,
     extract_path=None,
     y_dtype="str",
+    download_entire_repo=False,
 ):
     """Load dataset from UCR UEA time series archive.
 
@@ -119,6 +120,11 @@ def load_UCR_UEA_dataset(
         e.g. ``C:/Temp`` or relative, e.g. ``Temp`` or ``./Temp``.
     y_dtype: str, optional(default='str')
         This dtype of the target variable.
+    download_entire_repo : bool, optional (default=False)
+        If True, fetch a full snapshot of the HuggingFace repository that hosts
+        the ``sktime`` classification datasets when the dataset is first requested.
+        This turns hundreds of API calls for large benchmarking downloads into a
+        single snapshot download.
 
 
     Returns
@@ -138,7 +144,13 @@ def load_UCR_UEA_dataset(
     >>> X, y = load_UCR_UEA_dataset(name="ArrowHead") # doctest: +SKIP
     """
     return _load_dataset(
-        name, split, return_X_y, return_type, extract_path, y_dtype=y_dtype
+        name,
+        split,
+        return_X_y,
+        return_type,
+        extract_path,
+        y_dtype=y_dtype,
+        download_entire_repo=download_entire_repo,
     )
 
 

--- a/sktime/datasets/classification/ucr_uea_archive/_ucr_uea_datasets.py
+++ b/sktime/datasets/classification/ucr_uea_archive/_ucr_uea_datasets.py
@@ -22,6 +22,10 @@ class UCRUEADataset(BaseClassificationDataset):
     ----------
     name: str
         Name of the dataset to load.
+    download_entire_repo : bool, default=False
+        If True, download the full HuggingFace repository snapshot the first time the
+        dataset is requested. This drastically reduces API calls when iterating across
+        many datasets for benchmarking studies.
 
     Examples
     --------
@@ -48,10 +52,16 @@ class UCRUEADataset(BaseClassificationDataset):
     Dataset details: https://timeseriesclassification.com/dataset.php
     """
 
-    def __init__(self, name, return_mtype="pd-multiindex"):
+    def __init__(
+        self,
+        name,
+        return_mtype="pd-multiindex",
+        download_entire_repo=False,
+    ):
         super().__init__(return_mtype=return_mtype)
         self.name = name
         self.loader_func = load_UCR_UEA_dataset
+        self.download_entire_repo = download_entire_repo
 
         self.set_tags(name=self.name)
         self.set_tags(**DATASET_TAGS[self.name])
@@ -83,6 +93,9 @@ class UCRUEADataset(BaseClassificationDataset):
 
         if "split" in loader_func_params:
             kwargs["split"] = split
+
+        if "download_entire_repo" in loader_func_params:
+            kwargs["download_entire_repo"] = self.download_entire_repo
 
         for init_param_name, init_param_value in init_param_values.items():
             if init_param_name in loader_func_params:


### PR DESCRIPTION


What this fix does:

Added a download_entire_repo flag to _cache_dataset, _load_dataset, and load_UCR_UEA_dataset so large benchmarking jobs can request a single HuggingFace snapshot instead of per-dataset API pulls; the flag is forwarded through the strategy layer to DatasetDownloader(HuggingFaceDownloader) which now passes allow_patterns only when repo-wide download is disabled.

Extended UCRUEADataset to accept the same flag, storing it on the instance and injecting it into loader kwargs so benchmarking dataset objects can enable repo snapshots without extra wiring.

Backed the change with two monkeypatched tests in test_data_io.py that assert _cache_dataset and load_UCR_UEA_dataset propagate the flag, and noted the enhancement in the changelog.