### PR TITLE
[ENH] make `_safe_import` robust against package import errors

### DIFF
--- a/sktime/utils/dependencies/_safe_import.py
+++ b/sktime/utils/dependencies/_safe_import.py
@@ -81,7 +81,17 @@ def _safe_import(import_path, pkg_name=None):
             module_name, attr_name = import_path.rsplit(".", 1)
             module = importlib.import_module(module_name)
             return getattr(module, attr_name)
-        except (ImportError, AttributeError):
+        except Exception as e:
+            # if not (ImportError, AttributeError), raise warning
+            from warnings import warn
+
+            if not isinstance(e, (ImportError, AttributeError)):
+                warn(
+                    f"Importing '{import_path}' failed with error "
+                    "other than ImportError or AttributeError:"
+                    f": {e}. ",
+                    ImportWarning,
+                )
             pass
 
     mock_obj = _create_mock_class(obj_name)


### PR DESCRIPTION
This PR makes `_safe_import` robust against errors that are within imported packages, e.g., a failed import in the imported package itself.

In such a case, the function will exhibit the mock behaviour (failed import), but raise a warning.