### PR TITLE
[ENH] Add missing unit tests for sktime.utils.stats and sktime.utils.unique_str

### DIFF
--- a/sktime/utils/tests/test_stats.py
+++ b/sktime/utils/tests/test_stats.py
@@ -1,0 +1,175 @@
+"""Tests for weighted statistics utilities in sktime.utils.stats.
+
+Tests in this module
+--------------------
+    test_weighted_percentile_uniform_weights_matches_numpy
+    test_weighted_percentile_2d_shape
+    test_weighted_percentile_extreme_percentiles
+    test_weighted_percentile_concentrated_weight
+    test_weighted_geometric_mean_uniform_equals_scipy
+    test_weighted_geometric_mean_single_element
+    test_weighted_geometric_mean_incompatible_shapes
+    test_weighted_geometric_mean_heavy_weight_dominates
+    test_weighted_median_uniform_weights
+    test_weighted_min_max_bracket_data
+    test_weighted_min_max_ordering_invariant
+"""
+
+__author__ = ["oashe"]
+
+import numpy as np
+import pytest
+from scipy.stats import gmean as scipy_gmean
+
+from sktime.tests.test_switch import run_test_module_changed
+from sktime.utils.stats import (
+    _weighted_geometric_mean,
+    _weighted_max,
+    _weighted_median,
+    _weighted_min,
+    _weighted_percentile,
+)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils"]),
+    reason="Run if utils module has changed.",
+)
+class TestWeightedPercentile:
+    """Tests for _weighted_percentile function."""
+
+    def test_uniform_weights_matches_numpy_median(self):
+        """With equal weights, the 50th percentile should be close to np.median."""
+        rng = np.random.RandomState(0)
+        array = rng.rand(101)
+        weights = np.ones(101)
+        result = _weighted_percentile(array, weights, percentile=50)
+        np_median = np.median(array)
+        # allow tolerance because _weighted_percentile uses lower-bound convention
+        assert abs(result - np_median) < 0.05
+
+    def test_2d_column_independence(self):
+        """Each column of a 2D array should have its percentile computed independently."""
+        array = np.array([[1.0, 100.0], [2.0, 200.0], [3.0, 300.0]])
+        weights = np.ones(3)
+        result = _weighted_percentile(array, weights, percentile=50)
+        assert result.shape == (2,)
+        # column 0 median ~ 2, column 1 median ~ 200
+        assert result[0] <= 3.0
+        assert result[1] >= 100.0
+
+    def test_concentrated_weight_returns_that_element(self):
+        """If one element has overwhelming weight, percentile should return it."""
+        array = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        weights = np.array([0.0, 0.0, 0.0, 0.0, 1000.0])
+        result = _weighted_percentile(array, weights, percentile=50)
+        assert result == 5.0
+
+    @pytest.mark.parametrize("percentile", [0, 100])
+    def test_extreme_percentiles(self, percentile):
+        """Percentile 0 returns min, percentile 100 returns max."""
+        array = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
+        weights = np.ones(5)
+        result = _weighted_percentile(array, weights, percentile=percentile)
+        if percentile == 0:
+            assert result == 10.0
+        else:
+            assert result == 50.0
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils"]),
+    reason="Run if utils module has changed.",
+)
+class TestWeightedGeometricMean:
+    """Tests for _weighted_geometric_mean function."""
+
+    def test_uniform_weights_equals_scipy_gmean(self):
+        """Uniform weights should match scipy's geometric mean."""
+        rng = np.random.RandomState(42)
+        y = rng.rand(1, 5) + 0.1  # positive values
+        weights = np.ones(5)
+        result = _weighted_geometric_mean(y, weights=weights, axis=1)
+        expected = scipy_gmean(y, axis=1)
+        np.testing.assert_almost_equal(result, expected, decimal=8)
+
+    def test_single_element_is_identity(self):
+        """Geometric mean of a single value equals that value."""
+        y = np.array([[7.5]])
+        weights = np.array([1.0])
+        result = _weighted_geometric_mean(y, weights=weights, axis=1)
+        np.testing.assert_almost_equal(result, 7.5, decimal=10)
+
+    def test_heavy_weight_dominates(self):
+        """An element with overwhelming weight should dominate the result."""
+        y = np.array([[1.0, 1000.0]])
+        weights = np.array([1e-10, 1.0])
+        result = _weighted_geometric_mean(y, weights=weights, axis=1)
+        # result should be very close to 1000
+        assert result[0] > 900.0
+
+    def test_incompatible_2d_shapes_raise(self):
+        """Incompatible 2D y and weights shapes should raise ValueError."""
+        y = np.array([[1.0, 2.0, 3.0]])
+        weights = np.array([[1.0, 2.0]])
+        with pytest.raises(ValueError, match="inconsistent shapes"):
+            _weighted_geometric_mean(y, weights=weights, axis=1)
+
+    def test_1d_weights_wrong_length_on_axis0(self):
+        """1D weights inconsistent with axis=0 dimension should raise."""
+        y = np.array([[1.0, 2.0], [3.0, 4.0]])
+        weights = np.array([1.0, 2.0, 3.0])
+        with pytest.raises(ValueError):
+            _weighted_geometric_mean(y, weights=weights, axis=0)
+
+    def test_1d_weights_wrong_length_on_axis1(self):
+        """1D weights inconsistent with axis=1 dimension should raise."""
+        y = np.array([[1.0, 2.0, 3.0]])
+        weights = np.array([1.0, 2.0])
+        with pytest.raises(ValueError, match="Input features"):
+            _weighted_geometric_mean(y, weights=weights, axis=1)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils"]),
+    reason="Run if utils module has changed.",
+)
+class TestWeightedMedianMinMax:
+    """Tests for _weighted_median, _weighted_min, _weighted_max."""
+
+    def test_min_max_bracket_data(self):
+        """Weighted min/max should bracket the data range."""
+        rng = np.random.RandomState(7)
+        y = rng.rand(1, 20) * 100
+        weights = rng.rand(20) + 0.01
+        w_min = _weighted_min(y, axis=1, weights=weights)
+        w_max = _weighted_max(y, axis=1, weights=weights)
+        assert w_min[0] <= y.min() + 1e-10
+        assert w_max[0] >= y.max() - 1e-10
+
+    def test_min_less_equal_median_less_equal_max(self):
+        """Weighted min <= weighted median <= weighted max must always hold."""
+        rng = np.random.RandomState(123)
+        y = rng.rand(1, 15) * 50
+        weights = np.ones(15)
+        w_min = _weighted_min(y, axis=1, weights=weights)[0]
+        w_med = _weighted_median(y, axis=1, weights=weights)[0]
+        w_max = _weighted_max(y, axis=1, weights=weights)[0]
+        assert w_min <= w_med <= w_max
+
+    def test_uniform_data_all_equal(self):
+        """For constant data, min == median == max."""
+        y = np.full((1, 10), 42.0)
+        weights = np.ones(10)
+        w_min = _weighted_min(y, axis=1, weights=weights)[0]
+        w_med = _weighted_median(y, axis=1, weights=weights)[0]
+        w_max = _weighted_max(y, axis=1, weights=weights)[0]
+        assert w_min == w_med == w_max == 42.0
+
+    def test_single_element_all_agree(self):
+        """Single element: min == median == max == that element."""
+        y = np.array([[3.14]])
+        weights = np.array([1.0])
+        assert _weighted_min(y, axis=1, weights=weights)[0] == 3.14
+        assert _weighted_median(y, axis=1, weights=weights)[0] == 3.14
+        assert _weighted_max(y, axis=1, weights=weights)[0] == 3.14

