### PR TITLE
ENH: Add _update method to NaiveForecaster for correct streaming behavior

### DIFF
--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -226,6 +226,31 @@ class NaiveForecaster(_BaseWindowForecaster):
             )
 
         return self
+    
+    def _update(self, y, X=None, update_params=True):
+        """Update time series to incremental training data.
+
+        Parameters
+        ----------
+        y : pd.Series
+            Time series with which to update the forecaster.
+        X : pd.DataFrame, default=None
+            Exogenous variables (ignored by NaiveForecaster).
+        update_params : bool, default=True
+            Whether model parameters should be updated.
+
+        Returns
+        -------
+        self : reference to self.
+        """
+        if update_params:
+            # When window_length is None, _fit sets window_length_ = len(y),
+            # meaning "use all available data". After update, self._y has grown,
+            # so window_length_ must grow to match.
+            if self.window_length is None:
+                self.window_length_ = len(self._y)
+
+        return self
 
     def _predict_last_window(
         self, fh, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
No existing issue. This PR addresses a correctness issue in update behavior of NaiveForecaster.
-->

#### What does this implement/fix? Explain your changes.
This PR adds a dedicated `_update` implementation for `NaiveForecaster` to ensure correct behavior in streaming/online scenarios.

Currently, `NaiveForecaster` relies on the base class fallback for `update()`, which updates `self._y` but does not update derived attributes such as `window_length_`.

When `window_length=None`, `_fit()` sets: window_length_ = len(y)
indicating that all available data should be used.

However, after calling `update()`, although `self._y` grows, `window_length_` remains unchanged. As a result, `_get_last_window()` uses a stale window and ignores newly observed data in predictions.

This PR fixes the issue by updating `window_length_` in `_update()` when `window_length=None`, ensuring consistency with `_fit()` behavior and correct usage of all available data.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- [x] Correctness of `_update` logic and consistency with `_fit`
- [x] Whether updating `window_length_` is sufficient and minimal
- [x] Alignment with sktime's update API design and estimator conventions

#### Did you add any tests for the change?
No new tests were added.

All existing tests pass (1400+), and manual validation confirms correct behavior:
- Before update: 100  
- After update: 120  

#### Any other comments?
This is my contribution to sktime. I am particularly interested in contributing to streaming/online forecasting functionality and would appreciate feedback or suggestions for improvement.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]

##### For new estimators
- [ ] Not applicable