### PR TITLE
naive-forecaster-update-efficiency-3625094318449400835

### DIFF
--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -227,6 +227,30 @@ class NaiveForecaster(_BaseWindowForecaster):
 
         return self
 
+    def _update(self, y, X=None, update_params=True):
+        """Update time series to incremental training data.
+
+        Parameters
+        ----------
+        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+            Time series with which to update the forecaster.
+        X : optional (default=None)
+            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Exogeneous time series for the forecast
+        update_params : bool, optional (default=True)
+            whether model parameters should be updated
+
+        Returns
+        -------
+        self : reference to self
+        """
+        if update_params:
+            n_timepoints = len(self._y)
+            self.window_length_ = check_window_length(self.window_length, n_timepoints)
+            if self.window_length is None:
+                self.window_length_ = n_timepoints
+        return self
+
     def _predict_last_window(
         self, fh, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA
     ):


### PR DESCRIPTION
Reference Issues/PRs
Fixes #9481

What does this implement/fix? Explain your changes.
This PR implements an efficient _update method for the NaiveForecaster.

Previously, NaiveForecaster relied on the default BaseForecaster.update implementation, which performs a full refit of the model whenever new data is added. This was computationally inefficient, especially for expanding window scenarios or streaming data.

The new _update method:

Updates the internal self.window_length_ parameter based on the updated length of the training series self._y.
Handles different types of window_length:
None: Updates window_length_ to the full length of the series (expanding window).
float: Updates window_length_ based on the fraction of the new series length.
int: Keeps window_length_ fixed (rolling window).
Avoids re-running the full fit process, significantly improving performance.
Does your contribution introduce a new dependency? If yes, which one?
No.

What should a reviewer concentrate their feedback on?
The logic for updating window_length_ in _update.
Ensuring that check_window_length behaves as expected with the updated series length.
Did you add any tests for the change?
Yes, I added a new test function test_naive_update_efficiency_and_correctness in sktime/forecasting/tests/test_naive.py. This test:

Verifies that window_length_ is correctly updated when window_length is None (expanding) or float.
Verifies that window_length_ remains constant when window_length is an int.
Confirms that predictions made after an update are identical to predictions made after a full fit on the concatenated data.
PR checklist
I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
The PR title starts with either [ENH], [MNT], [DOC], or [BUG].


I have verified the fix with the following outputs:

1. Verification Script Output (reproduce_issue.py) This script confirms that the update is fast (0.36s for 44 updates), the window_length_ logic is correct for expanding, fixed, and float windows, and the predictions match those of a refitted model.

----------------------------------------------------------------
VERIFICATION SCRIPT: NaiveForecaster Update Efficiency & Correctness
----------------------------------------------------------------

[1] Performance Verification: update() vs refit
  Time taken for 44 updates: 0.3586 seconds
  (Expectation: Should be very fast, < 1 second)

[2] Logic Verification: window_length_ updates
  A. Expanding Window (None): Initial window_length_ = 100 (len(y_train)=100)
     After 1 update:          window_length_ = 101
     -> PASSED: window_length_ increased by 1.
  B. Fixed Window (12):       Initial window_length_ = 12
     After 1 update:          window_length_ = 12
     -> PASSED: window_length_ remained 12.
  C. Float Window (0.5):      Initial window_length_ = 50 (0.5 * 100 = 50)
     After 1 update:          window_length_ = 51 (ceil(0.5 * 101) = 51)
     -> PASSED: window_length_ increased to 51.

[3] Prediction Correctness: update() vs refit()
  Prediction via update: [219.7128712871287, 219.7128712871287, 219.7128712871287]
  Prediction via refit:  [219.7128712871287, 219.7128712871287, 219.7128712871287]
  -> PASSED: Predictions match.
2. Test Execution Output The newly added test passed successfully.

============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
Using --randomly-seed=864854330
rootdir: /app
configfile: setup.cfg
plugins: randomly-4.0.1, timeout-2.4.0, xdist-3.8.0
timeout: 600.0s
timeout method: signal
timeout func_only: False
created: 4/4 workers
4 workers [1 item]

.                                                                        [100%]
============================= slowest 20 durations =============================
0.07s call     sktime/forecasting/tests/test_naive.py::test_naive_update_efficiency_and_correctness

(2 durations < 0.005s hidden.  Use -vv to show these durations.)
============================== 1 passed in 5.64s ===============================