### PR TITLE
[ENH] remove deprecated cmaes sampler from `optuna` facing tests

### DIFF
--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -363,7 +363,7 @@ def optuna_samplers():
             None,
             optuna.samplers.NSGAIISampler(seed=42),
             optuna.samplers.QMCSampler(seed=42),
-            optuna.samplers.CmaEsSampler(seed=42),
+            # optuna.samplers.CmaEsSampler(seed=42),
         ]
 
 


### PR DESCRIPTION
The cmaes sampler has been removed in newer `optuna` versions, so it should not be used in `optuna` facing tests, e.g., in the forecasting tuner.

This PR removes all dependencies on the cmaes sampler.