### PR TITLE
DOC: add missing import in ColumnEnsembleClassifier docstring example

### DIFF
--- a/sktime/classification/compose/_column_ensemble.py
+++ b/sktime/classification/compose/_column_ensemble.py
@@ -236,6 +236,7 @@ class ColumnEnsembleClassifier(BaseColumnEnsembleClassifier):
     --------
     >>> from sktime.classification.dictionary_based import ContractableBOSS
     >>> from sktime.classification.interval_based import CanonicalIntervalForest
+    >>> from sktime.classification.compose import ColumnEnsembleClassifier
     >>> from sktime.datasets import load_basic_motions
     >>> X_train, y_train = load_basic_motions(split="train") # doctest: +SKIP
     >>> X_test, y_test = load_basic_motions(split="test") # doctest: +SKIP


### PR DESCRIPTION
## Summary
Adds a missing import line for ColumnEnsembleClassifier in the docstring example so users can directly copy-paste the example.

## Related issue
Closes #4400

## What changed
- Added rom sktime.classification.compose import ColumnEnsembleClassifier in the Examples section of ColumnEnsembleClassifier docs.

## Why
Issue #4400 requests adding missing import statements in sktime docstring examples where needed.

## GSoC note
This PR is submitted as my sktime GSoC 2026 entrance-task contribution.