### PR TITLE
[BUG] Fix unreachable 'ME' frequency check in ForecastingHorizon.freq setter

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -402,6 +402,9 @@ class ForecastingHorizon:
         else:
             freq_from_self = None
 
+        if freq_from_obj == "ME":
+            freq_from_obj = "M"
+
         if freq_from_self is not None and freq_from_obj is not None:
             with _suppress_pd22_warning():
                 freqs_unequal = freq_from_self != freq_from_obj
@@ -411,12 +414,8 @@ class ForecastingHorizon:
                     f"Current: {freq_from_self}, from update: {freq_from_obj}."
                 )
         elif freq_from_obj is not None:  # only freq_from_obj is not None
-            if freq_from_obj == "ME":
-                freq_from_obj = "M"
             self._freq = freq_from_obj
         else:
-            if freq_from_obj == "ME":
-                freq_from_obj = "M"
             # leave self._freq as freq_from_self, or set to None if does not exist yet
             self._freq = freq_from_self
 


### PR DESCRIPTION
Fixes #9755. This removes the dead code related to the 'ME' check in the `else` block of `ForecastingHorizon.freq` setter and moves the 'ME' -> 'M' normalization earlier to cover both branches.