### PR TITLE
[ENH] Add type validation for activation_hidden in MLPClassifierTorch (Closes #9536)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3776,6 +3776,15 @@
         "code",
         "maintenance"
       ]
+    },
+    {
+    "login": "vinitjain2005",
+    "name": "Vinit Jain",
+      "avatar_url": "https://avatars.githubusercontent.com/vinitjain2005",
+      "profile": "https://github.com/vinitjain2005",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/sktime/classification/deep_learning/mlp/_mlp_torch.py
+++ b/sktime/classification/deep_learning/mlp/_mlp_torch.py
@@ -196,10 +196,21 @@ class MLPClassifierTorch(BaseDeepClassifierPytorch):
                 f"but got shape {X.shape}. Please ensure your input data is "
                 "properly formatted."
             )
-
+        
         # n_instances, n_dims, n_timesteps = X.shape
         self.num_classes = len(np.unique(y))
         self.input_shape = X.shape
+
+# simple validation for activation_hidden
+        if self.activation_hidden is not None:
+            if not (
+                isinstance(self.activation_hidden, str)
+                or callable(self.activation_hidden)
+                ):
+                raise TypeError(
+                    "activation_hidden must be str, callable, or None."
+                    )
+
         return MLPNetworkTorch(
             input_shape=self.input_shape,
             num_classes=self.num_classes,


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #9536


#### What does this implement/fix? Explain your changes.

This PR adds simple type validation for the `activation_hidden` parameter
in `MLPClassifierTorch`.

Previously, invalid types for `activation_hidden` could propagate silently
to the network layer and result in unclear runtime errors.

With this change, `activation_hidden` must be one of:
- `str`
- `callable`
- `None`

Otherwise, a clear `TypeError` is raised.

Additionally, this PR adds the contributor entry for `vinitjain2005`
to the `.all-contributorsrc` file.


#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies are introduced.


#### What should a reviewer concentrate their feedback on?

- Correctness and necessity of the type validation logic
- Consistency with existing parameter validation patterns
- Whether additional validation cases should be considered


#### Did you add any tests for the change?

No new tests were added.

All existing classification tests pass locally, including
full estimator checks.


#### Any other comments?

This is a small enhancement focused on improving robustness
and parameter validation clarity for `MLPClassifierTorch`.


#### PR checklist

##### For all contributions
- [x] I've added myself to the contributors list with the `code` badge
- [x] The PR title starts with [ENH]

##### For new estimators
- [x] Not applicable

Github: @vinitjain2005