### PR TITLE
fix: remove deprecated copy=False from astype in WindowSummarizer

### DIFF
--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -305,7 +305,7 @@ class WindowSummarizer(BaseTransformer):
         lags = func_dict["summarizer"] == "lag"
         # Convert lags to default list notation with window_length 1
         boost_lag = func_dict.loc[lags, "window"].apply(lambda x: [int(x), 1])
-        func_dict["window"] = func_dict["window"].astype("object", copy=False)
+        func_dict["window"] = func_dict["window"].astype(object)
         func_dict.loc[lags, "window"] = boost_lag
         self.truncate_start = func_dict["window"].apply(lambda x: x[0] + x[1] - 1).max()
         self._func_dict = func_dict


### PR DESCRIPTION
## Summary

Removes the deprecated `copy=False` parameter from `astype()` call in `WindowSummarizer._fit`.

The `copy` parameter in `DataFrame.astype()` is deprecated as of pandas 2.2 and will be removed in pandas 3.0, raising a `FutureWarning` during `fit_transform` operations.

**Change:**
```python
# Before
func_dict["window"] = func_dict["window"].astype("object", copy=False)

# After
func_dict["window"] = func_dict["window"].astype(object)
```

## Related

Closes part of #9640.

## Checklist

- [x] The change addresses a documented warning from #9640
- [x] No functional behavior changed - only removes a deprecated parameter
- [x] Fix is minimal and focused