### PR TITLE
[BUG] Fix BaseTransformer not storing/updating self._y when remember_data=True

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -501,6 +501,9 @@ class BaseTransformer(BaseEstimator):
         if self.get_tag("remember_data", False):
             self._X = update_data(None, X_new=X_inner)
 
+            if y_inner is not None:
+                self._y = y_inner
+
         # skip the rest if fit_is_empty is True
         if self.get_tag("fit_is_empty"):
             self._is_fitted = True
@@ -887,6 +890,12 @@ class BaseTransformer(BaseEstimator):
         # update memory of X, if remember_data tag is set to True
         if self.get_tag("remember_data", False):
             self._X = update_data(None, X_new=X_inner)
+
+            if y_inner is not None:
+                if hasattr(self, "_y"):
+                    self._y = update_data(self._y, X_new=y_inner)
+                else:
+                    self._y = y_inner
 
         # skip everything if update_params is False
         # skip everything if fit_is_empty is True


### PR DESCRIPTION
Fixes #9548

## Context
PR #9588 fixed `self._X` history being overwritten in `update`. This PR addresses the remaining gap in #9548:
`self._y` is never stored in `fit` or appended in `update` when `remember_data=True`, even when `y` is provided.

## Changes
In `fit`: store `self._y = y_inner` when `y` is provided and `remember_data=True`.

In `update`: append to `self._y` using `update_data` when `y` is provided and `remember_data=True`, consistent with how `self._X` is handled.