### PR TITLE
[DOC] remove per-notebook setup instructions, add auto-generated header via nbsphinx_prolog

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -639,6 +639,15 @@ nbsphinx_prolog = f"""
 .. _Binder: {binder_url}
 
 |Binder|_
+
+.. note::
+
+   To run interactively: click the Binder badge above, no install needed.
+
+   To run locally: install ``sktime`` - see the
+   `installation guide <https://www.sktime.net/en/stable/installation.html>`_.
+   For a dev install, see the
+   `developer install instructions <https://www.sktime.net/en/stable/installation.html#development-versions>`_.
 """
 
 # add link to original notebook at the bottom

--- a/examples/01_forecasting.ipynb
+++ b/examples/01_forecasting.ipynb
@@ -4,18 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Set-up instructions:** this notebook give a tutorial on the forecasting learning task supported by `sktime`.\n",
-    "On binder, this should run out-of-the-box.\n",
-    "\n",
-    "To run this notebook as intended, ensure that `sktime` with basic dependency requirements is installed in your python environment.\n",
-    "\n",
-    "To run this notebook with a local development version of sktime, an editable developer installation is recommended, see the [sktime developer install guide](https://www.sktime.net/en/stable/installation.html#development-versions) for instructions."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "# Forecasting with sktime\n",
     "\n",
     "In forecasting, past data is used to make temporal forward predictions of a time series. This is notably different from tabular prediction tasks supported by `scikit-learn` and similar libraries.\n",

--- a/examples/AA_datatypes_and_datasets.ipynb
+++ b/examples/AA_datatypes_and_datasets.ipynb
@@ -5,13 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Abstract:** this notebook give an introduction to `sktime` in-memory data containers and data sets, with associated functionality such as in-memory format validation, conversion, and data set loading.\n",
-    "\n",
-    "**Set-up instructions:** on binder, this notebook should run out-of-the-box.\n",
-    "\n",
-    "To run this notebook as intended, ensure that `sktime` with basic dependency requirements is installed in your python environment.\n",
-    "\n",
-    "To run this notebook with a local development version of sktime, either uncomment and run the below, or `pip install -e` a local clone of the `sktime` `main` branch."
+    "**Abstract:** this notebook give an introduction to `sktime` in-memory data containers and data sets, with associated functionality such as in-memory format validation, conversion, and data set loading."
    ]
   },
   {


### PR DESCRIPTION
### Reference Issues/PRs

Fixes #1050.

### What does this implement/fix? Explain your changes.

The forecasting tutorial and a couple of other notebooks had manual "Set-up instructions" cells at the top. As discussed in the issue, these have been removed and replaced with a single auto-generated header that appears on every notebook in the docs.

### Changes:

docs/source/conf.py- added a .. note:: block to nbsphinx_prolog with a Binder run link and a link to the install guide. This gets prepended to every notebook automatically when the docs are built.

examples/01_forecasting.ipynb - removed the setup instructions cell entirely.

examples/AA_datatypes_and_datasets.ipynb - stripped the setup instructions paragraph, kept the abstract.

### Does your contribution introduce a new dependency? If yes, which one?

No.

### What should a reviewer concentrate their feedback on?

Changes and Whether any other notebooks need the same treatment (I only found two with explicit setup cells).

### Did you add any tests for the change?

No, this is a docs-only change.

### Any other comments?

The note reuses the existing nbsphinx_prolog mechanism already in place for the Binder badge, so no new infrastructure is needed.


##### For all contributions

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.


