### PR TITLE
[DOC] Improve clarity of time series definition in get_started.rst

### DIFF
--- a/docs/source/get_started.rst
+++ b/docs/source/get_started.rst
@@ -27,7 +27,7 @@ Therefore, a key set of common concepts and terminology is important.
 Data Types
 ~~~~~~~~~~
 
-``sktime`` is designed for time series machine learning. Time series data refers to data where the variables are ordered over time or
+``sktime`` is designed for time series machine learning. Time series data refers to data in which the variables are ordered over time or
 an index indicating the position of an observation in the sequence of values.
 
 In ``sktime`` time series data can refer to data that is univariate, multivariate or panel, with the difference relating to the number and interrelation


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR improves the wording of the time series data definition in `get_started.rst` to make the explanation clearer and easier to understand for new users. The change refines the sentence structure while keeping the original meaning intact, improving readability of the documentation.

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies were introduced.

#### What should a reviewer concentrate their feedback on?

Please review the wording change in the time series definition to ensure that the revised sentence accurately reflects the intended meaning and aligns with the existing documentation style.

#### Did you add any tests for the change?

No tests were added because this change only affects documentation.

#### Any other comments?

Thank you for maintaining the project and reviewing this contribution.