### PR TITLE
[ENH] multivariate target support in pytorch-forecasting adaptors

### DIFF
--- a/sktime/forecasting/base/adapters/_pytorchforecasting.py
+++ b/sktime/forecasting/base/adapters/_pytorchforecasting.py
@@ -73,7 +73,7 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
             "pd_multiindex_hier",
             "pd.DataFrame",
         ],
-        "scitype:y": "univariate",
+        "scitype:y": "both",
         "requires-fh-in-fit": True,
         "X-y-must-have-same-index": True,
         "capability:missing_values": False,
@@ -189,7 +189,8 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         Parameters
         ----------
         y : sktime time series object
-            guaranteed to have a single column/variable
+            guaranteed to be of an mtype in self.get_tag("y_inner_mtype")
+            Time series to fit to.
         fh : guaranteed to be ForecastingHorizon
             The forecasting horizon with the steps ahead to to predict.
         X : sktime time series object, optional (default=None)
@@ -281,8 +282,7 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         Returns
         -------
         y_pred : sktime time series object
-            guaranteed to have a single column/variable
-            Point predictions
+            Point predictions. Has the same number of columns as y passed to fit.
 
         Notes
         -----
@@ -466,11 +466,13 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         # might not the same order
         # store the target column names and index names (probably [None])
         # will be renamed !
-        self._target_name = y.columns[-1]
+        self._target_names = y.columns.tolist()
+        self._n_targets = len(self._target_names)
+        self._target_name = self._target_names[-1]
         self._index_names = y.index.names
         self._index_len = len(self._index_names)
         # store X, y column names (probably None or not str type)
-        # The target column and the index will be renamed
+        # The target columns and the index will be renamed
         # before being passed to the underlying model
         # because those names could be None or non-string type.
         if X is not None:
@@ -486,14 +488,18 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         y.index.rename(rename_input, inplace=True)
         if X is not None:
             X.index.rename(rename_input, inplace=True)
-        # rename X, y columns names to make sure they are all str type
+        # rename X columns to make sure they are all str type
         if X is not None:
             self._new_X_columns = [
                 "_X_column_" + str(i) for i in range(len(self._X_columns))
             ]
             X.columns = self._new_X_columns
-        self._new_target_name = "_target_column"
-        y.columns = [self._new_target_name]
+        # rename target columns to safe internal names
+        self._new_target_names = [
+            "_target_column_" + str(i) for i in range(self._n_targets)
+        ]
+        self._new_target_name = self._new_target_names[-1]
+        y.columns = self._new_target_names
         # combine X and y
         if X is not None:
             # only numeric columns
@@ -504,9 +510,10 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         else:
             time_varying_known_reals = []
             data = deepcopy(y)
-        # if fh is not continuous, there will be NaN after extend_y in prediect
+        # if fh is not continuous, there will be NaN after extend_y in predict
         data = data.copy()
-        data["_target_column"] = data["_target_column"].fillna(0)
+        for col in self._new_target_names:
+            data[col] = data[col].fillna(0)
         # add integer time_idx column as pytorch-forecasting requires
         if self._index_len > 1:
             time_idx = (
@@ -534,18 +541,22 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
                 + ["_auto_time_idx"]
             )
         ][data["_auto_time_idx"] > training_cutoff]
-        # infer time_idx column, target column and instances from data
+        # for multivariate, pytorch-forecasting expects a list of target columns
+        target_param = (
+            self._new_target_names if self._n_targets > 1 else self._new_target_names[0]
+        )
+        # infer time_idx column, target column(s) and instances from data
         _dataset_params = {
             "data": data[data["_auto_time_idx"] <= training_cutoff],
             "time_idx": "_auto_time_idx",
-            "target": self._new_target_name,
+            "target": target_param,
             "group_ids": (
                 self._new_index_names[0:-1]
                 if self._index_len > 1
                 else ["_auto_group_id"]
             ),
             "time_varying_known_reals": time_varying_known_reals,
-            "time_varying_unknown_reals": [self._new_target_name],
+            "time_varying_unknown_reals": self._new_target_names,
         }
         _dataset_params.update(dataset_params)
         # overwrite max_prediction_length
