### PR TITLE
[ENH] migrate mvts_transformer classifier to new _base_torch interface

### DIFF
--- a/sktime/classification/deep_learning/mvts_transformer.py
+++ b/sktime/classification/deep_learning/mvts_transformer.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from sktime.classification.deep_learning._pytorch import BaseDeepClassifierPytorch
+from sktime.classification.deep_learning.base._base_torch import BaseDeepClassifierPytorch
 from sktime.utils.dependencies import _safe_import
 
 torch = _safe_import("torch")


### PR DESCRIPTION
Reference issues/PRs

Migration of mvts_transformer classifier to the new _base_torch interface.

What does this implement/fix?

This PR migrates the mvts_transformer classifier to use the updated
BaseDeepClassifierPytorch implementation located in
classification/deep_learning/base/_base_torch.py.

The change ensures:

1. Alignment with the new PyTorch base class structure
2. Compatibility with the updated deep learning infrastructure

No architectural changes were introduced to the MVTS Transformer network itself.
Only the base class interface import was updated.

Does this introduce a new dependency?

No new dependencies were introduced. The implementation continues to rely on
PyTorch, which is already declared as a soft dependency.

Tests

All classification tests pass locally:

pytest sktime/classification -n 1