### PR TITLE
[DOC] Fix typos in docstrings and documentation

### DIFF
--- a/docs/source/developer_guide/documentation.rst
+++ b/docs/source/developer_guide/documentation.rst
@@ -48,10 +48,10 @@ Beyond basic NumPy docstring formatting conventions, developers should focus on:
 .. note::
 
     In many cases a parameter, attribute return object, or error may be described in many docstrings across sktime. To avoid confusion, developers should
-    make sure their docstrings are as similar as possible to existing docstring descriptions of the the same parameter, attribute, return object
+    make sure their docstrings are as similar as possible to existing docstring descriptions of the same parameter, attribute, return object
     or error.
 
-Accordingly, sktime estimators and most other public code artifcations should generally include the following NumPy docstring convention sections:
+Accordingly, sktime estimators and most other public code artifacts should generally include the following NumPy docstring convention sections:
 
 1. Summary
 2. Extended Summary

--- a/examples/01_forecasting.ipynb
+++ b/examples/01_forecasting.ipynb
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4597,7 +4597,7 @@
     "\n",
     "`sktime` interfaces a number of statistical forecasting algorithms from `statsmodels`: exponential smoothing, theta, and auto-ETS.\n",
     "\n",
-    "For example, to use exponential smoothing with an additive trend component and multiplicative seasonality on the airline data set, we can write the following. Note that since this is monthly data, a good choic for seasonal periodicity (sp) is 12 (= hypothesized periodicity of a year)."
+    "For example, to use exponential smoothing with an additive trend component and multiplicative seasonality on the airline data set, we can write the following. Note that since this is monthly data, a good choice for seasonal periodicity (sp) is 12 (= hypothesized periodicity of a year)."
    ]
   },
   {

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -170,8 +170,8 @@ class MyTimeSeriesClassifier(BaseClassifier):
             1D iterable, of shape [n_instances]
             or 2D iterable, of shape [n_instances, n_dimensions]
             class labels for fitting
-            if self.get_tag("capaility:multioutput") = False, guaranteed to be 1D
-            if self.get_tag("capaility:multioutput") = True, guaranteed to be 2D
+            if self.get_tag("capability:multioutput") = False, guaranteed to be 1D
+            if self.get_tag("capability:multioutput") = True, guaranteed to be 2D
 
         Returns
         -------
@@ -212,8 +212,8 @@ class MyTimeSeriesClassifier(BaseClassifier):
             or 2D iterable, of shape [n_instances, n_dimensions]
             predicted class labels
             indices correspond to instance indices in X
-            if self.get_tag("capaility:multioutput") = False, should be 1D
-            if self.get_tag("capaility:multioutput") = True, should be 2D
+            if self.get_tag("capability:multioutput") = False, should be 1D
+            if self.get_tag("capability:multioutput") = True, should be 2D
         """
 
         # implement here

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -628,8 +628,8 @@ class BaseClassifier(BasePanelMixin):
             1D iterable, of shape [n_instances]
             or 2D iterable, of shape [n_instances, n_dimensions]
             class labels for fitting
-            if self.get_tag("capaility:multioutput") = False, guaranteed to be 1D
-            if self.get_tag("capaility:multioutput") = True, guaranteed to be 2D
+            if self.get_tag("capability:multioutput") = False, guaranteed to be 1D
+            if self.get_tag("capability:multioutput") = True, guaranteed to be 2D
 
         Returns
         -------
@@ -661,8 +661,8 @@ class BaseClassifier(BasePanelMixin):
             or 2D iterable, of shape [n_instances, n_dimensions]
             predicted class labels
             indices correspond to instance indices in X
-            if self.get_tag("capaility:multioutput") = False, should be 1D
-            if self.get_tag("capaility:multioutput") = True, should be 2D
+            if self.get_tag("capability:multioutput") = False, should be 1D
+            if self.get_tag("capability:multioutput") = True, should be 2D
         """
         y_proba = self._predict_proba(X)
         y_pred = y_proba.argmax(axis=1)

--- a/sktime/classification/deep_learning/_pytorch.py
+++ b/sktime/classification/deep_learning/_pytorch.py
@@ -169,8 +169,8 @@ class BaseDeepClassifierPytorch(BaseClassifier):
             or 2D iterable, of shape [n_instances, n_dimensions]
             predicted class labels
             indices correspond to instance indices in X
-            if self.get_tag("capaility:multioutput") = False, should be 1D
-            if self.get_tag("capaility:multioutput") = True, should be 2D
+            if self.get_tag("capability:multioutput") = False, should be 1D
+            if self.get_tag("capability:multioutput") = True, should be 2D
         """
         y_pred_prob = self._predict_proba(X)
         y_pred = np.argmax(y_pred_prob, axis=-1)

--- a/sktime/classification/deep_learning/base/_base_torch.py
+++ b/sktime/classification/deep_learning/base/_base_torch.py
@@ -550,8 +550,8 @@ class BaseDeepClassifierPytorch(BaseClassifier):
             or 2D iterable, of shape [n_instances, n_dimensions]
             predicted class labels
             indices correspond to instance indices in X
-            if self.get_tag("capaility:multioutput") = False, should be 1D
-            if self.get_tag("capaility:multioutput") = True, should be 2D
+            if self.get_tag("capability:multioutput") = False, should be 1D
+            if self.get_tag("capability:multioutput") = True, should be 2D
         """
         y_pred_prob = self._predict_proba(X)
         y_pred = np.argmax(y_pred_prob, axis=-1)

--- a/sktime/classification/model_selection/_tune.py
+++ b/sktime/classification/model_selection/_tune.py
@@ -321,8 +321,8 @@ class TSCGridSearchCV(_DelegatedClassifier):
             1D iterable, of shape [n_instances]
             or 2D iterable, of shape [n_instances, n_dimensions]
             class labels for fitting
-            if self.get_tag("capaility:multioutput") = False, guaranteed to be 1D
-            if self.get_tag("capaility:multioutput") = True, guaranteed to be 2D
+            if self.get_tag("capability:multioutput") = False, guaranteed to be 1D
+            if self.get_tag("capability:multioutput") = True, guaranteed to be 2D
 
         Returns
         -------

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -365,8 +365,8 @@ class BaseRegressor(BasePanelMixin):
             1D iterable, of shape [n_instances]
             or 2D iterable, of shape [n_instances, n_dimensions]
             class labels for fitting
-            if self.get_tag("capaility:multioutput") = False, guaranteed to be 1D
-            if self.get_tag("capaility:multioutput") = True, guaranteed to be 2D
+            if self.get_tag("capability:multioutput") = False, guaranteed to be 1D
+            if self.get_tag("capability:multioutput") = True, guaranteed to be 2D
 
         Returns
         -------

--- a/sktime/regression/deep_learning/base/_base_torch.py
+++ b/sktime/regression/deep_learning/base/_base_torch.py
@@ -374,8 +374,8 @@ class BaseDeepRegressorTorch(BaseRegressor):
             or 2D iterable, of shape [n_instances, n_dimensions]
             predicted values
             indices correspond to instance indices in X
-            if self.get_tag("capaility:multioutput") = False, should be 1D
-            if self.get_tag("capaility:multioutput") = True, should be 2D
+            if self.get_tag("capability:multioutput") = False, should be 1D
+            if self.get_tag("capability:multioutput") = True, should be 2D
         """
         cat = _safe_import("torch.cat")
 

--- a/sktime/regression/model_selection/_tune.py
+++ b/sktime/regression/model_selection/_tune.py
@@ -315,8 +315,8 @@ class TSRGridSearchCV(_DelegatedRegressor):
             1D iterable, of shape [n_instances]
             or 2D iterable, of shape [n_instances, n_dimensions]
             class labels for fitting
-            if self.get_tag("capaility:multioutput") = False, guaranteed to be 1D
-            if self.get_tag("capaility:multioutput") = True, guaranteed to be 2D
+            if self.get_tag("capability:multioutput") = False, guaranteed to be 1D
+            if self.get_tag("capability:multioutput") = True, guaranteed to be 2D
 
         Returns
         -------


### PR DESCRIPTION
## Description
Fixes several typos found in docstrings and documentation:
- `capaility` → `capability` (in docstrings referencing the `capability:multioutput` tag)
- `artifcations` → `artifacts` in developer documentation
- `choic` → `choice` in forecasting example notebook
- Duplicate "the the" → "the" in documentation

## Type of change
- [x] Documentation fix

## Checklist
- [x] I have read the [Contributing Guide](https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md)
- [x] My changes do not introduce new bugs
- [x] All modified files are properly formatted