### PR TITLE
[BUG] Fix test_pred_int_tag MRO edge case for capability:pred_int (#9033)

### DIFF
--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -665,11 +665,13 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             )
 
         if pred_int_impl and not cls_tag:
-            raise ValueError(
-                f"{type(f).__name__} does implement probabilistic forecasting, "
-                'but "capability:pred_int" flag has been set to False incorrectly. '
-                'The flag "capability:pred_int" should instead be set to True.'
-            )
+            explicit_tags = getattr(type(f), "_tags", {})
+            if explicit_tags.get("capability:pred_int") is not False:
+                raise ValueError(
+                    f"{type(f).__name__} does implement probabilistic forecasting, "
+                    'but "capability:pred_int" flag has been set to False incorrectly. '
+                    'The flag "capability:pred_int" should instead be set to True.'
+                )
 
     @pytest.mark.parametrize(
         "fh_int_oos", TEST_OOS_FHS, ids=[f"fh={fh}" for fh in TEST_OOS_FHS]


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9033 

#### What does this implement/fix? Explain your changes.
This PR fixes an edge case where `test_pred_int_tag` incorrectly fails for estimators that explicitly set `"capability:pred_int": False `but inherit a `_predict_interval` method from an intermediate base class in their Method Resolution Order (MRO).

Previously, the test only checked if the method existed anywhere in the hierarchy, causing a false positive failure if the final concrete class did not actually support the capability.

The logic is now updated to check the concrete estimator's own _tags dictionary. If the developer explicitly overrides the tag to False, the test respects this and passes.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?

Please review the updated conditional logic in `sktime/forecasting/tests/test_all_forecasters.py::test_pred_int_tag`. 

Specifically, the use of `getattr(type(f), "_tags", {}).get("capability:pred_int") is not False`. This cleanly handles the MRO edge case without requiring extra pass blocks, while still correctly raising a `ValueError` if the developer forgot to set the tag entirely.

#### Did you add any tests for the change?
Changes in the test itself

#### Any other comments?
Ran pytest `sktime/forecasting/tests/test_all_forecasters.py -k "test_pred_int_tag"` locally across all forecasters and parameterizations pass cleanly.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


