### PR TITLE
[BUG] Fix MeanSquaredError.evaluate_by_index returning wrong values for RMSE

### DIFF
--- a/sktime/performance_metrics/forecasting/_mse.py
+++ b/sktime/performance_metrics/forecasting/_mse.py
@@ -222,7 +222,7 @@ class MeanSquaredError(BaseForecastingErrorMetric):
 
         pseudo_values = self._get_weighted_df(pseudo_values, **kwargs)
 
-        return self._handle_multioutput(raw_values, multioutput)
+        return self._handle_multioutput(pseudo_values, multioutput)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
## Reference Issues/PRs
Fixes #9302

## What does this implement/fix? Explain your changes.
This PR fixes a bug in the `MeanSquaredError.evaluate_by_index()` method where it incorrectly returns squared errors instead of jackknife pseudo-values when `square_root=True` (RMSE mode).

The bug was on line 225 of `_mse.py` where the method returned `raw_values` instead of `pseudo_values`. When `square_root=True`, the method correctly calculates jackknife pseudo-values for RMSE but then returns the wrong variable.

**Changes:**
- Changed line 225 from `return self._handle_multioutput(raw_values, multioutput)` to `return self._handle_multioutput(pseudo_values, multioutput)`

**Why this matters:**
- The documentation states that when `square_root=True`, `evaluate_by_index()` should return "the jackknife pseudo-value of the RMSE at that time index"
- Without this fix, users analyzing time-point-specific RMSE contributions get mathematically incorrect results
- The mean of `evaluate_by_index()` results doesn't equal the `evaluate()` result for RMSE

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies.

#### What should a reviewer concentrate their feedback on?
- Verify the fix is minimal and correct (only one line changed)
- Confirm the fix aligns with the documented behavior
- Check that existing tests still pass

#### Did you add any tests for the change?
Not yet in this PR. I wanted to keep the fix minimal for initial review. However, I can add tests in a follow-up commit if desired. The bug can be verified with the reproduction code in the issue #9302.

#### Any other comments?
This is a focused fix for a specific bug. Additional improvements (handling edge cases, fixing weighting inconsistencies) can be addressed in separate PRs to keep changes manageable.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
  **PR Title:** [BUG] Fix MeanSquaredError.evaluate_by_index returning wrong values for RMSE