### PR TITLE
[MNT] bound `torch<2.6`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,6 +301,7 @@ notebooks = [
   "dtw-python",
   "prophet",
   "pytorch-forecasting",
+  "torch<2.6",
   "skpro",
   "statsforecast",
 ]


### PR DESCRIPTION
 `torch 2.6` introduced a change that is breaking serialization and CI, see https://github.com/sktime/sktime/issues/9161

This PR adds an upper bound to `lightning` which can be bumped once resolved.