### PR TITLE
[MNT] bound `lightning<2.6`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,7 +269,7 @@ dl = [
   "torch; (sys_platform != 'darwin' or python_version < '3.13')",
   'transformers[torch]<4.41.0; python_version < "3.13"',
   "pytorch-forecasting>=1.0.0,<1.6.0; (sys_platform != 'darwin' or python_version != '3.13') and python_version < '3.14'",
-  'lightning>=2.0,<2.6; (sys_platform != 'darwin' or python_version < '3.13')",
+  "lightning>=2.0,<2.6; (sys_platform != 'darwin' or python_version < '3.13')",
   'gluonts>=0.14.3; python_version < "3.12"',
   'einops>0.7.0; python_version < "3.12"',
   'huggingface-hub>=0.23.0; python_version < "3.12"',


### PR DESCRIPTION
 `lightning 2.6` introduced a change that is breaking serialization and CI, see https://github.com/sktime/sktime/issues/9161

This PR adds an upper bound to `lightning` which can be bumped once resolved.