### PR TITLE
[BUG] Add encoding='utf-8' to JSONStorageHandler file operations (#9431)

### DIFF
--- a/sktime/benchmarking/_storage_handlers.py
+++ b/sktime/benchmarking/_storage_handlers.py
@@ -140,7 +140,7 @@ class JSONStorageHandler(BaseStorageHandler):
         results : ResultObject
             The results to save.
         """
-        with open(self.path, "w") as f:
+        with open(self.path, "w", encoding="utf-8") as f:
             json.dump(list(map(lambda x: asdict(x, pd_orient="list"), results)), f)
 
     def _load(self) -> list[ResultObject]:
@@ -152,7 +152,7 @@ class JSONStorageHandler(BaseStorageHandler):
             The loaded results.
         """
         results = []
-        with open(self.path) as f:
+        with open(self.path, encoding="utf-8") as f:
             results_json = json.load(f)
         for row in results_json:
             folds = {}

--- a/sktime/benchmarking/tests/test_storage_handlers.py
+++ b/sktime/benchmarking/tests/test_storage_handlers.py
@@ -126,3 +126,37 @@ def test_store_load_results_empty_training(tmp_path, storage_handler, file_exten
     assert results[0].folds[0].ground_truth is None
     assert results[0].folds[0].predictions is None
     assert results[0].folds[0].train_data is None
+
+
+def test_json_storage_handler_unicode(tmp_path):
+    """Test that JSONStorageHandler correctly handles unicode characters.
+
+    Regression test for https://github.com/sktime/sktime/issues/9431.
+    Without explicit encoding="utf-8", this can fail on Windows where
+    the default encoding may not support unicode characters.
+    """
+    handler = JSONStorageHandler(tmp_path / "results_unicode.json")
+
+    unicode_results = [
+        ResultObject(
+            model_id="modèle_réseau_neuronal",
+            task_id="validación_cruzada",
+            folds={
+                0: FoldResults(
+                    scores={"précision": 0.95, "données_f1": 0.88},
+                    ground_truth=None,
+                    predictions=None,
+                    train_data=None,
+                )
+            },
+        )
+    ]
+
+    handler.save(unicode_results)
+    results = handler.load()
+
+    assert len(results) == 1
+    assert results[0].model_id == "modèle_réseau_neuronal"
+    assert results[0].task_id == "validación_cruzada"
+    assert results[0].folds[0].scores["précision"] == 0.95
+    assert results[0].folds[0].scores["données_f1"] == 0.88


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #9431

#### What does this implement/fix?

`JSONStorageHandler` opens files without explicitly specifying the `encoding` parameter in `open()` calls. Without this, Python uses the platform default encoding (e.g., `cp1252` on Windows), which causes `UnicodeDecodeError` for non-ASCII characters in benchmark results (model IDs, score names, etc.).

This PR adds `encoding="utf-8"` to both `open()` calls in `JSONStorageHandler.save()` and `_load()`, ensuring consistent cross-platform behavior.


#### Did you add any tests for the change?

Yes, `test_json_storage_handler_unicode` verifies round-trip save/load of results with unicode characters in `model_id`, `task_id`, and score names.