### PR TITLE
[ENH] Implement efficient _evaluate_by_index for MeanLinexError

### DIFF
--- a/sktime/performance_metrics/forecasting/_mlinex.py
+++ b/sktime/performance_metrics/forecasting/_mlinex.py
@@ -6,7 +6,7 @@ Classes named as ``*Score`` return a value to maximize: the higher the better.
 Classes named as ``*Error`` or ``*Loss`` return a value to minimize:
 the lower the better.
 """
-
+import numpy as np
 from sktime.performance_metrics.forecasting._base import BaseForecastingErrorMetricFunc
 from sktime.performance_metrics.forecasting._functions import mean_linex_error
 
@@ -155,6 +155,39 @@ class MeanLinexError(BaseForecastingErrorMetricFunc):
             multilevel=multilevel,
             by_index=by_index,
         )
+    
+    def _evaluate_by_index(self, y_true, y_pred, **kwargs):
+        """Return the metric evaluated at each time point.
+
+        private _evaluate_by_index containing core logic, called from evaluate_by_index
+
+        Parameters
+        ----------
+        y_true : time series in sktime compatible pandas based data container format
+            Ground truth (correct) target values
+            Series scitype: pd.DataFrame
+            Panel scitype: pd.DataFrame with 2-level row MultiIndex
+            Hierarchical scitype: pd.DataFrame with 3 or more level row MultiIndex
+        y_pred : time series in sktime compatible data container format
+            Forecasted values to evaluate
+            must be of same format as y_true, same indices and columns if indexed
+
+        Returns
+        -------
+        loss : pd.Series or pd.DataFrame
+            Calculated metric, by time point.
+            pd.Series if self.multioutput="uniform_average" or array-like
+            pd.DataFrame if self.multioutput="raw_values"
+        """
+        multioutput = self.multioutput
+        a = self.a
+        b = self.b
+
+        error = y_true - y_pred
+        raw_values = b * (np.exp(a * error) - a * error - 1)
+        raw_values = self._get_weighted_df(raw_values, **kwargs)
+        
+        return self._handle_multioutput(raw_values, multioutput)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
Towards #4304

Implemented efficient `_evaluate_by_index` for `MeanLinexError`.

The implementation computes the LinEx error at each time point directly:
`b * (exp(a * error) - a * error - 1)`
where `error = y_true - y_pred` at each time index.