### PR TITLE
[BUG] fix probabilistic forecasting for pytorch-forecasting estimators, re-enable tests

### DIFF
--- a/sktime/forecasting/base/adapters/_pytorchforecasting.py
+++ b/sktime/forecasting/base/adapters/_pytorchforecasting.py
@@ -346,27 +346,23 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         )
         return output.loc[dateindex]
 
-    def _predict_quantiles(self, fh, X, alpha, y=None):
-        """Compute/return prediction quantiles for a forecast.
+    def _predict_quantiles_inner(self, fh, X, alpha, y=None):
+        """Core logic for probabilistic quantile forecasting via pytorch-forecasting.
 
-        private _predict_quantiles containing the core logic,
-            called from predict_quantiles and default _predict_interval
+        Shared implementation used by subclasses that support quantile prediction.
+        Calls the underlying model with ``mode="quantiles"`` and maps the output
+        back to the sktime quantile DataFrame format.
 
         Parameters
         ----------
-        fh : guaranteed to be ForecastingHorizon
-            The forecasting horizon with the steps ahead to to predict.
-        X : optional (default=None)
-            guaranteed to be of a type in self.get_tag("X_inner_mtype")
-            Exogeneous time series to predict from.
-            If ``y`` is passed (performing global forecasting), ``X`` must contain
-            all historical values and the time points to be predicted.
-        alpha : list of float, optional (default=[0.5])
-            A list of probabilities at which quantile forecasts are computed.
-        y : time series in ``sktime`` compatible format, optional (default=None)
-            Historical values of the time series that should be predicted.
-            If not None, global forecasting will be performed.
-            Only pass the historical values not the time points to be predicted.
+        fh : ForecastingHorizon
+            The forecasting horizon.
+        X : pd.DataFrame or None
+            Exogeneous time series.
+        alpha : list of float
+            Quantile levels to predict, e.g. [0.1, 0.5, 0.9].
+        y : time series in sktime format, optional (default=None)
+            Historical values for global forecasting.
 
         Returns
         -------
@@ -374,25 +370,8 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
             Column has multi-index: first level is variable name from y in fit,
                 second level being the values of alpha passed to the function.
             Row index is fh, with additional (upper) levels equal to instance levels,
