### PR TITLE
[ENH] in `AlignerDTW` and `AlignerDTWfromDist`, add check for incorrect `dtw` package installation

### DIFF
--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -134,13 +134,12 @@ class AlignerDTW(BaseAligner):
             self.set_tags(**{"alignment_type": "full"})
 
         # Check if the user has the incorrect 'dtw' package installed.
-        # 'dtw' on PyPI is the R-port (wrong one).
-        # 'dtw-python' is the correct one.
         if _check_soft_dependencies("dtw", severity="none"):
             raise ModuleNotFoundError(
                 "Error: usage of the incorrect 'dtw' package detected. "
-                "sktime requires 'dtw-python', but you have the unrelated "
-                "'dtw' package installed. "
+                f"{self.__class__.__name__} requires the 'dtw' package to be absent, "
+                "because 'dtw' uses the same import path as the required "
+                "'dtw-python' package. "
                 "Please run: `pip uninstall dtw` followed by `pip install dtw-python`."
             )
 
@@ -377,8 +376,9 @@ class AlignerDTWfromDist(BaseAligner):
         if _check_soft_dependencies("dtw", severity="none"):
             raise ModuleNotFoundError(
                 "Error: usage of the incorrect 'dtw' package detected. "
-                "sktime requires 'dtw-python', but you have the unrelated "
-                "'dtw' package installed. "
+                f"{self.__class__.__name__} requires the 'dtw' package to be absent, "
+                "because 'dtw' uses the same import path as the required "
+                "'dtw-python' package. "
                 "Please run: `pip uninstall dtw` followed by `pip install dtw-python`."
             )
 


### PR DESCRIPTION
Fixes #8810.

The `dtw` package (R-port) and `dtw-python` package both import as `dtw`, causing a namespace conflict that leads to confusing `TypeErrors` for users.

This PR adds a check in `AlignerDTW` and `AlignerDTWfromDist` to inspect the `dtw` module before use. If it lacks the `stepPattern` attribute (unique to `dtw-python`), it raises a helpful `ModuleNotFoundError` advising the user to reinstall the correct package.