### PR TITLE
fix(forecasting): resolve GroupbyCategoryForecaster predict_proba TypeError

### DIFF
--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -323,9 +323,10 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         # Finally, dynamically adding implementation of probabilistic
         # functions depending on the tags set.
         if self.get_tags()["capability:pred_int"]:
-            self._predict_interval = _predict_interval
-            self._predict_var = _predict_var
-            self._predict_proba = _predict_proba
+            import types
+            self._predict_interval = types.MethodType(_predict_interval, self)
+            self._predict_var = types.MethodType(_predict_var, self)
+            self._predict_proba = types.MethodType(_predict_proba, self)
 
     @property
     def _steps(self):


### PR DESCRIPTION
This PR fixes issue #9553. \n\n**Description**\n`GroupbyCategoryForecaster.predict_proba` (and related methods `predict_interval`, `predict_var`) were dynamically patched onto the instance in `__init__` without properly binding them as methods. This caused a `TypeError: missing 1 required positional argument: 'self'`. This PR binds these functions using `types.MethodType`.\n\nCloses #9553.