### PR TITLE
Update .all-contributorsrc

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3774,5 +3774,14 @@
         "maintenance"
       ]
     }
+{
+      "login": "AffanBasra",
+      "name": "Affan Ahmad Basra",
+      "avatar_url": "https://github.com/AffanBasra.png",
+      "profile": "https://github.com/AffanBasra",
+      "contributions": [
+        "doc"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
eference Issues/PRs
See also #8586 (probabilistic forecasting tutorial).

What does this implement/fix? Explain your changes.
Adds my profile to the .all-contributorsrc file with the doc badge, for my contribution of the probabilistic forecasting tutorial notebook (#8586).

Does your contribution introduce a new dependency? If yes, which one?
No.

What should a reviewer concentrate their feedback on?
Whether the entry in .all-contributorsrc is correctly formatted and placed alphabetically
Whether the badge type (doc) is appropriate
Did you add any tests for the change?
No — this is a contributor list update only.

Any other comments?
This is a follow-up to my documentation contribution in #8586, where I added the probabilistic forecasting tutorial notebook.

PR checklist
For all contributions
 I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
 Optionally, for added estimators: not applicable.
 The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. → [DOC]
For new estimators
Not applicable — no new estimators added.