### PR TITLE
[ENH] ensure test data in `test_update_with_exogenous` is nonsingular

### DIFF
--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -780,8 +780,9 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             y = pd.Series(range(25), index=index, name="y")
         else:
             y_data = {}
+            np.random.seed(42)
             for i in range(n_columns):
-                y_data[f"y_{i}"] = range(25)
+                y_data[f"y_{i}"] = np.random.randn(25)
             y = pd.DataFrame(y_data, index=index)
 
         # Create X data (exogenous variables)


### PR DESCRIPTION
Changes the test data generation in `test_update_with_exogenous` is nonsingular so data is not rank deficient - this can pose issues with some estimators.