### PR TITLE
[BUG] Improve PinballLoss missing-alpha error message and add regression test

### DIFF
--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -553,9 +553,11 @@ class PinballLoss(_BaseProbaForecastingErrorMetric):
             # if alpha was provided, check whether  they are predicted
             #   if not all alpha are observed, raise a ValueError
             if not np.isin(alpha, y_pred_alphas).all():
-                # todo: make error msg more informative
-                #   which alphas are missing
-                msg = "not all quantile values in alpha are available in y_pred"
+                missing = sorted(set(np.atleast_1d(alpha)) - set(y_pred_alphas))
+                msg = (
+                    "not all quantile values in alpha are available in y_pred; "
+                    f"missing: {missing}"
+                )
                 raise ValueError(msg)
             else:
                 alphas = alpha

--- a/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
@@ -186,6 +186,21 @@ def test_output_quantiles(metric, score_average, multioutput, sample_data):
     helper_check_output(metric, score_average, multioutput, sample_data)
 
 
+def test_pinballloss_missing_alpha_message():
+    y_true = pd.Series([1.0, 2.0, 3.0])
+    y_pred = pd.DataFrame({
+        ("Quantiles", 0.05): [0.5, 1.0, 1.5],
+        ("Quantiles", 0.95): [1.5, 2.5, 3.5],
+    })
+
+    metric = PinballLoss(alpha=[0.05, 0.5, 0.95])
+
+    with pytest.raises(ValueError, match="missing") as excinfo:
+        metric(y_true, y_pred)
+
+    assert "0.5" in str(excinfo.value)
+
+
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.performance_metrics"]),
     reason="Run if performance_metrics module has changed.",


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.

This PR improves the error message in `PinballLoss` when requested alpha values are missing in `y_pred`.

Previously, the error message only stated that some alpha values were missing.
Now the message clearly lists which quantile values are missing, making debugging easier.

A regression test was added to ensure the correct error message is raised when
requested alpha values are not present in the prediction output.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

- Correctness of the error message logic
- Test coverage for missing alpha case
- Style consistency with existing probabilistic metrics

#### Did you add any tests for the change?

Yes  
Added test in:

sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py

#### Any other comments?

This is my first contribution to sktime. Thank you for the review!

#### PR checklist

- [x] The PR title starts with [BUG]
- [ ] I've added myself to the contributors list (optional)