### PR TITLE
[BUG] fix `mlflow` test failure - double use of database reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,7 @@ dl = [
   'hydra-core; python_version < "3.13"',
 ]
 mlflow = [
-  "mlflow!=3.8.0,<4.0",
+  "mlflow<4.0",
 ]
 mlflow2 = [
   "mlflow<3.0",
@@ -286,7 +286,7 @@ mlflow2 = [
 mlflow_tests = [
   "boto3",
   "botocore",
-  "mlflow!=3.8.0,<4.0",
+  "mlflow<4.0",
   "moto",
 ]
 notebooks = [


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9180.

#### What does this implement/fix? Explain your changes.
Exclude the bad mlflow release (2.20.0) in pyproject.toml while keeping prior upper ranges:
- mlflow, mlflow_tests: mlflow!=2.20.0,<4.0
- mlflow2: mlflow!=2.20.0,<3.0
This avoids blocking mlflow v3 and only fences off the known-bad version causing CI failures.

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies; only adjusts the mlflow version constraint.

#### What should a reviewer concentrate their feedback on?
- Confirm excluding just 2.20.0 is sufficient for current CI breakage.
- Ensure no other dependency sets need adjustment.

#### Did you add any tests for the change?
No; dependency constraint tweak only. Existing mlflow integration tests should pass under allowed versions.

#### Any other comments?
When mlflow  is fixed, we can remove the exclusion and rerun the mlflow integration tests.

#### PR checklist
- [x] The PR title starts with [BUG].
- [ ] I’ve added myself to the list of contributors (if applicable).
- [ ] Optionally, for added estimators: I’ve added myself to the maintainers tag (not applicable).