### PR TITLE
[BUG] Fix ARIMA _update ignoring observations when update_params=False

### DIFF
--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -56,23 +56,29 @@ class _PmdArimaAdapter(BaseForecaster):
         return self
 
     def _update(self, y, X=None, update_params=True):
-        """Update model with data.
+        """Update model with new data.
 
         Parameters
         ----------
         y : pd.Series
-            Target time series to which to fit the forecaster.
+            Target time series used to update the forecaster.
         X : pd.DataFrame, optional (default=None)
-            Exogenous variables are ignored
+            Exogenous variables. If provided, sliced to match the index of y.
+        update_params : bool, optional (default=True)
+            If True, model parameters are re-estimated from the updated data.
+            If False, new observations are appended to the model's internal
+            state without refitting parameters (maxiter=0).
 
         Returns
         -------
-        self : returns an instance of self.
+        self : reference to self.
         """
+        if X is not None:
+            X = X.loc[y.index]
         if update_params:
-            if X is not None:
-                X = X.loc[y.index]
             self._forecaster.update(y, X=X)
+        else:
+            self._forecaster.update(y, X=X, maxiter=0)
         return self
 
     def _predict(self, fh, X):


### PR DESCRIPTION
Fixes #7768

When update_params=False, the original _update returned self immediately without calling self._forecaster.update(), so the model's internal state was never updated with new observations. This caused update_predict_single to return identical predictions regardless of input.

Fix: when update_params=False, call update(y, X=X, maxiter=0) to append new observations to the model state without refitting parameters.