-                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
-            Entries are quantile forecasts, for var in col index,
-                at quantile probability in second col index, for the row index.
+                from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
         """
-        methods_list = [
-            method[0]
-            for method in inspect.getmembers(
-                self.best_model.loss, predicate=inspect.ismethod
-            )
-        ]
-        if "to_quantiles" not in methods_list:
-            raise NotImplementedError(
-                "To perform probabilistic forecast, QuantileLoss or other loss"
-                "metrics that support to_quantiles function has to be used in fit."
-                f"With {self.best_model.loss}, it doesn't support probabilistic"
-                "forecast. Details can be found:"
-                "https://pytorch-forecasting.readthedocs.io/en/stable/metrics.html"
-            )
-
         X, y = self._Xy_precheck(X, y)
         # convert series to frame
         _y, self._convert_to_series = _series_to_frame(y)
@@ -417,7 +396,7 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         predictions = self.best_model.predict(
             validation.to_dataloader(**self._validation_to_dataloader_params),
             mode="quantiles",
-            mode_kwargs={"use_metric": False, "quantiles": alpha},
+            mode_kwargs={"quantiles": alpha},
             return_x=True,
             return_index=True,
             return_decoder_lengths=True,
@@ -432,16 +411,71 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
                 torch.set_rng_state(torch_state)
         except AttributeError:
             pass
-        # convert pytorch-forecasting predictions to dataframe
+
+        loss = self.best_model.loss
+        loss_to_quantiles_sig = inspect.signature(loss.to_quantiles)
+        loss_accepts_quantiles_kwarg = "quantiles" in loss_to_quantiles_sig.parameters
+
+        if loss_accepts_quantiles_kwarg:
+            # Output already has the requested quantiles.
+            output_alpha = alpha
+        else:
+            # QuantileLoss path: output has all loss.quantiles, need to interpolate.
+            output_alpha = list(getattr(loss, "quantiles", alpha))
+
+        # convert pytorch-forecasting predictions to dataframe using output_alpha
         output = self._predictions_to_dataframe(
-            predictions, self._max_prediction_length, alpha=alpha
+            predictions, self._max_prediction_length, alpha=output_alpha
         )
 
         absolute_horizons = self.fh.to_absolute_index(self.cutoff)
         dateindex = output.index.get_level_values(-1).map(
             lambda x: x in absolute_horizons
         )
-        return output.loc[dateindex]
+        output = output.loc[dateindex]
+
+        if list(output_alpha) != list(alpha):
+            # Interpolate from loss quantiles to the requested alpha values.
+            output = self._interpolate_quantiles(output, output_alpha, alpha)
+
+        return output
+
+    def _interpolate_quantiles(self, df, source_alpha, target_alpha):
+        """Interpolate quantile forecasts from source_alpha to target_alpha.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Quantile forecast DataFrame with MultiIndex columns (var, source_alpha).
+        source_alpha : list of float
+            Quantile levels present in df.
+        target_alpha : list of float
+            Desired quantile levels.
+
+        Returns
+        -------
+        pd.DataFrame
+            Quantile forecasts at target_alpha levels.
+        """
+        var_names = df.columns.get_level_values(0).unique()
+        result_dict = {}
+        for var in var_names:
+            var_df = df[var]  # shape (n_rows, len(source_alpha))
+            interpolated = np.zeros((len(var_df), len(target_alpha)))
+            for i, row in enumerate(var_df.values):
+                interpolated[i] = np.interp(target_alpha, source_alpha, row)
+            result_dict[var] = interpolated
+
+        # rebuild MultiIndex columns
+        col_idx = pd.MultiIndex.from_product([var_names, target_alpha])
+        result = pd.DataFrame(
+            data=np.concatenate(
+                [result_dict[v] for v in var_names], axis=1
+            ),
+            index=df.index,
+            columns=col_idx,
+        )
+        return result
 
     def _Xy_precheck(self, X, y):
         if y is None:

--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -123,7 +123,6 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
-        "tests:skip_all": True,
     }
 
     def __init__(
@@ -174,6 +173,35 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
                     ": self.allowed_encoder_known_variable_names,
             }
         )
+
+    def _predict_quantiles(self, fh, X, alpha, y=None):
+        """Compute/return prediction quantiles for a forecast.
+
+        private _predict_quantiles containing the core logic,
+            called from predict_quantiles and default _predict_interval
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon
+            The forecasting horizon with the steps ahead to to predict.
+        X : optional (default=None)
+            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Exogeneous time series to predict from.
+        alpha : list of float
+            A list of probabilities at which quantile forecasts are computed.
+        y : time series in sktime compatible format, optional (default=None)
+            Historical values of the time series that should be predicted.
+            If not None, global forecasting will be performed.
+
+        Returns
+        -------
+        quantiles : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+                second level being the values of alpha passed to the function.
+            Row index is fh, with additional (upper) levels equal to instance levels,
+                from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+        """
+        return self._predict_quantiles_inner(fh=fh, X=X, alpha=alpha, y=y)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -447,28 +475,6 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
             keyword arguments for the underlying algorithm class
         """
         return {}
-
-    @classmethod
-    def _implementation_counts(cls) -> dict:
-        """Functions need at least n overrides to be counted as implemented.
-
-        A function needs to be specified only if n!=1.
-
-        Returns
-        -------
-        dict
-            key is function name, and the value is n.
-        """
-        implementation_counts = super()._implementation_counts()
-        implementation_counts.update(
-            {
-                "_predict_proba": 3,
-                "_predict_var": 3,
-                "_predict_interval": 3,
-                "_predict_quantiles": 3,
-            }
-        )
-        return implementation_counts
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -754,6 +760,35 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
             }
         )
 
+    def _predict_quantiles(self, fh, X, alpha, y=None):
+        """Compute/return prediction quantiles for a forecast.
+
+        private _predict_quantiles containing the core logic,
+            called from predict_quantiles and default _predict_interval
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon
+            The forecasting horizon with the steps ahead to to predict.
+        X : optional (default=None)
+            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Exogeneous time series to predict from.
+        alpha : list of float
+            A list of probabilities at which quantile forecasts are computed.
+        y : time series in sktime compatible format, optional (default=None)
+            Historical values of the time series that should be predicted.
+            If not None, global forecasting will be performed.
+
+        Returns
+        -------
+        quantiles : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+                second level being the values of alpha passed to the function.
+            Row index is fh, with additional (upper) levels equal to instance levels,
+                from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+        """
+        return self._predict_quantiles_inner(fh=fh, X=X, alpha=alpha, y=y)
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
@@ -1038,6 +1073,35 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
                 "pooling_sizes": [1] * stacks,
             }
         return {}
