### PR TITLE
Add explicit check for empty time series inputs

### DIFF
--- a/sktime/utils/validation/series.py
+++ b/sktime/utils/validation/series.py
@@ -143,6 +143,10 @@ def check_series(
             f"{var_name} must be a one of {valid_data_types}, but found type: {type(Z)}"
         )
 
+    # Check for empty pandas Series or DataFrame
+    if isinstance(Z, (pd.Series, pd.DataFrame)) and Z.empty and not allow_empty:
+        raise ValueError("Input time series is empty. Provide at least one observation.")
+
     if enforce_univariate and enforce_multivariate:
         raise ValueError(
             "`enforce_univariate` and `enforce_multivariate` cannot both be set to "

--- a/sktime/utils/validation/tests/test_series.py
+++ b/sktime/utils/validation/tests/test_series.py
@@ -5,10 +5,12 @@
 __author__ = ["benheid"]
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from sktime.tests.test_switch import run_test_for_class
-from sktime.utils.validation.series import check_equal_time_index
+from sktime.utils.validation.series import check_equal_time_index, check_series
+
 
 first_arrays = (np.random.random(1000),)
 second_arrays = (np.random.random(1000),)
@@ -23,3 +25,38 @@ second_arrays = (np.random.random(1000),)
 def test_check_equal_time_index(first_array, second_array):
     """Test that fh validation throws an error with empty container."""
     check_equal_time_index(first_array, second_array)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(check_series),
+    reason="Run if tested function has changed.",
+)
+def test_check_series_empty():
+    """Test that check_series raises an error for empty pandas Series/DataFrame."""
+    # Test with empty Series
+    empty_series = pd.Series([], dtype=float)
+    with pytest.raises(ValueError, match="Input time series is empty. Provide at least one observation."):
+        check_series(empty_series)
+    
+    # Test with empty DataFrame
+    empty_df = pd.DataFrame()
+    with pytest.raises(ValueError, match="Input time series is empty. Provide at least one observation."):
+        check_series(empty_df)
+    
+    # Test that non-empty Series works fine
+    non_empty_series = pd.Series([1, 2, 3])
+    result = check_series(non_empty_series)
+    assert result is non_empty_series
+    
+    # Test that non-empty DataFrame works fine
+    non_empty_df = pd.DataFrame({"a": [1, 2, 3]})
+    result = check_series(non_empty_df)
+    assert result is non_empty_df
+    
+    # Test that empty Series is allowed when allow_empty=True
+    result = check_series(empty_series, allow_empty=True)
+    assert result is empty_series
+    
+    # Test that empty DataFrame is allowed when allow_empty=True
+    result = check_series(empty_df, allow_empty=True)
+    assert result is empty_df


### PR DESCRIPTION
Reference Issues/PRs
None.

What does this implement/fix?
Adds an explicit check for empty pandas Series/DataFrame inputs in the time series validation logic. This makes failures on empty inputs clearer and prevents confusing downstream errors. A small regression test is included.

New dependencies?
No.

What should reviewers focus on?

Correctness of the empty input check

Test coverage for this case

Tests added?
Yes.

Any other comments?
No.