### PR TITLE
[MNT] reduce duplication in skforecast adapters

### DIFF
--- a/sktime/forecasting/compose/_skforecast_reduce.py
+++ b/sktime/forecasting/compose/_skforecast_reduce.py
@@ -11,7 +11,186 @@ from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
 __author__ = ["Abhay-Lejith", "yarnabrina"]
 
 
-class SkforecastAutoreg(BaseForecaster):
+class _SkforecastAdapter(BaseForecaster):
+    """Shared private base for skforecast adapters."""
+
+    @staticmethod
+    def _coerce_column_names(X: pd.DataFrame | None):
+        if X is None:
+            return None
+
+        return X.rename(columns=lambda column_name: str(column_name))
+
+    @staticmethod
+    def _coerce_int_to_range_index(df):
+        new_df = df.copy(deep=True)
+        start = new_df.index[0]
+        stop = new_df.index[-1] + 1
+        if len(new_df.index) == 1:
+            step = 1
+        else:
+            step = new_df.index[1] - start
+
+        new_index = pd.RangeIndex(start, stop, step)
+        # testing if RangeIndex is matching the original integer Index.
+        # this will fail if indices are not equally spaced apart.
+        # exception is caught in _make_index_compatible.
+        np.testing.assert_array_equal(new_df.index, new_index)
+        # assigning RangeIndex to the new DataFrame
+        new_df.index = new_index
+        return new_df
+
+    @staticmethod
+    def _coerce_period_to_datetime_index(df):
+        new_df = df.copy(deep=True)
+        period_freq = new_df.index.freq
+        # converting the period index to the timestamp at the 'end' of the period
+        # Example:        Period                   Datetime
+        #          '2024-01-12 00:00' --> '2024-01-12 00:59:59.999999999'
+        #          '2024-01-12 01:00' --> '2024-01-12 01:59:59.999999999'
+        new_df.index = new_df.index.to_timestamp(how="e")
+        new_df.index.freq = period_freq
+        return new_df
+
+    def _make_index_compatible(self, df, input_var):
+        if df is None:
+            return None
+
+        if isinstance(df.index, (pd.RangeIndex, pd.DatetimeIndex)):
+            return df
+
+        if isinstance(df.index, pd.PeriodIndex):
+            new_df = self._coerce_period_to_datetime_index(df)
+        elif pd.api.types.is_integer_dtype(df.index):
+            try:
+                new_df = self._coerce_int_to_range_index(df)
+            except AssertionError:
+                raise ValueError(
+                    f"Coercion of index of {input_var} from integer pd.Index to "
+                    "pd.RangeIndex failed. Please ensure that indexes are equally "
+                    "spaced apart."
+                )
+        else:
+            raise ValueError(
+                f"{input_var} must have one of the following index types: "
+                "pd.RangeIndex, pd.DatetimeIndex, pd.PeriodIndex, pd.Index"
+                f"(int dtype). Found index of type: {type(df.index)}"
+            )
+        return new_df
+
+    def _get_fit_store_in_sample_residuals(self):
+        """Value to pass as ``store_in_sample_residuals`` in ``fit``, if needed."""
+        return None
+
+    def _get_predict_quantiles_kwargs(self):
+        """Extra kwargs for ``predict_quantiles``."""
+        return {}
+
+    def _fit(
+        self,
+        y: pd.Series,
+        X: pd.DataFrame | None,
+        fh: ForecastingHorizon | None,
+    ):
+        """Fit forecaster to training data."""
+        del fh  # avoid being detected as unused by ``vulture`` like tools
+
+        self._forecaster = self._create_forecaster()
+
+        # skforecast does not support PeriodIndex and Integer Index.
+        # So converting to supported index types here if necessary.
+        y_new = self._make_index_compatible(y, "y")
+        X_new = self._make_index_compatible(X, "X")
+
+        store_in_sample_residuals = self._get_fit_store_in_sample_residuals()
+        if store_in_sample_residuals is None:
+            self._forecaster.fit(y_new, exog=self._coerce_column_names(X_new))
+        else:
+            self._forecaster.fit(
+                y_new,
+                exog=self._coerce_column_names(X_new),
+                store_in_sample_residuals=store_in_sample_residuals,
+            )
+
+        return self
+
+    def _get_horizon_details(self, fh: ForecastingHorizon | None):
+        if not fh.is_all_out_of_sample(self.cutoff):
+            raise NotImplementedError(
+                f"{self.__class__.__name__} does not support in-sample predictions."
+            )
+
+        out_of_sample_horizon = fh.to_out_of_sample(self.cutoff)
+        maximum_forecast_horizon = out_of_sample_horizon.to_relative(self.cutoff)[-1]
+
+        absolute_horizons = out_of_sample_horizon.to_absolute_index(self.cutoff)
+        horizon_positions = out_of_sample_horizon.to_indexer(self.cutoff)
+
+        return maximum_forecast_horizon, absolute_horizons, horizon_positions
+
+    def _predict(
+        self,
+        fh: ForecastingHorizon | None,
+        X: pd.DataFrame | None,
+    ):
+        """Forecast time series at future horizon."""
+        (
+            maximum_forecast_horizon,
+            absolute_horizons,
+            horizon_positions,
+        ) = self._get_horizon_details(fh)
+
+        X_new = self._make_index_compatible(X, "X")
+
+        point_predictions = self._forecaster.predict(
+            maximum_forecast_horizon, exog=self._coerce_column_names(X_new)
+        ).to_numpy()
+        final_point_predictions = pd.Series(
+            point_predictions[horizon_positions],
+            index=absolute_horizons,
+            name=None if self._y.name is None else str(self._y.name),
+        )
+
+        return final_point_predictions
+
+    def _predict_quantiles(
+        self,
+        fh: ForecastingHorizon | None,
+        X: pd.DataFrame | None,
+        alpha: list[float],
+    ):
+        """Compute/return prediction quantiles for a forecast."""
+        (
+            maximum_forecast_horizon,
+            absolute_horizons,
+            horizon_positions,
+        ) = self._get_horizon_details(fh)
+
+        var_names = self._get_varnames()
+        var_name = var_names[0]
+
+        quantile_predictions_indices = pd.MultiIndex.from_product([var_names, alpha])
+        quantile_predictions = pd.DataFrame(
+            index=absolute_horizons, columns=quantile_predictions_indices
+        )
+
+        X_new = self._make_index_compatible(X, "X")
+
+        quantile_pred = self._forecaster.predict_quantiles(
+            maximum_forecast_horizon,
+            exog=self._coerce_column_names(X_new),
+            quantiles=alpha,
+            **self._get_predict_quantiles_kwargs(),
+        )
+
+        for quantile in alpha:
+            quantile_predictions[(var_name, quantile)] = (
+                quantile_pred[f"q_{quantile}"].iloc[horizon_positions].to_list()
+            )
+        return quantile_predictions
+
+
+class SkforecastAutoreg(_SkforecastAdapter):
     """Adapter for ``skforecast.ForecasterAutoreg.ForecasterAutoreg`` class [1]_.
 
     Parameters
@@ -190,237 +369,6 @@ class SkforecastAutoreg(BaseForecaster):
             binner_kwargs=self.binner_kwargs,
         )
 
-    @staticmethod
-    def _coerce_column_names(X: pd.DataFrame | None):
-        if X is None:
-            return None
-
-        return X.rename(columns=lambda column_name: str(column_name))
-
-    @staticmethod
-    def _coerce_int_to_range_index(df):
-        new_df = df.copy(deep=True)
-        start = new_df.index[0]
-        stop = new_df.index[-1] + 1
-        if len(new_df.index) == 1:
-            step = 1
-        else:
-            step = new_df.index[1] - start
-
-        new_index = pd.RangeIndex(start, stop, step)
-        # testing if RangeIndex is matching the original integer Index.
-        # this will fail if indices are not equally spaced apart.
-        # exception is caught in _make_index_compatible.
-        np.testing.assert_array_equal(new_df.index, new_index)
-        # assigning RangeIndex to the new DataFrame
-        new_df.index = new_index
-        return new_df
-
-    @staticmethod
-    def _coerce_period_to_datetime_index(df):
-        new_df = df.copy(deep=True)
-        period_freq = new_df.index.freq
-        # converting the period index to the timestamp at the 'end' of the period
-        # Example:        Period                   Datetime
-        #          '2024-01-12 00:00' --> '2024-01-12 00:59:59.999999999'
-        #          '2024-01-12 01:00' --> '2024-01-12 01:59:59.999999999'
-        new_df.index = new_df.index.to_timestamp(how="e")
-        new_df.index.freq = period_freq
-        return new_df
-
-    def _make_index_compatible(self, df, input_var):
-        if df is None:
-            return None
-
-        if isinstance(df.index, (pd.RangeIndex, pd.DatetimeIndex)):
-            return df
-
-        if isinstance(df.index, pd.PeriodIndex):
-            new_df = self._coerce_period_to_datetime_index(df)
-        elif pd.api.types.is_integer_dtype(df.index):
-            try:
-                new_df = self._coerce_int_to_range_index(df)
-            except AssertionError:
-                raise ValueError(
-                    f"Coercion of index of {input_var} from integer pd.Index to "
-                    "pd.RangeIndex failed. Please ensure that indexes are equally "
-                    "spaced apart."
-                )
-        else:
-            raise ValueError(
-                f"{input_var} must have one of the following index types: "
-                "pd.RangeIndex, pd.DatetimeIndex, pd.PeriodIndex, pd.Index"
-                f"(int dtype). Found index of type: {type(df.index)}"
-            )
-        return new_df
-
-    def _fit(
-        self: "SkforecastAutoreg",
-        y: pd.Series,
-        X: pd.DataFrame | None,
-        fh: ForecastingHorizon | None,
-    ):
-        """Fit forecaster to training data.
-
-        private _fit containing the core logic, called from fit
-
-        Writes to self:
-            Sets fitted model attributes ending in "_".
-
-        Parameters
-        ----------
-        y : pd.Series
-            Target time series to which to fit the forecaster.
-        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
-            The forecasting horizon with the steps ahead to to predict.
-            Required (non-optional) here.
-        X : pd.DataFrame, optional (default=None)
-            Exogeneous time series to fit to.
-
-        Returns
-        -------
-        self : reference to self
-        """
-        del fh  # avoid being detected as unused by ``vulture`` like tools
-
-        self._forecaster = self._create_forecaster()
-
-        # skforecast does not support PeriodIndex and Integer Index.
-        # So converting to supported index types here if necessary.
-        y_new = self._make_index_compatible(y, "y")
-        X_new = self._make_index_compatible(X, "X")
-
-        self._forecaster.fit(y_new, exog=self._coerce_column_names(X_new))
-
-        return self
-
-    def _get_horizon_details(self: "SkforecastAutoreg", fh: ForecastingHorizon | None):
-        if not fh.is_all_out_of_sample(self.cutoff):
-            raise NotImplementedError(
-                f"{self.__class__.__name__} does not support in-sample predictions."
-            )
-
-        out_of_sample_horizon = fh.to_out_of_sample(self.cutoff)
-        maximum_forecast_horizon = out_of_sample_horizon.to_relative(self.cutoff)[-1]
-
-        absolute_horizons = out_of_sample_horizon.to_absolute_index(self.cutoff)
-        horizon_positions = out_of_sample_horizon.to_indexer(self.cutoff)
-
-        return maximum_forecast_horizon, absolute_horizons, horizon_positions
-
-    def _predict(
-        self: "SkforecastAutoreg",
-        fh: ForecastingHorizon | None,
-        X: pd.DataFrame | None,
-    ):
-        """Forecast time series at future horizon.
-
-        private _predict containing the core logic, called from predict
-
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-            Fitted model attributes ending in "_"
-            self.cutoff
-
-        Parameters
-        ----------
-        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
-            The forecasting horizon with the steps ahead to to predict.
-        X : pd.DataFrame, optional (default=None)
-            Exogenous time series
-
-        Returns
-        -------
-        y_pred : pd.DataFrame
-            Point predictions
-        """
-        (
-            maximum_forecast_horizon,
-            absolute_horizons,
-            horizon_positions,
-        ) = self._get_horizon_details(fh)
-
-        X_new = self._make_index_compatible(X, "X")
-
-        point_predictions = self._forecaster.predict(
-            maximum_forecast_horizon, exog=self._coerce_column_names(X_new)
-        ).to_numpy()
-        final_point_predictions = pd.Series(
-            point_predictions[horizon_positions],
-            index=absolute_horizons,
-            name=None if self._y.name is None else str(self._y.name),
-        )
-
-        return final_point_predictions
-
-    def _predict_quantiles(
-        self: "SkforecastAutoreg",
-        fh: ForecastingHorizon | None,
-        X: pd.DataFrame | None,
-        alpha: list[float],
-    ):
-        """Compute/return prediction quantiles for a forecast.
-
-        private _predict_quantiles containing the core logic,
-            called from predict_quantiles and possibly predict_interval
-
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-            Fitted model attributes ending in "_"
-            self.cutoff
-
-        Parameters
-        ----------
-        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
-            The forecasting horizon with the steps ahead to to predict.
-        X :  sktime time series object, optional (default=None)
-            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
-            Exogeneous time series for the forecast
-        alpha : list of float (guaranteed not None and floats in [0,1] interval)
-            A list of probabilities at which quantile forecasts are computed.
-
-        Returns
-        -------
-        quantiles : pd.DataFrame
-            Column has multi-index: first level is variable name from y in fit,
-                second level being the values of alpha passed to the function.
-            Row index is fh, with additional (upper) levels equal to instance levels,
-                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
-            Entries are quantile forecasts, for var in col index,
-                at quantile probability in second col index, for the row index.
-        """
-        (
-            maximum_forecast_horizon,
-            absolute_horizons,
-            horizon_positions,
-        ) = self._get_horizon_details(fh)
-
-        var_names = self._get_varnames()
-        var_name = var_names[0]
-
-        quantile_predictions_indices = pd.MultiIndex.from_product([var_names, alpha])
-        quantile_predictions = pd.DataFrame(
-            index=absolute_horizons, columns=quantile_predictions_indices
-        )
-
-        X_new = self._make_index_compatible(X, "X")
-
-        quantile_pred = self._forecaster.predict_quantiles(
-            maximum_forecast_horizon,
-            exog=self._coerce_column_names(X_new),
-            quantiles=alpha,
-        )
-
-        for quantile in alpha:
-            quantile_predictions[(var_name, quantile)] = (
-                quantile_pred[f"q_{quantile}"].iloc[horizon_positions].to_list()
-            )
-        return quantile_predictions
-
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
@@ -460,7 +408,7 @@ class SkforecastAutoreg(BaseForecaster):
         return [param1, param2]
 
 
-class SkforecastRecursive(BaseForecaster):
+class SkforecastRecursive(_SkforecastAdapter):
     """Adapter for ``skforecast.recursive.ForecasterRecursive`` class [1]_.
 
     This class turns any regressor compatible with the scikit-learn API into a recursive
