### PR TITLE
[DOC] Fix doctest examples in MedianSquaredScaledError

### DIFF
--- a/sktime/performance_metrics/forecasting/_medsse.py
+++ b/sktime/performance_metrics/forecasting/_medsse.py
@@ -94,18 +94,18 @@ class MedianSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> rmdsse = MedianSquaredScaledError(square_root=True)
-    >>> rmdsse(y_true, y_pred, y_train=y_train)
+    >>> rmdsse(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     np.float64(0.16666666666666666)
     >>> y_train = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> rmdsse(y_true, y_pred, y_train=y_train)
+    >>> rmdsse(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     np.float64(0.1472819539849714)
     >>> rmdsse = MedianSquaredScaledError(multioutput='raw_values', square_root=True)
-    >>> rmdsse(y_true, y_pred, y_train=y_train)
+    >>> rmdsse(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     array([0.08687445, 0.20203051])
     >>> rmdsse = MedianSquaredScaledError(multioutput=[0.3, 0.7], square_root=True)
-    >>> rmdsse(y_true, y_pred, y_train=y_train)
+    >>> rmdsse(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     np.float64(0.16914781383660782)
     """
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -275,7 +275,6 @@ EXCLUDED_TESTS_BY_TEST = {
         # on lower version, prints 0.123456
         # on higher version, prints np.float64(0.123456)
         # therefore these doctests will fail either on lower or higher versions
-        "MedianSquaredScaledError",
         "GeometricMeanAbsoluteError",
         "MedianRelativeAbsoluteError",
         "MeanSquaredScaledError",


### PR DESCRIPTION
Towards #8515

Fixed doctest examples in MedianSquaredScaledError by adding
`# doctest: +SKIP` to output lines, resolving the between-versions
inconsistency in how np.float64 is printed.

Removed MedianSquaredScaledError from EXCLUDED_TESTS_BY_TEST
in sktime/tests/_config.py.