### PR TITLE
[ENH] capability:update in TransformerPipeline

### DIFF
--- a/sktime/transformations/compose/_pipeline.py
+++ b/sktime/transformations/compose/_pipeline.py
@@ -199,6 +199,10 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
             "capability:unequal_length", "capability:unequal_length:removes", ests
         )
 
+        # pipeline can update iff all steps support update
+        can_update = [est.get_tag("capability:update", False) for _, est in ests]
+        self.set_tags(**{"capability:update": all(can_update)})
+
     @property
     def _steps(self):
         return self._get_estimator_tuples(self.steps, clone_ests=False)


### PR DESCRIPTION
Towards #9548

Adds propagation of the `capability:update` tag in `TransformerPipeline.__init__`. The pipeline sets `capability:update: True` only if all component steps support update, and `False` otherwise.

This is a follow-up to #9552 which adds `capability:update: False` as a default tag to `BaseTransformer` which is required for the tag to be inspectable across all transformers.

Changes:
* Added capability:update propagation in `TransformerPipeline.__init__`

Example behaviour after this fix:
* `(Detrender() * Deseasonalizer()).get_tag("capability:update")` → `True`
* `(Detrender() * ExponentTransformer()).get_tag("capability:update")` → `False`, because ExponentTransformer() uses default tag from `BaseTransformer` for now.