### PR TITLE
[MNT] Use `uv` date cutoffs instead of extras for old dependency version testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -407,6 +407,40 @@ jobs:
       - name: Run tests
         run: make test_mlflow
 
+  test-deps-lowest:
+    needs: test-nosoftdeps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - run: git remote set-branches origin 'main'
+
+      - run: git fetch --depth 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install sktime and dependencies
+        run: uv pip install .[dev] --resolution lowest-direct
+        env:
+          UV_SYSTEM_PYTHON: 1
+
+      - name: Show dependencies
+        run: uv pip list
+
+      - name: Run tests
+        run: make PYTESTOPTIONS="--matrixdesign=False --timeout=600" test_softdeps_full
+
   test-deps-2023:
     needs: test-nosoftdeps
     runs-on: ubuntu-latest
@@ -431,9 +465,14 @@ jobs:
         run: python -c "import sys; print(sys.version)"
 
       - name: Install sktime and dependencies
-        run: pip install .[dev,dependencies_lower]
+        # We require `scikit-base>=0.6.1` which was released after the 2023 cutoff
+        # so we bump its date later
+        run: >
+          uv pip install .[dev]
+          --exclude-newer-package 'scikit-base=2024-01-01'
         env:
           UV_SYSTEM_PYTHON: 1
+          UV_EXCLUDE_NEWER: "2023-07-01"
 
       - name: Show dependencies
         run: uv pip list
@@ -465,9 +504,10 @@ jobs:
         run: python -c "import sys; print(sys.version)"
 
       - name: Install sktime and dependencies
-        run: pip install .[dev,dependencies_2024]
+        run: uv pip install .[dev]
         env:
           UV_SYSTEM_PYTHON: 1
+          UV_EXCLUDE_NEWER: "2024-09-01"
 
       - name: Show dependencies
         run: uv pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,31 +313,6 @@ compatibility_tests = [
   'catboost; python_version < "3.13"',
 ]
 
-dependencies_lowest = [
-    "numpy==1.21.0",
-    "pandas==1.1.0",
-    "scikit-learn==0.24.0",
-    "scipy==1.4.0",
-]
-
-# June 2023
-dependencies_lower = [
-    "numpy==1.25.0",
-    "pandas==2.0.2",
-    "scikit-learn==1.3.0",
-    "scipy==1.10.1",
-]
-
-# August 2024 (briefly after numpy2 release)
-dependencies_2024 = [
-    "numpy==2.1.0",
-    "pandas==2.3.2",
-    "scikit-learn==1.5.1",
-    "scipy==1.14.1",
-    "torch==2.4.0",
-    "lightning==2.4.0",
-]
-
 [project.urls]
 "API Reference" = "https://www.sktime.net/en/stable/api_reference.html"
 Documentation = "https://www.sktime.net"


### PR DESCRIPTION
Currently, there are frozen depsets for regression testing time frozen states in 2023 and 2024.

This causes issues with `uv sync` and `uv lock` due to `uv`'s universal dependency resolution.

Instead, the `UV_EXCLUDE_NEWER` environment variable can be used, which can be used to set a frozen time point for package dependency resolution.

Originally created by @zanieb, also see discussion on https://github.com/astral-sh/uv/issues/18026