### PR TITLE
[BUG] Fix probabilistic GroupbyCategoryForecaster binding and ArrowHead loader index

### DIFF
--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -293,7 +293,7 @@ def _load_provided_dataset(
             abspath, return_data_type="nested_univ", y_dtype=y_dtype
         )
 
-        X = pd.concat([X_train, X_test])
+        X = pd.concat([X_train, X_test], ignore_index=True)
         X = X.reset_index(drop=True)
         y = np.concatenate([y_train, y_test])
 

--- a/sktime/datasets/tests/test_datadownload.py
+++ b/sktime/datasets/tests/test_datadownload.py
@@ -18,9 +18,11 @@ from sktime.datasets.tsf_dataset_names import tsf_all, tsf_all_datasets
 from sktime.datatypes import check_is_mtype, check_raise
 from sktime.utils.dependencies import _check_soft_dependencies
 
-# test tsf download only on a random uniform subsample of datasets
+# test tsf download only on a subsample of datasets
+# use a deterministic subsample to keep test collection identical across
+# pytest-xdist workers
 N_TSF_SUBSAMPLE = 3
-TSF_SUBSAMPLE = np.random.choice(tsf_all_datasets, N_TSF_SUBSAMPLE)
+TSF_SUBSAMPLE = sorted(tsf_all_datasets)[:N_TSF_SUBSAMPLE]
 TSF_SUBSAMPLE_SMALL = [
     "wind_4_seconds_dataset",
     "m4_hourly_dataset",

--- a/sktime/datasets/tests/test_single_problem_loaders.py
+++ b/sktime/datasets/tests/test_single_problem_loaders.py
@@ -73,3 +73,12 @@ def test_load_numpy2d_multivariate_raises(loader):
     """Test that multivariate and/or unequal length raise the correct error."""
     with pytest.raises(ValueError, match="attempting to load into a numpy2d"):
         X, y = loader(return_type="numpy2d")
+
+
+def test_arrow_head_index_unique():
+    """ArrowHead combined train+test loader should return a unique index."""
+    from sktime.datasets import load_arrow_head
+
+    X, y = load_arrow_head(return_X_y=True)
+
+    assert X.index.is_unique

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -1,6 +1,8 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements compositors for performing forecasting by group."""
 
+from types import MethodType
+
 import pandas as pd
 
 from sktime.base._meta import _HeterogenousMetaEstimator
@@ -322,10 +324,12 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
 
         # Finally, dynamically adding implementation of probabilistic
         # functions depending on the tags set.
+        # Use MethodType to bind the module-level functions as proper
+        # instance methods, so that `self` is passed correctly.
         if self.get_tags()["capability:pred_int"]:
-            self._predict_interval = _predict_interval
-            self._predict_var = _predict_var
-            self._predict_proba = _predict_proba
+            self._predict_interval = MethodType(_predict_interval, self)
+            self._predict_var = MethodType(_predict_var, self)
+            self._predict_proba = MethodType(_predict_proba, self)
 
     @property
     def _steps(self):

--- a/sktime/forecasting/compose/tests/test_groupbycategoryforecaster.py
+++ b/sktime/forecasting/compose/tests/test_groupbycategoryforecaster.py
@@ -65,6 +65,21 @@ def timeseries(timeseries_index):
     )
 
 
+class _DummyProbabilisticForecaster(NaiveForecaster):
+    """Naive forecaster that advertises probabilistic capability.
+
+    This class is used only for testing descriptor binding in
+    GroupbyCategoryForecaster. It sets the relevant capability tags but does not
+    rely on skpro distributions, so we can focus the test on method binding.
+    """
+
+    _tags = {
+        **NaiveForecaster._tags,
+        "capability:pred_int": True,
+        "capability:pred_int:insample": True,
+    }
+
+
 def test_predefined_output(timeseries):
     transform_output = pd.Series(["A"])
     transformer = PredefinedCategory(transform_output=transform_output)
@@ -116,3 +131,72 @@ def test_series_without_panel_level():
     y_pred = forecaster.predict(X=X, fh=[1, 2, 3])
 
     assert y_pred.index.nlevels == 1
+
+
+def test_groupby_category_probabilistic_binding():
+    """Probabilistic methods are bound correctly on GroupbyCategoryForecaster.
+
+    This specifically verifies that the dynamically attached private methods
+    `_predict_interval`, `_predict_var`, and `_predict_proba` are bound methods
+    (i.e., receive `self` correctly) and delegate to
+    `_iterate_predict_method_over_categories` with the expected arguments.
+    """
+    # construct a minimal but probabilistic-capable groupby forecaster
+    dummy = _DummyProbabilisticForecaster()
+    categories = pd.Series([0, 1], index=[("A", "A1"), ("B", "B1")], name="category")
+    transformer = PredefinedCategory(transform_output=categories)
+
+    gf = GroupbyCategoryForecaster(
+        forecasters={0: dummy, 1: dummy.clone()},
+        transformer=transformer,
+    )
+
+    # Sanity-check that the probabilistic capability tag is set, which is the
+    # precondition for dynamic binding.
+    assert gf.get_tags()["capability:pred_int"] is True
+
+    captured_calls = []
+
+    def fake_iter(self, methodname, X=None, **kwargs):
+        captured_calls.append(
+            {
+                "self": self,
+                "methodname": methodname,
+                "X": X,
+                "kwargs": kwargs,
+            }
+        )
+        return "ok"
+
+    # Bind the fake iterator as an instance method
+    gf._iterate_predict_method_over_categories = fake_iter.__get__(
+        gf, GroupbyCategoryForecaster
+    )
+
+    # Call the dynamically attached private probabilistic helpers.
+    # If these were raw, unbound functions in the instance dict, each of these
+    # calls would raise a TypeError due to missing `self`.
+    result_interval = gf._predict_interval(fh="fh_int", X="X_int", coverage=[0.8, 0.9])
+    result_var = gf._predict_var(fh="fh_var", X="X_var", cov=True)
+    result_proba = gf._predict_proba(fh="fh_proba", X="X_proba", marginal=False)
+
+    assert result_interval == "ok"
+    assert result_var == "ok"
+    assert result_proba == "ok"
+
+    # Verify that the fake iterator saw the correct `self` and arguments
+    assert len(captured_calls) == 3
+    for call in captured_calls:
+        assert call["self"] is gf
+
+    assert captured_calls[0]["methodname"] == "predict_interval"
+    assert captured_calls[0]["X"] == "X_int"
+    assert captured_calls[0]["kwargs"] == {"fh": "fh_int", "coverage": [0.8, 0.9]}
+
+    assert captured_calls[1]["methodname"] == "predict_var"
+    assert captured_calls[1]["X"] == "X_var"
+    assert captured_calls[1]["kwargs"] == {"fh": "fh_var", "cov": True}
+
+    assert captured_calls[2]["methodname"] == "predict_proba"
+    assert captured_calls[2]["X"] == "X_proba"
+    assert captured_calls[2]["kwargs"] == {"fh": "fh_proba", "marginal": False}


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #9553.

#### What does this implement/fix? Explain your changes.

- Fixes a descriptor binding bug in `GroupbyCategoryForecaster` where probabilistic methods (`_predict_proba`, `_predict_interval`, `_predict_var`) were attached as raw functions on the instance, causing `TypeError: ... missing 1 required positional argument: 'self'` when `predict_proba` (or related methods) were called.
  - Uses `types.MethodType` in `GroupbyCategoryForecaster.__init__` to bind the module-level helper functions as proper bound methods whenever `capability:pred_int` is set.
  - Adds a focused unit test (`test_groupby_category_probabilistic_binding`) that validates the private probabilistic helpers delegate correctly to `_iterate_predict_method_over_categories` and receive `self` as expected, without depending on skpro distribution concatenation.
- Fixes the ArrowHead dataset loader index when combining TRAIN and TEST splits:
  - Changes `pd.concat([X_train, X_test])` to `pd.concat([X_train, X_test], ignore_index=True)` in `_data_io.py`, ensuring a unique, clean index for the combined dataset.
  - Adds `test_arrow_head_index_unique` in `test_single_problem_loaders.py` to assert that `load_arrow_head(return_X_y=True)` returns a `DataFrame` with a unique index.
- Stabilizes `test_datadownload.py` under `pytest-xdist`:
  - Replaces the non-deterministic `np.random.choice(tsf_all_datasets, N_TSF_SUBSAMPLE)` with a deterministic subset `sorted(tsf_all_datasets)[:N_TSF_SUBSAMPLE]` so that all workers collect the same parametrized tests and xdist no longer reports “Different tests were collected between gwX and gwY”.

#### Does your contribution introduce a new dependency? If yes, which one?

No. The changes only use `types.MethodType` from the Python standard library and modify existing tests and dataset utilities.

#### What should a reviewer concentrate their feedback on?

- Correctness and robustness of the `GroupbyCategoryForecaster` probabilistic method binding:
  - The use of `MethodType` and the conditions around `capability:pred_int`.
  - The new test’s approach of intercepting `_iterate_predict_method_over_categories` to validate delegation while avoiding external distribution-concat behavior.
- Dataset-related changes:
  - The ArrowHead loader’s use of `ignore_index=True` and whether this matches expected API/semantics for other UCR/UEA loaders.
  - The new ArrowHead index test and its alignment with how similar loaders are tested.
- xdist stability of `test_datadownload.py`:
  - Whether the deterministic sub-sampling of `tsf_all_datasets` is acceptable from a coverage/performance perspective.

#### Did you add any tests for the change?

Yes:

- `sktime/forecasting/compose/tests/test_groupbycategoryforecaster.py`
  - `test_groupby_category_probabilistic_binding` (new): verifies that `_predict_interval`, `_predict_var`, and `_predict_proba` are bound methods and correctly delegate to `_iterate_predict_method_over_categories` with the expected arguments.
- `sktime/datasets/tests/test_single_problem_loaders.py`
  - `test_arrow_head_index_unique` (new): checks that `load_arrow_head(return_X_y=True)` returns a `DataFrame` with a unique index.
- Existing datasets tests were also run to confirm no regressions:
  - `python -m pytest sktime/forecasting/compose/tests/test_groupbycategoryforecaster.py sktime/datasets/tests/test_single_problem_loaders.py -q`
  - `python -m pytest sktime/datasets/tests -q`

#### Any other comments?

- The probabilistic binding fix is intentionally minimal and focused on the descriptor/`self` issue; it does not attempt to change distribution concatenation behavior, which is expected to be handled in skpro and/or follow-up work.
- Download-heavy `datadownload` tests are relatively slow, but they now pass reliably under the default xdist configuration used in the repo.

#### PR checklist

- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. Here: `[BUG]`.