### PR TITLE
Fixed #9434 by chainging first_disc_ary to second_desc_array in secon…

### DIFF
--- a/sktime/classification/distance_based/_shape_dtw.py
+++ b/sktime/classification/distance_based/_shape_dtw.py
@@ -510,7 +510,7 @@ class ShapeDTW(BaseClassifier):
             )
         for x in second_desc.columns:
             second_desc_array.append(
-                convert(first_desc[x], from_type="nested_univ", to_type="numpyflat")
+                convert(second_desc[x], from_type="nested_univ", to_type="numpyflat")
             )
 
         # Concatenate the arrays together


### PR DESCRIPTION
Reference Issues/PRs
Fixes #9434

Corrected a copy-paste error in `ShapeDTW._combine_data_frames ` where `first_desc` was incorrectly referenced in both descriptor conversion loops. This ensures the second descriptor's data is actually used when using compound mode.

### Does your contribution introduce a new dependency? If yes, which one?
No.

### What should a reviewer concentrate their feedback on?
Logic of the variable change in line 513.

### Did you add any tests for the change?
Verified with check_estimator(ShapeDTW) and a local reproduction script (all passed).

