### PR TITLE
[DOC] Improved example clarity in TransformedTargetForecaster

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -829,7 +829,6 @@ class TransformedTargetForecaster(_Pipeline):
         reference to pairs in ``steps_`` that precede ``forecaster_``
     transformers_post_ : list of tuples (str, transformer) of sktime transformers
         reference to pairs in ``steps_`` that succeed ``forecaster_``
-
     Examples
     --------
     >>> from sktime.datasets import load_airline
@@ -837,19 +836,21 @@ class TransformedTargetForecaster(_Pipeline):
     >>> from sktime.forecasting.compose import TransformedTargetForecaster
     >>> from sktime.transformations.series.impute import Imputer
     >>> from sktime.transformations.series.detrend import Detrender
-    >>> from sktime.transformations.series.exponent import ExponentTransformer
+
     >>> y = load_airline()
 
-        Example 1: string/estimator pairs
-
+    # Create pipeline with preprocessing and forecasting model
     >>> pipe = TransformedTargetForecaster(steps=[
     ...     ("imputer", Imputer(method="mean")),
     ...     ("detrender", Detrender()),
     ...     ("forecaster", NaiveForecaster(strategy="drift")),
     ... ])
+
+    # Fit the model
     >>> pipe.fit(y)
-    TransformedTargetForecaster(...)
-    >>> y_pred = pipe.predict(fh=[1,2,3])
+
+    # Predict next 3 time steps
+    >>> y_pred = pipe.predict(fh=[1, 2, 3])
 
         Example 2: without strings
 


### PR DESCRIPTION
#### Reference Issues/PRs
Part of documentation improvement (no specific issue linked).

---

#### What does this implement/fix? Explain your changes.
This PR improves the readability and clarity of the example in 
`TransformedTargetForecaster` by adding explanatory comments and making 
the workflow (fit → predict) easier to understand for new users.

---

#### Does your contribution introduce a new dependency? If yes, which one?
No.

---

#### What should a reviewer concentrate their feedback on?
- Clarity and readability of the updated example
- Consistency with existing documentation style

---

#### Did you add any tests for the change?
No, this is a documentation-only change.

---

#### Any other comments?
This is my first contribution to sktime. Happy to make any changes if needed.

---

#### PR checklist

##### For all contributions
- [  ] I've added myself to the list of contributors
- [x] The PR title starts with [DOC]

##### For new estimators
(Not applicable)
