### PR TITLE
[DOC] Add usage example to UpdateEvery

### DIFF
--- a/sktime/forecasting/stream/_update.py
+++ b/sktime/forecasting/stream/_update.py
@@ -463,7 +463,7 @@ class DontUpdate(_DelegatedForecaster):
     refit_window_lag : difference of sktime indices (int or timedelta), optional
         lag of the data window to refit to, w.r.t. cutoff, in case update calls fit
         default = 0, i.e., refit window ends with and includes cutoff
-    """
+""" 
 
     # attribute for _DelegatedForecaster, which then delegates
     #     all non-overridden methods are same as of getattr(self, _delegate_name)


### PR DESCRIPTION
###Reference Issues/PRs
None.

###What does this implement/fix? Explain your changes.
This PR adds a numpydoc-style Examples section to the UpdateEvery estimator docstring in sktime/forecasting/stream/_update.py.
The example demonstrates:
>constructing the estimator
>fitting on a time series
>updating with new observations
>generating predictions
The structure follows the existing sktime docstring conventions used for other estimators. No functional code or behavior was modified.

###Does your contribution introduce a new dependency? If yes, which one?
No.
This change only updates documentation.

###What should a reviewer concentrate their feedback on?
Clarity and correctness of the example
Conformance with sktime docstring standards
Alignment with actual UpdateEvery behavior

###Did you add any tests for the change?
No.
This change affects documentation only and does not modify estimator logic.

###Any other comments?
I ran the full test suite locally. Two unrelated failures appeared in frequency conversion tests, likely due to local pandas version differences. Since this PR only modifies docstrings, it does not impact functional behavior.

###PR checklist
For all contributions
[ ] I've added myself to the list of contributors with any new badges I've earned
[ ]Optionally, for added estimators: I've added myself to the maintainers tag
[*]The PR title starts with either [ENH], [MNT], [DOC], or [BUG].