### PR TITLE
[ENH] Add dedicated update to NaiveForecaster with tests

### DIFF
--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -725,6 +725,39 @@ class NaiveVariance(BaseForecaster):
 
         return self
 
+    def update(self, y, X=None, update_params=True):
+        """Update the forecaster with new data.
+
+        For NaiveForecaster, updating is inexpensive: we append new observations
+        to the stored training data and (optionally) refresh lightweight derived
+        attributes such as window length and seasonal periodicity.
+
+        Parameters
+        ----------
+        y : sktime-compatible time series container
+        New observations used to update the model.
+        X : pd.DataFrame, optional (default=None)
+        Exogenous variables (ignored by NaiveForecaster but accepted for API
+        compatibility).
+        update_params : bool, optional (default=True)
+        If True, refresh model parameters/state derived from training data.
+        If False, only update the internal data store and cutoff.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        super().update(y=y, X=X, update_params=False)
+
+        if update_params:
+            self._fit(
+                y=self._y,
+                X=getattr(self, "_X", None),
+                fh=getattr(self, "_fh", None),
+            )
+
+        return self
+
     def _predict(self, fh, X):
         return self.forecaster_.predict(fh=fh, X=X)
 

--- a/sktime/forecasting/tests/test_naive_forecaster_update.py
+++ b/sktime/forecasting/tests/test_naive_forecaster_update.py
@@ -1,0 +1,45 @@
+from sktime.datasets import load_airline
+from sktime.forecasting.naive import NaiveForecaster
+
+
+def test_naive_update_advances_cutoff():
+    y = load_airline()
+    f = NaiveForecaster(strategy="last")
+    f.fit(y[:-3])
+
+    old_cutoff = f.cutoff
+    f.update(y[-3:])
+
+    assert f.cutoff > old_cutoff
+
+
+def test_naive_update_changes_prediction_last():
+    y = load_airline()
+    f = NaiveForecaster(strategy="last")
+    f.fit(y[:-1])
+
+    pred_before = f.predict(fh=[1])
+    f.update(y[-1:])
+    pred_after = f.predict(fh=[1])
+
+    # compare scalar values to avoid index/metadata differences
+    assert pred_before.iloc[0] != pred_after.iloc[0]
+
+
+def test_naive_update_update_params_false_updates_data_only():
+    y = load_airline()
+    f = NaiveForecaster(strategy="last")
+    f.fit(y[:-1])
+
+    # capture lightweight derived attributes if they exist
+    old_window_length = getattr(f, "window_length_", None)
+    old_sp = getattr(f, "sp_", None)
+
+    f.update(y[-1:], update_params=False)
+
+    # data should be updated (latest value changed)
+    assert f._y.iloc[-1] == y.iloc[-1]
+
+    # derived attributes should be unchanged when update_params=False
+    assert getattr(f, "window_length_", None) == old_window_length
+    assert getattr(f, "sp_", None) == old_sp


### PR DESCRIPTION
#### Reference Issues/PRs
None.

#### What does this implement/fix? Explain your changes.
This PR adds a dedicated `update()` implementation to `NaiveForecaster` to support streaming and online forecasting workflows.

Changes:
- Overrides `update()` to append new observations and advance the cutoff via the base class logic.
- When `update_params=True`, refreshes lightweight derived state using `_fit` (cheap for `NaiveForecaster`).
- Ensures behavior aligns with `update_params=False`: stored data updates without refreshing derived attributes.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Correctness of `update()` semantics relative to other forecasters.
- Whether the `update_params` behavior is consistent with sktime design.
- Test coverage for streaming update behavior.

#### Did you add any tests for the change?
Yes.

Added:
`sktime/forecasting/tests/test_naive_forecaster_update.py`

Tests cover:
- cutoff advancement after `update`
- prediction change for `strategy="last"` after update
- `update_params=False` updates stored data without refreshing derived attributes

#### Any other comments?
Local checks run:
- `pre-commit run --all-files`
- `pytest -q sktime/forecasting/tests/test_naive_forecaster_update.py`

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the maintainers tag (not applicable)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].