### PR TITLE
[BUG] Fix plot_series KeyError when plotting interval of multivariate time series

### DIFF
--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -238,15 +238,16 @@ def plot_interval(ax, interval_df):
 
     import seaborn as sns
 
-    var_name = interval_df.columns.levels[0][0]
+    var_name = interval_df.columns.get_level_values(0)[0]
 
-    n = len(interval_df.columns.levels[1])
+    coverages = interval_df.columns.get_level_values(1).unique()
+    n = len(coverages)
     if n == 1:
         colors = [ax.get_lines()[-1].get_c()]
     else:
         colors = sns.color_palette("colorblind", n_colors=n)
 
-    for i, cov in enumerate(interval_df.columns.levels[1]):
+    for i, cov in enumerate(coverages):
         ax.fill_between(
             interval_df.index,
             interval_df[var_name][cov]["lower"].astype("float64").to_numpy(),


### PR DESCRIPTION
## Reference Issues/PRs
Fixes #9523

## What does this implement/fix? Explain your changes.

This PR fixes a `KeyError` in `plot_series` when plotting prediction intervals of multivariate time series after subsetting the DataFrame.

### Root Cause
The bug occurs in `plot_interval()` because `pd.DataFrame.columns.levels` retains ALL original level values after subsetting (it keeps a "pool" of all possible values), not just the values present in the sliced DataFrame.

Example demonstrating the issue:
```python
# Full interval has ['x1', 'x2', 'x3']
# After slicing: y_pred_interval[['x3']]
subset.columns.levels[0][0]           # Returns 'x1' (WRONG - from pool)
subset.columns.get_level_values(0)[0] # Returns 'x3' (CORRECT - actual value)
```

### Fix
Changed `plot_interval()` to use `get_level_values()` instead of `levels[]` to get the actual values present in the subset:

- **Line 241**: `get_level_values(0)[0]` instead of `levels[0][0]` for `var_name`
- **Line 243-244**: `get_level_values(1).unique()` for coverages
- **Line 248**: Iterate over `coverages` instead of `levels[1]`

## Does your contribution introduce a new dependency? If yes, which one?
No

## Any other comments?
Tested with multiple edge cases:
- Subset to first/middle/last variable
- Multiple coverage levels (0.9 and 0.95)
- Single variable with single coverage
- Full dataframe (no subsetting)