@@ -662,242 +610,8 @@ class SkforecastRecursive(BaseForecaster):
             binner_kwargs=self.binner_kwargs,
         )
 
-    @staticmethod
-    def _coerce_column_names(X: pd.DataFrame | None):
-        if X is None:
-            return None
-
-        return X.rename(columns=lambda column_name: str(column_name))
-
-    @staticmethod
-    def _coerce_int_to_range_index(df):
-        new_df = df.copy(deep=True)
-        start = new_df.index[0]
-        stop = new_df.index[-1] + 1
-        if len(new_df.index) == 1:
-            step = 1
-        else:
-            step = new_df.index[1] - start
-
-        new_index = pd.RangeIndex(start, stop, step)
-        # testing if RangeIndex is matching the original integer Index.
-        # this will fail if indices are not equally spaced apart.
-        # exception is caught in _make_index_compatible.
-        np.testing.assert_array_equal(new_df.index, new_index)
-        # assigning RangeIndex to the new DataFrame
-        new_df.index = new_index
-        return new_df
-
-    @staticmethod
-    def _coerce_period_to_datetime_index(df):
-        new_df = df.copy(deep=True)
-        period_freq = new_df.index.freq
-        # converting the period index to the timestamp at the 'end' of the period
-        # Example:        Period                   Datetime
-        #          '2024-01-12 00:00' --> '2024-01-12 00:59:59.999999999'
-        #          '2024-01-12 01:00' --> '2024-01-12 01:59:59.999999999'
-        new_df.index = new_df.index.to_timestamp(how="e")
-        new_df.index.freq = period_freq
-        return new_df
-
-    def _make_index_compatible(self, df, input_var):
-        if df is None:
-            return None
-
-        if isinstance(df.index, (pd.RangeIndex, pd.DatetimeIndex)):
-            return df
-
-        if isinstance(df.index, pd.PeriodIndex):
-            new_df = self._coerce_period_to_datetime_index(df)
-        elif pd.api.types.is_integer_dtype(df.index):
-            try:
-                new_df = self._coerce_int_to_range_index(df)
-            except AssertionError:
-                raise ValueError(
-                    f"Coercion of index of {input_var} from integer pd.Index to "
-                    "pd.RangeIndex failed. Please ensure that indexes are equally "
-                    "spaced apart."
-                )
-        else:
-            raise ValueError(
-                f"{input_var} must have one of the following index types: "
-                "pd.RangeIndex, pd.DatetimeIndex, pd.PeriodIndex, pd.Index"
-                f"(int dtype). Found index of type: {type(df.index)}"
-            )
-        return new_df
-
-    def _fit(
-        self: "SkforecastRecursive",
-        y: pd.Series,
-        X: pd.DataFrame | None,
-        fh: ForecastingHorizon | None,
-    ):
-        """Fit forecaster to training data.
-
-        private _fit containing the core logic, called from fit
-
-        Writes to self:
-            Sets fitted model attributes ending in "_".
-
-        Parameters
-        ----------
-        y : pd.Series
-            Target time series to which to fit the forecaster.
-        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
-            The forecasting horizon with the steps ahead to to predict.
-            Required (non-optional) here.
-        X : pd.DataFrame, optional (default=None)
-            Exogeneous time series to fit to.
-
-        Returns
-        -------
-        self : reference to self
-        """
-        del fh  # avoid being detected as unused by ``vulture`` like tools
-
-        self._forecaster = self._create_forecaster()
-
-        # skforecast does not support PeriodIndex and Integer Index.
-        # So converting to supported index types here if necessary.
-        y_new = self._make_index_compatible(y, "y")
-        X_new = self._make_index_compatible(X, "X")
-
-        self._forecaster.fit(
-            y_new,
-            exog=self._coerce_column_names(X_new),
-            store_in_sample_residuals=self.store_in_sample_residuals,
-        )
-
-        return self
-
-    def _get_horizon_details(
-        self: "SkforecastRecursive", fh: ForecastingHorizon | None
-    ):
-        if not fh.is_all_out_of_sample(self.cutoff):
-            raise NotImplementedError(
-                f"{self.__class__.__name__} does not support in-sample predictions."
-            )
-
-        out_of_sample_horizon = fh.to_out_of_sample(self.cutoff)
-        maximum_forecast_horizon = out_of_sample_horizon.to_relative(self.cutoff)[-1]
-
-        absolute_horizons = out_of_sample_horizon.to_absolute_index(self.cutoff)
-        horizon_positions = out_of_sample_horizon.to_indexer(self.cutoff)
-
-        return maximum_forecast_horizon, absolute_horizons, horizon_positions
-
-    def _predict(
-        self: "SkforecastRecursive",
-        fh: ForecastingHorizon | None,
-        X: pd.DataFrame | None,
-    ):
-        """Forecast time series at future horizon.
-
-        private _predict containing the core logic, called from predict
-
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-            Fitted model attributes ending in "_"
-            self.cutoff
-
-        Parameters
-        ----------
-        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
-            The forecasting horizon with the steps ahead to to predict.
-        X : pd.DataFrame, optional (default=None)
-            Exogenous time series
-
-        Returns
-        -------
-        y_pred : pd.DataFrame
-            Point predictions
-        """
-        (
-            maximum_forecast_horizon,
-            absolute_horizons,
-            horizon_positions,
-        ) = self._get_horizon_details(fh)
-
-        X_new = self._make_index_compatible(X, "X")
-
-        point_predictions = self._forecaster.predict(
-            maximum_forecast_horizon, exog=self._coerce_column_names(X_new)
-        ).to_numpy()
-        final_point_predictions = pd.Series(
-            point_predictions[horizon_positions],
-            index=absolute_horizons,
-            name=None if self._y.name is None else str(self._y.name),
-        )
-
-        return final_point_predictions
-
-    def _predict_quantiles(
-        self: "SkforecastRecursive",
-        fh: ForecastingHorizon | None,
-        X: pd.DataFrame | None,
-        alpha: list[float],
-    ):
-        """Compute/return prediction quantiles for a forecast.
-
-        private _predict_quantiles containing the core logic,
-            called from predict_quantiles and possibly predict_interval
-
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-            Fitted model attributes ending in "_"
-            self.cutoff
-
-        Parameters
-        ----------
-        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
-            The forecasting horizon with the steps ahead to to predict.
-        X :  sktime time series object, optional (default=None)
-            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
-            Exogeneous time series for the forecast
-        alpha : list of float (guaranteed not None and floats in [0,1] interval)
-            A list of probabilities at which quantile forecasts are computed.
-
-        Returns
-        -------
-        quantiles : pd.DataFrame
-            Column has multi-index: first level is variable name from y in fit,
-                second level being the values of alpha passed to the function.
-            Row index is fh, with additional (upper) levels equal to instance levels,
-                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
-            Entries are quantile forecasts, for var in col index,
-                at quantile probability in second col index, for the row index.
-        """
-        (
-            maximum_forecast_horizon,
-            absolute_horizons,
-            horizon_positions,
-        ) = self._get_horizon_details(fh)
-
-        var_names = self._get_varnames()
-        var_name = var_names[0]
-
-        quantile_predictions_indices = pd.MultiIndex.from_product([var_names, alpha])
-        quantile_predictions = pd.DataFrame(
-            index=absolute_horizons, columns=quantile_predictions_indices
-        )
-
-        X_new = self._make_index_compatible(X, "X")
-
-        quantile_pred = self._forecaster.predict_quantiles(
-            maximum_forecast_horizon,
-            exog=self._coerce_column_names(X_new),
-            quantiles=alpha,
-        )
-
-        for quantile in alpha:
-            quantile_predictions[(var_name, quantile)] = (
-                quantile_pred[f"q_{quantile}"].iloc[horizon_positions].to_list()
-            )
-        return quantile_predictions
+    def _get_fit_store_in_sample_residuals(self):
+        return self.store_in_sample_residuals
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #7451.

