### PR TITLE
[ENH] Expose dropout parameters in CNTCNetwork and TapNetNetwork 

### DIFF
--- a/sktime/classification/deep_learning/cntc.py
+++ b/sktime/classification/deep_learning/cntc.py
@@ -45,6 +45,13 @@ class CNTCClassifier(BaseDeepClassifier):
         number of lstm units in the CLSTM arm.
     dense_size : int, default = 64
         dimension of dense layer in CNTC.
+    dropout : float or tuple of floats, default = (0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1)
+        dropout rate(s), in the range [0, 1).
+        If a single float is provided, the same dropout rate is applied to all layers.
+        If a tuple is provided, it should have 7 values corresponding to:
+        (conv1_dropout, rnn1_dropout, conv2_dropout, lstm_dropout,
+         avg_dropout, att_dropout, mlp_dropout)
+        where mlp_dropout is applied to both MLP layers.
     random_state : int or None, default=None
         Seed for random number generation.
     verbose : boolean, default = False
@@ -117,6 +124,7 @@ class CNTCClassifier(BaseDeepClassifier):
         rnn_size=64,
         lstm_size=8,
         dense_size=64,
+        dropout=(0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1),
         callbacks=None,
         verbose=False,
         loss="categorical_crossentropy",
@@ -136,6 +144,7 @@ class CNTCClassifier(BaseDeepClassifier):
         self.rnn_size = rnn_size
         self.lstm_size = lstm_size
         self.dense_size = dense_size
+        self.dropout = dropout
         self.callbacks = callbacks
         self.n_epochs = n_epochs
         self.batch_size = batch_size
@@ -150,6 +159,7 @@ class CNTCClassifier(BaseDeepClassifier):
             activation=self.activation_hidden,
             activation_attention=self.activation_attention,
             random_state=self.random_state,
+            dropout=self.dropout,
         )
 
     def build_model(self, input_shape, n_classes, **kwargs):

--- a/sktime/classification/deep_learning/tapnet.py
+++ b/sktime/classification/deep_learning/tapnet.py
@@ -36,6 +36,8 @@ class TapNetClassifier(BaseDeepClassifier):
         List of Keras callbacks to apply during model training.
     dropout : float, default = 0.5
         dropout rate, in the range [0, 1)
+    lstm_dropout : float, default = 0.8
+        dropout rate for the LSTM layer, in the range [0, 1)
     dilation : int, default = 1
         dilation value
     activation : str, default = "sigmoid"
@@ -130,6 +132,7 @@ class TapNetClassifier(BaseDeepClassifier):
         metrics=None,
         callbacks=None,
         verbose=False,
+        lstm_dropout=0.8,
     ):
         _check_dl_dependencies(severity="error")
 
@@ -154,6 +157,7 @@ class TapNetClassifier(BaseDeepClassifier):
         self.verbose = verbose
 
         self.dropout = dropout
+        self.lstm_dropout = lstm_dropout
         self.use_lstm = use_lstm
         self.use_cnn = use_cnn
 
@@ -177,6 +181,7 @@ class TapNetClassifier(BaseDeepClassifier):
             use_cnn=self.use_cnn,
             random_state=self.random_state,
             padding=self.padding,
+            lstm_dropout=self.lstm_dropout,
         )
 
     def build_model(self, input_shape, n_classes, **kwargs):

--- a/sktime/networks/cntc.py
+++ b/sktime/networks/cntc.py
@@ -26,6 +26,13 @@ class CNTCNetwork(BaseDeepNetwork):
         activation function inside the self attention module;
         List of available keras activation functions:
         https://keras.io/api/layers/activations/
+    dropout : float or tuple of floats, default = (0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1)
+        dropout rate(s), in the range [0, 1).
+        If a single float is provided, the same dropout rate is applied to all layers.
+        If a tuple is provided, it should have 7 values corresponding to:
+        (conv1_dropout, rnn1_dropout, conv2_dropout, lstm_dropout,
+         avg_dropout, att_dropout, mlp_dropout)
+        where mlp_dropout is applied to both MLP layers.
     random_state : int, default = 0
         seed to any needed random actions
 
@@ -75,6 +82,7 @@ class CNTCNetwork(BaseDeepNetwork):
         dense_size=64,
         activation="relu",
         activation_attention="sigmoid",
+        dropout=(0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1),
     ):
         _check_dl_dependencies(severity="error")
 
@@ -86,6 +94,7 @@ class CNTCNetwork(BaseDeepNetwork):
         self.kernel_sizes = kernel_sizes
         self.lstm_size = lstm_size
         self.dense_size = dense_size
+        self.dropout = dropout
 
         super().__init__()
 
@@ -111,7 +120,18 @@ class CNTCNetwork(BaseDeepNetwork):
         # CNN Arm
         input_layers.append(keras.layers.Input(input_shape))
         input_layers.append(keras.layers.Input(input_shape))
