### PR TITLE
Enh/vectorizer fast track

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -2067,7 +2067,10 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         #   y_inner_scitype are same as X_inner_scitype
         #   y_inner_scitype always includes "less index" scitypes
 
-        # convert X & y to a supported internal mtype
+        # convert X & y to supported inner type, if necessary
+        #####################################################
+
+        # convert X and y to a supported internal mtype
         #  it X/y mtype is already supported, no conversion takes place
         #  if X/y is None, then no conversion takes place (returns None)
         #  if vectorization is required, we wrap in Vect
@@ -2388,9 +2391,12 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
 
             if methodname == "fit":
                 est_template = self.clone().set_config(
-                    known_y_mtype="pd.DataFrame",
+                    known_y_mtype="pd.DataFrame", 
                     known_X_mtype="pd.DataFrame"
                 )
+                #passing these dummy values acts as a switch earlier when the known_mtypes were None we ran the complete _check_X_y() 
+                #now since we have provided some value only the convert/coerce part of _check_X_y() runs 
+                #the actual mtype is determined there this is just a dummy value which acts as the switch
                 forecasters_ = y.vectorize_est(
                     est_template,
                     method="clone",

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -115,6 +115,8 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
     # configs and default config values
     # see set_config documentation for details
     _config = {
+        "known_y_mtype": None,
+        "known_X_mtype": None,
         "backend:parallel": None,  # parallelization backend for broadcasting
         #  {None, "dask", "loky", "multiprocessing", "threading"}
         #  None: no parallelization
@@ -1802,8 +1804,74 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         _y_metadata : dict with str keys, metadata from checking y
         _converter_store_y : dict, metadata from conversion for back-conversion
         """
+
         if X is None and y is None:
             return None, None
+        
+
+
+        #No need for heavy computations if the mtype is known, it means that the data had passed through _check_X_y before
+        config = self.get_config()
+        known_y_mtype = config.get("known_y_mtype")
+        known_X_mtype = config.get("known_X_mtype")
+        
+        #Doing the conversion/coersion part before hand if mtype is known
+        if known_y_mtype is not None:
+            import pandas as pd
+            from sktime.datatypes import convert
+
+            if y_inner_mtype is None:
+                y_inner_mtype = self.get_tag("y_inner_mtype")
+            X_inner_mtype = self.get_tag("X_inner_mtype")
+
+            # Dynamically detect pandas mtype and feature names to bypass slow discovery
+            if isinstance(y, pd.Series):
+                actual_y_mtype = "pd.Series"
+                feature_names = [y.name] if y.name is not None else [0]
+            elif isinstance(y, pd.DataFrame):
+                actual_y_mtype = "pd.DataFrame"
+                feature_names = y.columns.tolist()
+            else:
+                actual_y_mtype = known_y_mtype
+                feature_names = [0]
+
+            y_inner = convert(
+                y,
+                from_type=actual_y_mtype,
+                to_type=y_inner_mtype,
+                as_scitype="Series",
+                store=self._converter_store_y,
+                store_behaviour="reset",
+            )
+
+            if X is not None and known_X_mtype is not None:
+                if isinstance(X, pd.Series):
+                    actual_X_mtype = "pd.Series"
+                elif isinstance(X, pd.DataFrame):
+                    actual_X_mtype = "pd.DataFrame"
+                else:
+                    actual_X_mtype = known_X_mtype
+
+                X_inner = convert(
+                    X,
+                    from_type=actual_X_mtype,
+                    to_type=X_inner_mtype,
+                    as_scitype="Series"
+                )
+            else:
+                X_inner = None
+            # Set complete metadata passport so predictions compile perfectly
+            self._y_metadata = {
+                "mtype": actual_y_mtype,
+                "scitype": "Series",
+                "feature_names": feature_names,
+                "is_univariate": len(feature_names) == 1,
+            }
+            self._y_mtype_last_seen = actual_y_mtype
+
+            return X_inner, y_inner
+
+
 
         def _most_complex_scitype(scitypes, smaller_equal_than=None):
             """Return most complex scitype in a list of str."""
@@ -1999,10 +2067,7 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         #   y_inner_scitype are same as X_inner_scitype
         #   y_inner_scitype always includes "less index" scitypes
 
-        # convert X & y to supported inner type, if necessary
-        #####################################################
-
-        # convert X and y to a supported internal mtype
+        # convert X & y to a supported internal mtype
         #  it X/y mtype is already supported, no conversion takes place
         #  if X/y is None, then no conversion takes place (returns None)
         #  if vectorization is required, we wrap in Vect
@@ -2322,8 +2387,12 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
             self._yvec = y
 
             if methodname == "fit":
+                est_template = self.clone().set_config(
+                    known_y_mtype="pd.DataFrame",
+                    known_X_mtype="pd.DataFrame"
+                )
                 forecasters_ = y.vectorize_est(
-                    self,
+                    est_template,
                     method="clone",
                     rowname_default="forecasters",
                     colname_default="forecasters",


### PR DESCRIPTION
#### Reference Issues/PRs
Solves Issue #9679 which deals with bypassing the heavy input checks for vectorized data.

#### What does this implement/fix? Explain your changes.
This PR implements a massive performance optimization for [VectorizedDF] ( by intentionally bypassing the slow `check_is_scitype` discovery phase for vectorized clones, dramatically speeding up [fit]) and [predict] loops on hierarchical/panel data.

**Key Changes:**
1. **Addition to _config:** Added two new parameters to _config in forecaster/_base.py -> known_X_mtype and known_y_mtype
2. **The Vectorizer Template:** Modified [_vectorize] in [forecaster/_base.py] to stamp `known_y_mtype="pd.DataFrame"` onto the `est_template` config before [VectorizedDF] generates its clones.
3. **The Fast-Track Bypass:** Made some additions to the  [_check_X_y]. If `known_y_mtype` is present in the `get_config()`, execution immediately enters a fast-track block, completely bypassing the heavy  `check_is_scitype` data discovery. 
4. **Dynamic Type Safety:** Even though `"pd.DataFrame"` is used as the dummy activation key (which acts like the on switch in order to bypass the heavy checks), the fast-track block uses dynamic `isinstance(y, pd.Series)` checks to safely determine the actual slice format on the fly
5. **Metadata Recreation:** I noticed that vectorizer heavily relied on the metadata which was passed to it by the `check_is_scitype` to avoid its reliance on the heavy function I explicitly captured`feature_names` and `is_univariate` and injected them into `self._y_metadata`, completely mimicking `check_is_scitype`'s metadata output.
6. **Column Name Preservation:** Passed `store=self._converter_store_y` and `store_behaviour="reset"` to the internal `convert` call so that [predict] can perfectly reconstruct the output DataFrames with the correct string column names (e.g., `"passengers"`) rather than defaulting to `0`)

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- The dynamic `isinstance` logic in [_check_X_y] that checks whether data slices coming from the vectorizer is  `pd.Series` or `pd.DataFrame` 
- The manual reconstruction of the `self._y_metadata` dictionary inside the fast-track block. All current `pytest` checks pass  but still it a check is required in case some edge case is missing.