### PR TITLE
[ENH] Add auto assign and unassign good first issues workflow

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -9,8 +9,8 @@ permissions:
 
 jobs:
   take-issue:
-    if: contains(github.event.comment.body, '.take')
     runs-on: ubuntu-latest
+    if: github.event.issue.pull_request == null
 
     steps:
       - name: Assign issue to commenter
@@ -19,9 +19,14 @@ jobs:
           script: |
             const issue = context.payload.issue;
             const commenter = context.payload.comment.user.login;
+            const commentBody = context.payload.comment.body.trim();
 
-            
+          
+            if (commentBody !== ".take") return;
+
             const labels = issue.labels.map(l => l.name);
+
+        
             if (!labels.includes("good first issue")) {
               await github.rest.issues.createComment({
                 ...context.repo,
@@ -31,7 +36,7 @@ jobs:
               return;
             }
 
-           
+            
             if (issue.assignees.length > 0) {
               await github.rest.issues.createComment({
                 ...context.repo,
@@ -41,15 +46,25 @@ jobs:
               return;
             }
 
-          
+           
             await github.rest.issues.addAssignees({
               ...context.repo,
               issue_number: issue.number,
               assignees: [commenter]
             });
 
+            if (!labels.includes("claimed")) {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: issue.number,
+                labels: ["claimed"]
+              });
+            }
+
+            
             await github.rest.issues.createComment({
               ...context.repo,
               issue_number: issue.number,
-              body: `Assigned to @${commenter}. Please open a PR within **15 days**, or the issue will be unassigned automatically.`
+              body: `Assigned to @${commenter}.\n\n Please open a PR or post an update within **15 days**, otherwise the issue will be unassigned automatically.`
             });
+

--- a/.github/workflows/unassign-issues.yml
+++ b/.github/workflows/unassign-issues.yml
@@ -32,15 +32,31 @@ jobs:
               if (issues.length === 0) break;
 
               for (const issue of issues) {
-                
+
+              
                 if (issue.pull_request) continue;
 
                 
                 if (issue.assignees.length === 0) continue;
 
+                const labels = issue.labels.map(l => l.name);
+
+                if (!labels.includes("claimed")) continue;
+
                 const lastUpdated = new Date(issue.updated_at);
                 const diffDays = (now - lastUpdated) / (1000 * 60 * 60 * 24);
 
+              
+                if (diffDays >= 12 && diffDays < 15) {
+                  await github.rest.issues.createComment({
+                    ...context.repo,
+                    issue_number: issue.number,
+                    body: " **Reminder:** This **good first issue** has been inactive for nearly **12 days**.\n\nPlease post an update or open a PR within **3 days**, otherwise it will be unassigned automatically."
+                  });
+                  continue;
+                }
+
+               
                 if (diffDays >= 15) {
                   await github.rest.issues.removeAssignees({
                     ...context.repo,
@@ -48,10 +64,17 @@ jobs:
                     assignees: issue.assignees.map(a => a.login)
                   });
 
+                  
+                  await github.rest.issues.removeLabel({
+                    ...context.repo,
+                    issue_number: issue.number,
+                    name: "claimed"
+                  });
+
                   await github.rest.issues.createComment({
                     ...context.repo,
                     issue_number: issue.number,
-                    body: "Unassigned due to **15 days of inactivity** on a **good first issue**. This issue is now available again."
+                    body: " Unassigned due to **15 days of inactivity** on a **good first issue**.\n\nThe issue is now available again for others to claim."
                   });
                 }
               }


### PR DESCRIPTION
### Reference Issues/PRs

Fixes #7528

---

### What does this implement/fix? Explain your changes.

This PR adds a GitHub Actions–based automation to streamline issue assignment for contributors.

**Key features introduced:**

Exact ".take" command for safe auto-assignment
Auto-assigns good first issues to contributors
Uses claimed label to track bot-managed issues
12-day inactivity reminder comment
15-day automatic unassignment
Cleanup workflow affects only bot-claimed issues
Skips PRs and manually assigned issues

---

### Does your contribution introduce a new dependency? If yes, which one?

No.
---

### Did you add any tests for the change?

No tests were added.
---

### Any other comments?

This implementation was designed based on reviewer feedback in the original issue discussion, with particular care taken to:

* Avoid third-party action dependencies
* Prevent unintended assignment behavior
* Keep the solution simple, auditable, and maintainable

Happy to iterate further if reviewers prefer alternative commands, labels, or timeout durations.
---

### PR checklist

#### For all contributions

*  I've added myself to the list of contributors
* [x] The PR title starts with `[ENH]`