### PR TITLE
[DOC] Fix typo in SFAFast docstring: "feature selectiona" → "feature selection"

### DIFF
--- a/sktime/transformations/panel/dictionary_based/_sfa_fast.py
+++ b/sktime/transformations/panel/dictionary_based/_sfa_fast.py
@@ -74,7 +74,7 @@ class SFAFast(BaseTransformer):
     feature_selection: {"chi2", "none", "random"}, default: chi2
         Sets the feature selections strategy to be used. Chi2 reduces the number
         of words significantly and is thus much faster (preferred). Random also
-        reduces the number significantly. None applies not feature selectiona and
+        reduces the number significantly. None applies not feature selection and
         yields large bag of words, e.g. much memory may be needed.
 
     p_threshold:  int, default=0.05 (disabled by default)


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #9583

#### What does this implement/fix? Explain your changes.
Fixed a typo in the SFAFast estimator docstring where "feature selectiona" appeared instead of "feature selection" in the parameter description on line 77.

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies introduced.

#### What should a reviewer concentrate their feedback on?
This is a simple typo fix, so minimal review needed. Just verify that the typo correction is accurate.

#### Did you add any tests for the change?
No tests needed for a documentation typo fix.

#### Any other comments?
This is a minor documentation fix to improve code quality and readability.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->