### PR TITLE
[BUG] fixes to `craft` utility and datatypes returns

### DIFF
--- a/sktime/datatypes/_table/_check.py
+++ b/sktime/datatypes/_table/_check.py
@@ -657,6 +657,7 @@ def _check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
                     "all entries must be of primitive type (str, int, float), but "
                     f"found {type(d[key])} at index {i}, key {key}"
                 )
+                return _ret(False, msg, None, return_metadata)
 
     # we now know obj is a list of dict
     # check whether there any nans; compute only if requested

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -45,7 +45,7 @@ def _extract_class_names(spec):
 
     # we need to exclude expressions that look like classes per the regex
     # but aren't
-    EXCLUDE_LIST = ["True", "False"]
+    EXCLUDE_LIST = ["True", "False", "None"]
     cls_name_list = [x for x in cls_name_list if x not in EXCLUDE_LIST]
 
     return cls_name_list


### PR DESCRIPTION
This PR adds fixes from other repositories with (temporarily) duplicate code:

* `craft` utility to recognize `None` as a keyword
* missing `_ret` statement in a datatype checker