### PR TITLE
[BUG] fix SARIMAX update crash when update_params=False with seen data

### DIFF
--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -90,10 +90,10 @@ class _StatsModelsAdapter(BaseForecaster):
                 index_diff = y.index.difference(
                     self._fitted_forecaster.fittedvalues.index
                 )
-                if index_diff.isin(y.index).all():
-                    y = y.loc[index_diff]
-                    X = X.loc[index_diff].set_index(y.index) if X is not None else None
-
+                if len(index_diff) == 0:
+                    return self
+                y = y.loc[index_diff]
+                X = X.loc[index_diff] if X is not None else None
                 self._fitted_forecaster = self._fitted_forecaster.append(y, exog=X)
 
     def _predict(self, fh, X):
@@ -275,3 +275,4 @@ def _coerce_int_to_range_index(y, X=None):
     if X is not None:
         X.index = new_index
     return y, X
+

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -90,7 +90,7 @@ class _StatsModelsAdapter(BaseForecaster):
                 index_diff = y.index.difference(
                     self._fitted_forecaster.fittedvalues.index
                 )
-                if len(index_diff) == 0:
+                if index_diff.empty:
                     return self
                 y = y.loc[index_diff]
                 X = X.loc[index_diff] if X is not None else None

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -360,7 +360,7 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
                     nodes = mi
                 else:
                     # For nlevels = 2, 'nodes' is pd.Index object (L286)
-                    nodes = nodes.append(mi)
+                    nodes = pd.concat([nodes, mi])
             else:
                 node_l = []
                 for i in range(len(node)):

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -360,7 +360,7 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
                     nodes = mi
                 else:
                     # For nlevels = 2, 'nodes' is pd.Index object (L286)
-                    nodes = pd.concat([nodes, mi])
+                    nodes = nodes.union(mi, sort=False)
             else:
                 node_l = []
                 for i in range(len(node)):


### PR DESCRIPTION
Fixes #9630
`update(y_train, update_params=False)` crashed when called with seen data because `index_diff` was empty and `append` failed. Fixed by adding early return when `index_diff` is empty.