### PR TITLE
[BUG] Fix plot_series KeyError when plotting interval of subsetted mu…

### DIFF
--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -238,26 +238,30 @@ def plot_interval(ax, interval_df):
 
     import seaborn as sns
 
-    # Handle MultiIndex columns safely
-    if hasattr(interval_df.columns, 'remove_unused_levels'):
-        idx = interval_df.columns.remove_unused_levels()
-    else:
-        idx = interval_df.columns
+    # Ensure columns are a pandas MultiIndex as returned by `predict_interval`
+    import pandas as pd
+    idx = interval_df.columns
+    if not isinstance(idx, pd.MultiIndex):
+        raise TypeError(
+            "plot_interval expects `interval_df` with MultiIndex columns, "
+            "as returned by `predict_interval`. "
+            f"Got columns of type: {type(idx).__name__}."
+        )
     
-    # Extract variable name - handle both MultiIndex and regular Index
-    if hasattr(idx, 'levels'):
-        var_name = idx.levels[0][0]
-    else:
-        var_name = idx[0] if len(idx) > 0 else 'value'
-
-    # Handle coverage levels safely
-    if hasattr(idx, 'levels') and len(idx.levels) > 1:
-        coverage_levels = idx.levels[1]
-        n = len(coverage_levels)
-    else:
-        # Fallback for non-MultiIndex - assume single coverage level
-        coverage_levels = [0.95]  # Default coverage level
-        n = 1
+    # Remove unused levels to handle subsetted DataFrames
+    idx = idx.remove_unused_levels()
+    
+    # Extract variable name and coverage levels from MultiIndex columns
+    if len(idx.levels) < 2:
+        raise ValueError(
+            "interval_df must have MultiIndex columns with a coverage level "
+            "as the second level for interval plotting. Received MultiIndex "
+            f"with only {len(idx.levels)} level(s)."
+        )
+    
+    var_name = idx.levels[0][0]
+    coverage_levels = idx.levels[1]
+    n = len(coverage_levels)
     
     if n == 1:
         colors = [ax.get_lines()[-1].get_c()]
@@ -265,18 +269,8 @@ def plot_interval(ax, interval_df):
         colors = sns.color_palette("colorblind", n_colors=n)
 
     for i, cov in enumerate(coverage_levels):
-        # Handle column access for both MultiIndex and regular Index
-        if hasattr(idx, 'levels') and len(idx.levels) > 1:
-            lower_col = interval_df[var_name][cov]["lower"]
-            upper_col = interval_df[var_name][cov]["upper"]
-        else:
-            # For non-MultiIndex, assume columns are named directly
-            if "lower" in interval_df.columns and "upper" in interval_df.columns:
-                lower_col = interval_df["lower"]
-                upper_col = interval_df["upper"]
-            else:
-                # Skip if we can't find appropriate columns
-                continue
+        lower_col = interval_df[var_name][cov]["lower"]
+        upper_col = interval_df[var_name][cov]["upper"]
         
         ax.fill_between(
             interval_df.index,


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9523

#### What does this implement/fix? Explain your changes.

Fixes a `KeyError` in [plot_interval()](cci:1://file:///home/nicholas/Documents/esc26/folk/sktime/sktime/utils/plotting.py:183:0-259:13) when plotting a subsetted multivariate prediction interval DataFrame.

**Root cause:** After subsetting a MultiIndex DataFrame (e.g., `y_pred_ints[["GNPDEFL"]]`), pandas retains the original column levels. Accessing `.columns.levels[0][0]` returns the wrong variable name, causing a `KeyError`.

**Fix:** Call `.columns.remove_unused_levels()` before accessing `.levels`, consistent with the pattern already used in `check_interval_df` in `sktime/utils/validation/forecasting.py`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- The 3-line fix in [plot_interval()](cci:1://file:///home/nicholas/Documents/esc26/folk/sktime/sktime/utils/plotting.py:183:0-259:13) at [sktime/utils/plotting.py](cci:7://file:///home/nicholas/Documents/esc26/folk/sktime/sktime/utils/plotting.py:0:0-0:0)

#### Did you add any tests for the change?

The existing test [test_plotting_dataframe_with_unused_levels](cci:1://file:///home/nicholas/Documents/esc26/folk/sktime/sktime/utils/tests/test_plotting.py:384:0-412:15) already covers this exact scenario and now passes with the fix.

#### Any other comments?

This is part of my ESoC 2026 entrance task.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].