### PR TITLE
[BUG] Fix MeanSquaredError.evaluate_by_index returning raw_values ins…

### DIFF
--- a/sktime/performance_metrics/forecasting/_mse.py
+++ b/sktime/performance_metrics/forecasting/_mse.py
@@ -222,7 +222,7 @@ class MeanSquaredError(BaseForecastingErrorMetric):
 
         pseudo_values = self._get_weighted_df(pseudo_values, **kwargs)
 
-        return self._handle_multioutput(raw_values, multioutput)
+        return self._handle_multioutput(pseudo_values, multioutput)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
**Title:** [BUG] Fix MeanSquaredError.evaluate_by_index returning raw_values instead of pseudo_values when square_root=True (#9302)

<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #9302

#### What does this implement/fix? Explain your changes.
When `MeanSquaredError(square_root=True)` is used with `evaluate_by_index`, the method correctly calculates `pseudo_values` (the jackknife values) but then mistakenly returns `raw_values` (the squared errors) on line 225.

This PR fixes the return statement to return `pseudo_values` as intended.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
Standard review. Validated locally with reproduction script from the issue.

#### Did you add any tests for the change?
Verified with local reproduction script (included in issue #9302). No new test files added to repo.

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).
