### PR TITLE
[BUG] fix NaiveForecaster.predict_var returning NaN when cov=True

### DIFF
--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -599,9 +599,8 @@ class NaiveForecaster(_BaseWindowForecaster):
         fh_idx = fh.to_absolute_index(self.cutoff)
         if cov:
             fh_size = len(fh)
-            cov_matrix = np.fill_diagonal(
-                np.zeros(shape=(fh_size, fh_size)), marginal_vars
-            )
+            cov_matrix = np.zeros(shape=(fh_size, fh_size))
+            np.fill_diagonal(cov_matrix, marginal_vars)
             pred_var = pd.DataFrame(cov_matrix, columns=fh_idx, index=fh_idx)
         else:
             pred_var = pd.DataFrame(marginal_vars, index=fh_idx)


### PR DESCRIPTION
# [BUG] fix NaiveForecaster.predict_var returning NaN when cov=True

## Reference Issues/PRs

Fixes #9634

## What does this implement/fix? Explain your changes.

`NaiveForecaster._predict_var()` returns a DataFrame full of `NaN` when called with `cov=True`.
The issue is that `np.fill_diagonal()` modifies the array in-place and returns `None`, but the current code assigns its return value:

### Before (broken)

```python
cov_matrix = np.fill_diagonal(
    np.zeros(shape=(fh_size, fh_size)), marginal_vars
)
# cov_matrix is None here
```
This means `pd.DataFrame(None, columns=fh_idx, index=fh_idx)` creates an all-NaN DataFrame.
<img width="434" height="258" alt="Screenshot from 2026-03-12 19-42-46" src="https://github.com/user-attachments/assets/b8ce136d-d93a-473f-a58b-ff9c41ec0d05" />

### After (fixed)

```python
cov_matrix = np.zeros(shape=(fh_size, fh_size))
np.fill_diagonal(cov_matrix, marginal_vars)
```
<img width="492" height="258" alt="Screenshot from 2026-03-12 19-48-31" src="https://github.com/user-attachments/assets/616569ef-2514-491b-9b1a-7ccf1b1271b9" />

## Does your contribution introduce a new dependency?

No.

## What should a reviewer concentrate their feedback on?

* The fix itself is a simple 2-line change in `sktime/forecasting/naive/_naive.py`
* Whether an additional unit test specifically for the `cov=True` path would be useful

## Did you add any tests for the change?

No new tests added. The existing test suite covers `predict_var` but doesn't specifically assert non-NaN output for `cov=True`. Happy to add one if reviewers think it's needed.

## Any other comments?

I ran into this while using `NaiveForecaster` with the drift strategy and trying to get the full covariance matrix. The `cov=False` path works fine - only the `cov=True` branch is affected.