### PR TITLE
DOC: Add estimator types reference page

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -36,6 +36,7 @@ For a list of object and estimator tags, see :ref:`tags_ref`.
     api_reference/base
     api_reference/exceptions
     api_reference/tags
+    api_reference/estimator_types
     api_reference/pipeline
     api_reference/benchmarking
     api_reference/catalogues

--- a/docs/source/api_reference/estimator_types.rst
+++ b/docs/source/api_reference/estimator_types.rst
@@ -1,0 +1,30 @@
+Estimator Types
+===============
+
+sktime provides different estimator types used across the library.
+
+These estimator types define the type of machine learning task an estimator performs.
+
+Forecaster
+----------
+Used for time series forecasting tasks.
+
+Classifier
+----------
+Used for time series classification tasks.
+
+Regressor
+---------
+Used for regression tasks on time series data.
+
+Transformer
+-----------
+Used to transform time series data.
+
+Detector
+--------
+Used for anomaly or change point detection.
+
+Clusterer
+---------
+Used for clustering time series data.


### PR DESCRIPTION
## Reference Issues/PRs
Fixes #9495

## What does this implement/fix?
This PR adds a new API reference page for estimator types in sktime.

## Changes
- Created `estimator_types.rst`
- Added descriptions for estimator types
- Updated API reference to include the new page

## Dependencies
No new dependencies introduced.

## Reviewer focus
- Structure and clarity of the new documentation page
- Correct integration into API reference

## Tests
No tests required (documentation change).

## Checklist
- [x] PR title starts with [DOC]