@@ -558,7 +569,22 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
 
     def _predictions_to_dataframe(self, predictions, max_prediction_length, alpha=None):
         # output is the actual predictions points but without index
-        output = predictions.output.cpu().numpy()
+        # for multivariate, pytorch-forecasting returns a tuple of tensors (one per
+        # target), each shaped (n_series, horizon, out_size). For point forecasts
+        # out_size=1, for quantile forecasts it equals the number of quantiles.
+        raw_output = predictions.output
+        if isinstance(raw_output, (list, tuple)):
+            arrays = []
+            for t in raw_output:
+                arr = t.cpu().numpy()
+                if arr.ndim == 3 and arr.shape[-1] == 1:
+                    arr = arr[..., 0]
+                arrays.append(arr)
+            output = np.stack(arrays, axis=-1)
+        else:
+            output = raw_output.cpu().numpy()
+            if output.ndim == 2:
+                output = output[..., np.newaxis]
         # index will be combined with output
         index = predictions.index
         # in pytorch-forecasting predictions, the first index is the time_idx
@@ -609,28 +635,37 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         else:
             rename_input = self._index_names
         data.index.rename(rename_input, inplace=True)
-        # add the target column at the end
+
+        n_rows = output.shape[0] * max_prediction_length
+        n_targets = output.shape[2]
+
+        # add the target column(s) at the end
         if alpha is not None:
-            quantiles = output.reshape((-1, len(alpha)))
-            quantiles = pd.DataFrame(
-                data=quantiles,
-                index=data.index,
-            )
+            quantiles = output.reshape((n_rows, -1))
+            quantiles = pd.DataFrame(data=quantiles, index=data.index)
             data = pd.concat([data, quantiles], axis=1)
-            data.columns = [
-                [self._target_name if self._target_name is not None else 0]
-                * len(alpha),
-                alpha,
-            ]
-        else:
-            data[self._target_name] = output.flatten()
-        # # set target name back to original input in fit
-        # data.columns = [self._target_name]
-        # convert back to pd.series if needed
-        if self._convert_to_series and alpha is None:
-            data = pd.Series(
-                data=data[self._target_name], index=data.index, name=self._target_name
+            target_col = (
+                self._target_names[-1]
+                if self._target_names[-1] is not None
+                else 0
             )
+            data.columns = pd.MultiIndex.from_arrays(
+                [[target_col] * len(alpha), alpha]
+            )
+        else:
+            flat_output = output.reshape((n_rows, n_targets))
+            target_df = pd.DataFrame(
+                flat_output,
+                index=data.index,
+                columns=self._target_names,
+            )
+            data = pd.concat([data, target_df], axis=1)
+            if self._convert_to_series and n_targets == 1:
+                data = pd.Series(
+                    data=data[self._target_names[0]],
+                    index=data.index,
+                    name=self._target_names[0],
+                )
         return data
 
     def _dummy_X(self, X, y):

--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -118,7 +118,7 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
         "capability:global_forecasting": True,
         "capability:insample": False,
         "X-y-must-have-same-index": True,
-        "scitype:y": "univariate",
+        "scitype:y": "both",
         "capability:pred_int": True,
         # CI and test flags
         # -----------------
@@ -405,7 +405,7 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
         "capability:exogenous": False,
         "capability:insample": False,
         "X-y-must-have-same-index": True,
-        "scitype:y": "univariate",
+        "scitype:y": "both",
     }
 
     def __init__(
@@ -699,7 +699,7 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
         "capability:global_forecasting": True,
         "capability:insample": False,
         "X-y-must-have-same-index": True,
-        "scitype:y": "univariate",
+        "scitype:y": "both",
         "capability:pred_int": True,
     }
 
@@ -978,7 +978,7 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
         "capability:global_forecasting": True,
         "capability:insample": False,
         "X-y-must-have-same-index": True,
-        "scitype:y": "univariate",
+        "scitype:y": "both",
         "capability:pred_int": True,
     }
 

