### PR TITLE
[DOC] Improve explanations in forecasting tutorial notebook (#1447)

### DIFF
--- a/examples/01a_forecasting_sklearn.ipynb
+++ b/examples/01a_forecasting_sklearn.ipynb
@@ -81,10 +81,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Load the airline passenger dataset as a pandas Series\n",
     "y = load_airline()"
    ]
   },
@@ -162,6 +163,21 @@
     "* there are a number of implicit hyper-parameters here, such as window and lag size. If done without caution, these are not explicit or tracked in the experiment, which can lead to \"p-value hacking\".\n",
     "\n",
     "Below is an example of such boilerplate code to demonstrate this. The code is closely modelled on the R code used in the [M4 competition](https://github.com/Mcompetitions/M4-methods):"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Understanding the Forecasting Horizon (`fh`)\n",
+    "\n",
+    "The `fh` parameter stands for **Forecasting Horizon**. It tells the forecaster **how many steps ahead** to make predictions.\n",
+    "\n",
+    "- `fh = np.arange(1, 37)` → predict the next **36 consecutive time steps** (steps 1 through 36 after the end of training data).\n",
+    "- `fh = 12` → predict **only the 12th step ahead**.\n",
+    "- You can also use lists like `fh = [1, 3, 12]` to predict only specific future points.\n",
+    "\n",
+    "This is relative to the end of the training data by default. Later sections show absolute horizons using dates."
    ]
   },
   {


### PR DESCRIPTION
**Related Issue:** Closes part of #1447 (feedback on tutorial notebooks).

**Changes Made:**
- Added a markdown section explaining the 'fh' parameter before its first use, including examples of `range(1,37)` vs `12`.
- Added inline comments to key code cells for better readability (e.g., on data loading).
- This addresses recent feedback about unclear parameters in the "Getting Started with Forecasting" notebook.

This is my entrance task PR to show I can contribute meaningfully. Happy to make adjustments based on review

