### PR TITLE
[DOC] Add example to TimeBinner docstring

### DIFF
--- a/sktime/transformations/panel/reduce.py
+++ b/sktime/transformations/panel/reduce.py
@@ -80,8 +80,8 @@ class TimeBinner(BaseTransformer):
     This estimator converts nested pandas dataframe containing
     time-series/panel data with numpy arrays or pandas Series in
     dataframe cells into a tabular pandas dataframe with only primitives in
-    cells. The primitives are calculated based on Intervals defined
-    by the IntervalIndex and aggregated by aggfunc.
+    cells. The primitives are calculated based on intervals defined
+    by the IntervalIndex and aggregated by ``aggfunc``.
 
     This is useful for transforming time-series/panel data
     into a format that is accepted by standard validation learning
@@ -90,11 +90,21 @@ class TimeBinner(BaseTransformer):
     Parameters
     ----------
     idx : pd.IntervalIndex
-        IntervalIndex defining intervals considered by aggfunc
-    aggfunc : callable
+        IntervalIndex defining intervals considered by aggfunc.
+    aggfunc : callable, optional (default=None)
         Function used to aggregate the values in intervals.
-        Should have signature 1D -> float and defaults
-        to mean if None
+        Should have signature 1D -> float and defaults to mean if None.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.datasets import load_basic_motions
+    >>> from sktime.transformations.panel.reduce import TimeBinner
+    >>> X, y = load_basic_motions(return_X_y=True)
+    >>> idx = pd.interval_range(start=0, end=100, freq=20, closed="left")
+    >>> transformer = TimeBinner(idx=idx)
+    >>> Xt = transformer.fit_transform(X)
+    >>> Xt.shape
     """
 
     _tags = {


### PR DESCRIPTION
#### Reference Issues/PRs

Part of #4264.


#### What does this implement/fix? Explain your changes.

Adds a minimal usage example to the TimeBinner estimator docstring.

The example demonstrates basic usage with a panel dataset and
an IntervalIndex for binning.


#### Does your contribution introduce a new dependency? If yes, which one?

No.


#### What should a reviewer concentrate their feedback on?

- Correct formatting of the Examples section
- Appropriateness and clarity of the usage example


#### Did you add any tests for the change?

No. This PR only adds a docstring example and does not modify functionality.


#### Any other comments?

None.


#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured dependency isolation.