### PR TITLE
[DOC] Fix np.float64 doctest inconsistency in forecasting metrics

### DIFF
--- a/sktime/performance_metrics/forecasting/_gmae.py
+++ b/sktime/performance_metrics/forecasting/_gmae.py
@@ -102,17 +102,17 @@ class GeometricMeanAbsoluteError(BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> gmae = GeometricMeanAbsoluteError()
-    >>> gmae(y_true, y_pred)
+    >>> gmae(y_true, y_pred) # doctest: +SKIP
     np.float64(0.000529527232030127)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> gmae(y_true, y_pred)
+    >>> gmae(y_true, y_pred) # doctest: +SKIP
     np.float64(0.5000024031086919)
     >>> gmae = GeometricMeanAbsoluteError(multioutput='raw_values')
-    >>> gmae(y_true, y_pred)
+    >>> gmae(y_true, y_pred) # doctest: +SKIP
     array([4.80621738e-06, 1.00000000e+00])
     >>> gmae = GeometricMeanAbsoluteError(multioutput=[0.3, 0.7])
-    >>> gmae(y_true, y_pred)
+    >>> gmae(y_true, y_pred) # doctest: +SKIP
     np.float64(0.7000014418652152)
     """
 

--- a/sktime/performance_metrics/forecasting/_gmrelae.py
+++ b/sktime/performance_metrics/forecasting/_gmrelae.py
@@ -75,18 +75,18 @@ class GeometricMeanRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> y_pred_benchmark = y_pred*1.1
     >>> gmrae = GeometricMeanRelativeAbsoluteError()
-    >>> gmrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> gmrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.0007839273064064755)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> y_pred_benchmark = y_pred*1.1
-    >>> gmrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> gmrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.5578632807409556)
     >>> gmrae = GeometricMeanRelativeAbsoluteError(multioutput='raw_values')
-    >>> gmrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> gmrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     array([4.97801163e-06, 1.11572158e+00])
     >>> gmrae = GeometricMeanRelativeAbsoluteError(multioutput=[0.3, 0.7])
-    >>> gmrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> gmrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.7810066018326863)
     """
 

--- a/sktime/performance_metrics/forecasting/_gmrelse.py
+++ b/sktime/performance_metrics/forecasting/_gmrelse.py
@@ -82,18 +82,18 @@ class GeometricMeanRelativeSquaredError(BaseForecastingErrorMetricFunc):
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> y_pred_benchmark = y_pred*1.1
     >>> gmrse = GeometricMeanRelativeSquaredError()
-    >>> gmrse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> gmrse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.0008303544925949156)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> y_pred_benchmark = y_pred*1.1
-    >>> gmrse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> gmrse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.622419372049448)
     >>> gmrse = GeometricMeanRelativeSquaredError(multioutput='raw_values')
-    >>> gmrse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> gmrse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     array([4.09227746e-06, 1.24483465e+00])
     >>> gmrse = GeometricMeanRelativeSquaredError(multioutput=[0.3, 0.7])
-    >>> gmrse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> gmrse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.8713854839582426)
     """
 

--- a/sktime/performance_metrics/forecasting/_mae.py
+++ b/sktime/performance_metrics/forecasting/_mae.py
@@ -87,17 +87,17 @@ class MeanAbsoluteError(BaseForecastingErrorMetric):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> mae = MeanAbsoluteError()
-    >>> mae(y_true, y_pred)
+    >>> mae(y_true, y_pred) # doctest: +SKIP
     np.float64(0.55)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> mae(y_true, y_pred)
+    >>> mae(y_true, y_pred) # doctest: +SKIP
     np.float64(0.75)
     >>> mae = MeanAbsoluteError(multioutput='raw_values')
-    >>> mae(y_true, y_pred)
+    >>> mae(y_true, y_pred) # doctest: +SKIP
     array([0.5, 1. ])
     >>> mae = MeanAbsoluteError(multioutput=[0.3, 0.7])
-    >>> mae(y_true, y_pred)
+    >>> mae(y_true, y_pred) # doctest: +SKIP
     np.float64(0.85)
     """
 

--- a/sktime/performance_metrics/forecasting/_mape.py
+++ b/sktime/performance_metrics/forecasting/_mape.py
@@ -116,28 +116,28 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetric):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> mape = MeanAbsolutePercentageError(symmetric=False)
-    >>> mape(y_true, y_pred)
+    >>> mape(y_true, y_pred) # doctest: +SKIP
     np.float64(0.33690476190476193)
     >>> smape = MeanAbsolutePercentageError(symmetric=True)
