### PR TITLE
[BUG] Fix user-defined context and prediction lengths in NHiTS adapter

### DIFF
--- a/sktime/forecasting/base/adapters/_pytorchforecasting.py
+++ b/sktime/forecasting/base/adapters/_pytorchforecasting.py
@@ -15,6 +15,7 @@ import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
 from sktime.forecasting.base import ForecastingHorizon, _BaseGlobalForecaster
+from sktime.utils.validation import is_int
 
 __all__ = ["_PytorchForecastingAdapter"]
 __author__ = ["XinyuWu"]
@@ -30,7 +31,10 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         for example: {"lstm_layers": 3, "hidden_continuous_size": 10} for TFT model
     dataset_params : Dict[str, Any] (default=None)
         parameters to initialize `TimeSeriesDataSet` [1]_ from `pandas.DataFrame`
-        max_prediction_length will be overwrite according to fh
+        By default, `max_prediction_length` is inferred from `fh` passed to ``fit``.
+        If `max_prediction_length` is explicitly passed here (or
+        `prediction_length` is passed via `model_params`), it is used instead and
+        must be at least as large as the maximum step in `fh`.
         time_idx, target, group_ids, time_varying_known_reals, time_varying_unknown_reals
         will be inferred from data, so you do not have to pass them
     train_to_dataloader_params : Dict[str, Any] (default=None)
@@ -173,6 +177,64 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         random_log_dir = os.getcwd() + "/lightning_logs/" + str(abs(random_num))
         return random_log_dir
 
