### PR TITLE
[BUG] fix NaiveForecaster.predict_var(cov=True) returning all-NaN

### DIFF
--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -599,9 +599,8 @@ class NaiveForecaster(_BaseWindowForecaster):
         fh_idx = fh.to_absolute_index(self.cutoff)
         if cov:
             fh_size = len(fh)
-            cov_matrix = np.fill_diagonal(
-                np.zeros(shape=(fh_size, fh_size)), marginal_vars
-            )
+            cov_matrix = np.zeros(shape=(fh_size, fh_size))
+            np.fill_diagonal(cov_matrix, marginal_vars)
             pred_var = pd.DataFrame(cov_matrix, columns=fh_idx, index=fh_idx)
         else:
             pred_var = pd.DataFrame(marginal_vars, index=fh_idx)


### PR DESCRIPTION
## Summary
- Fixes #9634
- `NaiveForecaster.predict_var(fh, cov=True)` returns an all-NaN DataFrame instead of a diagonal covariance matrix
- Root cause: `np.fill_diagonal()` operates in-place and returns `None`. The code assigned its return value to `cov_matrix`, making it `None`, so `pd.DataFrame(None, ...)` produced all NaN.

## Changes
Split the single expression into two statements:
```python
# Before (broken)
cov_matrix = np.fill_diagonal(
    np.zeros(shape=(fh_size, fh_size)), marginal_vars
)

# After (fixed)
cov_matrix = np.zeros(shape=(fh_size, fh_size))
np.fill_diagonal(cov_matrix, marginal_vars)
```

## Test plan
- [x] Verified `predict_var(cov=False)` still returns marginal variances
- [x] Verified `predict_var(cov=True)` now returns a proper diagonal covariance matrix instead of all-NaN