-        self.dropout = 0.2
+
+        # Handle dropout parameter - can be float or tuple
+        if isinstance(self.dropout, (int, float)):
+            dropout_values = (self.dropout,) * 7
+        else:
+            if len(self.dropout) != 7:
+                raise ValueError(
+                    f"dropout tuple must have 7 values, got {len(self.dropout)}. "
+                    "Expected: (conv1_dropout, rnn1_dropout, conv2_dropout, "
+                    "lstm_dropout, avg_dropout, att_dropout, mlp_dropout)"
+                )
+            dropout_values = self.dropout
 
         conv1 = keras.layers.Conv1D(
             self.filter_sizes[0],
@@ -121,7 +141,7 @@ class CNTCNetwork(BaseDeepNetwork):
             kernel_initializer="glorot_uniform",
         )(input_layers[0])
         conv1 = keras.layers.BatchNormalization()(conv1)
-        conv1 = keras.layers.Dropout(self.dropout)(conv1)
+        conv1 = keras.layers.Dropout(dropout_values[0])(conv1)
         conv1 = keras.layers.Dense(
             input_shape[1],
             input_shape=(input_shape[0], keras.backend.int_shape(conv1)[2]),
@@ -135,7 +155,7 @@ class CNTCNetwork(BaseDeepNetwork):
             kernel_initializer="glorot_uniform",
         )(input_layers[1])
         rnn1 = keras.layers.BatchNormalization()(rnn1)
-        rnn1 = keras.layers.Dropout(self.dropout)(rnn1)
+        rnn1 = keras.layers.Dropout(dropout_values[1])(rnn1)
         rnn1 = keras.layers.Reshape((64, input_shape[1]))(rnn1)
 
         # Combining CNN and RNN
@@ -156,7 +176,7 @@ class CNTCNetwork(BaseDeepNetwork):
             input_shape=(input_shape[0], keras.backend.int_shape(conv2)[2]),
         )(conv2)
         conv2 = keras.layers.BatchNormalization()(conv2)
-        conv2 = keras.layers.Dropout(0.1)(conv2)
+        conv2 = keras.layers.Dropout(dropout_values[2])(conv2)
 
         # CLSTM Arm
         input_layers.append(keras.layers.Input(input_shape))
@@ -167,7 +187,7 @@ class CNTCNetwork(BaseDeepNetwork):
             activation=self.activation,
         )(input_layers[2])
         lstm1 = keras.layers.Reshape((self.lstm_size, input_shape[1]))(lstm1)
-        lstm1 = keras.layers.Dropout(self.dropout)(lstm1)
+        lstm1 = keras.layers.Dropout(dropout_values[3])(lstm1)
         merge = keras.layers.Concatenate(
             axis=-2, name="contextual_convolutional_layer2"
         )([conv2, lstm1])
@@ -176,7 +196,7 @@ class CNTCNetwork(BaseDeepNetwork):
         avg = keras.layers.MaxPooling1D(pool_size=1, strides=None, padding="valid")(
             merge
         )
-        avg = keras.layers.Dropout(0.1)(avg)
+        avg = keras.layers.Dropout(dropout_values[4])(avg)
 
         # Adding self attention
         att = SeqSelfAttention(
@@ -185,7 +205,7 @@ class CNTCNetwork(BaseDeepNetwork):
             name="Attention",
             attention_type="multiplicative",
         )(avg)
-        att = keras.layers.Dropout(0.1)(att)
+        att = keras.layers.Dropout(dropout_values[5])(att)
 
         # Adding output MLP Layer
         mlp1 = keras.layers.Dense(
@@ -193,12 +213,12 @@ class CNTCNetwork(BaseDeepNetwork):
             kernel_initializer="glorot_uniform",
             activation=self.activation,
         )(att)
-        mlp1 = keras.layers.Dropout(0.1)(mlp1)
+        mlp1 = keras.layers.Dropout(dropout_values[6])(mlp1)
         mlp2 = keras.layers.Dense(
             self.dense_size,
             kernel_initializer="glorot_uniform",
             activation=self.activation,
         )(mlp1)
-        mlp2 = keras.layers.Dropout(0.1)(mlp2)
+        mlp2 = keras.layers.Dropout(dropout_values[6])(mlp2)
         flat = keras.layers.Flatten()(mlp2)
         return input_layers, flat

--- a/sktime/networks/tapnet.py
+++ b/sktime/networks/tapnet.py
@@ -30,6 +30,8 @@ class TapNetNetwork(BaseDeepNetwork):
         parameters for random permutation
     dropout : float, default = 0.5
         dropout rate, in the range [0, 1)
+    lstm_dropout : float, default = 0.8
+        dropout rate for the LSTM layer, in the range [0, 1)
     dilation : int, default = 1
         dilation value
     padding : str, default = 'same'
@@ -71,6 +73,7 @@ class TapNetNetwork(BaseDeepNetwork):
         random_state=1,
         padding="same",
         activation="leaky_relu",
+        lstm_dropout=0.8,
     ):
         _check_dl_dependencies(severity="error")
 
@@ -87,6 +90,7 @@ class TapNetNetwork(BaseDeepNetwork):
         self.padding = padding
 
         self.dropout = dropout
