### PR TITLE
[BUG] Fix MS (MonthStart) frequency coercion in ForecastingHorizon

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -411,11 +411,11 @@ class ForecastingHorizon:
                     f"Current: {freq_from_self}, from update: {freq_from_obj}."
                 )
         elif freq_from_obj is not None:  # only freq_from_obj is not None
-            if freq_from_obj == "ME":
+            if freq_from_obj in ("ME", "MS"):
                 freq_from_obj = "M"
             self._freq = freq_from_obj
         else:
-            if freq_from_obj == "ME":
+            if freq_from_obj in ("ME", "MS"):
                 freq_from_obj = "M"
             # leave self._freq as freq_from_self, or set to None if does not exist yet
             self._freq = freq_from_self

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -1071,3 +1071,33 @@ def test_timestamp_format_to_absolute():
     fh = ForecastingHorizon([1, 2, 3], freq="D")
     y_pred_idx = fh.to_absolute_index(cutoff)
     assert "12:00:00" in str(y_pred_idx)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("pandas>=2.1.0", severity="none"),
+    reason="MS frequency requires pandas>=2.1.0",
+)
+def test_ms_frequency_coercion():
+    """Test that MS (MonthStart) frequency is coerced to M for period conversion.
+
+    Failure case in bug #7610.
+    """
+    # Create data with MS (MonthStart) frequency
+    y = pd.Series(
+        [1, 2, 3, 4, 5],
+        index=pd.date_range("2020-01-01", periods=5, freq="MS"),
+    )
+
+    # Create ForecastingHorizon and set freq from MS index
+    fh = ForecastingHorizon([1, 2, 3])
+    fh.freq = y.index
+
+    # The freq should be stored as "M" (not "MS") to work with to_period()
+    # This is because pandas Period does not support "MS" frequency
+    assert fh.freq == "M", f"Expected 'M' but got '{fh.freq}'"
+
+    # Verify to_absolute works (this would fail without the fix)
+    cutoff = y.index[[-1]]
+    cutoff.freq = y.index.freq
+    fh_absolute = fh.to_absolute(cutoff)
+    assert len(fh_absolute) == 3


### PR DESCRIPTION
## Reference Issues/PRs
Closes #7610
Related to #6057 (original ME frequency fix)

## What does this implement/fix?

This PR fixes a bug where the `MS` (MonthStart) frequency string was not being coerced to `"M"` in the `ForecastingHorizon.freq` setter, causing a `ValueError` when using pandas 2.2.x with MonthStart frequency data.

### Root Cause
In `sktime/forecasting/base/_fh.py`, the `freq` setter (lines 414-419) handled `"ME"` (MonthEnd) → `"M"` conversion but didn't handle `"MS"` (MonthStart) → `"M"`. This caused `to_period()` to fail with:
```
ValueError: <MonthBegin> is not supported as period frequency
```

### Fix
Extended the existing frequency coercion to also handle `"MS"`:
```python
# Before (only handles ME):
if freq_from_obj == "ME":
    freq_from_obj = "M"

# After (handles both ME and MS):
if freq_from_obj in ("ME", "MS"):
    freq_from_obj = "M"
```

## Changes
- **`sktime/forecasting/base/_fh.py`**: Add `"MS"` to the frequency coercion check alongside `"ME"` (2 locations in the `freq` setter)
- **`sktime/forecasting/base/tests/test_fh.py`**: Add regression test `test_ms_frequency_coercion()` for the MS frequency coercion

## Testing
- The fix follows the same pattern as the existing `"ME"` → `"M"` coercion added in PR #6057
- Added regression test that:
  1. Creates data with MS frequency
  2. Sets the frequency on a ForecastingHorizon
  3. Verifies the freq is stored as "M"
  4. Verifies `to_absolute()` works correctly

## Does your contribution introduce a new dependency?
No

## PR checklist
- [x] PR title starts with `[BUG]` (bug fix)
- [x] Tests added for the fix
- [x] Code passes `ruff check` and `ruff format`
- [x] Follows existing code patterns from #6057
