### PR TITLE
[BUG] Replace `.rename()` with `.rename_categories()` to prevent `FutureWarning` in `DateTimeFeatures`

### DIFF
--- a/sktime/transformations/series/date.py
+++ b/sktime/transformations/series/date.py
@@ -458,6 +458,7 @@ def _prep_dummies(DUMMIES):
 
     col = DUMMIES["child"]
     DUMMIES.insert(0, "ts_frequency", col)
+
     DUMMIES["ts_frequency"] = DUMMIES["ts_frequency"].cat.rename_categories(
         {
             "year": "Y",

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -2,6 +2,8 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
 """Unit tests of DateTimeFeatures functionality."""
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -395,7 +397,7 @@ def test_manual_selection_hour_of_week(df_panel):
     """Tests that "hour_of_week" returns correct result in `manual_selection`."""
     y = pd.DataFrame(
         data={"y": range(6)},
-        index=pd.date_range(start="2023-01-01", freq="H", periods=6),
+        index=pd.date_range(start="2023-01-01", freq="h", periods=6),
     )
     transformer = DateTimeFeatures(
         manual_selection=["hour_of_week"], keep_original_columns=True
@@ -407,3 +409,17 @@ def test_manual_selection_hour_of_week(df_panel):
         index=y.index,
     )
     assert_frame_equal(yt, expected)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DateTimeFeatures),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_fit_transform_no_warnings():
+    """Regression test: assert no warnings are raised during fit_transform."""
+    y = load_airline()
+    transformer = DateTimeFeatures(ts_freq="M")
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        transformer.fit_transform(y)
+        assert len(w) == 0


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9432 

#### What does this implement/fix? Explain your changes.
Added rename_categories in `sktime/transformations/series/date.py:461`.
Changed freq = "H" to freq="h" in
`sktime/transformations/series/date.py:400` to prevent warning.

#### Does your contribution introduce a new dependency? If yes, which
one?
N/A

#### What should a reviewer concentrate their feedback on?
Code Quality 

#### Did you add any tests for the change?
Yes, added regression test.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of
contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md)
with any new badges I've earned :-)
How to: add yourself to the [all-contributors
file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in
the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges:
`code` - fixing a bug, or adding code logic. `doc` - writing or
improving documentation or docstrings. `bug` - reporting or diagnosing a
bug (get this plus `code` if you also fixed the bug in the
PR).`maintenance` - CI, test framework, release.
See here for [full badge
reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
[BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving
code, [DOC] - writing or improving documentation or docstrings.