--- a/sktime/forecasting/tests/test_pytorchforecasting.py
+++ b/sktime/forecasting/tests/test_pytorchforecasting.py
@@ -109,3 +109,60 @@ def test_load_model_from_disk(model_class) -> None:
     index_pred = y_pred.iloc[:max_prediction_length].index.get_level_values(2)
     _assert_correct_pred_time_index(index_pred, cutoff, fh)
     _assert_correct_columns(y_pred, y_test)
+
+
+@pytest.mark.parametrize(
+    "model_class",
+    [
+        PytorchForecastingNHiTS,
+        PytorchForecastingTFT,
+    ],
+)
+@pytest.mark.skipif(
+    not run_test_for_class(
+        [
+            PytorchForecastingNHiTS,
+            PytorchForecastingTFT,
+        ]
+    ),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_multivariate_y(model_class) -> None:
+    """Test that models can fit and predict with multivariate y (multiple targets)."""
+    data_length = 60
+    data = _make_hierarchical(
+        (3, 20),
+        n_columns=3,
+        max_timepoints=data_length,
+        min_timepoints=data_length,
+    )
+    # use two columns as targets (multivariate y)
+    y = data[["c0", "c1"]]
+    X = data[["c2"]]
+
+    max_prediction_length = 3
+    fh = ForecastingHorizon(range(1, max_prediction_length + 1), is_relative=True)
+
+    len_levels = len(y.index.names)
+    y_train = y.groupby(level=list(range(len_levels - 1))).apply(
+        lambda x: x.droplevel(list(range(len_levels - 1))).iloc[:-max_prediction_length]
+    )
+    X_train = X.groupby(level=list(range(len_levels - 1))).apply(
+        lambda x: x.droplevel(list(range(len_levels - 1))).iloc[:-max_prediction_length]
+    )
+
+    params = model_class.get_test_params()[0]
+    model = model_class(**params)
+    model.fit(y=y_train, X=X_train, fh=fh)
+
+    y_pred = model.predict(fh=fh, X=X, y=y_train)
+
+    # predictions should have the same columns as y
+    assert list(y_pred.columns) == list(y.columns), (
+        f"Expected columns {list(y.columns)}, got {list(y_pred.columns)}"
+    )
+    # predictions should have the right number of rows
+    n_instances = y_train.index.droplevel(-1).nunique()
+    assert len(y_pred) == n_instances * max_prediction_length, (
+        f"Expected {n_instances * max_prediction_length} rows, got {len(y_pred)}"
+    )


### PR DESCRIPTION


#### Reference Issues/PRs

Fixes #8173

#### What does this implement/fix? Explain your changes.

The pytorch-forecasting adaptors only supported univariate targets. This adds multivariate target support (multiple y columns) to the base adapter.

Changes:
- `scitype:y` tag changed from `"univariate"` to `"both"` in the base adapter and all four model classes (TFT, NBeats, DeepAR, NHiTS)
- `_Xy_to_dataset`: stores all target column names, renames them to safe internal names, passes a list to pytorch-forecasting's `target=` param when there are multiple targets, and fills NaN for all target columns
- `_predictions_to_dataframe`: handles the tuple-of-tensors output that pytorch-forecasting returns for multivariate targets — squeezes the trailing dim per tensor before stacking into `(n_series, horizon, n_targets)`, then builds the output DataFrame with the original column names restored. Univariate behaviour is unchanged.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- The tensor unpacking logic in `_predictions_to_dataframe` — specifically how the tuple output from pytorch-forecasting is handled for point vs quantile forecasts
- Whether the `time_varying_unknown_reals` being set to all target column names is correct for all four model types
- NBeats and DeepAR are tagged `"both"` but not included in `test_multivariate_y` since NBeats doesn't natively support multiple targets and DeepAR has limitations — worth confirming if those should be excluded or handled separately

#### Did you add any tests for the change?

Yes, added `test_multivariate_y` in `sktime/forecasting/tests/test_pytorchforecasting.py`. It fits NHiTS and TFT on a two-column y, runs predict, and checks that the output columns match the input and the number of rows is correct.

#### Any other comments?

pytorch-forecasting isn't installed in the CI environment by default so the new test is gated behind the same `run_test_for_class` skip guard used by the existing tests.
#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.


