### PR TITLE
[BUG] fix FutureWarning in DateTimeFeatures from categorical replace …

### DIFF
--- a/sktime/transformations/series/date.py
+++ b/sktime/transformations/series/date.py
@@ -459,20 +459,17 @@ def _prep_dummies(DUMMIES):
     col = DUMMIES["child"]
     DUMMIES.insert(0, "ts_frequency", col)
 
-    DUMMIES = DUMMIES.replace(
-        {
-            "ts_frequency": {
-                "year": "Y",
-                "quarter": "Q",
-                "month": "M",
-                "week": "W",
-                "day": "D",
-                "hour": "H",
-                "minute": "T",
-                "second": "S",
-                "millisecond": "L",
-            }
-        }
-    )
+    freq_map = {
+        "year": "Y",
+        "quarter": "Q",
+        "month": "M",
+        "week": "W",
+        "day": "D",
+        "hour": "H",
+        "minute": "T",
+        "second": "S",
+        "millisecond": "L",
+    }
+    DUMMIES["ts_frequency"] = DUMMIES["ts_frequency"].cat.rename_categories(freq_map)
 
     return DUMMIES

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -2,6 +2,8 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
 """Unit tests of DateTimeFeatures functionality."""
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -395,7 +397,7 @@ def test_manual_selection_hour_of_week(df_panel):
     """Tests that "hour_of_week" returns correct result in `manual_selection`."""
     y = pd.DataFrame(
         data={"y": range(6)},
-        index=pd.date_range(start="2023-01-01", freq="H", periods=6),
+        index=pd.date_range(start="2023-01-01", freq="h", periods=6),
     )
     transformer = DateTimeFeatures(
         manual_selection=["hour_of_week"], keep_original_columns=True
@@ -407,3 +409,16 @@ def test_manual_selection_hour_of_week(df_panel):
         index=y.index,
     )
     assert_frame_equal(yt, expected)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DateTimeFeatures),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_no_future_warning_on_fit_transform():
+    """Test that fit_transform does not raise FutureWarning, regression for #9432."""
+    y = load_airline()
+    transformer = DateTimeFeatures(ts_freq="M")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        transformer.fit_transform(y)


### PR DESCRIPTION
### Reference Issues/PRs
Fixes #9432

### What does this implement/fix? Explain your changes.
_prep_dummies in date.py was calling DataFrame.replace on ts_frequency, which is a categorical column. pandas is deprecating this usage and recommends cat.rename_categories instead.

Changed the replace call to extract the mapping as freq_map and apply it via cat.rename_categories.

Also fixed a pre-existing freq="H" deprecation warning in the test for hour_of_week.

### Does your contribution introduce a new dependency? If yes, which one?
No.

### What should a reviewer concentrate their feedback on?
The one-line change in _prep_dummies and whether the regression test approach (simplefilter("error", FutureWarning)) is preferred over record=True.

### Did you add any tests for the change?
Yes, added test_no_future_warning_on_fit_transform in test_date.py which turns FutureWarning into an error during fit_transform, so CI will catch it if this regresses.

### Any other comments?
No.



##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.


