### PR TITLE
[ENH] Migrate test skip config for DynamicFactor to estimator tags

### DIFF
--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -142,6 +142,10 @@ class DynamicFactor(_StatsModelsAdapter):
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
         "capability:non_contiguous_X": False,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_predict_time_index_in_sample_full"],
+        # skipped as capability:insample is False, in-sample prediction not supported, see #4765
     }
 
     def __init__(

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -117,9 +117,6 @@ EXCLUDED_TESTS = {
     # SAX returns strange output format
     # this needs to be fixed, was not tested previously due to legacy exception
     "SAXlegacy": ["test_fit_transform_output"],
-    "DynamicFactor": [
-        "test_predict_time_index_in_sample_full",  # refer to #4765
-    ],
     "ARIMA": [
         "test_predict_time_index_in_sample_full",  # refer to #4765
     ],


### PR DESCRIPTION
Towards #8515

Migrated test skip config for DynamicFactor from EXCLUDED_TESTS 
in sktime/tests/_config.py to estimator tag tests:skip_by_name 
directly in the estimator class.

Changes:
- Added "tests:skip_by_name" tag to DynamicFactor._tags
- Removed DynamicFactor from EXCLUDED_TESTS in sktime/tests/_config.py