### PR TITLE
[ENH]: Add MeanShift (moving average) change point detector

### DIFF
--- a/sktime/detection/ma.py
+++ b/sktime/detection/ma.py
@@ -1,0 +1,165 @@
+"""Mean shift change point detector based on Moving Averages."""
+
+import numpy as np
+import pandas as pd
+
+from sktime.detection.base import BaseDetector
+
+__author__ = ["Waqibsk"]
+
+
+class MeanShift(BaseDetector):
+    """Mean Shift (Moving Average) change point detector.
+
+    This detector identifies change points by comparing the moving average of a
+    trailing window (left) against a leading window (right). If the absolute
+    difference between these means exceeds a specified threshold, a change point
+    is flagged.
+
+    Parameters
+    ----------
+    window_size : int
+        The size of the sliding window used to calculate the means on either side
+        of a potential change point.
+    threshold : float
+        The threshold for the difference between the left and right window means.
+        If the difference is greater than this value, it is considered a candidate
+        change point.
+    min_cp_distance : int, default=0
+        Minimum distance between detected change points. If multiple points exceed
+        the threshold in close proximity, only the one with the highest divergence
+        is kept.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.detection.ma import MeanShift
+    >>> X = pd.Series([1, 1, 1, 1, 5, 5, 5, 5])
+    >>> model = MeanShift(window_size=2, threshold=2)
+    >>> model.fit_predict(X)
+       ilocs
+    0    3
+    dtype: int64
+    """
+
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": ["Waqibsk"],
+        "maintainers": ["Waqibsk"],
+        # estimator type
+        # --------------
+        "fit_is_empty": True,
+        "capability:multivariate": False,
+        "task": "change_point_detection",
+        "learning_type": "unsupervised",
+        "X_inner_mtype": "pd.Series",
+    }
+
+    def __init__(self, window_size, threshold, min_cp_distance=0):
+        self.window_size = window_size
+        self.threshold = threshold
+        self.min_cp_distance = min_cp_distance
+        super().__init__()
+
+    def _compute_scores(self, X):
+        """Compute the divergence scores between left and right windows.
+
+        Parameters
+        ----------
+        X : pd.Series
+            The input time series.
+
+        Returns
+        -------
+        pd.Series
+            A series of absolute differences between left and right rolling means.
+        """
+        # compute left rolling mean 
+        left_mean = X.rolling(window=self.window_size).mean()
+
+        # compute right rolling mean (leading) using a reverse roll
+        # we shift X so that the index aligns with the "split" point
+        right_mean = (
+            X.iloc[::-1]
+            .rolling(window=self.window_size)
+            .mean()
+            .iloc[::-1]
+            .shift(-1) 
+        )
+
+        # calculate absolute difference
+        scores = (left_mean - right_mean).abs()
+        return scores.fillna(0)
+
+    def _find_change_points(self, scores):
+        """Find peaks in the score series that exceed the threshold.
+
+        Parameters
+        ----------
+        scores : pd.Series
+            The divergence scores calculated by _compute_scores.
+
+        Returns
+        -------
+        list[int]
+            A sorted list of change point indices.
+        """
+        candidates = scores[scores > self.threshold]
+        if candidates.empty:
+            return []
+
+        # sort candidates by score descending to prioritize strongest signals
+        candidate_indices = candidates.sort_values(ascending=False).index.tolist()
+        
+        final_change_points = []
+        
+        # simple greedy suppression based on min_cp_distance
+        for cp in candidate_indices:
+            is_too_close = False
+            for selected in final_change_points:
+                if abs(cp - selected) < self.min_cp_distance:
+                    is_too_close = True
+                    break
+            
+            if not is_too_close:
+                final_change_points.append(cp)
+
+        return sorted(final_change_points)
+
+    def _predict(self, X, Y=None):
+        """Detect change points in X.
+
+        Parameters
+        ----------
+        X : pd.Series
+            Timeseries on which the change points will be detected.
+        Y : any
+            Unused argument. Included for compatibility with sklearn.
+
+        Returns
+        -------
+        pd.Series
+            Series whose values are the indexes of the change points.
+        """
+        scores = self._compute_scores(X)
+        change_points = self._find_change_points(scores)
+        return pd.Series(change_points, dtype="int64")
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return.
+
+        Returns
+        -------
+        params : list of dict
+            Parameters to create testing instances of the class.
+        """
+        params0 = {"window_size": 2, "threshold": 1.0}
+        params1 = {"window_size": 3, "threshold": 0.5, "min_cp_distance": 2}
+        return [params0, params1]

--- a/sktime/detection/tests/test_ma.py
+++ b/sktime/detection/tests/test_ma.py
@@ -1,0 +1,42 @@
+import pandas as pd
+import pytest
+
+from sktime.detection.ma import MeanShift
+from sktime.tests.test_switch import run_test_for_class
+
+__author__ = ["Waqibsk"]
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(MeanShift),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize(
+    "X,expected_change_points",
+    [
+        (pd.Series([1, 1, 1, 1, 3, 3, 3, 3]), [3]),
+    ],
+)
+def test_fit_predict(X, expected_change_points):
+    """Test the fit_predict method for mean shift."""
+    model = MeanShift(window_size=2, threshold=1)
+    change_points = model.fit_predict(X)
+    assert change_points.values.flatten().tolist() == expected_change_points
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(MeanShift),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize(
+    "X,expected_change_points,min_cp_distance",
+    [
+        (pd.Series([0, 0, 0, 10, 10, 10]), [1, 2, 3], 0),
+        (pd.Series([0, 0, 0, 10, 10, 10]), [2], 2),
+    ],
+)
+def test_min_cp_distance(X, expected_change_points, min_cp_distance):
+    """Test the effect of changing the minimum distance between change points."""
+    model = MeanShift(window_size=2, threshold=4, min_cp_distance=min_cp_distance)
+    change_points = model.fit_predict(X)
+    assert sorted(change_points.values.flatten().tolist()) == expected_change_points


### PR DESCRIPTION

#### Reference Issues/PRs
Related to #6481.
#### What does this implement/fix? Explain your changes.

This PR implements a new **Moving Average Mean Shift change point detector** in `sktime.detection`.

The MeanShift detector identifies change points in a univariate time series by comparing the moving average of a trailing window (left) against a leading window (right). If the absolute difference between these means exceeds a specified threshold, a change point is flagged.




#### Did you add any tests for the change?
Yes, I have added a new test file in `sktime/detection/tests/test_ma.py`
#### Any other comments?

let me know if the changes look fine , then i will change the docs accordingly 
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

