### PR TITLE
[BUG] Followup bug fixing on Inceptiontime

### DIFF
--- a/sktime/classification/deep_learning/inceptiontime/_inceptiontime_torch.py
+++ b/sktime/classification/deep_learning/inceptiontime/_inceptiontime_torch.py
@@ -235,6 +235,7 @@ class InceptionTimeClassifierTorch(BaseDeepClassifierPytorch):
             activation=self._validated_activation,
             activation_hidden=self.activation_hidden,
             activation_inception=self.activation_inception,
+            init_weights=self.init_weights,
         )
 
     @classmethod

--- a/sktime/networks/inceptiontime/_inceptiontime_torch.py
+++ b/sktime/networks/inceptiontime/_inceptiontime_torch.py
@@ -70,7 +70,7 @@ class InceptionTimeNetworkTorch(NNModule):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["hfawaz", "JamesLarge", "Withington", "noxthot"],
+        "authors": ["hfawaz", "JamesLarge", "Withington", "noxthot", "Faakhir30"],
         "maintainers": ["Faakhir30"],
         "python_version": ">=3.10",
         "python_dependencies": "torch",
@@ -156,7 +156,7 @@ class InceptionTimeNetworkTorch(NNModule):
         self.global_avg_pool = nnAdaptiveAvgPool1d(1)
 
         nnLinear = _safe_import("torch.nn.Linear")
-        self.fc = nnLinear(current_channels, num_classes)
+        self.fc = nnLinear(current_channels, self.num_classes)
 
         if self.init_weights is not None:
             self.apply(self._init_weights)


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs

Followup on #9314
Implements reviewed suggestions/bugfixes from #9330

#### What does this implement/fix? Explain your changes.
- `self.var` should be used inside **init** where possible
- `init_weigts` should be passed to network layer.

#### Does your contribution introduce a new dependency? If yes, which one?

NO


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [x] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.