+        self.lstm_dropout = lstm_dropout
         self.use_lstm = use_lstm
         self.use_cnn = use_cnn
 
@@ -177,7 +181,7 @@ class TapNetNetwork(BaseDeepNetwork):
             x_lstm = keras.layers.LSTM(self.lstm_dim, return_sequences=True)(
                 input_layer
             )
-            x_lstm = keras.layers.Dropout(0.8)(x_lstm)
+            x_lstm = keras.layers.Dropout(self.lstm_dropout)(x_lstm)
 
             if self.use_att:
                 x_lstm = SeqSelfAttention(128, attention_type="multiplicative")(x_lstm)

--- a/sktime/regression/deep_learning/cntc.py
+++ b/sktime/regression/deep_learning/cntc.py
@@ -32,6 +32,13 @@ class CNTCRegressor(BaseDeepRegressor):
         number of lstm units in the CLSTM arm.
     dense_size : int, default = 64
         dimension of dense layer in CNTC.
+    dropout : float or tuple of floats, default = (0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1)
+        dropout rate(s), in the range [0, 1).
+        If a single float is provided, the same dropout rate is applied to all layers.
+        If a tuple is provided, it should have 7 values corresponding to:
+        (conv1_dropout, rnn1_dropout, conv2_dropout, lstm_dropout,
+         avg_dropout, att_dropout, mlp_dropout)
+        where mlp_dropout is applied to both MLP layers.
     random_state : int or None, default=None
         Seed for random number generation.
     verbose : boolean, default = False
@@ -97,6 +104,7 @@ class CNTCRegressor(BaseDeepRegressor):
         rnn_size=64,
         lstm_size=8,
         dense_size=64,
+        dropout=(0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1),
         callbacks=None,
         verbose=False,
         loss="mean_squared_error",
@@ -116,6 +124,7 @@ class CNTCRegressor(BaseDeepRegressor):
         self.rnn_size = rnn_size
         self.lstm_size = lstm_size
         self.dense_size = dense_size
+        self.dropout = dropout
         self.callbacks = callbacks
         self.n_epochs = n_epochs
         self.batch_size = batch_size
@@ -130,6 +139,7 @@ class CNTCRegressor(BaseDeepRegressor):
             activation=self.activation_hidden,
             activation_attention=self.activation_attention,
             random_state=self.random_state,
+            dropout=self.dropout,
         )
 
     def build_model(self, input_shape, **kwargs):

--- a/sktime/regression/deep_learning/tapnet.py
+++ b/sktime/regression/deep_learning/tapnet.py
@@ -37,6 +37,8 @@ class TapNetRegressor(BaseDeepRegressor):
         List of Keras callbacks to apply during model training.
     dropout : float, default = 0.5
         dropout rate, in the range [0, 1)
+    lstm_dropout : float, default = 0.8
+        dropout rate for the LSTM layer, in the range [0, 1)
     dilation : int, default = 1
         dilation value
     activation : str, default = "linear"
@@ -111,6 +113,7 @@ class TapNetRegressor(BaseDeepRegressor):
         metrics=None,
         callbacks=None,
         verbose=False,
+        lstm_dropout=0.8,
     ):
         _check_dl_dependencies(severity="error")
 
@@ -135,6 +138,7 @@ class TapNetRegressor(BaseDeepRegressor):
         self.verbose = verbose
 
         self.dropout = dropout
+        self.lstm_dropout = lstm_dropout
         self.use_lstm = use_lstm
         self.use_cnn = use_cnn
 
@@ -158,6 +162,7 @@ class TapNetRegressor(BaseDeepRegressor):
             use_cnn=self.use_cnn,
             random_state=self.random_state,
             padding=self.padding,
+            lstm_dropout=self.lstm_dropout,
         )
 
     def build_model(self, input_shape, **kwargs):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes 
* #9103. 

Related to
*  #9109.

#### What does this implement/fix? Explain your changes.
This PR continues the work from #9109 to expose hidden layer dropout parameters in deep learning models. It addresses the remaining networks that had hardcoded dropout values:

#### CNTCNetwork:

Added dropout parameter that accepts either a float `uniform dropout` or a tuple of 7 floats `layer-wise dropout`
Default: `0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1` - matching the previously hardcoded values
The 7 values correspond to: conv1, rnn1, conv2, lstm, avg, attention, and mlp layers
Added validation to ensure tuple length matches expected layers

#### TapNetNetwork:

Added lstm_dropout parameter `default: 0.8` to expose the previously hardcoded LSTM dropout
The existing dropout parameter was not being used for the LSTM layer

#### Updated classifiers/regressors:

CNTCClassifier, CNTCRegressor: Added dropout parameter
TapNetClassifier, TapNetRegressor: Added lstm_dropout parameter
All changes are backward compatible - default values preserve existing behavior.


#### Any other comments?
The ConvTimeNet files `_dlutils.py, _patch_layers.py` have `hardcoded nn.Dropout(0.1)` but these are defined and never used in their forward() methods.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

