### PR TITLE
[DOC] refine PanelGluontsPandas mtype docstring

### DIFF
--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -1405,34 +1405,48 @@ class PanelGluontsList(ScitypePanel):
 
 
 class PanelGluontsPandas(ScitypePanel):
-    """Data type: polars.DataFrame based specification of panel of time series.
+    """Data type: gluonts PandasDataset specification of panel of time series.
+
+    Name: ``"gluonts_PandasDataset_panel"``
+
+    Short description:
+
+    A ``gluonts.dataset.pandas.PandasDataset`` object interpreted as a panel,
+    where each item corresponds to one time series instance and is backed by
+    a pandas ``DataFrame`` indexed by time.
+
+    Long description:
+
+    The ``"gluonts_PandasDataset_panel"`` :term:`mtype` is a concrete
+    specification that implements the ``Panel`` :term:`scitype`, i.e., a
+    collection of time series.
 
     Parameters
     ----------
     is_univariate: bool
-        True iff table has one variable
+        True iff table has one variable.
     is_equally_spaced : bool
-        True iff series index is equally spaced
+        True iff each series index is equally spaced.
     is_equal_length: bool
-        True iff all series in panel are of equal length
+        True iff all series in panel are of equal length.
     is_empty: bool
-        True iff table has no variables or no instances
+        True iff table has no variables or no instances.
     is_one_series: bool
-        True iff there is only one series in the panel of time series
+        True iff there is only one series in the panel of time series.
     has_nans: bool
-        True iff the table contains NaN values
+        True iff the table contains NaN values.
     n_instances: int
-        number of instances in the panel of time series
+        Number of instances in the panel of time series.
     n_features: int
-        number of variables in table
+        Number of variables in table.
     feature_names: list of int or object
-        names of variables in table
+        Names of variables in table.
     dtypekind_dfip: list of DtypeKind enum
-        list of DtypeKind enum values for each feature in the panel,
-        following the data frame interface protocol
+        List of DtypeKind enum values for each feature in the panel,
+        following the data frame interface protocol.
     feature_kind: list of str
-        list of feature kind strings for each feature in the panel,
-        coerced to FLOAT or CATEGORICAL type
+        List of feature kind strings for each feature in the panel,
+        coerced to FLOAT or CATEGORICAL type.
     """
 
     _tags = {


### PR DESCRIPTION
#### Reference Issues/PRs
Refs #7386.

#### What does this implement/fix? Explain your changes.
This updates the `PanelGluontsPandas` mtype docstring in `sktime/datatypes/_panel/_check.py`.

The previous text incorrectly described this class as a polars-based panel format. This PR rewrites the docstring to correctly describe the GluonTS `PandasDataset`-based panel representation and keeps the parameter/metadata descriptions aligned with the checker behavior.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Accuracy of the `PanelGluontsPandas` format description.
- Consistency between the docstring and `_tags` metadata for this class.

#### Did you add any tests for the change?
No new tests were added (documentation-only change).

Local checks run:
- `python -m ruff check sktime/datatypes/_panel/_check.py`
- `python -m pytest sktime/datatypes/tests/test_lookup.py -q -n 0`

#### Any other comments?
This is one focused item under #7386 (one format per PR).

#### PR checklist
##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned.
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] Not applicable.
