### PR TITLE
[ENH] `TimeCopilotForecaster` for LLM-based forecasting

### DIFF
--- a/sktime/forecasting/timecopilot.py
+++ b/sktime/forecasting/timecopilot.py
@@ -187,18 +187,6 @@ class TimeCopilotForecaster(_HeterogenousMetaEstimator, BaseForecaster):
 
         from timecopilot import TimeCopilot
 
-        # Set API key if provided
-        if self.api_key is not None:
-            import os
-
-            # Determine provider from llm string
-            if self.llm.startswith("openai:"):
-                os.environ["OPENAI_API_KEY"] = self.api_key
-            elif self.llm.startswith("anthropic:"):
-                os.environ["ANTHROPIC_API_KEY"] = self.api_key
-            elif self.llm.startswith("google"):
-                os.environ["GOOGLE_API_KEY"] = self.api_key
-
         # Convert y to the format expected by TimeCopilot
         # TimeCopilot expects: unique_id, ds, y columns
         df = self._convert_to_timecopilot_format(y)
@@ -211,10 +199,14 @@ class TimeCopilotForecaster(_HeterogenousMetaEstimator, BaseForecaster):
             h = None
 
         # Initialize TimeCopilot
-        tc = TimeCopilot(
-            llm=self.llm,
-            retries=self.retries,
-        )
+        tc_kwargs = {
+            "llm": self.llm,
+            "retries": self.retries,
+        }
+        if self.api_key is not None:
+            tc_kwargs["api_key"] = self.api_key
+
+        tc = TimeCopilot(**tc_kwargs)
 
         # Build kwargs for forecast call
         # freq and seasonality are inferred by TimeCopilot from the data


### PR DESCRIPTION
Adds TimeCopilotForecaster - a wrapper for the timecopilot package that combines large language models with time series foundation models.

Features:
- Integration with sktime BaseForecaster interface
- Support for custom forecasters list via _HeterogenousMetaEstimator
- Natural language query interface via get_user_query_response()
- Methods to access forecast analysis and model selection reasoning
- Configurable LLM model, frequency, seasonality, and retry settings

<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->

Fixes #9492

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

This PR adds `TimeCopilotForecaster`, a wrapper for the [timecopilot](https://github.com/TimeCopilot/timecopilot) package that combines large language models (LLMs) with time series foundation models for automated forecasting workflows.

**New file:** `sktime/forecasting/timecopilot.py`

**Class:** `TimeCopilotForecaster`
- Inherits from `_HeterogenousMetaEstimator` and `BaseForecaster`
- Soft dependency on `timecopilot` package
- Tagged with `"tests:vm": True` for CI testing

**Parameters:**
| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `forecasters` | list or None | None | List of sktime forecasters as candidates |
| `llm` | str | "openai:gpt-4o-mini" | LLM model identifier |
| `query` | str or None | None | Natural language question |
| `freq` | str or None | None | Time series frequency |
| `seasonality` | int or None | None | Seasonal period |
| `retries` | int | 3 | API retry count |
| `verbose` | bool | False | Enable verbose logging |
| `api_key` | str or None | None | LLM provider API key |

**Methods:**
- `get_user_query_response()` - Get LLM response to user query
- `get_forecast_analysis()` - Get LLM analysis of forecast
- `get_model_selection_reason()` - Get explanation for model selection
- `get_selected_model()` - Get name of selected model

**Example Usage:**

```python
from sktime.forecasting.timecopilot import TimeCopilotForecaster
from sktime.datasets import load_airline

y = load_airline()

# Basic usage with natural language query
forecaster = TimeCopilotForecaster(
    llm="openai:gpt-4o-mini",
    query="What is the expected trend for the next year?"
)
forecaster.fit(y, fh=[1, 2, 3, 4, 5, 6])
y_pred = forecaster.predict()

# Access LLM insights
print(forecaster.get_user_query_response())
print(forecaster.get_forecast_analysis())
print(forecaster.get_selected_model())
```

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

**Yes** - soft dependency on `timecopilot` package

- Package: `timecopilot`
- PyPI: https://pypi.org/project/timecopilot/
- License: MIT
- Added as soft dependency (not required for core sktime functionality)

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- API design - Is the interface intuitive for users?
- Meta-estimator pattern - Correct use of `_HeterogenousMetaEstimator` for forecaster list handling
- Data format conversion - Conversion between sktime and TimeCopilot formats
- Error handling - Appropriate error messages for unfitted forecaster access

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

- Added `get_test_params()` for estimator check compatibility
- Tests require API key, so tagged with `"tests:vm": True`

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

**References:**
- TimeCopilot paper: arXiv:2509.00616
- TimeCopilot GitHub: https://github.com/TimeCopilot/timecopilot
- Related sktime forecasters: ChronosForecaster, MoiraiForecaster

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [x] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
