### PR TITLE
[BUG] Add input validation and safety restrictions to craft function …

### DIFF
--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -149,3 +149,30 @@ def test_sklearn_imports():
         est_obj = craft(est_spec)
 
         assert est_obj.__class__.__name__ == est_name
+
+
+def test_craft_rejects_non_string():
+    """Check that craft raises TypeError for non-string input."""
+    with pytest.raises(TypeError, match="spec must be a string"):
+        craft(42)
+
+    with pytest.raises(TypeError, match="spec must be a string"):
+        craft(None)
+
+
+@pytest.mark.parametrize(
+    "unsafe_spec",
+    [
+        "__import__('os').system('echo pwned')",
+        "NaiveForecaster().__class__.__subclasses__()",
+        "NaiveForecaster().__class__.__bases__[0].__builtins__",
+        "__globals__",
+    ],
+)
+def test_craft_rejects_unsafe_patterns(unsafe_spec):
+    """Check that craft raises ValueError for specs with unsafe patterns.
+
+    Regression test for https://github.com/sktime/sktime/issues/9430.
+    """
+    with pytest.raises(ValueError, match="Potentially unsafe pattern"):
+        craft(unsafe_spec)


### PR DESCRIPTION
#### Reference Issue

Fixes #9430

#### What does this implement/fix?

The `craft()` function in `sktime/registry/_craft.py` uses `eval()` and `exec()` to construct objects from string specifications without any input validation or sanitization. While primarily used for internal deserialization, `craft` is a public API, making it a potential security concern if untrusted strings are ever passed to it.

This PR adds three layers of defense:

1. **Type check**: Rejects non-string inputs with `TypeError`
2. **Pattern blocklist**: Rejects specs containing known dangerous patterns (`__import__`, `subprocess`, `os.system`, `__subclasses__`, `__builtins__`, `__globals__`, `shutil.rmtree`) with `ValueError`
3. **Restricted builtins**: Removes dangerous built-in functions (`__import__`, `open`, `exec`, `eval`, `compile`, `breakpoint`) from the execution context while preserving all safe builtins needed for legitimate estimator construction
4. **Documentation**: Adds security warnings to both the module docstring and the `craft` function docstring, along with proper `Raises` and `Warnings` sections

#### Does my contribution introduce a new dependency?

No.

#### Did I add any tests for the change?

Yes, two new tests:
- `test_craft_rejects_non_string`: Verifies `TypeError` for non-string inputs (`int`, `None`)
- `test_craft_rejects_unsafe_patterns`: Parametrized test with 4 unsafe pattern variants (`__import__`, `__subclasses__`, `__builtins__`, `__globals__`)

All existing passing tests continue to pass with the restricted builtins.