### PR TITLE
[MAINT] Fix Pyright static type checking errors in build tools

### DIFF
--- a/build_tools/check_backticks.py
+++ b/build_tools/check_backticks.py
@@ -28,14 +28,14 @@ def extract_docstrings(filename):
         if (
             isinstance(node, ast.Expr)
             and isinstance(node.value, ast.Constant)
-            and isinstance(node.value.value, str)
+            and isinstance(getattr(node.value, "value", None), str)
         ):
             # if the node is an expression and
             # its value is a constant and
             # constant's value is a string
             # the node represents a docstring
             # See https://docs.python.org/3/library/ast.html#abstract-grammar
-            docstring = node.value.value
+            docstring = getattr(node.value, "value")
             lineno = node.value.lineno
             docstrings[lineno] = docstring
 

--- a/build_tools/make_release.py
+++ b/build_tools/make_release.py
@@ -18,7 +18,7 @@ import os
 import re
 import webbrowser
 
-import colorama
+import colorama  # type: ignore
 
 ROOT_DIR = os.path.abspath(os.path.dirname(__file__)).replace("build_tools", "")
 PACKAGE_NAME = "sktime"
@@ -130,7 +130,7 @@ class Step:
         wait_for_enter()
         os.system(cmd)
 
-    def action(self, context):
+    def action(self, context) -> None:
         """Carry out action."""
         raise NotImplementedError("abstract method")
 


### PR DESCRIPTION
Here is a ready-to-use PR description that you can copy and paste. It follows the standard `sktime` conventions for pull requests:  

***

**PR Title:**  
`[MAINT] Fix Pyright static type checking errors in build tools`

**PR Description:**

### Describe your changes:

This PR addresses static type checking errors (Pyright) reported by IDEs in the repository's build tools scripts without affecting runtime behaviors. 

Specifically, it handles the following issues:
1. **[build_tools/make_release.py](cci:7://file:///Users/kirtan/Desktop/sktime/build_tools/make_release.py:0:0-0:0)**:
   - Added a `# type: ignore` annotation for the `colorama` import to silence the IDE's unresolved import warnings.
   - Annotated the `Step.action` method with a `-> None` return type. Previously, because the abstract method only contained a `raise NotImplementedError`, the type checker inferred a `NoReturn` return type. This caused Pyright to flag all subclass implementations (which inherently return `None`) as inconsistent method overrides.
2. **[build_tools/check_backticks.py](cci:7://file:///Users/kirtan/Desktop/sktime/build_tools/check_backticks.py:0:0-0:0)**:
   - Used `getattr(node.value, "value", None)` instead of direct access (`node.value.value`) when parsing the AST. This satisfies strict type checkers that complain `ast.expr` the base class does not have a `value` attribute.

### Related Issue:
*(Leave this blank if there's no open issue for this)*

### Check the following:
- [x] I've added tests to check that my changes work (Not Applicable)
- [x] I've added docstrings and checked that the docs are rendered properly (Not Applicable)
- [x] I've formatted the code using `pre-commit` hook or `black`

***

You can just copy all the contents above and paste them directly into your GitHub Pull Request form! Let me know if you need anything else.