-    >>> smape(y_true, y_pred)
+    >>> smape(y_true, y_pred) # doctest: +SKIP
     np.float64(0.5553379953379953)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> mape(y_true, y_pred)
+    >>> mape(y_true, y_pred) # doctest: +SKIP
     np.float64(0.5515873015873016)
-    >>> smape(y_true, y_pred)
+    >>> smape(y_true, y_pred) # doctest: +SKIP
     np.float64(0.6080808080808081)
     >>> mape = MeanAbsolutePercentageError(multioutput='raw_values', symmetric=False)
-    >>> mape(y_true, y_pred)
+    >>> mape(y_true, y_pred) # doctest: +SKIP
     array([0.38095238, 0.72222222])
     >>> smape = MeanAbsolutePercentageError(multioutput='raw_values', symmetric=True)
-    >>> smape(y_true, y_pred)
+    >>> smape(y_true, y_pred) # doctest: +SKIP
     array([0.71111111, 0.50505051])
     >>> mape = MeanAbsolutePercentageError(multioutput=[0.3, 0.7], symmetric=False)
-    >>> mape(y_true, y_pred)
+    >>> mape(y_true, y_pred) # doctest: +SKIP
     np.float64(0.6198412698412699)
     >>> smape = MeanAbsolutePercentageError(multioutput=[0.3, 0.7], symmetric=True)
-    >>> smape(y_true, y_pred)
+    >>> smape(y_true, y_pred) # doctest: +SKIP
     np.float64(0.5668686868686869)
     """
 

--- a/sktime/performance_metrics/forecasting/_mase.py
+++ b/sktime/performance_metrics/forecasting/_mase.py
@@ -119,18 +119,18 @@ class MeanAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetric):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> mase = MeanAbsoluteScaledError()
-    >>> mase(y_true, y_pred, y_train=y_train)
+    >>> mase(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     np.float64(0.18333333333333335)
     >>> y_train = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> mase(y_true, y_pred, y_train=y_train)
+    >>> mase(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     np.float64(0.18181818181818182)
     >>> mase = MeanAbsoluteScaledError(multioutput='raw_values')
-    >>> mase(y_true, y_pred, y_train=y_train)
+    >>> mase(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     array([0.10526316, 0.28571429])
     >>> mase = MeanAbsoluteScaledError(multioutput=[0.3, 0.7])
-    >>> mase(y_true, y_pred, y_train=y_train)
+    >>> mase(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     np.float64(0.21935483870967742)
     """
 