+
+    def _predict_quantiles(self, fh, X, alpha, y=None):
+        """Compute/return prediction quantiles for a forecast.
+
+        private _predict_quantiles containing the core logic,
+            called from predict_quantiles and default _predict_interval
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon
+            The forecasting horizon with the steps ahead to to predict.
+        X : optional (default=None)
+            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Exogeneous time series to predict from.
+        alpha : list of float
+            A list of probabilities at which quantile forecasts are computed.
+        y : time series in sktime compatible format, optional (default=None)
+            Historical values of the time series that should be predicted.
+            If not None, global forecasting will be performed.
+
+        Returns
+        -------
+        quantiles : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+                second level being the values of alpha passed to the function.
+            Row index is fh, with additional (upper) levels equal to instance levels,
+                from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+        """
+        return self._predict_quantiles_inner(fh=fh, X=X, alpha=alpha, y=y)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -59,10 +59,6 @@ EXCLUDE_ESTIMATORS = [
     "M5Dataset",
     # Test estimators
     "_TransformChangeNInstances",
-    # ptf global models fail the tests, see #7997
-    "PytorchForecastingNBeats",
-    "PytorchForecastingNHiTS",
-    "PytorchForecastingDeepAR",
     # STDBSCAN is not API compliant, see #7994
     "STDBSCAN",
     # Temporarily remove RRF from tests, while #7380 is not merged


### PR DESCRIPTION


#### Reference Issues/PRs

Fixes #7997

#### What does this implement/fix? Explain your changes.

`PytorchForecastingTFT`, `PytorchForecastingNHiTS`, and `PytorchForecastingDeepAR` were failing `test_predict_quantiles` and `test_predict_interval` due to two bugs in the adapter.

First, `_predict_quantiles` on the base adapter was calling `predict` with `mode_kwargs={"use_metric": False, "quantiles": alpha}`. With `use_metric=False`, pytorch-forecasting bypasses the loss's `to_quantiles` and returns raw output - for `QuantileLoss` (used by TFT and NHiTS) this is shape `(n, pred_len, 7)` regardless of how many quantiles were requested, so the subsequent reshape against `len(alpha)` would fail whenever the caller didn't happen to ask for exactly 7 quantiles.

Second, `NBeats` was inheriting `_predict_quantiles` from the base class, which made `_has_implementation_of("_predict_quantiles")` return `True`, conflicting with its `capability:pred_int=False` tag and causing `test_pred_int_tag` to fail. There was a dead `_implementation_counts` override trying to work around this, but the mechanism it relied on had been removed.

The fix moves the shared quantile logic into `_predict_quantiles_inner` on the base (not a real sktime override, so NBeats doesn't inherit it). TFT, NHiTS, and DeepAR each get their own `_predict_quantiles` that delegates to it. The call now uses `mode_kwargs={"quantiles": alpha}` without `use_metric=False`. For losses like `QuantileLoss` that ignore the `quantiles` kwarg and return all their fixed levels, we detect this via `inspect.signature` and interpolate to the requested alpha using `np.interp`. For distribution-based losses like `NormalDistributionLoss` (DeepAR default) that do accept the kwarg, the output is used directly. The dead `_implementation_counts` override on NBeats is removed.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

The `inspect.signature` check to distinguish `QuantileLoss` from distribution-based losses - worth confirming this holds for any other loss types in pytorch-forecasting that someone might pass in. Also the `np.interp` interpolation is linear; if there's a preference for a different interpolation method that's worth discussing.

#### Did you add any tests for the change?

No new tests added. The existing `test_predict_quantiles`, `test_predict_interval`, and `test_pred_int_tag` tests in `test_all_forecasters.py` cover this - they were the ones failing before and pass now. The temporary skips for these estimators in `_config.py` are also removed as part of this PR.

#### Any other comments?

The tests were skipped in #7998 pending a fix. This is that fix.

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

