### PR TITLE
[MNT] prioritize empty return in `run_test_vm`

### DIFF
--- a/sktime/tests/_test_vm.py
+++ b/sktime/tests/_test_vm.py
@@ -33,6 +33,14 @@ def run_test_vm(cls_name):
     from sktime.utils import check_estimator
     from sktime.utils.dependencies import _check_estimator_deps
 
+    cls = craft(cls_name)
+    if not _check_estimator_deps(cls, severity="none"):
+        print(
+            f"Skipping estimator: {cls} due to incompatibility "
+            "with python or OS version."
+        )
+        return
+
     if _check_soft_dependencies("torch", severity="none"):
         # disable mps for macos runners if torch is available
         if platform.system() == "Darwin":
@@ -45,12 +53,5 @@ def run_test_vm(cls_name):
         if platform.system() == "Darwin":
             os.environ["HF_XET_NUM_CONCURRENT_RANGE_GETS"] = "4"
 
-    cls = craft(cls_name)
-    if _check_estimator_deps(cls, severity="none"):
-        skips = cls.get_class_tag("tests:skip_by_name", None)
-        check_estimator(cls, raise_exceptions=True, tests_to_exclude=skips)
-    else:
-        print(
-            f"Skipping estimator: {cls} due to incompatibility "
-            "with python or OS version."
-        )
+    skips = cls.get_class_tag("tests:skip_by_name", None)
+    check_estimator(cls, raise_exceptions=True, tests_to_exclude=skips)


### PR DESCRIPTION
Updates logic inside `run_test_vm` to prioritize an empty return if the testing logic is not meant to run.

Minimizes side effects on environment variables.