### PR TITLE
ENH: warn when exogenous columns used at fit are missing at predict (fixes #9277)

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -467,6 +467,23 @@ class _Reducer(_BaseWindowForecaster):
         # contains the value the window is summarized to.
 
         if self._X is not None:
+            # Warn if exogenous columns used during fit are missing at predict time
+            if X_update is not None:
+                fit_cols = set(self._X.columns)
+                pred_cols = set(X_update.columns)
+                missing_cols = fit_cols - pred_cols
+
+                if missing_cols:
+                    warn(
+                        (
+                            "Exogenous columns missing at predict time: "
+                            f"{missing_cols}. "
+                            "They will be filled with zeros, which may lead "
+                            "to incorrect forecasts."
+                        ),
+                        obj=self,
+                    )
+
             X = _create_fcst_df([index_range[-1]], self._X)
             X.update(self._X)
             if X_update is not None:


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #9277

---

#### What does this implement/fix? Explain your changes.

This PR addresses issue #9277.

Currently, reduction forecasters silently fill missing exogenous columns
with zeros at predict time when those columns were present during fit.
This can lead to incorrect forecasts without user awareness.

This PR adds a `UserWarning` inside `_get_shifted_window`
to detect when exogenous columns used during fit are missing during predict.
If missing columns are found, a warning is raised informing the user
that those columns will be filled with zeros.

The change improves transparency without introducing breaking behavior.

---

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies introduced.

---

#### What should a reviewer concentrate their feedback on?

- Whether `_get_shifted_window` is the appropriate location for this validation.
- Whether a warning is preferable to raising an error.
- Edge cases involving global vs local pooling.

---

#### Did you add any tests for the change?

Yes. A new test was added using `pytest.warns(UserWarning)` to verify that a warning
is raised when predict-time `X` is missing columns that were present during fit.

---

#### Any other comments?

This PR does not change existing behavior except adding visibility
to previously silent column mismatches during prediction.

---

#### PR checklist

##### For all contributions

- [x] The PR title starts with [ENH]
