### PR TITLE
DOC: add missing import to convert_align_to_align_loc docstring example

### DIFF
--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -553,9 +553,11 @@ class PinballLoss(_BaseProbaForecastingErrorMetric):
             # if alpha was provided, check whether  they are predicted
             #   if not all alpha are observed, raise a ValueError
             if not np.isin(alpha, y_pred_alphas).all():
-                # todo: make error msg more informative
-                #   which alphas are missing
-                msg = "not all quantile values in alpha are available in y_pred"
+                missing = sorted(set(np.atleast_1d(alpha)) - set(y_pred_alphas))
+                msg = (
+                    "not all quantile values in alpha are available in y_pred; "
+                    f"missing: {missing}"
+                )
                 raise ValueError(msg)
             else:
                 alphas = alpha

--- a/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
@@ -186,6 +186,21 @@ def test_output_quantiles(metric, score_average, multioutput, sample_data):
     helper_check_output(metric, score_average, multioutput, sample_data)
 
 
+def test_pinballloss_missing_alpha_message():
+    y_true = pd.Series([1.0, 2.0, 3.0])
+    y_pred = pd.DataFrame({
+        ("Quantiles", 0.05): [0.5, 1.0, 1.5],
+        ("Quantiles", 0.95): [1.5, 2.5, 3.5],
+    })
+
+    metric = PinballLoss(alpha=[0.05, 0.5, 0.95])
+
+    with pytest.raises(ValueError, match="missing") as excinfo:
+        metric(y_true, y_pred)
+
+    assert "0.5" in str(excinfo.value)
+
+
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.performance_metrics"]),
     reason="Run if performance_metrics module has changed.",


### PR DESCRIPTION
Fixes part of #4400

Added missing import statements in the Examples section of
convert_align_to_align_loc so the example can be copy-pasted and run.

Only the docstring was modified.

First contribution, feedback welcome.