### PR TITLE
[ENH] Inherit Splitters from `BaseSplitter`

### DIFF
--- a/sktime/series_as_features/model_selection/_split.py
+++ b/sktime/series_as_features/model_selection/_split.py
@@ -65,7 +65,7 @@ class PresplitFilesCV(BaseSplitter):
             for train, test in self.cv.split(idx, y=y):
                 yield train, test
 
-    def get_n_splits(self):
+    def get_n_splits(self, data=None):
         """Return the number of splits.
 
         Returns
@@ -154,6 +154,6 @@ class SingleSplit(BaseSplitter):
         )
 
     @staticmethod
-    def get_n_splits():
+    def get_n_splits(data=None):
         """Return the number of splits (1)."""
         return 1


### PR DESCRIPTION
Currently `PresplitFilesCV` and `SingleSplit` doesn't inherit from `BaseSplitter` which leads to them not getting discovered by the registry. This PR fixes it.