### PR TITLE
[ENH] Migrate GRU & GRUFCNN classifiers from _pytorch.py to base/_base_torch.py

### DIFF
--- a/sktime/classification/deep_learning/gru.py
+++ b/sktime/classification/deep_learning/gru.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from sktime.classification.deep_learning._pytorch import BaseDeepClassifierPytorch
+from sktime.classification.deep_learning.base import BaseDeepClassifierPytorch
 
 
 class GRUClassifier(BaseDeepClassifierPytorch):
@@ -134,7 +134,6 @@ class GRUClassifier(BaseDeepClassifierPytorch):
             random_state=random_state,
         )
 
-        self.criterions = {}
 
     def _build_network(self, X, y):
         from sktime.networks.gru import GRU
@@ -352,7 +351,6 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
             random_state=random_state,
         )
 
-        self.criterions = {}
 
     def _build_network(self, X, y):
         from sktime.networks.gru import GRUFCNN


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9325. Sub-issue of #8699.

#### What does this implement/fix?

Migrates `GRUClassifier` and `GRUFCNNClassifier` from the old `BaseDeepClassifierPytorch` in `sktime.classification.deep_learning._pytorch` to the new one in `sktime.classification.deep_learning.base._base_torch`.

#### Changes
- **Import path**: `_pytorch.py` → `base/_base_torch.py`
- **Removed `self.criterions = {}`** from both classifiers

#### Analysis of old vs new base class

| Aspect | Old `_pytorch.py` | New `base/_base_torch.py` |
|---|---|---|
| Torch imports | Direct `import torch` | Uses `_safe_import()` for lazy loading |
| Optimizers | 5 hardcoded (Adadelta, Adam, AdamW, SGD, Adagrad) | 13 comprehensive, case-insensitive |
| Criterions | Uses `self.criterions` dict on subclass | Uses internal `self._all_criterions` with 20+ loss functions |
| Random state | Set in `_fit()` | Set in `__init__()` via `_safe_import("torch.manual_seed")` |
| Activation | Not supported | Supports `activation` param with validation against criterion |
| Callbacks | Not supported | Supports LR schedulers as callbacks |
| Input validation | None | `_internal_convert` enforces strict 3D input |

#### Why `self.criterions = {}` was removed

The old base class's `_instantiate_criterion()` looked up criterions via `self.criterions` dict. Both GRU classifiers set `self.criterions = {}`, meaning no custom criterions were registered (default `CrossEntropyLoss` was used via the else branch).

The new base class uses `self._all_criterions` internally with comprehensive built-in criterion support. The `self.criterions` attribute is no longer referenced, so keeping it would be dead code.

#### Breakage risk assessment

**No breakage expected:**
- GRU/GRUFCNN don't pass `activation` to super → defaults to `None`, which is correct for `CrossEntropyLoss`
- GRU/GRUFCNN don't use callbacks → defaults to `None`
- Optimizer strings like `"Adam"` are now matched case-insensitively (still works)
- Default criterion (`CrossEntropyLoss`) behavior is preserved
- `_internal_convert` 3D validation is compatible since GRU already expects 3D input `(n_instances, n_dims, series_length)`

#### Testing

Verified locally:
- Import and instantiation of both classifiers
- `fit()` and `predict()` with numeric labels
- `fit()` and `predict()` with string labels (label encoding)
- Custom optimizer (`SGD`) usage