### PR TITLE
[DOC] correct typo 'occurence' to 'occurrence'

### DIFF
--- a/sktime/param_est/cointegration/_johansen.py
+++ b/sktime/param_est/cointegration/_johansen.py
@@ -17,7 +17,7 @@ class JohansenCointegration(BaseParamFitter):
     Direct interface to ``statsmodels.tsa.vector_ar.vecm``.
 
     The Johansen Cointegration test is a test solely used in Vector Error
-    Correction Models (VECM) to determine the occurence of a long-term relationship
+    Correction Models (VECM) to determine the occurrence of a long-term relationship
     (cointegration rank) between two time series or several long-term relationships
     in case of multiple time-series. The idea of the underlying test is to estimate,
     if such (a) relationship(s) exist(s). In case there is a relationship (or several),


### PR DESCRIPTION
Fixes typo in cointegration module docstring:
- `occurence` → `occurrence`