### PR TITLE
fix: apply random_state seed in RNNNetworkTorch __init__

### DIFF
--- a/sktime/networks/rnn/_rnn_torch.py
+++ b/sktime/networks/rnn/_rnn_torch.py
@@ -93,6 +93,12 @@ class RNNNetworkTorch(NNModule):
         self.bidirectional = bidirectional
         super().__init__()
 
+        torch_module = _safe_import("torch")
+        if torch_module is not None and self.random_state is not None:
+            torch_module.manual_seed(self.random_state)
+        if self.random_state is not None:
+            np.random.seed(self.random_state)
+
         # Checking input dimensions
         if isinstance(self.input_size, int):
             in_features = self.input_size


### PR DESCRIPTION
Fixes #9625

## Summary
- `RNNNetworkTorch` accepted `random_state` but never used it to set the actual random seed
- Added `torch.manual_seed(random_state)` call in `__init__` to ensure reproducibility
- Also added `np.random.seed(random_state)` for numpy operations
- Matches the pattern used in `sktime/classification/deep_learning/_pytorch.py`

## Changes
- Modified `sktime/networks/rnn/_rnn_torch.py`: added seed initialization in `__init__`

🤖 Generated with [Claude Code](https://claude.com/claude-code)