+    @staticmethod
+    def _coerce_positive_int(value: Any, param_name: str) -> int:
+        """Cast input to positive integer."""
+        if not is_int(value):
+            raise TypeError(
+                f"`{param_name}` must be a positive integer, but found {value!r}."
+            )
+
+        value_int = int(value)
+
+        if value_int < 1:
+            raise ValueError(
+                f"`{param_name}` must be a positive integer, but found {value!r}."
+            )
+
+        return value_int
+
+    def _resolve_prediction_length(self, fh: ForecastingHorizon) -> int:
+        """Resolve prediction length used to build pytorch-forecasting datasets."""
+        fh_max_prediction_length = self._coerce_positive_int(
+            np.max(fh.to_relative(self.cutoff)), "maximum step in `fh`"
+        )
+
+        if "max_prediction_length" in self._dataset_params:
+            model_prediction_length = self._coerce_positive_int(
+                self._dataset_params["max_prediction_length"],
+                "dataset_params['max_prediction_length']",
+            )
+        elif "prediction_length" in self._model_params:
+            model_prediction_length = self._coerce_positive_int(
+                self._model_params["prediction_length"],
+                "model_params['prediction_length']",
+            )
+        else:
+            model_prediction_length = fh_max_prediction_length
+
+        if fh_max_prediction_length > model_prediction_length:
+            raise ValueError(
+                "The maximum step in `fh` must be less than or equal to the model "
+                "prediction length, but found "
+                f"{fh_max_prediction_length} > {model_prediction_length}. "
+                "Set a larger `model_params['prediction_length']` or "
+                "`dataset_params['max_prediction_length']`."
+            )
+
+        return model_prediction_length
+
+    def _sync_context_length_with_dataset_params(self):
+        """Map model context_length to dataset max_encoder_length if not set."""
+        if "max_encoder_length" in self._dataset_params:
+            return
+
+        if "context_length" in self._model_params:
+            self._dataset_params["max_encoder_length"] = self._coerce_positive_int(
+                self._model_params["context_length"],
+                "model_params['context_length']",
+            )
+
     def _fit(
         self: "_PytorchForecastingAdapter",
         y: pd.DataFrame,
@@ -201,13 +263,15 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         self : _PytorchForecastingAdapter
             reference to self
         """
-        self._max_prediction_length = np.max(fh.to_relative(self.cutoff))
         if not fh.is_all_out_of_sample(self.cutoff):
             raise NotImplementedError(
                 f"No in sample predict support, but found fh with in sample index: {fh}"
             )
+        self._sync_context_length_with_dataset_params()
+        self._max_prediction_length = self._resolve_prediction_length(fh)
         # check if dummy X is needed
-        # only the TFT model need X to fit, probably a bug in pytorch-forecasting
+        # only the TFT model needs X to fit, probably due to a bug in
+        # pytorch-forecasting
         X = self._dummy_X(X, y)
         # convert series to frame
         _y, self._convert_to_series = _series_to_frame(y)

--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -22,7 +22,10 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
         for example: {"lstm_layers": 3, "hidden_continuous_size": 10}
     dataset_params : dict[str, Any] (default=None)
         parameters to initialize `TimeSeriesDataSet` [2]_ from `pandas.DataFrame`
-        max_prediction_length will be overwrite according to fh
+        By default, `max_prediction_length` is inferred from `fh` passed to ``fit``.
+        If explicitly set in `dataset_params` (or via
+        `model_params['prediction_length']`), it must be at least as large
+        as the maximum step in `fh`.
         time_idx, target, group_ids, time_varying_known_reals, time_varying_unknown_reals
         will be inferred from data, so you do not have to pass them
     train_to_dataloader_params : dict[str, Any] (default=None)
@@ -310,7 +313,10 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
         for example: {"num_blocks": [5, 5], "widths": [128, 1024]}
     dataset_params : dict[str, Any] (default=None)
         parameters to initialize `TimeSeriesDataSet` [2]_ from `pandas.DataFrame`
-        max_prediction_length will be overwrite according to fh
+        By default, `max_prediction_length` is inferred from `fh` passed to ``fit``.
+        If explicitly set in `dataset_params` (or via
+        `model_params['prediction_length']`), it must be at least as large
+        as the maximum step in `fh`.
         time_idx, target, group_ids, time_varying_known_reals, time_varying_unknown_reals
         will be inferred from data, so you do not have to pass them
     train_to_dataloader_params : dict[str, Any] (default=None)
@@ -601,7 +607,10 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
         for example: {"cell_type": "GRU", "rnn_layers": 3}
     dataset_params : dict[str, Any] (default=None)
         parameters to initialize `TimeSeriesDataSet` [2]_ from `pandas.DataFrame`
-        max_prediction_length will be overwrite according to fh
+        By default, `max_prediction_length` is inferred from `fh` passed to ``fit``.
+        If explicitly set in `dataset_params` (or via
+        `model_params['prediction_length']`), it must be at least as large
+        as the maximum step in `fh`.
         time_idx, target, group_ids, time_varying_known_reals, time_varying_unknown_reals
         will be inferred from data, so you do not have to pass them
     train_to_dataloader_params : dict[str, Any] (default=None)
@@ -882,7 +891,10 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
         for example: {"interpolation_mode": "nearest", "activation": "Tanh"}
     dataset_params : dict[str, Any] (default=None)
         parameters to initialize `TimeSeriesDataSet` [2]_ from `pandas.DataFrame`
-        max_prediction_length will be overwrite according to fh
+        By default, `max_prediction_length` is inferred from `fh` passed to ``fit``.
+        If explicitly set in `dataset_params` (or via
+        `model_params['prediction_length']`), it must be at least as large
+        as the maximum step in `fh`.
         time_idx, target, group_ids, time_varying_known_reals, time_varying_unknown_reals
         will be inferred from data, so you do not have to pass them
     train_to_dataloader_params : dict[str, Any] (default=None)

--- a/sktime/forecasting/tests/test_pytorchforecasting.py
+++ b/sktime/forecasting/tests/test_pytorchforecasting.py
@@ -109,3 +109,131 @@ def test_load_model_from_disk(model_class) -> None:
     index_pred = y_pred.iloc[:max_prediction_length].index.get_level_values(2)
     _assert_correct_pred_time_index(index_pred, cutoff, fh)
     _assert_correct_columns(y_pred, y_test)
+
+
+def _make_train_test_data(data_length=80):
+    """Create hierarchical train/test data for pytorch-forecasting adapter tests."""
+    data = _make_hierarchical(
+        (2, 20),
+        n_columns=2,
+        max_timepoints=data_length,
+        min_timepoints=data_length,
+    )
+    x = data["c0"].to_frame()
+    y = data["c1"].to_frame()
+    X_train, _, y_train, _ = train_test_split(
+        x, y, test_size=0.1, train_size=0.9, shuffle=False
+    )
+    _, X_test, _, y_test = train_test_split(
+        x, y, test_size=0.2, train_size=0.8, shuffle=False
+    )
+    return X_train, X_test, y_train, y_test
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(PytorchForecastingNHiTS),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_nhits_uses_model_length_params_when_fh_is_shorter():
+    """Test that NHiTS preserves model context/prediction length from model_params."""
+    X_train, X_test, y_train, y_test = _make_train_test_data()
+    fh_max = 3
+    fh = ForecastingHorizon(range(1, fh_max + 1), is_relative=True)
+
+    len_levels = len(y_test.index.names)
+    y_test = y_test.groupby(level=list(range(len_levels - 1))).apply(
+        lambda x: x.droplevel(list(range(len_levels - 1))).iloc[:-fh_max]
+    )
+
+    model = PytorchForecastingNHiTS(
+        model_params={
+            "context_length": 10,
+            "prediction_length": 6,
+            "hidden_size": 4,
+            "n_blocks": [1, 1],
+            "n_layers": 1,
+            "log_interval": -1,
+        },
+        trainer_params={
+            "max_epochs": 1,
+            "limit_train_batches": 2,
+            "enable_checkpointing": False,
+            "logger": False,
+        },
+        train_to_dataloader_params={"batch_size": 2},
+    )
+
+    model.fit(y_train, X_train, fh=fh)
+    y_pred = model.predict(fh=fh, X=X_test, y=y_test)
+
+    assert model._forecaster.hparams.context_length == 10
+    assert model._forecaster.hparams.prediction_length == 6
+    assert model._forecaster.hparams.hidden_size == 4
+
+    cutoff = get_cutoff(y_test, return_index=True)
+    index_pred = y_pred.iloc[:fh_max].index.get_level_values(2)
+    _assert_correct_pred_time_index(index_pred, cutoff, fh)
+    _assert_correct_columns(y_pred, y_test)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(PytorchForecastingNHiTS),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_nhits_raises_if_fh_exceeds_configured_prediction_length():
+    """Test that fh cannot exceed a fixed model prediction length."""
+    X_train, _, y_train, _ = _make_train_test_data()
+    fh = ForecastingHorizon(range(1, 4), is_relative=True)
+    model = PytorchForecastingNHiTS(
+        model_params={
+            "prediction_length": 2,
+            "hidden_size": 4,
+            "n_blocks": [1, 1],
+            "n_layers": 1,
+            "log_interval": -1,
+        },
+        trainer_params={
+            "max_epochs": 1,
+            "limit_train_batches": 1,
+            "enable_checkpointing": False,
+            "logger": False,
+        },
+        train_to_dataloader_params={"batch_size": 2},
+    )
+
+    with pytest.raises(ValueError, match="maximum step in `fh`.*less than or equal to"):
+        model.fit(y_train, X_train, fh=fh)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(PytorchForecastingNHiTS),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_nhits_refit_can_increase_prediction_length_if_not_fixed():
+    """Test that inferred prediction_length tracks fh across refits."""
+    X_train, _, y_train, _ = _make_train_test_data()
+
+    model = PytorchForecastingNHiTS(
+        model_params={
+            "hidden_size": 4,
+            "n_blocks": [1, 1],
+            "n_layers": 1,
+            "log_interval": -1,
+        },
+        trainer_params={
+            "max_epochs": 1,
+            "limit_train_batches": 1,
+            "enable_checkpointing": False,
+            "logger": False,
+        },
+        train_to_dataloader_params={"batch_size": 2},
+    )
+
+    fh_short = ForecastingHorizon(range(1, 3), is_relative=True)
+    fh_long = ForecastingHorizon(range(1, 5), is_relative=True)
+
+    model.fit(y_train, X_train, fh=fh_short)
+    assert model._forecaster.hparams.prediction_length == 2
+
+    model.fit(y_train, X_train, fh=fh_long)
+    assert model._forecaster.hparams.prediction_length == 4


### PR DESCRIPTION
### LLM generated content, by GPT-5.4

#### Reference Issues/PRs
Fixes #8477.

#### What does this implement/fix? Explain your changes.
This PR fixes the handling of user-defined `context_length` and `prediction_length` in the NHiTS pytorch-forecasting adapter.

The change ensures that explicitly provided values are respected instead of being overridden or inferred incorrectly in the adapter setup.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Whether the adapter now consistently respects user-provided `context_length` and `prediction_length`
- Whether the change is aligned with existing pytorch-forecasting adapter behavior
- Whether the regression tests cover the relevant failure modes

#### Did you add any tests for the change?
Yes. I added coverage in `sktime/forecasting/tests/test_pytorchforecasting.py`.

Testing performed:
- Installed CPU-only `torch`, `lightning`, and `pytorch-forecasting` in a local test environment
- Ran `python -m pytest sktime/forecasting/tests/test_pytorchforecasting.py -q -rs`
- The pytest run still skips these tests because `PytorchForecastingNHiTS` is currently listed in `EXCLUDE_ESTIMATORS`
- Manually executed the three NHiTS-specific regression tests, and they all passed:
  - `test_nhits_uses_model_length_params_when_fh_is_shorter`
  - `test_nhits_raises_if_fh_exceeds_configured_prediction_length`
  - `test_nhits_refit_can_increase_prediction_length_if_not_fixed`

#### Any other comments?
No.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] Not applicable
- [ ] Not applicable
- [ ] Not applicable
