### PR TITLE
ENH: add native PELT change point detector

### DIFF
--- a/docs/source/api_reference/detection.rst
+++ b/docs/source/api_reference/detection.rst
@@ -46,6 +46,17 @@ Change Point Detection
         pelt.PELT
         seeded_binseg.SeededBinarySegmentation
 
+Dynamic Programming (Native)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. currentmodule:: sktime.detection
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    pelt.PELT
+
 Naive Baselines
 ^^^^^^^^^^^^^^^
 

--- a/sktime/detection/pelt.py
+++ b/sktime/detection/pelt.py
@@ -1,0 +1,276 @@
+"""PELT (Pruned Exact Linear Time) change point detector."""
+
+import numpy as np
+import pandas as pd
+
+from sktime.detection.base import BaseDetector
+
+__author__ = ["RajdeepKushwaha5"]
+
+
+class PELT(BaseDetector):
+    r"""PELT (Pruned Exact Linear Time) change point detector.
+
+    Implements the PELT algorithm [1]_ for exact, globally optimal detection of
+    multiple change points in the mean of a univariate time series.
+
+    PELT minimises the total segmentation cost plus a linear penalty for each
+    additional change point:
+
+    .. math::
+
+        \min_{\tau_{1:m}} \left[
+            \sum_{i=1}^{m+1} \mathcal{C}(x_{\tau_{i-1}+1:\tau_i})
+            + m \cdot \beta
+        \right]
+
+    where :math:`\tau_{1:m}` are the change point locations and
+    :math:`\mathcal{C}` is the L2 segment cost (negative log-likelihood of a
+    Gaussian with unknown mean and known unit variance):
+
+    .. math::
+
+        \mathcal{C}(x_{s:e}) =
+            \sum_{t=s}^{e} x_t^2 - \frac{\bigl(\sum_{t=s}^{e} x_t\bigr)^2}{e - s + 1}
+
+    The algorithm is *exact* (finds the globally optimal partition) and runs in
+    :math:`O(n)` expected time via a pruning step that discards candidate
+    change points that cannot be optimal for any future position.
+
+    Parameters
+    ----------
+    penalty : float
+        Cost penalty :math:`\beta` added for each additional change point.
+        Larger values produce fewer, more certain change points.  A popular
+        data-driven choice is ``2 * log(n)`` (BIC-like; can be set after
+        inspecting the series length).
+    min_cp_distance : int, default=2
+        Minimum number of observations between two successive change points
+        (i.e. minimum segment length).  Must be at least 1.
+
+    Notes
+    -----
+    The reported change point iloc follows the sktime convention used by
+    ``BinarySegmentation``: each value is the *last index of the left
+    (pre-change) segment*, i.e. if the new segment begins at position ``s``
+    (0-indexed), the change point is reported as ``s - 1``.
+
+    The L2 cost is computed in :math:`O(1)` per segment using prefix sums,
+    making the overall algorithm :math:`O(n)` in practice with the PELT
+    pruning rule.
+
+    References
+    ----------
+    .. [1] Killick, R., Fearnhead, P., & Eckley, I. A. (2012). Optimal
+           detection of changepoints with a linear computational cost.
+           Journal of the American Statistical Association, 107(500), 1590-1598.
+           https://doi.org/10.1080/01621459.2012.737745
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.detection.pelt import PELT
+    >>> X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    >>> model = PELT(penalty=2)
+    >>> model.fit_predict(X)
+       ilocs
+    0     19
+
+    Multiple change points:
+
+    >>> X2 = pd.Series([0.0] * 15 + [5.0] * 15 + [0.0] * 15, dtype=float)
+    >>> PELT(penalty=2).fit_predict(X2)
+       ilocs
+    0     14
+    1     29
+    """
+
+    _tags = {
+        "authors": "RajdeepKushwaha5",
+        "maintainers": "RajdeepKushwaha5",
+        "fit_is_empty": True,
+        "capability:multivariate": False,
+        "task": "change_point_detection",
+        "learning_type": "unsupervised",
+        "X_inner_mtype": "pd.Series",
+    }
+
+    def __init__(self, penalty, min_cp_distance=2):
+        if penalty < 0:
+            raise ValueError(f"penalty must be non-negative, got penalty={penalty!r}")
+        if min_cp_distance < 1:
+            raise ValueError(
+                f"min_cp_distance must be a positive integer, "
+                f"got min_cp_distance={min_cp_distance!r}"
+            )
+        self.penalty = penalty
+        self.min_cp_distance = min_cp_distance
+        super().__init__()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_prefix_sums(x):
+        """Return cumulative sum and sum-of-squares arrays (length n+1).
+
+        Parameters
+        ----------
+        x : np.ndarray, shape (n,)
+            Raw float array.
+
+        Returns
+        -------
+        S : np.ndarray, shape (n+1,)
+            ``S[i] = sum(x[:i])``
+        S2 : np.ndarray, shape (n+1,)
+            ``S2[i] = sum(x[:i]**2)``
+        """
+        S = np.zeros(len(x) + 1)
+        S2 = np.zeros(len(x) + 1)
+        S[1:] = np.cumsum(x)
+        S2[1:] = np.cumsum(x**2)
+        return S, S2
+
+    @staticmethod
+    def _segment_cost(S, S2, s, e):
+        """Return the L2 cost of segment ``x[s:e]`` (half-open Python slice).
+
+        Cost = sum of squared deviations from segment mean.
+
+        Parameters
+        ----------
+        S : np.ndarray
+            Prefix sums (length n+1).
+        S2 : np.ndarray
+            Prefix sums of squares (length n+1).
+        s : int
+            Segment start (inclusive, 0-indexed).
+        e : int
+            Segment end (exclusive, 0-indexed).
+
+        Returns
+        -------
+        float
+        """
+        n_seg = e - s
+        if n_seg <= 0:
+            return 0.0
+        seg_sum = S[e] - S[s]
+        seg_sum2 = S2[e] - S2[s]
+        return float(seg_sum2 - seg_sum**2 / n_seg)
+
+    def _run_pelt(self, x):
+        """Run the core PELT dynamic programme over a raw float array.
+
+        Parameters
+        ----------
+        x : np.ndarray, shape (n,)
+            Raw float values extracted from the input Series.
+
+        Returns
+        -------
+        change_points : list of int
+            Sorted list of iloc positions (0-indexed) of detected change points,
+            where each value is the *last index of the left segment*.
+        """
+        n = len(x)
+        d = self.min_cp_distance
+        penalty = self.penalty
+
+        S, S2 = self._build_prefix_sums(x)
+        cost = lambda s, e: self._segment_cost(S, S2, s, e)  # noqa: E731
+
+        # F[t] = optimal cost for x[0:t].  F[0] = -penalty so the first
+        # segment does not incur an extra penalty (standard initialisation).
+        F = np.full(n + 1, np.inf)
+        F[0] = -penalty
+
+        # prev[t] = the start of the last segment in the optimal partition of
+        # x[0:t].  prev[t] = 0 means the whole x[0:t] is one segment.
+        prev = np.full(n + 1, -1, dtype=np.intp)
+
+        # Candidate set: tau values such that the segment x[tau:t] is still
+        # potentially optimal.
+        candidates = [0]
+
+        for t in range(1, n + 1):
+            # Enforce minimum segment length: only tau ≤ t - d are valid starts
+            # for the segment ending at t.
+            valid = [tau for tau in candidates if tau <= t - d]
+            if not valid:
+                # No valid start; fall back to the furthest admissible position
+                valid = [max(0, t - n)]  # whole series as one segment
+
+            best_cost = np.inf
+            best_tau = valid[0]
+            for tau in valid:
+                c = F[tau] + cost(tau, t) + penalty
+                if c < best_cost:
+                    best_cost = c
+                    best_tau = tau
+
+            F[t] = best_cost
+            prev[t] = best_tau
+
+            # PELT pruning: discard tau if it cannot be optimal for any t' > t
+            candidates = [tau for tau in candidates if F[tau] + cost(tau, t) <= F[t]]
+            # The current position t becomes a candidate start for future segments
+            candidates.append(t)
+
+        # Back-track through prev[] to recover change points
+        change_points = []
+        t = n
+        while True:
+            s = int(prev[t])
+            if s == 0:
+                break
+            change_points.append(s - 1)  # last index of left segment
+            t = s
+
+        change_points.sort()
+        return change_points
+
+    # ------------------------------------------------------------------
+    # BaseDetector interface
+    # ------------------------------------------------------------------
+
+    def _predict(self, X):
+        """Detect change points via PELT.
+
+        Parameters
+        ----------
+        X : pd.Series
+            Univariate time series.
+
+        Returns
+        -------
+        pd.Series of int
+            Sorted iloc positions of detected change points.  Each value is
+            the last index of the left (pre-change) segment, matching the
+            convention used by ``BinarySegmentation``.
+        """
+        x = X.to_numpy(dtype=float)
+        change_points = self._run_pelt(x)
+        return pd.Series(change_points, dtype="int64")
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+
+        Returns
+        -------
+        params : dict or list of dict
+            Each dict forms parameters for a valid test instance via ``cls(**params)``.
+            ``create_test_instance`` uses the first (or only) dict entry.
+        """
+        params0 = {"penalty": 2.0}
+        params1 = {"penalty": 10.0, "min_cp_distance": 3}
+        return [params0, params1]

--- a/sktime/detection/tests/test_pelt.py
+++ b/sktime/detection/tests/test_pelt.py
@@ -1,0 +1,174 @@
+"""Tests for the PELT change point detector."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sktime.detection.pelt import PELT
+from sktime.tests.test_switch import run_test_for_class
+
+__author__ = ["RajdeepKushwaha5"]
+
+_SKIP = pytest.mark.skipif(
+    not run_test_for_class(PELT),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Correctness tests
+# ---------------------------------------------------------------------------
+
+
+@_SKIP
+@pytest.mark.parametrize(
+    "X, expected",
+    [
+        # single upward step
+        (pd.Series([0.0] * 20 + [5.0] * 20, dtype=float), [19]),
+        # single downward step
+        (pd.Series([5.0] * 20 + [0.0] * 20, dtype=float), [19]),
+        # two steps: up then back down
+        (pd.Series([0.0] * 20 + [5.0] * 15 + [0.0] * 20, dtype=float), [19, 34]),
+        # no change: constant series — no CPs reported
+        (pd.Series([0.0] * 40, dtype=float), []),
+    ],
+)
+def test_pelt_known_change_points(X, expected):
+    """PELT returns exact change point ilocs for synthetic step signals."""
+    model = PELT(penalty=2.0)
+    result = model.fit_predict(X)
+    assert result.values.flatten().tolist() == expected
+
+
+@_SKIP
+def test_pelt_flat_series_no_detection():
+    """A perfectly flat series must yield no change points for any penalty."""
+    X = pd.Series([3.14] * 50, dtype=float)
+    result = PELT(penalty=1.0).fit_predict(X)
+    assert len(result) == 0
+
+
+@_SKIP
+def test_pelt_high_penalty_fewer_cps():
+    """Higher penalty should produce fewer (or equal) change points."""
+    X = pd.Series([0.0] * 10 + [5.0] * 10 + [0.0] * 10 + [5.0] * 10, dtype=float)
+    n_low = len(PELT(penalty=2.0).fit_predict(X))
+    n_high = len(PELT(penalty=1e6).fit_predict(X))
+    assert n_high <= n_low
+
+
+@_SKIP
+def test_pelt_single_cp_symmetric():
+    """Symmetric up-then-down series: two CPs at the known positions."""
+    X = pd.Series([0.0] * 15 + [5.0] * 15 + [0.0] * 15, dtype=float)
+    result = PELT(penalty=2.0).fit_predict(X)
+    assert result.values.flatten().tolist() == [14, 29]
+
+
+@_SKIP
+def test_pelt_bic_penalty():
+    """BIC penalty (2*log(n)) should still detect an obvious shift."""
+    X = pd.Series([0.0] * 20 + [10.0] * 20, dtype=float)
+    n = len(X)
+    model = PELT(penalty=2 * np.log(n))
+    result = model.fit_predict(X)
+    assert 19 in result.values.flatten().tolist()
+
+
+# ---------------------------------------------------------------------------
+# Output-contract tests
+# ---------------------------------------------------------------------------
+
+
+@_SKIP
+def test_pelt_output_type_and_column():
+    """fit_predict returns a pd.DataFrame with an 'ilocs' column."""
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    result = PELT(penalty=2.0).fit_predict(X)
+    assert isinstance(result, pd.DataFrame)
+    assert "ilocs" in result.columns
+
+
+@_SKIP
+def test_pelt_output_sorted():
+    """Change points are returned in ascending order."""
+    X = pd.Series([0.0] * 10 + [4.0] * 10 + [-4.0] * 10 + [0.0] * 10, dtype=float)
+    result = PELT(penalty=2.0).fit_predict(X)
+    ilocs = result.values.flatten().tolist()
+    assert ilocs == sorted(ilocs)
+
+
+@_SKIP
+def test_pelt_output_dtype():
+    """Change point values are integers (int64)."""
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    result = PELT(penalty=2.0).fit_predict(X)
+    assert result["ilocs"].dtype == np.dtype("int64")
+
+
+@_SKIP
+def test_pelt_all_ilocs_in_bounds():
+    """All returned ilocs must be valid indices of X."""
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    result = PELT(penalty=2.0).fit_predict(X)
+    for iloc in result.values.flatten():
+        assert 0 <= iloc < len(X)
+
+
+# ---------------------------------------------------------------------------
+# Edge-case tests
+# ---------------------------------------------------------------------------
+
+
+@_SKIP
+def test_pelt_very_short_series():
+    """Series shorter than 2 * min_cp_distance should not crash."""
+    X = pd.Series([0.0, 1.0, 2.0], dtype=float)
+    result = PELT(penalty=2.0).fit_predict(X)
+    assert isinstance(result, pd.DataFrame)
+
+
+@_SKIP
+def test_pelt_non_default_index_preserved_in_output_rows():
+    """PELT output row count matches number of detected CPs regardless of index."""
+    idx = pd.date_range("2020-01-01", periods=40, freq="D")
+    X = pd.Series([0.0] * 20 + [5.0] * 20, index=idx, dtype=float)
+    result = PELT(penalty=2.0).fit_predict(X)
+    assert len(result) == 1  # one change point expected
+
+
+# ---------------------------------------------------------------------------
+# Parameter-validation tests
+# ---------------------------------------------------------------------------
+
+
+@_SKIP
+@pytest.mark.parametrize(
+    "bad_params, match",
+    [
+        ({"penalty": -1.0}, "penalty must be non-negative"),
+        ({"penalty": 2.0, "min_cp_distance": 0}, "min_cp_distance must be a positive"),
+        ({"penalty": 2.0, "min_cp_distance": -3}, "min_cp_distance must be a positive"),
+    ],
+)
+def test_pelt_invalid_params_raise(bad_params, match):
+    """PELT raises ValueError for invalid constructor parameters."""
+    with pytest.raises(ValueError, match=match):
+        PELT(**bad_params)
+
+
+# ---------------------------------------------------------------------------
+# Consistency with BinarySegmentation
+# ---------------------------------------------------------------------------
+
+
+@_SKIP
+def test_pelt_matches_bs_on_clean_signal():
+    """On a clean two-segment signal PELT and BinarySegmentation agree."""
+    from sktime.detection.bs import BinarySegmentation
+
+    X = pd.Series([0.0] * 20 + [5.0] * 20, dtype=float)
+    pelt_cp = PELT(penalty=2.0).fit_predict(X).values.flatten().tolist()
+    bs_cp = BinarySegmentation(threshold=1).fit_predict(X).values.flatten().tolist()
+    assert pelt_cp == bs_cp


### PR DESCRIPTION
Closes #9470

### What this PR adds

| File | Lines | Purpose |
|---|---|---|
| `sktime/detection/pelt.py` | ~270 | `PELT` class, full implementation |
| `sktime/detection/tests/test_pelt.py` | ~175 | 18 unit tests |
| `docs/source/api_reference/detection.rst` | +10 | "Dynamic Programming (Native)" subsection |

### Algorithm

The PELT algorithm (Killick et al. 2012) solves the globally optimal
multiple-change-point problem in O(n) expected time using dynamic programming
with a linear-time pruning step.

**Cost function (L2 / change in mean)**

$$\mathcal{C}(x_{s:e}) = \sum_{t=s}^{e} x_t^2 - \frac{\bigl(\sum_{t=s}^{e} x_t\bigr)^2}{e-s+1}$$

computed in O(1) using prefix sums.

**Relation to existing skchange adapter**

`sktime.detection.skchange_cp.pelt.PELT` wraps the external `skchange`
package. This PR adds a *native* implementation with no extra dependencies,
following the same pattern as `BinarySegmentation` (native) alongside the
`SeededBinarySegmentation` adapter.

### Checklist
- [x] 18/18 tests pass
- [x] `pre-commit` all pass
- [x] No new dependencies
- [x] API reference updated
- [x] Follows `extension_templates/detection.py` conventions