### PR TITLE
[ENH] complete deprecation of `fdiff(mode="full")` - replace `DeprecationWarning` with `ValueError`

### DIFF
--- a/sktime/libs/fracdiff/fdiff.py
+++ b/sktime/libs/fracdiff/fdiff.py
@@ -1,6 +1,5 @@
 """Fractional differentiation core implementation."""
 
-import warnings
 from functools import partial
 
 import numpy as np
@@ -149,12 +148,7 @@ def fdiff(
     a = _combine_pre_append(a, prepend, append, axis)
 
     if mode == "full":
-        warnings.warn(
-            "mode 'full' was renamed to 'same'.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        mode = "same"
+        raise ValueError("mode 'full' was renamed to 'same'.")
 
     if a.ndim == 0:
         raise ValueError("diff requires input that is at least one dimensional")


### PR DESCRIPTION
Fixes #9661

`fdiff.py` was raising `DeprecationWarning` as an exception, crashing callers passing `mode="full"`. Replaced with `ValueError`.