### PR TITLE
ENH: Add capability:update tests and enable for Detrender, Deseasonal…

### DIFF
--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -3579,6 +3579,12 @@ ESTIMATOR_TAG_REGISTER = [
         "can the classifier set n_jobs to use multiple threads?",
     ),
     (
+        "capability:update",
+        "transformer",
+        "bool",
+        "can the transformer be updated with new data?",
+    ),
+    (
         "classifier_type",
         "classifier",
         (

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -138,6 +138,8 @@ class BaseTransformer(BaseEstimator):
         # is transform result always guaranteed to contain no missing values?
         "capability:categorical_in_X": True,
         "capability:categorical_in_y": True,
+        #is update supported (default=False)
+        "capability:update": False,
         # does the transformer apply hierarchical reconciliation?
         "remember_data": False,  # whether all data seen is remembered as self._X
         "python_version": None,  # PEP 440 python version specifier to limit versions

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -84,6 +84,8 @@ class Deseasonalizer(BaseTransformer):
         "transform-returns-same-time-index": True,
         "capability:categorical_in_X": False,
         "capability:multivariate": False,
+        #update flag
+        "capability:update": True,
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?

--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -88,6 +88,8 @@ class Detrender(BaseTransformer):
         "capability:inverse_transform": True,
         "transform-returns-same-time-index": True,
         "capability:categorical_in_X": False,
+        #update flag
+        "capability:update": True,
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -138,6 +138,7 @@ class Lag(BaseTransformer):
         "capability:unequal_length:removes": False,
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:missing_values:removes": False,
+        "capability:update": True, #update flag
         "remember_data": True,  # remember all data seen as _X
         # CI and test flags
         # -----------------

--- a/sktime/transformations/tests/test_transformer_update_tag.py
+++ b/sktime/transformations/tests/test_transformer_update_tag.py
@@ -1,0 +1,95 @@
+"""Tests for the capability:update tag on transformers.
+
+Covers the contract introduced in issue #9548:
+    - BaseTransformer defaults capability:update to False.
+    - Transformers with a meaningful _update method set capability:update to True.
+    - If fit_is_empty is True, capability:update must be False (no-op).
+"""
+
+__author__ = ["AnimeshPatra2005"]
+__all__ = []
+
+import pytest
+
+from sktime.tests.test_switch import run_test_module_changed
+from sktime.transformations.series.detrend import Deseasonalizer, Detrender
+from sktime.transformations.series.lag import Lag
+from sktime.utils._testing.series import _make_series
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.transformations"),
+    reason="run test only if anything in sktime.transformations module has changed",
+)
+def test_base_transformer_update_tag_default():
+    """Test that BaseTransformer defaults capability:update to False.
+
+    BaseTransformer._tags should have "capability:update" = False.
+    This ensures that transformers which do not implement _update
+    are not falsely reported as supporting update.
+    """
+    from sktime.transformations.base import BaseTransformer
+
+    tag_val = BaseTransformer._tags.get("capability:update")
+    assert tag_val is False, (
+        "BaseTransformer default for 'capability:update' should be False, "
+        f"but got {tag_val!r}"
+    )
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.transformations"),
+    reason="run test only if anything in sktime.transformations module has changed",
+)
+@pytest.mark.parametrize(
+    "transformer_class",
+    [Detrender, Deseasonalizer, Lag],
+)
+def test_transformer_update_tag_is_true(transformer_class):
+    """Test that transformers with _update set capability:update to True.
+
+    Detrender, Deseasonalizer, and Lag all implement meaningful _update logic,
+    so their capability:update tag should be True.
+    """
+    tag_val = transformer_class._tags.get("capability:update")
+    assert tag_val is True, (
+        f"{transformer_class.__name__} has a meaningful _update method, "
+        f"so 'capability:update' should be True, but got {tag_val!r}"
+    )
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.transformations"),
+    reason="run test only if anything in sktime.transformations module has changed",
+)
+def test_update_tag_false_implies_noop():
+    """Test that a transformer with capability:update=False does not change state.
+
+    If a transformer declares capability:update=False, calling update()
+    should be a no-op: the transformer state must not change.
+    We verify this by checking the transformer returns self and
+    that transform output is identical before and after update.
+    """
+    from sktime.transformations.series.exponent import ExponentTransformer
+
+    # ExponentTransformer has fit_is_empty=True and capability:update=False
+    est = ExponentTransformer()
+    assert not est.get_class_tag("capability:update", tag_value_default=False), (
+        "ExponentTransformer should have capability:update=False"
+    )
+
+    X_train = _make_series(n_timepoints=20)
+    X_new = _make_series(n_timepoints=5)
+
+    est.fit(X_train)
+    Xt_before = est.transform(X_train)
+
+    # update should be a no-op and return self
+    result = est.update(X_new)
+    assert result is est, "update() should return self"
+
+    Xt_after = est.transform(X_train)
+    assert (Xt_before == Xt_after).all().all(), (
+        "Transform output should not change after update() on a "
+        "transformer with capability:update=False"
+    )


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9548.

#### What does this implement/fix? Explain your changes.
This PR introduces tests and establishes the correct usage of the `capability:update` tag across transformers, fulfilling the contract defined in #9548. 

Specifically, this PR:
1. Adds a new test file [sktime/transformations/tests/test_transformer_update_tag.py]
2. Verifies that `BaseTransformer` correctly defaults this tag to `False`.
3. Verifies that transformers which lack this capability (e.g., `fit_is_empty=True`) correctly act as no-ops during [update()]
4. Adds the `capability:update: True` tag to three targeted transformers that have meaningful [_update]
   - [Detrender]
   - [Deseasonalizer]
   - [Lag]

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- The design of the tests in [test_transformer_update_tag.py](sktime/transformations/tests/test_transformer_update_tag.py]) ensuring they capture the correct contract for the tag.
- Whether any other transformers should be explicitly tagged `capability:update: True` as part of this initial rollout.

#### Did you add any tests for the change?
- [x] Yes, added [test_transformer_update_tag.py] which runs three distinct checks on the update tag contract. 

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. 
