### PR TITLE
[DOC] Fix broken link in related software

### DIFF
--- a/docs/source/related_software.rst
+++ b/docs/source/related_software.rst
@@ -223,4 +223,4 @@ Time series databases and frameworks
 Acknowledgements
 ================
 
-Thanks to `Max Christ <https://github.com/MaxBenChrist/>`_ who started the list `here <https://github.com/MaxBenChrist/awesome_time_series_in_python/blob/main/README.md>`_.
+Thanks to `Max Christ <https://github.com/MaxBenChrist/>`_ who started the list `here <https://github.com/MaxBenChrist/awesome_time_series_in_python/blob/master/README.md>`_.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9738

#### What does this implement/fix? Explain your changes.
This PR fixes a broken link in the "Related Software" documentation. The "here" link in the Acknowledgements section pointing to Max Christ's time series list was returning a 404 error. The URL has been updated to correctly link to the repository root.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
Nothing specific, this is a straightforward one-line documentation link fix.

#### Did you add any tests for the change?
No tests needed for this documentation change.

#### PR checklist
##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. 

##### For new estimators
- [ ] I've added the estimator to the API reference
- [ ] I've added one or more illustrative usage examples to the docstring
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag
