### PR TITLE
[BUG] Fix PytorchForecastingNHiTS crash on short input data

### DIFF
--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -1039,6 +1039,25 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
             }
         return {}
 
+    def _fit(self, y, X, fh):
+        """Fit the model.
+
+        Overrides base class to provide a more descriptive error message
+        when the input series is too short for the model configuration.
+        """
+        try:
+            return super()._fit(y, X, fh)
+        # Catch AssertionError because pytorch-forecasting uses 'assert' for this check
+        except AssertionError as e:
+            if "filters should not remove entries" in str(e):
+                raise ValueError(
+                    "The input time series is too short for the current model "
+                    "configuration (encoder/decoder lengths). "
+                    "Please increase the length of your input data or adjust "
+                    "'min_encoder_length' in 'dataset_params'."
+                ) from e
+            raise e
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #8258

#### What does this implement/fix? Explain your changes.
This PR improves error handling in the `PytorchForecastingNHiTS` estimator when the input time series is too short for the model's configuration (specifically when `pytorch-forecasting` filters out all entries due to `min_encoder_length` constraints).

Previously, this scenario raised an obscure `AssertionError: filters should not remove entries`.
This change adds a `try-except` block in `_fit` to catch that specific `AssertionError` and re-raise it as a descriptive `ValueError`, instructing the user to increase their data length or adjust `min_encoder_length`.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
* Verify that catching `AssertionError` is the correct approach (since the underlying library uses `assert` for this check).
* Check that the error message is clear and helpful.

#### Did you add any tests for the change?
I verified the fix locally using the reproduction script provided in issue #8258. The script now raises the expected `ValueError` instead of crashing with an assertion error.

#### Any other comments?
None.

#### PR checklist
##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].