--- a/sktime/utils/tests/test_unique_str.py
+++ b/sktime/utils/tests/test_unique_str.py
@@ -1,0 +1,48 @@
+"""Tests for unique string utilities."""
+
+import pytest
+
+from sktime.tests.test_switch import run_test_module_changed
+from sktime.utils.unique_str import _make_strings_unique
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils"]),
+    reason="Run if utils module has changed.",
+)
+class TestMakeStringsUnique:
+    """Tests for _make_strings_unique function."""
+
+    def test_new_str_already_unique(self):
+        """Test that a unique string is returned unchanged."""
+        result = _make_strings_unique(["a", "b", "c"], "d")
+        assert result == "d"
+
+    def test_new_str_conflicts_once(self):
+        """Test that a conflicting string gets _2 appended."""
+        result = _make_strings_unique(["a", "b", "c"], "a")
+        assert result == "a_2"
+
+    def test_new_str_conflicts_multiple_times(self):
+        """Test that a string conflicting with existing _2 gets _4 appended.
+
+        Counter logic: first call appends _2 (clashes), recursive call
+        increments counter to 4 and appends _4 (free).
+        """
+        result = _make_strings_unique(["a", "a_2", "b"], "a")
+        assert result == "a_4"
+
+    def test_new_str_conflicts_three_times(self):
+        """Test the chain a -> a_2 -> a_3 -> a_4."""
+        result = _make_strings_unique(["a", "a_2", "a_3"], "a")
+        assert result == "a_4"
+
+    def test_empty_list(self):
+        """Test with an empty list (no conflicts)."""
+        result = _make_strings_unique([], "x")
+        assert result == "x"
+
+    def test_non_conflicting_similar_strings(self):
+        """Test that similar but non-conflicting strings pass through."""
+        result = _make_strings_unique(["ab", "abc"], "a")
+        assert result == "a"


### PR DESCRIPTION
#### Reference Issues/PRs
Resolves #9685

#### What does this implement/fix? Explain your changes.
Adds unit tests for two utility modules that had no test coverage:

- [sktime/utils/tests/test_stats.py](cci:7://file:///Users/oashe/Desktop/sktime/sktime/utils/tests/test_stats.py:0:0-0:0) — 15 tests for the weighted stats functions (`_weighted_percentile`, `_weighted_geometric_mean`, `_weighted_median`, `_weighted_min`, `_weighted_max`). Covers correctness against numpy/scipy, edge cases like concentrated weights and constant arrays, shape validation, and ordering invariants.
- [sktime/utils/tests/test_unique_str.py](cci:7://file:///Users/oashe/Desktop/sktime/sktime/utils/tests/test_unique_str.py:0:0-0:0) — 6 tests for [_make_strings_unique](cci:1://file:///Users/oashe/Desktop/sktime/sktime/utils/unique_str.py:3:0-28:18). Covers basic dedup, chain collisions with the recursive counter, empty input, and substring non-conflict.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Whether the test cases cover the right edge cases
- Whether the test structure follows sktime conventions properly

#### Did you add any tests for the change?
Yes — this PR is entirely about adding tests. 21 new tests total, all passing locally.

#### Any other comments?
Both modules had zero direct test coverage before this. Tests use `run_test_module_changed` guards and `pytest.mark.parametrize` where appropriate.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [MNT] - CI, test framework.
