### PR TITLE
[DOC] Fix broken rendering of transformer return type table in fit_transform docstring

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -697,14 +697,32 @@ class BaseTransformer(BaseEstimator):
         Returns
         -------
         transformed version of X
+        
         type depends on type of X and scitype:transform-output tag:
-            |   `X`    | `tf-output`  |     type of return     |
-            |----------|--------------|------------------------|
-            | `Series` | `Primitives` | `pd.DataFrame` (1-row) |
-            | `Panel`  | `Primitives` | `pd.DataFrame`         |
-            | `Series` | `Series`     | `Series`               |
-            | `Panel`  | `Series`     | `Panel`                |
-            | `Series` | `Panel`      | `Panel`                |
+        
+        .. list-table::
+           :widths: 35 35 40
+           :header-rows: 1
+        
+           * - X
+             - tf-output
+             - type of return
+           * - Series
+             - Primitives
+             - pd.DataFrame (1-row)
+           * - Panel
+             - Primitives
+             - pd.DataFrame
+           * - Series
+             - Series
+             - Series
+           * - Panel
+             - Series
+             - Panel
+           * - Series
+             - Panel
+             - Panel
+             
         instances in return correspond to instances in `X`
         combinations not in the table are currently not supported
 


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

### Reference Issues/PRs
Fixes #2453

---

### What does this implement/fix? Explain your changes.

This PR fixes the broken rendering of the input/output type table in the `fit_transform` docstring located in `sktime/transformations/base.py`.

Previously, the relationship between `X`, `tf-output`, and the returned type was described using an ASCII-style table inside the docstring. This format does not render correctly in Sphinx-generated documentation, causing the table to appear as plain text instead of a structured table.

To resolve this issue, the ASCII table has been replaced with a properly formatted reStructuredText `list-table` directive. This ensures the table renders correctly in the documentation (ReadTheDocs and API reference pages) and improves readability.

This change only affects documentation formatting and does not modify any functionality.

---

### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies are introduced.

---

### What should a reviewer concentrate their feedback on?

- Correct rendering of the `list-table` directive in the documentation.
- Proper indentation and formatting of the reStructuredText inside the docstring.
- Ensuring that the updated table correctly reflects the original return type mappings.

---

### Did you add any tests for the change?

No tests were added since this change only affects documentation formatting and does not change runtime behavior.

---

### Any other comments?

No comments

---

## PR checklist

### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

### For new estimators
- [ ] I've added the estimator to the API reference.
- [ ] I've added illustrative usage examples to the docstring.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag.