### PR TITLE
[BUG] fix RNNNetworkTorch crash when activation is a torch.nn.Module instance

### DIFF
--- a/sktime/networks/rnn/_rnn_torch.py
+++ b/sktime/networks/rnn/_rnn_torch.py
@@ -80,6 +80,7 @@ class RNNNetworkTorch(NNModule):
         bidirectional: bool = False,
         random_state: int = 0,
     ):
+        super().__init__()
         self.input_size = input_size
         self.random_state = random_state
         self.hidden_dim = hidden_dim
@@ -91,7 +92,6 @@ class RNNNetworkTorch(NNModule):
         self.bias = bias
         self.dropout = dropout
         self.bidirectional = bidirectional
-        super().__init__()
 
         # Checking input dimensions
         if isinstance(self.input_size, int):

--- a/sktime/networks/tests/test_rnn_torch.py
+++ b/sktime/networks/tests/test_rnn_torch.py
@@ -1,0 +1,57 @@
+"""Tests for RNNNetworkTorch."""
+
+import pytest
+
+from sktime.utils.dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("torch", severity="none"),
+    reason="skip test if torch is not available",
+)
+class TestRNNNetworkTorch:
+    """Tests for RNNNetworkTorch."""
+
+    def test_activation_module_instance(self):
+        """Test that passing a torch.nn.Module instance as activation works.
+
+        Regression test for https://github.com/sktime/sktime/issues/9627.
+        """
+        import torch
+
+        from sktime.networks.rnn._rnn_torch import RNNNetworkTorch
+
+        # This should not raise AttributeError
+        network = RNNNetworkTorch(
+            input_size=5,
+            num_classes=2,
+            activation=torch.nn.Sigmoid(),
+        )
+        assert network is not None
+
+        # Verify forward pass works with module activation
+        X = torch.randn(4, 3, 5)
+        output = network(X)
+        assert output.shape == (4, 2)
+
+    def test_activation_string(self):
+        """Test that passing a string activation still works after the fix."""
+        from sktime.networks.rnn._rnn_torch import RNNNetworkTorch
+
+        network = RNNNetworkTorch(
+            input_size=5,
+            num_classes=2,
+            activation="sigmoid",
+        )
+        assert network is not None
+
+    def test_activation_none(self):
+        """Test that passing None as activation still works."""
+        from sktime.networks.rnn._rnn_torch import RNNNetworkTorch
+
+        network = RNNNetworkTorch(
+            input_size=5,
+            num_classes=2,
+            activation=None,
+        )
+        assert network is not None


### PR DESCRIPTION
## Summary
- Fixes #9627 — `RNNNetworkTorch` crashes with `AttributeError: cannot assign module before Module.__init__() call` when `activation` is a `torch.nn.Module` instance (e.g., `torch.nn.Sigmoid()`)
- **Root cause**: `super().__init__()` was called *after* `self.activation = activation`, but PyTorch's `nn.Module.__setattr__` requires `Module.__init__()` to have run first
- **Fix**: Move `super().__init__()` to the first line of `RNNNetworkTorch.__init__`, before any attribute assignments

## Test plan
- [x] Added regression tests in `sktime/networks/tests/test_rnn_torch.py` covering:
  - `torch.nn.Module` instance as activation (the failing case)
  - String activation (`"sigmoid"`)
  - `None` activation
- [x] All 3 tests pass locally
- [x] Verified the exact reproduction code from the issue works after the fix