### PR TITLE
[BUG] fixed ARDL.predict() with Single-Value ForecastingHorizon ≥ 3

### DIFF
--- a/sktime/forecasting/ardl.py
+++ b/sktime/forecasting/ardl.py
@@ -433,6 +433,8 @@ class ARDL(_StatsModelsAdapter):
         # beginning of the training series when passing integers
 
         start, end = fh.to_absolute_int(self._y.index[0], self.cutoff)[[0, -1]]
+        if start == end:
+            start = 0
         # statsmodels forecasts all periods from start to end of forecasting
         # horizon, but only return given time points in forecasting horizon
         valid_indices = fh.to_absolute_index(self.cutoff)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9145 

#### What does this implement/fix? Explain your changes.
Implemented the proposed solution in the issue description.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### Did you add any tests for the change?
No,

we can just adjust `TEST_OOS_FHS` in `sktime/forecasting/tests/_config.py` to cover more values if we want:
**Current:**
`TEST_OOS_FHS = [1, np.array([2, 5], dtype="int64")]`
**Proposed:**
`TEST_OOS_FHS = [1, 3, np.array([2, 5], dtype="int64")]`

