### PR TITLE
fix: add UTF-8 encoding to JSONStorageHandler file operations

### DIFF
--- a/sktime/benchmarking/_storage_handlers.py
+++ b/sktime/benchmarking/_storage_handlers.py
@@ -140,7 +140,7 @@ class JSONStorageHandler(BaseStorageHandler):
         results : ResultObject
             The results to save.
         """
-        with open(self.path, "w") as f:
+        with open(self.path, "w", encoding="utf-8") as f:
             json.dump(list(map(lambda x: asdict(x, pd_orient="list"), results)), f)
 
     def _load(self) -> list[ResultObject]:
@@ -152,7 +152,7 @@ class JSONStorageHandler(BaseStorageHandler):
             The loaded results.
         """
         results = []
-        with open(self.path) as f:
+        with open(self.path, "r", encoding="utf-8") as f:
             results_json = json.load(f)
         for row in results_json:
             folds = {}


### PR DESCRIPTION
## Description
Add explicit encoding='utf-8' parameter to file operations in JSONStorageHandler to ensure consistent behavior across all platforms.

### Problem
The JSONStorageHandler class opens files without explicitly specifying the encoding parameter, leading to:
- Platform-dependent behavior (Windows uses different default encoding than Linux/macOS)
- Potential UnicodeDecodeError when dealing with non-ASCII characters
- Inconsistent behavior when benchmarking results are shared across different systems

This is particularly important for the benchmarking framework which may be used by researchers worldwide with potentially non-ASCII characters in their model names, dataset names, or metric names.

### Solution
Added explicit UTF-8 encoding to file operations:
- Line 143: `open(self.path, "w", encoding="utf-8")` in save() method
- Line 155: `open(self.path, "r", encoding="utf-8")` in _load() method

### Benefits
- Cross-platform consistency (Windows, Linux, macOS)
- Proper handling of Unicode characters in model names, dataset names, or metric names
- Avoidance of platform-dependent default encoding issues
- Prevents UnicodeDecodeError when loading files created on different platforms

### Backward Compatibility
This change is backward compatible as UTF-8 is the de facto standard for JSON encoding and is widely supported across all platforms. JSON files created with UTF-8 encoding can be read by any standard-compliant JSON parser.

## Type of Change
- [x] Bug fix (non-breaking change which fixes cross-platform compatibility)

## Related Issues
Fixes: #9431