### PR TITLE
[ENH] Fix pandas ChainedAssignment warning in make_reduction

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -445,12 +445,16 @@ class _Reducer(_BaseWindowForecaster):
         # y_raw is a dataframe window_length forecasting steps into the past in order to
         # calculate the new X from y features based on the transformer provided
 
-        y_raw.update(self._y)
+        overlap = y_raw.index.intersection(self._y.index)
+        if len(overlap) > 0:
+            y_raw.loc[overlap] = self._y.loc[overlap]
         # Historical values are passed here for all time steps of y_raw that lie in
         # the past .
 
         if y_update is not None:
-            y_raw.update(y_update)
+            overlap_upd = y_raw.index.intersection(y_update.index)
+            if len(overlap_upd) > 0:
+                y_raw.loc[overlap_upd] = y_update.loc[overlap_upd]
         # The y_raw dataframe will is updated with recursively forecast values.
 
         if len(self.transformers_) == 1:
@@ -468,9 +472,13 @@ class _Reducer(_BaseWindowForecaster):
 
         if self._X is not None:
             X = _create_fcst_df([index_range[-1]], self._X)
-            X.update(self._X)
+            x_overlap = X.index.intersection(self._X.index)
+            if len(x_overlap) > 0:
+                X.loc[x_overlap] = self._X.loc[x_overlap]
             if X_update is not None:
-                X.update(X_update)
+                x_overlap_upd = X.index.intersection(X_update.index)
+                if len(x_overlap_upd) > 0:
+                    X.loc[x_overlap_upd] = X_update.loc[x_overlap_upd]
             X_cut = _cut_df(X)
             X = pd.concat([X_from_y_cut, X_cut], axis=1)
             # X_from_y_cut is added to X dataframe (no features need to be calculated).
@@ -1028,7 +1036,9 @@ class _RecursiveReducer(_Reducer):
                 y_pred_curr = _create_fcst_df(
                     [index_range[i]], self._y, fill=y_pred_vector
                 )
-                y_pred.update(y_pred_curr)
+                pred_overlap = y_pred.index.intersection(y_pred_curr.index)
+                if len(pred_overlap) > 0:
+                    y_pred.loc[pred_overlap] = y_pred_curr.loc[pred_overlap]
 
                 # # Update last window with previous prediction.
                 if i + 1 != fh_max:


### PR DESCRIPTION
## Summary
Addresses warning 4 from #9640 — `FutureWarning: ChainedAssignment` in `make_reduction` with `pooling="global"` during `predict()`.

## Root Cause
`_get_shifted_window` in `sktime/forecasting/compose/_reduce.py` uses `DataFrame.update()` which performs inplace modification. Under pandas Copy-on-Write (CoW) mode, this triggers a `FutureWarning` about inplace operations on DataFrame copies.

## Changes
- Replaced all `DataFrame.update()` calls in `_get_shifted_window` and `_predict_global` with explicit `.loc[]` assignment on overlapping indices
- This is functionally equivalent but avoids inplace operations that trigger CoW warnings

## How to Test
```python
import numpy as np
from sklearn.linear_model import LinearRegression
from sktime.datasets import load_airline
from sktime.forecasting.compose import make_reduction
from sktime.transformations.series.summarize import WindowSummarizer

y = load_airline()
fh = np.arange(1, 36)

forecaster = make_reduction(
    LinearRegression(),
    transformers=[WindowSummarizer(lag_feature={"lag": [1, 12]})],
    window_length=None,
    pooling="global",
)
forecaster.fit(y, fh=fh)
forecaster.predict()
# Should no longer emit FutureWarning from _reduce.py
```