### PR TITLE
Allow sklearn estimators in benchmarking

### DIFF
--- a/sktime/benchmarking/tests/test_benchmarks.py
+++ b/sktime/benchmarking/tests/test_benchmarks.py
@@ -1,0 +1,10 @@
+from sklearn.ensemble import RandomForestClassifier
+from sktime.benchmarking.benchmarks import BaseBenchmark
+
+
+def test_sklearn_estimator_can_be_added():
+    bench = BaseBenchmark()
+    clf = RandomForestClassifier()
+    bench.add_estimator(clf)
+
+    assert "RandomForestClassifier" in bench.estimators.entities


### PR DESCRIPTION
### What does this PR do?
This PR relaxes estimator validation in the benchmarking framework to allow
sklearn-based estimators to be registered and benchmarked.

### Why is this needed?
Currently, estimators inheriting from sklearn's `BaseEstimator` (e.g.
`RandomForestClassifier`, and sktime estimators such as `RotationForest`)
are rejected due to strict inheritance checks and incompatible cloning.

### What was changed?
- Allow both sktime and sklearn `BaseEstimator` instances
- Prevent unsafe iteration over estimator objects
- Use sklearn’s `clone` when `.clone()` is not available
- Add regression test for sklearn estimator registration

### Related issue
Closes #9230
