### PR TITLE
Decouple update fallback from stored data

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -976,10 +976,10 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
 
         Writes to self:
 
-                        * Updates ``self.cutoff`` to latest index seen in ``y``.
-                        * If ``update_params=True`` and a custom ``update``
-                            is implemented, updates fitted model attributes
-                            ending in "_".
+            * Updates ``self.cutoff`` to latest index seen in ``y``.
+            * If ``update_params=True`` and a custom ``update``
+              is implemented, updates fitted model attributes
+              ending in "_".
 
         Parameters
         ----------


### PR DESCRIPTION
This PR updates the default BaseForecaster.update() fallback behavior to remove implicit refitting based on stored self._y and self._X. Cutoff updates are now fully independent of any stored training data, making the update path safer and more explicit.

The PR also clarifies behavior when remember_data=False, including raising a clear and explicit error when residuals are requested without stored data. This aligns update() semantics with the intended API contract and avoids hidden dependencies on remembered state.

This change supports the planned breaking changes for the 1.0 release by making update behavior more predictable and robust.

Refs #9209