### PR TITLE
[BUG] Fix GroupNormalizer clone compatibility in pytorch-forecasting …

### DIFF
--- a/sktime/forecasting/base/adapters/_pytorchforecasting.py
+++ b/sktime/forecasting/base/adapters/_pytorchforecasting.py
@@ -94,7 +94,12 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         broadcasting: bool = False,
     ) -> None:
         self.model_params = model_params
-        self.dataset_params = dataset_params
+        # deepcopy dataset_params to prevent mutation of user-provided objects
+        # like GroupNormalizer, whose constructor modifies its own arguments
+        # see https://github.com/sktime/sktime/issues/9366
+        self.dataset_params = (
+            deepcopy(dataset_params) if dataset_params else dataset_params
+        )
         self.trainer_params = trainer_params
         self.train_to_dataloader_params = train_to_dataloader_params
         self.validation_to_dataloader_params = validation_to_dataloader_params
@@ -460,6 +465,11 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         max_prediction_length,
     ):
         from pytorch_forecasting.data import TimeSeriesDataSet
+
+        # Deep copy dataset_params to prevent mutation of user-provided objects
+        # like GroupNormalizer, whose constructor modifies its own arguments
+        # see https://github.com/sktime/sktime/issues/9366
+        dataset_params = deepcopy(dataset_params)
 
         # X, y must have same index or X is None
         # assert X is None or (X.index == y.index).all()


### PR DESCRIPTION
#### Reference Issue

Fixes #9366

#### What does this implement/fix?

`GroupNormalizer` from `pytorch-forecasting` cannot be cloned using `sktime.base.clone()`. This is because `GroupNormalizer`'s constructor **mutates** its `method_kwargs` argument in-place. When `sktime`'s `clone()` mechanism calls `get_params()` and then reconstructs the object with those parameters, the mutated `method_kwargs` dict causes corruption.

This critically breaks any `sktime` forecaster that uses `GroupNormalizer` with internal cloning, including `Reconciler`, benchmarking, and grid search.

**Root cause**: The `_PytorchForecastingAdapter.__init__()` stored the user-provided `dataset_params` dict directly (by reference). When `GroupNormalizer` inside that dict mutated its arguments, subsequent clone operations would receive already-mutated parameters.

**Fix**: `deepcopy` the `dataset_params` at two points:
1. At adapter `__init__` time - so the user's original objects are never mutated
2. Before passing to `TimeSeriesDataSet` in `_Xy_to_dataset()` - so each fit/predict call gets a clean copy

#### Does my contribution introduce a new dependency?

No. (`deepcopy` from `copy` was already imported in the file.)

#### Did I add any tests for the change?

Yes, `test_adapter_deepcopies_dataset_params` creates a mock normalizer class that mutates constructor arguments (simulating `GroupNormalizer` behavior) and verifies the original user-provided dict is NOT corrupted after adapter construction.

The test uses `pytest.importorskip("pytorch_forecasting")` to skip gracefully when the soft dependency is not installed.