### PR TITLE
[ENH] add dedicated _update to ExponentialSmoothing

### DIFF
--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -178,6 +178,33 @@ class ExponentialSmoothing(_StatsModelsAdapter):
 
         super().__init__(random_state=random_state)
 
+    def _update(self, y, X=None, update_params=True):
+        if update_params:
+            self._fit_forecaster(self._y)
+        else:
+            from statsmodels.tsa.holtwinters import (
+                ExponentialSmoothing as _ExponentialSmoothing,
+            )
+
+            params = self._fitted_forecaster.params
+            self._forecaster = _ExponentialSmoothing(
+                self._y,
+                trend=self.trend,
+                damped_trend=self.damped_trend,
+                seasonal=self.seasonal,
+                seasonal_periods=self.sp,
+                use_boxcox=self.use_boxcox,
+                initialization_method="heuristic",
+            )
+            self._fitted_forecaster = self._forecaster.fit(
+                smoothing_level=params["smoothing_level"],
+                smoothing_trend=params["smoothing_trend"],
+                smoothing_seasonal=params["smoothing_seasonal"],
+                damping_trend=params["damping_trend"],
+                optimized=False,
+            )
+        return self
+
     def _fit_forecaster(self, y, X=None):
         from statsmodels.tsa.holtwinters import (
             ExponentialSmoothing as _ExponentialSmoothing,

--- a/sktime/forecasting/tests/test_exp_smoothing.py
+++ b/sktime/forecasting/tests/test_exp_smoothing.py
@@ -43,6 +43,68 @@ def test_set_params():
     not run_test_for_class(ExponentialSmoothing),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+def test_update_params_true():
+    """Test update advances cutoff and refits."""
+    y = load_airline()
+    y_train, y_update = y[:100], y[100:110]
+
+    f = ExponentialSmoothing(trend="add", seasonal="mul", sp=12)
+    f.fit(y_train)
+    cutoff_before = f.cutoff
+
+    f.update(y_update, update_params=True)
+
+    assert f.cutoff > cutoff_before
+    pred = f.predict(fh=[1, 2, 3])
+    assert len(pred) == 3
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ExponentialSmoothing),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+def test_update_params_false_preserves_smoothing_params():
+    """Test update_params=False preserves fitted smoothing params."""
+    y = load_airline()
+    y_train, y_update = y[:100], y[100:110]
+
+    f = ExponentialSmoothing(trend="add", seasonal="mul", sp=12)
+    f.fit(y_train)
+    level_before = f._fitted_forecaster.params["smoothing_level"]
+    trend_before = f._fitted_forecaster.params["smoothing_trend"]
+
+    f.update(y_update, update_params=False)
+
+    assert f._fitted_forecaster.params["smoothing_level"] == level_before
+    assert f._fitted_forecaster.params["smoothing_trend"] == trend_before
+    pred = f.predict(fh=[1, 2, 3])
+    assert len(pred) == 3
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ExponentialSmoothing),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+def test_update_simple_no_trend_no_seasonal():
+    """Test update for simple exponential smoothing."""
+    y = load_airline()
+    y_train, y_update = y[:100], y[100:105]
+
+    f = ExponentialSmoothing()
+    f.fit(y_train)
+    f.update(y_update, update_params=False)
+    pred = f.predict(fh=[1, 2])
+    assert len(pred) == 2
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ExponentialSmoothing),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def check_panel_expsmooth():
     """Test exponential smoothing on panel data with datetime index."""
     # make panel with hour of day panel and datetime index


### PR DESCRIPTION
#### Reference Issues/PRs
Related to #9491.

#### What does this implement/fix? Explain your changes.

Adds a dedicated `_update` method to `ExponentialSmoothing`.

Previously, calling `update()` on `ExponentialSmoothing` fell through to
the base class which either warned and refitted from scratch
(`update_params=True`) or warned it could not accept new data
(`update_params=False`), since `HoltWintersResultsWrapper` has no
`.append()` method.

- `update_params=True`: calls `_fit_forecaster(self._y)` directly,
  clean refit without the base class warning
- `update_params=False`: rebuilds the model on extended data with
  smoothing parameters locked (`optimized=False`), so alpha/beta/gamma
  are preserved

#### Did you add any tests for the change?

Yes, three tests in `test_exp_smoothing.py`:
- `test_update_params_true`
- `test_update_params_false_preserves_smoothing_params`
- `test_update_simple_no_trend_no_seasonal`