### PR TITLE
[ENH] Add EWMA (Exponentially Weighted Moving Average) control chart detector

### DIFF
--- a/docs/source/api_reference/detection.rst
+++ b/docs/source/api_reference/detection.rst
@@ -46,6 +46,17 @@ Change Point Detection
         pelt.PELT
         seeded_binseg.SeededBinarySegmentation
 
+Statistical Process Control (Native)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. currentmodule:: sktime.detection
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ewma.EWMA
+
 Naive Baselines
 ^^^^^^^^^^^^^^^
 

--- a/sktime/detection/ewma.py
+++ b/sktime/detection/ewma.py
@@ -1,0 +1,255 @@
+"""EWMA (Exponentially Weighted Moving Average) control chart detector."""
+
+import pandas as pd
+
+from sktime.detection.base import BaseDetector
+
+__author__ = ["RajdeepKushwaha5"]
+
+
+class EWMA(BaseDetector):
+    r"""EWMA (Exponentially Weighted Moving Average) control chart detector.
+
+    Implements the EWMA control chart [1]_ for offline detection of multiple
+    change points in the mean of a univariate time series.
+
+    The EWMA statistic smooths the series with exponential weights:
+
+    .. math::
+
+        Z_t = \lambda X_t + (1 - \lambda) Z_{t-1}, \qquad Z_0 = \mu_0
+
+    A change point is declared at iloc ``t - 1`` (last index of the left
+    segment) the first time the deviation from the reference mean exceeds the
+    threshold ``h``:
+
+    .. math::
+
+        |Z_t - \mu_0| > h
+
+    After each detection, ``Z`` is re-initialised to the reference mean of the
+    new segment, so that subsequent changes can be found.
+
+    EWMA complements CUSUM: with a small ``lambda`` it detects *small sustained
+    shifts* earlier than CUSUM because the smoothing reduces the variance of the
+    statistic and the effective control limit narrows.
+
+    Parameters
+    ----------
+    lam : float, default=0.2
+        Smoothing factor (``0 < lam <= 1``).  ``lam = 1`` reduces to a raw
+        threshold on each individual observation.  Smaller values produce a
+        smoother statistic that reacts slowly to sudden large shifts but is
+        more sensitive to small, persistent shifts.
+    h : float, default=1.0
+        Detection threshold.  A change is flagged when
+        :math:`|Z_t - \mu_0| > h`.  Higher values reduce false alarms at the
+        cost of detection lag.
+    target : float or None, default=None
+        Initial reference mean :math:`\mu_0`.  If ``None``, estimated from
+        the first ``warmup_len`` samples of the current segment.
+    warmup_len : int or None, default=None
+        Number of samples used to estimate the reference mean of each segment.
+        Defaults to ``min(max(5, n // 10), 20)`` where ``n`` is the series
+        length.
+
+    Notes
+    -----
+    The reported change point iloc is ``t - 1``, where ``t`` is the alarm
+    index (first index where :math:`|Z_t - \mu| > h`).  This matches the
+    sktime convention used in ``BinarySegmentation`` and ``CUSUM``.
+
+    References
+    ----------
+    .. [1] Roberts, S. W. (1959). Control chart tests based on geometric moving
+           averages. Technometrics, 1(3), 239-250.
+           https://doi.org/10.1080/00401706.1959.10489860
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.detection.ewma import EWMA
+    >>> X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    >>> model = EWMA(lam=0.2, h=1.0)
+    >>> model.fit_predict(X)
+       ilocs
+    0     20
+
+    Two change points — up then back down:
+
+    >>> X2 = pd.Series([0.0] * 15 + [5.0] * 15 + [0.0] * 15, dtype=float)
+    >>> EWMA(lam=0.2, h=1.0).fit_predict(X2)
+       ilocs
+    0     15
+    1     30
+    """
+
+    _tags = {
+        "authors": "RajdeepKushwaha5",
+        "maintainers": "RajdeepKushwaha5",
+        "fit_is_empty": True,
+        "capability:multivariate": False,
+        "task": "change_point_detection",
+        "learning_type": "unsupervised",
+        "X_inner_mtype": "pd.Series",
+    }
+
+    def __init__(self, lam=0.2, h=1.0, target=None, warmup_len=None):
+        if not (0 < lam <= 1):
+            raise ValueError(f"lam must satisfy 0 < lam <= 1, got lam={lam!r}")
+        if h <= 0:
+            raise ValueError(f"h must be positive, got h={h!r}")
+        if warmup_len is not None and warmup_len < 1:
+            raise ValueError(
+                f"warmup_len must be a positive integer or None, got {warmup_len!r}"
+            )
+        self.lam = lam
+        self.h = h
+        self.target = target
+        self.warmup_len = warmup_len
+        super().__init__()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _effective_warmup(self, n):
+        """Return the number of samples used to estimate a segment mean."""
+        if self.warmup_len is not None:
+            return self.warmup_len
+        return min(max(5, n // 10), 20)
+
+    @staticmethod
+    def _segment_mean(x, start, warmup):
+        """Return the mean of up to ``warmup`` samples beginning at ``start``."""
+        end = min(start + warmup, len(x))
+        return float(x[start:end].mean())
+
+    def _run_ewma(self, x):
+        """Run the core EWMA loop over a raw float array.
+
+        All three public detection paths (_predict, _predict_scores,
+        _transform_scores) call this so the statistics are computed once.
+
+        Parameters
+        ----------
+        x : np.ndarray, shape (n,)
+            Raw float values extracted from the input Series.
+
+        Returns
+        -------
+        change_points : list of int
+            iloc of each detected change point (``t - 1`` convention).
+        alarm_scores : list of float
+            Value of ``|Z_t - mu|`` at the step that fired each alarm.
+        running_scores : list of float
+            ``|Z_t - mu|`` at every timepoint.  Resets immediately after
+            each alarm so that subsequent segments start fresh.
+        """
+        n = len(x)
+        warmup = self._effective_warmup(n)
+        mu = (
+            self.target if self.target is not None else self._segment_mean(x, 0, warmup)
+        )
+        lam = self.lam
+        h = self.h
+
+        change_points = []
+        alarm_scores = []
+        running_scores = []
+        z = mu  # initialise EWMA statistic to reference mean
+
+        for t in range(n):
+            z = lam * x[t] + (1 - lam) * z
+            score = abs(z - mu)
+
+            if score > h and t > 0:
+                change_points.append(t - 1)
+                alarm_scores.append(score)
+                mu = self._segment_mean(x, t, warmup)
+                z = mu  # re-initialise to new segment mean
+                running_scores.append(0.0)
+            else:
+                running_scores.append(score)
+
+        return change_points, alarm_scores, running_scores
+
+    # ------------------------------------------------------------------
+    # BaseDetector interface
+    # ------------------------------------------------------------------
+
+    def _predict(self, X):
+        """Detect change points via the EWMA control chart.
+
+        Parameters
+        ----------
+        X : pd.Series
+            Univariate time series.
+
+        Returns
+        -------
+        pd.Series of int
+            Sorted iloc positions of detected change points.  Each value is
+            the last index of the left (pre-change) segment, matching the
+            convention used by ``BinarySegmentation`` and ``CUSUM``.
+        """
+        x = X.to_numpy(dtype=float)
+        change_points, _, _ = self._run_ewma(x)
+        return pd.Series(change_points, dtype="int64")
+
+    def _predict_scores(self, X):
+        r"""Return sparse EWMA scores, one per detected change point.
+
+        Parameters
+        ----------
+        X : pd.Series
+            Univariate time series.
+
+        Returns
+        -------
+        pd.Series of float
+            One score per detected change point, equal to
+            :math:`|Z_t - \mu|` at the step that fired the alarm.
+        """
+        x = X.to_numpy(dtype=float)
+        _, alarm_scores, _ = self._run_ewma(x)
+        return pd.Series(alarm_scores, dtype=float)
+
+    def _transform_scores(self, X):
+        r"""Return the running EWMA deviation statistic at every timepoint.
+
+        Parameters
+        ----------
+        X : pd.Series
+            Univariate time series.
+
+        Returns
+        -------
+        pd.Series of float
+            :math:`|Z_t - \mu|` at each index of ``X``.  Resets to 0.0
+            immediately after each alarm.  Values above ``h`` indicate a
+            detected change point at the *previous* index.
+        """
+        x = X.to_numpy(dtype=float)
+        _, _, running_scores = self._run_ewma(x)
+        return pd.Series(running_scores, index=X.index, dtype=float)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+
+        Returns
+        -------
+        params : dict or list of dict
+            Each dict forms parameters for a valid test instance via ``cls(**params)``.
+            ``create_test_instance`` uses the first (or only) dict entry.
+        """
+        params0 = {"lam": 0.2, "h": 1.0}
+        params1 = {"lam": 0.5, "h": 2.0, "target": 0.0, "warmup_len": 5}
+        return [params0, params1]

--- a/sktime/detection/tests/test_ewma.py
+++ b/sktime/detection/tests/test_ewma.py
@@ -1,0 +1,226 @@
+"""Tests for the EWMA change point detector."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sktime.detection.ewma import EWMA
+from sktime.tests.test_switch import run_test_for_class
+
+__author__ = ["RajdeepKushwaha5"]
+
+_SKIP = pytest.mark.skipif(
+    not run_test_for_class(EWMA),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+
+# ---------------------------------------------------------------------------
+# Correctness tests
+# ---------------------------------------------------------------------------
+
+
+@_SKIP
+@pytest.mark.parametrize(
+    "X, target, expected",
+    [
+        # single upward shift: alarm fires 2 steps into new regime → CP=20
+        (pd.Series([0.0] * 20 + [5.0] * 20, dtype=float), 0.0, [20]),
+        # single downward shift: symmetric to upward → CP=20
+        (pd.Series([5.0] * 20 + [0.0] * 20, dtype=float), 5.0, [20]),
+        # two shifts: up then back down → CPs at 20 and 35
+        # (EWMA alarm fires one step after z first exceeds h; reported CP is
+        # the last  observation in the warmup of the new segment)
+        (
+            pd.Series([0.0] * 20 + [5.0] * 15 + [0.0] * 20, dtype=float),
+            0.0,
+            [20, 35],
+        ),
+        # no shift: flat series → no CPs
+        (pd.Series([0.0] * 40, dtype=float), 0.0, []),
+    ],
+)
+def test_ewma_known_target(X, target, expected):
+    """EWMA returns correct change point ilocs for synthetic step signals."""
+    model = EWMA(lam=0.2, h=1.0, target=target)
+    result = model.fit_predict(X)
+    assert result.values.flatten().tolist() == expected
+
+
+@_SKIP
+def test_ewma_auto_target():
+    """EWMA estimates the baseline from warmup when target is None."""
+    X = pd.Series([0.0] * 25 + [8.0] * 25)
+    model = EWMA(lam=0.2, h=1.0, warmup_len=10)
+    result = model.fit_predict(X)
+    # warmup mean is 0.0; alarm fires quickly in the 8.0 regime
+    ilocs = result.values.flatten().tolist()
+    assert len(ilocs) == 1
+    assert ilocs[0] >= 24  # alarm must be at or after the true shift point
+
+
+@_SKIP
+def test_ewma_high_threshold_no_detection():
+    """EWMA returns an empty Series when the threshold is never exceeded."""
+    X = pd.Series([0.0] * 40)
+    model = EWMA(lam=0.2, h=1000.0, target=0.0)
+    result = model.fit_predict(X)
+    assert len(result) == 0
+
+
+@_SKIP
+def test_ewma_lam_one_is_threshold_detector():
+    """lam=1 reduces EWMA to a raw point-level threshold on each observation."""
+    # With lam=1, Z_t = x_t, so score = |x_t - mu|. Alarm fires when any
+    # x_t deviates from mu by more than h.
+    X = pd.Series([0.0] * 10 + [5.0] * 10, dtype=float)
+    model = EWMA(lam=1.0, h=0.5, target=0.0)
+    result = model.fit_predict(X)
+    ilocs = result.values.flatten().tolist()
+    # First observation > threshold is at index 10; alarm fires (t=10, t>0), CP=9
+    assert ilocs == [9]
+
+
+# ---------------------------------------------------------------------------
+# Score-method tests
+# ---------------------------------------------------------------------------
+
+
+@_SKIP
+def test_ewma_predict_scores_length_matches_cps():
+    """predict_scores returns one score per detected change point."""
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    model = EWMA(lam=0.2, h=1.0, target=0.0)
+    model.fit(X)
+    n_cp = len(model.predict(X))
+    n_sc = len(model.predict_scores(X))
+    assert n_cp == n_sc
+
+
+@_SKIP
+def test_ewma_predict_scores_value():
+    """predict_scores returns |Z_t - mu| at the alarm timepoint."""
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    model = EWMA(lam=0.2, h=1.0, target=0.0)
+    model.fit(X)
+    scores_df = model.predict_scores(X)
+    assert len(scores_df) == 1
+    # alarm fires at t=21 → z = lam*5 + (1-lam)*lam*5 = 1.8 → score = 1.8
+    assert abs(scores_df.iloc[0, 0] - 1.8) < 1e-9
+
+
+@_SKIP
+def test_ewma_predict_scores_type():
+    """predict_scores returns a pd.DataFrame (wraps _predict_scores result)."""
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    model = EWMA(lam=0.2, h=1.0, target=0.0).fit(X)
+    scores = model.predict_scores(X)
+    assert isinstance(scores, pd.DataFrame)
+
+
+@_SKIP
+def test_ewma_predict_scores_empty_when_no_cp():
+    """predict_scores is empty when no change point is detected."""
+    X = pd.Series([2.0] * 40, dtype=float)
+    model = EWMA(lam=0.2, h=1000.0).fit(X)
+    assert len(model.predict_scores(X)) == 0
+
+
+@_SKIP
+def test_ewma_transform_scores_length():
+    """transform_scores returns one value per observation."""
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    model = EWMA(lam=0.2, h=1.0, target=0.0).fit(X)
+    ts = model.transform_scores(X)
+    assert len(ts) == len(X)
+
+
+@_SKIP
+def test_ewma_transform_scores_index_preserved():
+    """transform_scores preserves the original Series index."""
+    idx = pd.date_range("2020-01-01", periods=40, freq="D")
+    X = pd.Series([0.0] * 20 + [5.0] * 20, index=idx, dtype=float)
+    model = EWMA(lam=0.2, h=1.0, target=0.0).fit(X)
+    ts = model.transform_scores(X)
+    pd.testing.assert_index_equal(ts.index, idx)
+
+
+@_SKIP
+def test_ewma_transform_scores_pre_change_zero():
+    """Running statistic is 0 for all timepoints in the flat pre-shift region."""
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    model = EWMA(lam=0.2, h=1.0, target=0.0).fit(X)
+    ts = model.transform_scores(X)
+    assert (ts.iloc[:20] == 0.0).all()
+
+
+@_SKIP
+def test_ewma_transform_scores_resets_after_alarm():
+    """Running statistic resets to 0.0 immediately after an alarm fires."""
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    model = EWMA(lam=0.2, h=1.0, target=0.0).fit(X)
+    ts = model.transform_scores(X)
+    # alarm fires at t=21; running_scores[21] = 0 (reset)
+    assert ts.iloc[21] == 0.0
+
+
+@_SKIP
+def test_ewma_transform_scores_type():
+    """transform_scores returns a pd.Series."""
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    model = EWMA(lam=0.2, h=1.0, target=0.0).fit(X)
+    ts = model.transform_scores(X)
+    assert isinstance(ts, pd.Series)
+
+
+# ---------------------------------------------------------------------------
+# Output-contract tests
+# ---------------------------------------------------------------------------
+
+
+@_SKIP
+def test_ewma_output_dtype():
+    """Change point values are int64."""
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    result = EWMA(lam=0.2, h=1.0, target=0.0).fit_predict(X)
+    assert result["ilocs"].dtype == np.dtype("int64")
+
+
+@_SKIP
+def test_ewma_output_type_and_column():
+    """fit_predict returns a pd.DataFrame with an 'ilocs' column."""
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    result = EWMA(lam=0.2, h=1.0, target=0.0).fit_predict(X)
+    assert isinstance(result, pd.DataFrame)
+    assert "ilocs" in result.columns
+
+
+@_SKIP
+def test_ewma_single_element_series():
+    """EWMA does not crash on a length-1 Series."""
+    X = pd.Series([3.14])
+    result = EWMA(lam=0.2, h=1.0).fit_predict(X)
+    assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# Parameter-validation tests
+# ---------------------------------------------------------------------------
+
+
+@_SKIP
+@pytest.mark.parametrize(
+    "bad_params, match",
+    [
+        ({"lam": 0.0}, "0 < lam"),
+        ({"lam": -0.5}, "0 < lam"),
+        ({"lam": 1.5}, "0 < lam"),
+        ({"lam": 0.2, "h": 0}, "h must be positive"),
+        ({"lam": 0.2, "h": -1.0}, "h must be positive"),
+        ({"lam": 0.2, "warmup_len": 0}, "warmup_len must be a positive integer"),
+        ({"lam": 0.2, "warmup_len": -3}, "warmup_len must be a positive integer"),
+    ],
+)
+def test_ewma_invalid_params_raise(bad_params, match):
+    """EWMA raises ValueError for out-of-range constructor parameters."""
+    with pytest.raises(ValueError, match=match):
+        EWMA(**bad_params)


### PR DESCRIPTION
### What this PR adds

| File | Lines | Purpose |
|---|---|---|
| `sktime/detection/ewma.py` | ~256 | `EWMA` class |
| `sktime/detection/tests/test_ewma.py` | ~235 | 26 unit tests |
| `docs/source/api_reference/detection.rst` | +10 | "Statistical Process Control (Native)" subsection |

### Algorithm

The EWMA control chart (Roberts, 1959) smooths the series with exponential weights:

$$Z_t = \lambda X_t + (1-\lambda) Z_{t-1}, \quad Z_0 = \mu_0$$

A change point is declared at iloc `t − 1` when $|Z_t - \mu_0| > h$.
After each alarm, `Z` is re-initialised to the new segment mean.

### Why EWMA alongside CUSUM?

Both are classical SPC methods but with different sensitivities:

| Property | CUSUM | EWMA |
|---|---|---|
| Best at | Large, sudden shifts | Small, sustained drifts |
| Statistic | Cumulative sum | Exponentially smoothed average |
| Reset | Yes (after alarm) | Yes (after alarm) |
| Score methods | ✅ | ✅ |

EWMA is the only SPC change-point detector in sktime's native (non-adapter) detection module.

### Checklist
- [x] 26/26 tests pass
- [x] `pre-commit` all pass (including `r"""` prefix for backslash docstrings)
- [x] `_predict_scores` and `_transform_scores` both implemented
- [x] No new dependencies
- [x] API reference updated