### PR TITLE
[ENH] Fix pandas ChainedAssignment warning in ForecastingGridSearchCV

### DIFF
--- a/sktime/forecasting/model_selection/_base.py
+++ b/sktime/forecasting/model_selection/_base.py
@@ -220,8 +220,12 @@ class BaseGridSearch(_DelegatedForecaster):
         results = pd.DataFrame(results)
 
         # Rank results, according to whether greater is better for the given scoring.
-        results[f"rank_{scoring_name}"] = results.loc[:, f"mean_{scoring_name}"].rank(
-            ascending=scoring.get_tag("lower_is_better")
+        results = results.assign(
+            **{
+                f"rank_{scoring_name}": results[f"mean_{scoring_name}"].rank(
+                    ascending=scoring.get_tag("lower_is_better")
+                )
+            }
         )
 
         self.cv_results_ = results


### PR DESCRIPTION
## Summary
Addresses warning 5 from #9640 — `FutureWarning: ChainedAssignment` in `ForecastingGridSearchCV` during `fit()`.

## Root Cause
In `_fit` within `sktime/forecasting/model_selection/_base.py`, the rank column is assigned using bracket notation combined with `.loc[:, ...]` access, which can trigger a pandas `FutureWarning` about chained assignment under Copy-on-Write (CoW) mode.

## Changes
- Replaced `results[f"rank_{scoring_name}"] = results.loc[:, ...].rank(...)` with `results = results.assign(...)` which is the recommended pandas CoW-compatible pattern for adding new columns

## How to Test
```python
import numpy as np
from sktime.datasets import load_airline
from sktime.forecasting.exp_smoothing import ExponentialSmoothing
from sktime.forecasting.model_selection import ForecastingGridSearchCV
from sktime.split import ExpandingGreedySplitter

y = load_airline()
fh = np.arange(1, 36)

grid_cv = ForecastingGridSearchCV(
    forecaster=ExponentialSmoothing(seasonal="multiplicative"),
    param_grid={"trend": ["add", "mul"], "sp": [6, 12]},
    cv=ExpandingGreedySplitter(test_size=12, folds=2),
)
grid_cv.fit(y, fh=fh)
# Should no longer emit FutureWarning from _base.py
```