### PR TITLE
[DOC] Add usage example to DontUpdate docstring

### DIFF
--- a/sktime/forecasting/stream/_update.py
+++ b/sktime/forecasting/stream/_update.py
@@ -463,6 +463,20 @@ class DontUpdate(_DelegatedForecaster):
     refit_window_lag : difference of sktime indices (int or timedelta), optional
         lag of the data window to refit to, w.r.t. cutoff, in case update calls fit
         default = 0, i.e., refit window ends with and includes cutoff
+
+        Examples
+    --------
+    >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> from sktime.forecasting.stream import DontUpdate
+    >>> from sktime.datasets import load_airline
+    >>> y = load_airline()
+    >>> forecaster = DontUpdate(NaiveForecaster())
+    >>> forecaster.fit(y[:36])
+    DontUpdate(...)
+    >>> forecaster.predict(fh=[1, 2, 3])
+    ...
+    >>> forecaster.update(y[:48])
+    DontUpdate(...)
     """
 
     # attribute for _DelegatedForecaster, which then delegates


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #4264

#### What does this implement/fix? Explain your changes.

Added a usage example to the DontUpdate estimator docstring 
in numpydoc style, as requested in #4264.

The example demonstrates basic usage:
- Wrapping a NaiveForecaster with DontUpdate
- fit() call
- predict() call
- update() call (which DontUpdate ignores by design)

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

Please check if the example follows correct numpydoc style
and covers the expected behavior of DontUpdate.

#### Did you add any tests for the change?

No new tests added - this is a documentation-only change.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].