--- a/sktime/performance_metrics/forecasting/_medae.py
+++ b/sktime/performance_metrics/forecasting/_medae.py
@@ -86,17 +86,17 @@ class MedianAbsoluteError(BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> mdae = MedianAbsoluteError()
-    >>> mdae(y_true, y_pred)
+    >>> mdae(y_true, y_pred) # doctest: +SKIP
     np.float64(0.5)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> mdae(y_true, y_pred)
+    >>> mdae(y_true, y_pred) # doctest: +SKIP
     np.float64(0.75)
     >>> mdae = MedianAbsoluteError(multioutput='raw_values')
-    >>> mdae(y_true, y_pred)
+    >>> mdae(y_true, y_pred) # doctest: +SKIP
     array([0.5, 1. ])
     >>> mdae = MedianAbsoluteError(multioutput=[0.3, 0.7])
-    >>> mdae(y_true, y_pred)
+    >>> mdae(y_true, y_pred) # doctest: +SKIP
     np.float64(0.85)
     """
 

--- a/sktime/performance_metrics/forecasting/_medape.py
+++ b/sktime/performance_metrics/forecasting/_medape.py
@@ -116,28 +116,28 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> mdape = MedianAbsolutePercentageError(symmetric=False)
-    >>> mdape(y_true, y_pred)
+    >>> mdape(y_true, y_pred) # doctest: +SKIP
     np.float64(0.16666666666666666)
     >>> smdape = MedianAbsolutePercentageError(symmetric=True)
-    >>> smdape(y_true, y_pred)
+    >>> smdape(y_true, y_pred) # doctest: +SKIP
     np.float64(0.18181818181818182)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> mdape(y_true, y_pred)
+    >>> mdape(y_true, y_pred) # doctest: +SKIP
     np.float64(0.5714285714285714)
-    >>> smdape(y_true, y_pred)
+    >>> smdape(y_true, y_pred) # doctest: +SKIP
     np.float64(0.39999999999999997)
     >>> mdape = MedianAbsolutePercentageError(multioutput='raw_values', symmetric=False)
-    >>> mdape(y_true, y_pred)
+    >>> mdape(y_true, y_pred) # doctest: +SKIP
     array([0.14285714, 1.        ])
     >>> smdape = MedianAbsolutePercentageError(multioutput='raw_values', symmetric=True)
-    >>> smdape(y_true, y_pred)
+    >>> smdape(y_true, y_pred) # doctest: +SKIP
     array([0.13333333, 0.66666667])
     >>> mdape = MedianAbsolutePercentageError(multioutput=[0.3, 0.7], symmetric=False)
-    >>> mdape(y_true, y_pred)
+    >>> mdape(y_true, y_pred) # doctest: +SKIP
     np.float64(0.7428571428571428)
     >>> smdape = MedianAbsolutePercentageError(multioutput=[0.3, 0.7], symmetric=True)
-    >>> smdape(y_true, y_pred)
+    >>> smdape(y_true, y_pred) # doctest: +SKIP
     np.float64(0.5066666666666666)
     """  # noqa: E501
 

--- a/sktime/performance_metrics/forecasting/_medase.py
+++ b/sktime/performance_metrics/forecasting/_medase.py
@@ -109,18 +109,18 @@ class MedianAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFun
     >>> y_true = np.array([3, -0.5, 2, 7])
     >>> y_pred = np.array([2.5, 0.0, 2, 8])
     >>> mdase = MedianAbsoluteScaledError()
-    >>> mdase(y_true, y_pred, y_train=y_train)
+    >>> mdase(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     np.float64(0.16666666666666666)
     >>> y_train = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> mdase(y_true, y_pred, y_train=y_train)
+    >>> mdase(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     np.float64(0.18181818181818182)
     >>> mdase = MedianAbsoluteScaledError(multioutput='raw_values')
-    >>> mdase(y_true, y_pred, y_train=y_train)
+    >>> mdase(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     array([0.10526316, 0.28571429])
     >>> mdase = MedianAbsoluteScaledError(multioutput=[0.3, 0.7])
-    >>> mdase( y_true, y_pred, y_train=y_train)
+    >>> mdase( y_true, y_pred, y_train=y_train) # doctest: +SKIP
     np.float64(0.21935483870967742)
     """
 

--- a/sktime/performance_metrics/forecasting/_medrelae.py
+++ b/sktime/performance_metrics/forecasting/_medrelae.py
@@ -73,18 +73,18 @@ class MedianRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> y_pred_benchmark = y_pred*1.1
     >>> mdrae = MedianRelativeAbsoluteError()
-    >>> mdrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> mdrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(1.0)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> y_pred_benchmark = y_pred*1.1
-    >>> mdrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> mdrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.6944444444444443)
     >>> mdrae = MedianRelativeAbsoluteError(multioutput='raw_values')
-    >>> mdrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> mdrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     array([0.55555556, 0.83333333])
     >>> mdrae = MedianRelativeAbsoluteError(multioutput=[0.3, 0.7])
-    >>> mdrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> mdrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.7499999999999999)
     """
 

--- a/sktime/performance_metrics/forecasting/_medse.py
+++ b/sktime/performance_metrics/forecasting/_medse.py
@@ -108,28 +108,28 @@ class MedianSquaredError(BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> mdse = MedianSquaredError()
-    >>> mdse(y_true, y_pred)
+    >>> mdse(y_true, y_pred) # doctest: +SKIP
     np.float64(0.25)
     >>> rmdse = MedianSquaredError(square_root=True)
-    >>> rmdse(y_true, y_pred)
+    >>> rmdse(y_true, y_pred) # doctest: +SKIP
     np.float64(0.5)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> mdse(y_true, y_pred)
+    >>> mdse(y_true, y_pred) # doctest: +SKIP
     np.float64(0.625)
-    >>> rmdse(y_true, y_pred)
+    >>> rmdse(y_true, y_pred) # doctest: +SKIP
     np.float64(0.75)
     >>> mdse = MedianSquaredError(multioutput='raw_values')
-    >>> mdse(y_true, y_pred)
+    >>> mdse(y_true, y_pred) # doctest: +SKIP
     array([0.25, 1.  ])
     >>> rmdse = MedianSquaredError(multioutput='raw_values', square_root=True)
-    >>> rmdse(y_true, y_pred)
+    >>> rmdse(y_true, y_pred) # doctest: +SKIP
     array([0.5, 1. ])
     >>> mdse = MedianSquaredError(multioutput=[0.3, 0.7])
-    >>> mdse(y_true, y_pred)
+    >>> mdse(y_true, y_pred) # doctest: +SKIP
     np.float64(0.7749999999999999)
     >>> rmdse = MedianSquaredError(multioutput=[0.3, 0.7], square_root=True)
-    >>> rmdse(y_true, y_pred)
+    >>> rmdse(y_true, y_pred) # doctest: +SKIP
     np.float64(0.85)
     """
 

--- a/sktime/performance_metrics/forecasting/_medspe.py
+++ b/sktime/performance_metrics/forecasting/_medspe.py
@@ -102,30 +102,30 @@ class MedianSquaredPercentageError(BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> mdspe = MedianSquaredPercentageError(symmetric=False)
-    >>> mdspe(y_true, y_pred)
+    >>> mdspe(y_true, y_pred) # doctest: +SKIP
     np.float64(0.027777777777777776)
     >>> smdspe = MedianSquaredPercentageError(square_root=True, symmetric=False)
-    >>> smdspe(y_true, y_pred)
+    >>> smdspe(y_true, y_pred) # doctest: +SKIP
     np.float64(0.16666666666666666)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> mdspe(y_true, y_pred)
+    >>> mdspe(y_true, y_pred) # doctest: +SKIP
     np.float64(0.5102040816326531)
-    >>> smdspe(y_true, y_pred)
+    >>> smdspe(y_true, y_pred) # doctest: +SKIP
     np.float64(0.5714285714285714)
     >>> mdspe = MedianSquaredPercentageError(multioutput='raw_values', symmetric=False)
-    >>> mdspe(y_true, y_pred)
+    >>> mdspe(y_true, y_pred) # doctest: +SKIP
     array([0.02040816, 1.        ])
     >>> smdspe = MedianSquaredPercentageError(multioutput='raw_values', \
     symmetric=False, square_root=True)
-    >>> smdspe(y_true, y_pred)
+    >>> smdspe(y_true, y_pred) # doctest: +SKIP
     array([0.14285714, 1.        ])
     >>> mdspe = MedianSquaredPercentageError(multioutput=[0.3, 0.7], symmetric=False)
-    >>> mdspe(y_true, y_pred)
+    >>> mdspe(y_true, y_pred) # doctest: +SKIP
     np.float64(0.7061224489795918)
     >>> smdspe = MedianSquaredPercentageError(multioutput=[0.3, 0.7], \
     symmetric=False, square_root=True)
-    >>> smdspe(y_true, y_pred)
+    >>> smdspe(y_true, y_pred) # doctest: +SKIP
     np.float64(0.7428571428571428)
     """
 

--- a/sktime/performance_metrics/forecasting/_mrelae.py
+++ b/sktime/performance_metrics/forecasting/_mrelae.py
@@ -73,18 +73,18 @@ class MeanRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> y_pred_benchmark = y_pred*1.1
     >>> mrae = MeanRelativeAbsoluteError()
-    >>> mrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> mrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.9511111111111111)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> y_pred_benchmark = y_pred*1.1
-    >>> mrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> mrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.8703703703703702)
     >>> mrae = MeanRelativeAbsoluteError(multioutput='raw_values')
-    >>> mrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> mrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     array([0.51851852, 1.22222222])
     >>> mrae = MeanRelativeAbsoluteError(multioutput=[0.3, 0.7])
-    >>> mrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> mrae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(1.0111111111111108)
     """
 

--- a/sktime/performance_metrics/forecasting/_mse.py
+++ b/sktime/performance_metrics/forecasting/_mse.py
@@ -104,26 +104,26 @@ class MeanSquaredError(BaseForecastingErrorMetric):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> mse = MeanSquaredError()
-    >>> mse(y_true, y_pred)
+    >>> mse(y_true, y_pred) # doctest: +SKIP
     np.float64(0.4125)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> mse(y_true, y_pred)
+    >>> mse(y_true, y_pred) # doctest: +SKIP
     np.float64(0.7083333333333334)
     >>> rmse = MeanSquaredError(square_root=True)
-    >>> rmse(y_true, y_pred)
+    >>> rmse(y_true, y_pred) # doctest: +SKIP
     np.float64(0.8227486121839513)
     >>> rmse = MeanSquaredError(multioutput='raw_values')
-    >>> rmse(y_true, y_pred)
+    >>> rmse(y_true, y_pred) # doctest: +SKIP
     array([0.41666667, 1.        ])
     >>> rmse = MeanSquaredError(multioutput='raw_values', square_root=True)
-    >>> rmse(y_true, y_pred)
+    >>> rmse(y_true, y_pred) # doctest: +SKIP
     array([0.64549722, 1.        ])
     >>> rmse = MeanSquaredError(multioutput=[0.3, 0.7])
-    >>> rmse(y_true, y_pred)
+    >>> rmse(y_true, y_pred) # doctest: +SKIP
     np.float64(0.825)
     >>> rmse = MeanSquaredError(multioutput=[0.3, 0.7], square_root=True)
-    >>> rmse(y_true, y_pred)
+    >>> rmse(y_true, y_pred) # doctest: +SKIP
     np.float64(0.8936491673103708)
     """  # noqa: E501
 

--- a/sktime/performance_metrics/forecasting/_mspe.py
+++ b/sktime/performance_metrics/forecasting/_mspe.py
@@ -98,30 +98,30 @@ class MeanSquaredPercentageError(BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> mspe = MeanSquaredPercentageError(symmetric=False)
-    >>> mspe(y_true, y_pred)
+    >>> mspe(y_true, y_pred) # doctest: +SKIP
     np.float64(0.23776218820861678)
     >>> smspe = MeanSquaredPercentageError(square_root=True, symmetric=False)
-    >>> smspe(y_true, y_pred)
+    >>> smspe(y_true, y_pred) # doctest: +SKIP
     np.float64(0.48760864246710883)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> mspe(y_true, y_pred)
+    >>> mspe(y_true, y_pred) # doctest: +SKIP
     np.float64(0.5080309901738473)
-    >>> smspe(y_true, y_pred)
+    >>> smspe(y_true, y_pred) # doctest: +SKIP
     np.float64(0.7026794936195895)
     >>> mspe = MeanSquaredPercentageError(multioutput='raw_values', symmetric=False)
-    >>> mspe(y_true, y_pred)
+    >>> mspe(y_true, y_pred) # doctest: +SKIP
     array([0.34013605, 0.67592593])
     >>> smspe = MeanSquaredPercentageError(multioutput='raw_values', \
     symmetric=False, square_root=True)
-    >>> smspe(y_true, y_pred)
+    >>> smspe(y_true, y_pred) # doctest: +SKIP
     array([0.58321184, 0.82214714])
     >>> mspe = MeanSquaredPercentageError(multioutput=[0.3, 0.7], symmetric=False)
-    >>> mspe(y_true, y_pred)
+    >>> mspe(y_true, y_pred) # doctest: +SKIP
     np.float64(0.5751889644746787)
     >>> smspe = MeanSquaredPercentageError(multioutput=[0.3, 0.7], \
     symmetric=False, square_root=True)
-    >>> smspe(y_true, y_pred)
+    >>> smspe(y_true, y_pred) # doctest: +SKIP
     np.float64(0.7504665536595034)
     """
 

--- a/sktime/performance_metrics/forecasting/_msse.py
+++ b/sktime/performance_metrics/forecasting/_msse.py
@@ -92,18 +92,18 @@ class MeanSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> rmsse = MeanSquaredScaledError(square_root=True)
-    >>> rmsse(y_true, y_pred, y_train=y_train)
+    >>> rmsse(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     np.float64(0.20568833780186058)
     >>> y_train = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> rmsse(y_true, y_pred, y_train=y_train)
+    >>> rmsse(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     np.float64(0.15679361328058636)
     >>> rmsse = MeanSquaredScaledError(multioutput='raw_values', square_root=True)
-    >>> rmsse(y_true, y_pred, y_train=y_train)
+    >>> rmsse(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     array([0.11215443, 0.20203051])
     >>> rmsse = MeanSquaredScaledError(multioutput=[0.3, 0.7], square_root=True)
-    >>> rmsse(y_true, y_pred, y_train=y_train)
+    >>> rmsse(y_true, y_pred, y_train=y_train) # doctest: +SKIP
     np.float64(0.17451891814894502)
     """
 

--- a/sktime/performance_metrics/forecasting/_rell.py
+++ b/sktime/performance_metrics/forecasting/_rell.py
@@ -87,22 +87,22 @@ class RelativeLoss(BaseForecastingErrorMetricFunc):
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> y_pred_benchmark = y_pred*1.1
     >>> relative_mae = RelativeLoss()
-    >>> relative_mae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> relative_mae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.8148148148148147)
     >>> relative_mse = RelativeLoss(relative_loss_function=mean_squared_error)
-    >>> relative_mse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> relative_mse(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.5178095088655261)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> y_pred_benchmark = y_pred*1.1
     >>> relative_mae = RelativeLoss()
-    >>> relative_mae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> relative_mae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.8490566037735847)
     >>> relative_mae = RelativeLoss(multioutput='raw_values')
-    >>> relative_mae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> relative_mae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     array([0.625     , 1.03448276])
     >>> relative_mae = RelativeLoss(multioutput=[0.3, 0.7])
-    >>> relative_mae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark)
+    >>> relative_mae(y_true, y_pred, y_pred_benchmark=y_pred_benchmark) # doctest: +SKIP
     np.float64(0.927272727272727)
     """
 

--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -494,10 +494,10 @@ class PinballLoss(_BaseProbaForecastingErrorMetric):
     ...     ('Quantiles', 0.95): [3.75, 0, 3, 12, 1.875],
     ... })
     >>> pl = PinballLoss()
-    >>> pl(y_true, y_pred)
+    >>> pl(y_true, y_pred) # doctest: +SKIP
     np.float64(0.1791666666666667)
     >>> pl = PinballLoss(score_average=False)
-    >>> pl(y_true, y_pred).to_numpy()
+    >>> pl(y_true, y_pred).to_numpy() # doctest: +SKIP
     array([0.16625, 0.275  , 0.09625])
     >>> y_true = pd.DataFrame({
     ...     "Quantiles1": [3, -0.5, 2, 7, 2],
@@ -512,10 +512,10 @@ class PinballLoss(_BaseProbaForecastingErrorMetric):
     ...     ('Quantiles2', 0.95): [7.5, 2, 6, 24, 3.75],
     ... })
     >>> pl = PinballLoss(multioutput='raw_values')
-    >>> pl(y_true, y_pred).to_numpy()
+    >>> pl(y_true, y_pred).to_numpy() # doctest: +SKIP
     array([0.16233333, 0.465     ])
     >>> pl = PinballLoss(multioutput=np.array([0.3, 0.7]))
-    >>> pl(y_true, y_pred)
+    >>> pl(y_true, y_pred) # doctest: +SKIP
     np.float64(0.3742000000000001)
     """  # noqa: E501
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -269,32 +269,7 @@ EXCLUDED_TESTS_BY_TEST = {
         "TSBootstrapAdapter",
         "ThetaModularForecaster",
         "WeightedEnsembleClassifier",
-    ],
-    "test_doctest_examples": [
-        # between-versions inconsistency how doctest handles np.float64.
-        # on lower version, prints 0.123456
-        # on higher version, prints np.float64(0.123456)
-        # therefore these doctests will fail either on lower or higher versions
-        "MedianSquaredScaledError",
-        "GeometricMeanAbsoluteError",
-        "MedianRelativeAbsoluteError",
-        "MeanSquaredScaledError",
-        "GeometricMeanRelativeAbsoluteError",
-        "GeometricMeanRelativeSquaredError",
-        "MedianSquaredPercentageError",
-        "MedianAbsoluteScaledError",
-        "MedianSquaredError",
-        "MeanAbsoluteError",
-        "MeanAbsolutePercentageError",
-        "MeanAbsoluteScaledError",
-        "MedianAbsoluteError",
-        "MeanSquaredPercentageError",
-        "MedianAbsolutePercentageError",
-        "MeanSquaredError",
-        "PinballLoss",
-        "RelativeLoss",
-        "MeanRelativeAbsoluteError",
-    ],
+    ]
 }
 
 # estimators that have 2 test params only when their soft dependency is installed


### PR DESCRIPTION
Towards #8515

The between-versions inconsistency in how np.float64 is printed in doctest 
examples was previously handled by skipping the entire test_doctest_examples 
test for 18 metrics via EXCLUDED_TESTS_BY_TEST in _config.py.

This PR moves the skip to the specific output lines in docstrings using 
`# doctest: +SKIP`, following the same pattern already used in 
GeometricMeanSquaredError.

Removed the test_doctest_examples block from EXCLUDED_TESTS_BY_TEST 
in sktime/tests/_config.py.

Note: MedianSquaredScaledError was handled separately in PR #9715.