### PR TITLE
[ENH] Add _update implementation for ExponentialSmoothing forecaster

### DIFF
--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -208,6 +208,68 @@ class ExponentialSmoothing(_StatsModelsAdapter):
             minimize_kwargs=self.minimize_kwargs,
             use_brute=self.use_brute,
         )
+    
+    def _update(self, y, X=None, update_params=True):
+        """Update fitted parameters with new data.
+
+        Parameters
+        ----------
+        y : pd.Series
+            New time series to update with.
+        X : pd.DataFrame, optional (default=None)
+            Exogenous variables are ignored.
+        update_params : bool, optional (default=True)
+            If True, refit model on updated data using existing
+            optimized parameters (no re-optimization).
+            If False, only update the cutoff index.
+
+        Returns
+        -------
+        self : reference to self.
+        """
+        from statsmodels.tsa.holtwinters import (
+            ExponentialSmoothing as _ExponentialSmoothing,
+        )
+
+        if update_params:
+            # get existing optimized parameters - avoids re-optimization
+            fitted_params = self._fitted_forecaster.params
+
+            # append new data to existing training data
+            import pandas as pd
+            y_updated = pd.concat([self._y, y])
+            y_updated = y_updated[~y_updated.index.duplicated(keep="last")]
+
+            # refit model on updated data using existing params
+            self._forecaster = _ExponentialSmoothing(
+                y_updated,
+                trend=self.trend,
+                damped_trend=self.damped_trend,
+                seasonal=self.seasonal,
+                seasonal_periods=self.sp,
+                use_boxcox=self.use_boxcox,
+                initialization_method=self.initialization_method,
+            )
+
+            # fit with existing smoothing params, no re-optimization
+            self._fitted_forecaster = self._forecaster.fit(
+                smoothing_level=fitted_params["smoothing_level"]
+                if not pd.isna(fitted_params["smoothing_level"])
+                else None,
+                smoothing_trend=fitted_params["smoothing_trend"]
+                if not pd.isna(fitted_params["smoothing_trend"])
+                else None,
+                smoothing_seasonal=fitted_params["smoothing_seasonal"]
+                if not pd.isna(fitted_params["smoothing_seasonal"])
+                else None,
+                damping_trend=fitted_params["damping_trend"]
+                if not pd.isna(fitted_params["damping_trend"])
+                else None,
+                optimized=False,
+                remove_bias=self.remove_bias,
+            )
+
+        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/tests/tests/test_exp_smoothing_update.py
+++ b/sktime/tests/tests/test_exp_smoothing_update.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pandas as pd
+from sktime.datasets import load_airline
+from sktime.forecasting.exp_smoothing import ExponentialSmoothing
+from sktime.split import temporal_train_test_split
+
+
+def test_update_simple_model_matches_refit():
+    """Test that update matches full refit for simple model."""
+    y = load_airline()
+    y_train, y_test = temporal_train_test_split(y, test_size=12)
+
+    f = ExponentialSmoothing()
+    f.fit(y_train)
+    f.update(y_test.iloc[:3])
+
+    f2 = ExponentialSmoothing()
+    f2.fit(pd.concat([y_train, y_test.iloc[:3]]))
+
+    pred1 = f.predict([1, 2, 3]).values
+    pred2 = f2.predict([1, 2, 3]).values
+
+    assert np.allclose(pred1, pred2)
+
+
+def test_update_trend_seasonal_close_to_refit():
+    """Test that update is close to refit for seasonal model."""
+    y = load_airline()
+    y_train, y_test = temporal_train_test_split(y, test_size=12)
+
+    f = ExponentialSmoothing(trend="add", seasonal="add", sp=12)
+    f.fit(y_train)
+    f.update(y_test.iloc[:3])
+
+    f2 = ExponentialSmoothing(trend="add", seasonal="add", sp=12)
+    f2.fit(pd.concat([y_train, y_test.iloc[:3]]))
+
+    pred1 = f.predict([1, 2, 3]).values
+    pred2 = f2.predict([1, 2, 3]).values
+
+    assert np.allclose(pred1, pred2, rtol=1e-1)

--- a/test_update.py
+++ b/test_update.py
@@ -1,0 +1,46 @@
+from sktime.forecasting.exp_smoothing import ExponentialSmoothing
+from sktime.datasets import load_airline
+from sktime.forecasting.model_selection import temporal_train_test_split
+import pandas as pd
+import numpy as np
+
+# load data
+y = load_airline()
+y_train, y_test = temporal_train_test_split(y, test_size=12)
+
+print("=== SIMPLE MODEL TEST ===")
+# simple model (no trend/seasonality)
+f = ExponentialSmoothing()
+f.fit(y_train)
+f.update(y_test.iloc[:3])
+
+f2 = ExponentialSmoothing()
+f2.fit(pd.concat([y_train, y_test.iloc[:3]]))
+
+pred1 = f.predict([1, 2, 3]).values
+pred2 = f2.predict([1, 2, 3]).values
+
+print("Update model:", pred1)
+print("Full refit model:", pred2)
+
+# exact match expected
+print("Exact match:", np.allclose(pred1, pred2))
+
+
+print("\n=== TREND + SEASONAL MODEL TEST ===")
+# complex model
+f = ExponentialSmoothing(trend="add", seasonal="add", sp=12)
+f.fit(y_train)
+f.update(y_test.iloc[:3])
+
+f2 = ExponentialSmoothing(trend="add", seasonal="add", sp=12)
+f2.fit(pd.concat([y_train, y_test.iloc[:3]]))
+
+pred1 = f.predict([1, 2, 3]).values
+pred2 = f2.predict([1, 2, 3]).values
+
+print("Update model:", pred1)
+print("Full refit model:", pred2)
+
+# close match expected (not exact)
+print("Close match:", np.allclose(pred1, pred2, rtol=1e-1))


### PR DESCRIPTION
#### Reference Issues/PRs

Enhancement to update functionality of forecasting estimators.

**What does this implement/fix?**

This PR implements the `_update` method for the `ExponentialSmoothing` forecaster.

The update method enables efficient model updates by appending new data to the existing training series and reusing previously fitted smoothing parameters, avoiding full re-optimization.

The implementation retrieves the fitted parameters from the existing model and refits the model on the updated data with `optimized=False`. This improves computational efficiency compared to a full refit.

For simple exponential smoothing models (without trend or seasonality), the updated model produces results identical to a full refit. For models with trend and/or seasonality, the results are numerically close, with minor differences due to internal state re-initialization in statsmodels.
This improves performance for incremental forecasting workflows where frequent updates are required.

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies are introduced.


#### What should a reviewer concentrate their feedback on?

- Correctness of the `_update` implementation
- Proper reuse of fitted smoothing parameters
- Handling of updated time series data
- Behavior differences between simple and seasonal models
- Test coverage and validation approach


#### Did you add any tests for the change?

Yes.

Added tests to verify:
- Exact equivalence with full refit for simple exponential smoothing models
- Approximate equivalence (using `np.allclose`) for models with trend and seasonality


#### Any other comments?

Minor numerical differences for models with trend and seasonality are expected due to limitations in statsmodels internal state handling when reusing parameters without full re-optimization.


#### PR checklist

##### For all contributions
- [x] I've added myself to the list of contributors
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] I've added the estimator to the API reference
- [ ] I've added one or more illustrative usage examples to the docstring
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag