### PR TITLE
[ENH] Add dedicated _update method to Croston and TSB forecasters

### DIFF
--- a/sktime/forecasting/croston.py
+++ b/sktime/forecasting/croston.py
@@ -133,6 +133,55 @@ class Croston(BaseForecaster):
                 f[t + 1] = f[t]
                 p += 1
         self._f = f
+        self._last_p = p
+        self._last_q = q[-1]
+        self._last_a = a[-1]
+
+        return self
+    
+    def _update(self, y, X=None, update_params=True):
+        """Update Croston model with new observations.
+
+        Parameters
+        ----------
+        y : pd.DataFrame
+            New observations to update the model with.
+        X : pd.DataFrame, optional (default=None)
+            Exogenous variables, ignored.
+        update_params : bool, optional (default=True)
+            If True, updates the smoothing state with new observations.
+            If False, no update is performed.
+
+        Returns
+        -------
+        self : reference to self.
+        """
+        if not update_params:
+            return self
+
+        smoothing = self.smoothing
+        y_new = y.to_numpy().flatten()
+        n_timepoints = len(y_new)
+
+        q = self._last_q
+        a = self._last_a
+        p = self._last_p
+
+        f_last = self._f[-1]
+
+        for t in range(0, n_timepoints):
+            if y_new[t] > 0:
+                q = smoothing * y_new[t] + (1 - smoothing) * q
+                a = smoothing * p + (1 - smoothing) * a
+                f_last = q / a
+                p = 1
+            else:
+                p += 1
+
+        self._last_q = q
+        self._last_a = a
+        self._last_p = p
+        self._f = np.append(self._f, f_last)
 
         return self
 

--- a/sktime/forecasting/tsb.py
+++ b/sktime/forecasting/tsb.py
@@ -112,6 +112,52 @@ class TSB(BaseForecaster):
                 f[t + 1] = d[t + 1] * p[t + 1]
 
         self._f = f
+        self._last_d = d[-1]
+        self._last_p = p[-1]
+        self._last_f = f[-1]
+
+        return self
+    
+    def _update(self, y, X=None, update_params=True):
+        """Update TSB model with new observations.
+
+        Parameters
+        ----------
+        y : pd.Series
+            New observations to update the model with.
+        X : pd.DataFrame, optional (default=None)
+            Exogenous variables, ignored.
+        update_params : bool, optional (default=True)
+            If True, updates the smoothing state with new observations.
+            If False, no update is performed.
+
+        Returns
+        -------
+        self : reference to self.
+        """
+        if not update_params:
+            return self
+
+        alpha = self.alpha
+        beta = self.beta
+        y_new = y.to_numpy().flatten()
+        n_timepoints = len(y_new)
+
+        d = self._last_d
+        p = self._last_p
+
+        f_last = self._f[-1]
+        for t in range(0, n_timepoints):
+            if y_new[t] > 0:
+                d = alpha * y_new[t] + (1 - alpha) * d
+                p = beta * 1 + (1 - beta) * p
+            else:
+                p = (1 - beta) * p
+            f_last = d * p
+
+        self._last_d = d
+        self._last_p = p
+        self._f = np.append(self._f, f_last)
 
         return self
 


### PR DESCRIPTION
Closes #9772
Closes #9773 

`Croston` and `TSB` had no dedicated `_update` method, causing `update()` to fall back to the base class default which refits from scratch on full history which is inefficient for streaming/online use cases.

Changes:
Both forecasters now implement `_update` that continues the exponential smoothing loop from the last stored state, without refitting from scratch.

**Croston:** stores `_last_q`, `_last_a`, `_last_p` after `_fit` and continues the smoothing loop in `_update`.

**TSB:** stores `_last_d`, `_last_p` after `_fit` and continues the smoothing loop in `_update`.