### PR TITLE
[DOC] Typo fixes and docstring cleanup in clustering and distances

### DIFF
--- a/sktime/clustering/metrics/averaging/_averaging.py
+++ b/sktime/clustering/metrics/averaging/_averaging.py
@@ -37,7 +37,7 @@ def _resolve_average_callable(
 
     Parameters
     ----------
-    averaging_method: str or Callable, defaults = 'mean'
+    averaging_method: str or Callable, default='mean'
         Averaging method to compute the average of a cluster. Any of the following
         strings are valid: ['mean']. If a Callable is provided must take the form
         Callable[[np.ndarray], np.ndarray].
@@ -50,7 +50,7 @@ def _resolve_average_callable(
     if isinstance(averaging_method, str):
         if averaging_method not in _AVERAGE_DICT:
             raise ValueError(
-                "averaging_method string is invalid. Please use one of thefollowing",
+                "averaging_method string is invalid. Please use one of the following",
                 _AVERAGE_DICT.keys(),
             )
         return _AVERAGE_DICT[averaging_method]

--- a/sktime/clustering/metrics/averaging/_dba.py
+++ b/sktime/clustering/metrics/averaging/_dba.py
@@ -18,26 +18,26 @@ def dba(
 ) -> np.ndarray:
     """Compute the dtw barycenter average of time series.
 
-    This implements the'petitjean' version (original) DBA algorithm [1]_.
+    This implements the 'petitjean' version (original) DBA algorithm [1]_.
 
     Parameters
     ----------
     X : np.ndarray (3d array of shape (n, m, p) where n is number of instances, m
-                    is the dimensions and p is the timepoints))
+                    is the dimensions and p is the timepoints)
         Time series instances compute average from.
-    max_iters: int, defaults = 30
+    max_iters: int, default=30
         Maximum number iterations for dba to update over.
-    tol : float (default: 1e-5)
+    tol : float (default=1e-5)
         Tolerance to use for early stopping: if the decrease in cost is lower
         than this value, the Expectation-Maximization procedure stops.
-    averaging_distance_metric: str, defaults = 'dtw'
+    averaging_distance_metric: str, default='dtw'
         String that is the distance metric to derive the distance alignment path.
-    medoids_distance_metric: str, defaults = 'euclidean'
+    medoids_distance_metric: str, default='euclidean'
         String that is the distance metric to use with medoids
     precomputed_medoids_pairwise_distance: np.ndarray (of shape (len(X), len(X)),
-                defulats = None
+                default=None
         Precomputed medoids pairwise.
-    verbose: bool, defaults = False
+    verbose: bool, default=False
         Boolean that controls the verbosity.
 
     Returns

--- a/sktime/clustering/metrics/medoids.py
+++ b/sktime/clustering/metrics/medoids.py
@@ -19,9 +19,9 @@ def medoids(
     X : np.ndarray (3d array of shape (n_instances, n_dimensions, series_length))
         Time series to compute medoids from.
     precomputed_pairwise_distance: np.ndarray (2d array of shape
-        (n_instances, n_instances)), defaults = None
+        (n_instances, n_instances)), default=None
         Precomputed pairwise distance between each time series in X.
-    distance_metric: str, defaults = 'dtw'
+    distance_metric: str, default='dtw'
         String of distance metric to compute.
 
     Returns

--- a/sktime/distances/_dtw.py
+++ b/sktime/distances/_dtw.py
@@ -72,15 +72,15 @@ class _DtwDistance(NumbaDistance):
             First time series.
         y: np.ndarray (2d array of shape (d,m2)).
             Second time series.
-        return_cost_matrix: bool, defaults = False
+        return_cost_matrix: bool, default=False
             Boolean that when true will also return the cost matrix.
-        window: Float, defaults = None
+        window: float, default=None
             Float that is the radius of the sakoe chiba window (if using Sakoe-Chiba
             lower bounding). Must be between 0 and 1.
-        itakura_max_slope: float, defaults = None
+        itakura_max_slope: float, default=None
             Gradient of the slope for itakura parallelogram (if using Itakura
             Parallelogram lower bounding). Must be between 0 and 1.
-        bounding_matrix: np.ndarray (2d array of shape (m1,m2)), defaults = None
+        bounding_matrix: np.ndarray (2d array of shape (m1,m2)), default=None
             Custom bounding matrix to use. If defined then other lower_bounding params
             are ignored. The matrix should be structure so that indexes considered in
             bound should be the value 0. and indexes outside the bounding matrix should
@@ -154,13 +154,13 @@ class _DtwDistance(NumbaDistance):
             First time series.
         y: np.ndarray (2d array of shape (d,m2)).
             Second time series.
-        window: Float, defaults = None
+        window: float, default=None
             Float that is the radius of the sakoe chiba window (if using Sakoe-Chiba
             lower bounding). Must be between 0 and 1.
-        itakura_max_slope: float, defaults = None
+        itakura_max_slope: float, default=None
             Gradient of the slope for itakura parallelogram (if using Itakura
             Parallelogram lower bounding). Must be between 0 and 1.
-        bounding_matrix: np.ndarray (2d array of shape (m1,m2)), defaults = None
+        bounding_matrix: np.ndarray (2d array of shape (m1,m2)), default=None
             Custom bounding matrix to use. If defined then other lower_bounding params
             are ignored. The matrix should be structure so that indexes considered in
             bound should be the value 0. and indexes outside the bounding matrix should


### PR DESCRIPTION
This PR fixes several small typos and standardizes docstring formatting in the clustering and distances modules. 

### Changes:
- **Typo Fixes**: 
    - Corrected 'petitjean' spelling and fixed extra parentheses in `_dba.py`.
    - Fixed typo 'one ofthefollowing' (missing space) in `_averaging.py`.
    - Corrected 'defulats' to 'default' in `_dba.py`.
- **Consistency**:
    - Standardized `defaults =` to `default=` across `_dba.py`, `_averaging.py`, `medoids.py`, and `_dtw.py` to match `sktime` standards.
    - Updated `Float` (capitalized) in type hints to `float` in `_dtw.py`.

Verified with `pre-commit` (all checks passed).
