### PR TITLE
[ENH] fix `optuna` sampler fixtures in tests

### DIFF
--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -352,9 +352,7 @@ def optuna_param_grids():
 
 
 def optuna_samplers():
-    try:
-        _check_soft_dependencies("optuna", severity="error")
-    except ModuleNotFoundError:
+    if not _check_soft_dependencies("optuna", severity="none")
         return [None]
     else:
         import optuna
@@ -364,8 +362,6 @@ def optuna_samplers():
             optuna.samplers.NSGAIISampler(seed=42),
             optuna.samplers.QMCSampler(seed=42),
         ]
-        if hasattr(optuna.samplers, "CmaEsSampler"):
-            samplers.append(optuna.samplers.CmaEsSampler(seed=42))
         return samplers
 
 

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -352,7 +352,7 @@ def optuna_param_grids():
 
 
 def optuna_samplers():
-    if not _check_soft_dependencies("optuna", severity="none")
+    if not _check_soft_dependencies("optuna", severity="none"):
         return [None]
     else:
         import optuna


### PR DESCRIPTION
In tests, the `optuna` sampler fixture generation for the testing of the `optuna` integration would cause errors or have problems:

* try/except was used for an if/else logic - this was replaced with a proper if/else
* the `cmaes` sampler was still being invoked. This was fixed.