### PR TITLE
[MNT] bound `lightning<2.6` in the `dl` depset, due to new release breaking serialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,7 +269,7 @@ dl = [
   "torch; (sys_platform != 'darwin' or python_version < '3.13')",
   'transformers[torch]<4.41.0; python_version < "3.13"',
   "pytorch-forecasting>=1.0.0,<1.6.0; (sys_platform != 'darwin' or python_version != '3.13') and python_version < '3.14'",
-  'lightning>=2.0; python_version < "3.12"',
+  'lightning>=2.0,<2.6; python_version < "3.12"',
   'gluonts>=0.14.3; python_version < "3.12"',
   'einops>0.7.0; python_version < "3.12"',
   'huggingface-hub>=0.23.0; python_version < "3.12"',


### PR DESCRIPTION
bounds `lightning<2.6` due to new release breaking serialization