### PR TITLE
[DOC] Fix math rendering and typos in forecasting module docstrings

### DIFF
--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -463,21 +463,21 @@ def evaluate(
     In case of global evaluation (cv_global is not None):
 
     The test folds are denoted by :math:`y_{train, 1}, y_{hist, 1}, y_{true, 1},
-    \dots, y_{train, K}`, y_{hist, K}, y_{true, K}`.
+    \dots, y_{train, K}, y_{hist, K}, y_{true, K}`.
     :math:`y_{train, i}, y_{test, i}`` are produced by the generator
     ``cv_global.split_series(y)``. Whereby :math:`y_{train, i}, y_{test, i}`
     are different time series.
     :math:`y_{test, i}` is further split into :math:`y_{hist, i}, y_{true, i}` by
     the generator ``cv.split_series(y_test)``.
     Denote by :math:`X_{train, 1}, X_{hist, 1}, X_{true, 1}, \dots, X_{train, K},
-    X_{hist, K}, X_{true, K}` the train/test folds are produced analogue by
+    X_{hist, K}, X_{true, K}` the train/test folds are produced analogously by
     ``cv_global.split_series(X)`` and ``cv.split_series(X_test)``.
 
     1. Initialize the counter to ``i = 1``
-    2. Fit the ``forecaster`` to :math:`y_{train, i}`, :math:`X_{train, 1i`,
+    2. Fit the ``forecaster`` to :math:`y_{train, i}`, :math:`X_{train, i}`,
        with ``fh`` set to the absolute indices of :math:`y_{true, i}`.
     3. Use the ``forecaster`` to make a prediction ``y_pred`` with the exogeneous
-        data :math:`X_{true, i}` and the historical values :math:`y{hist, i}`.
+        data :math:`X_{true, i}` and the historical values :math:`y_{hist, i}`.
         Predictions are made using either ``predict``,
         ``predict_proba`` or ``predict_quantiles``, depending on ``scoring``.
     4. Compute the ``scoring`` function on ``y_pred`` versus :math:`y_{true, i}`

--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -163,7 +163,7 @@ class NaiveForecaster(_BaseWindowForecaster):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, default=None
-            The forecasters horizon with the steps ahead to to predict.
+            The forecasters horizon with the steps ahead to predict.
         X : pd.DataFrame, default=None
             Exogenous variables are ignored.
 


### PR DESCRIPTION
#### Reference Issues/PRs

*First-time contribution, no associated issue.*

#### What does this implement/fix? Explain your changes.

This PR fixes formatting issues and typographical errors in the docstrings of the forecasting module to ensure the documentation website renders correctly. Specifically, it addresses:
* **Broken Sphinx/LaTeX Math Tags:** Fixed stray backticks, missing underscores (e.g., `:math:y_{hist, i}`), and broken brackets in the `evaluate` function docstring in `forecasting/model_evaluation/_functions.py`.
* **Grammar and Typos:** Corrected grammatical errors (e.g., changing "analogue" to "analogously") in `_functions.py` and removed double words (e.g., "to to") in the `_fit` method docstring of `forecasting/naive/_naive.py`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

* Confirming that the updated `:math:` tags in the `evaluate` docstring now render properly in the Sphinx documentation build.

#### Did you add any tests for the change?

No tests were added as these are strictly documentation string fixes.

#### Any other comments?

*None.*

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-) 
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured dependency isolation.