#### What does this implement/fix? Explain your changes.
This PR now focuses on reducing duplication between `SkforecastAutoreg` and `SkforecastRecursive` in `sktime/forecasting/compose/_skforecast_reduce.py`.

Context:
- `SkforecastAutoreg` is already intentionally scoped to `skforecast<0.14`.
- `SkforecastRecursive` already covers the modern `skforecast>=0.14` interface.

So instead of migrating `SkforecastAutoreg` to the recursive backend, this change implements the future-scope refactor discussed in #7451:
- Introduce a private shared base class `_SkforecastAdapter` with common adapter logic.
- Move shared index coercion, fit/predict, horizon handling, and quantile scaffolding into that base.
- Keep `SkforecastAutoreg` and `SkforecastRecursive` as public estimators with their existing version contracts and class-specific forecaster construction.
- Keep recursive-specific residual storage behavior via class-specific hook (`store_in_sample_residuals`).

Net effect:
- Significant internal de-duplication.
- No intended change to public behavior or dependency boundaries of either estimator.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Whether extraction of shared logic into `_SkforecastAdapter` preserves behavior for both concrete estimators.
- Whether class-specific hooks (`_get_fit_store_in_sample_residuals`) are a clear and maintainable split point.
- Whether this refactor is aligned with the future scope described in #7451.

#### Did you add any tests for the change?
No new tests were added.
Existing skforecast adapter tests were run to validate behavior preservation.

Local checks run:
- `python -m ruff check sktime/forecasting/compose/_skforecast_reduce.py sktime/forecasting/compose/tests/test_skforecast_reduce.py`
- `python -m pytest sktime/forecasting/compose/tests/test_skforecast_reduce.py -q -n 0`
- `python -m pytest sktime/forecasting/compose/tests -q -n 0 -k skforecast`

#### Any other comments?
None.

#### PR checklist
##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned.
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] Not applicable.
