### PR TITLE
[ENH] add missing `capability:non_contiguous_X` tags

### DIFF
--- a/sktime/forecasting/auto_reg.py
+++ b/sktime/forecasting/auto_reg.py
@@ -100,6 +100,7 @@ class AutoREG(_StatsModelsAdapter):
         "scitype:y": "univariate",
         "capability:exogenous": True,
         "requires-fh-in-fit": False,
+        "capability:non_contiguous_X": False,
     }
 
     def __init__(


### PR DESCRIPTION
 adds missing `capability:non_contiguous_X` tags:

* `AutoREG` forecaster