### PR TITLE
[ENH] move test skip config for SquaringResiduals to estimator tags

### DIFF
--- a/sktime/forecasting/squaring_residuals.py
+++ b/sktime/forecasting/squaring_residuals.py
@@ -99,6 +99,12 @@ class SquaringResiduals(BaseForecaster):
         "capability:insample": False,
         "capability:pred_int": True,  # does forecaster implement proba forecasts?
         "capability:pred_int:insample": False,
+        "tests:skip_by_name": [
+            "test_predict_time_index",
+            "test_predict_residuals",
+            "test_predict_interval",
+            "test_predict_time_index_with_X",
+        ],
     }
 
     def __init__(

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -83,12 +83,6 @@ EXCLUDE_ESTIMATORS = [
 EXCLUDED_TESTS = {
     # issue when prediction intervals, see #3479 and #4504
     # known issue with prediction intervals that needs fixing, tracked in #4181
-    "SquaringResiduals": [
-        "test_predict_time_index",
-        "test_predict_residuals",
-        "test_predict_interval",
-        "test_predict_time_index_with_X",  # separate - refer to #4765
-    ],
     # known issue when X is passed, wrong time indices are returned, #1364
     "StackingForecaster": ["test_predict_time_index_with_X"],
     "TapNetRegressor": [


### PR DESCRIPTION
#### Reference Issues/PRs
#8515

#### What does this implement/fix?
Moves test skip configuration for `SquaringResiduals` from the 
central `tests/_config.py` to the estimator's own `_tags`, 
as part of the migration initiative in #8515.

Changes:
- Removed `SquaringResiduals` entry from `EXCLUDED_TESTS` in `sktime/tests/_config.py`
- Added `tests:skip_by_name` tag to `SquaringResiduals` in `sktime/forecasting/squaring_residuals.py`
- References original issues: #3479, #4504, #4181, #4765

No behavioral changes. Test skip behavior is fully preserved.

#### Does your contribution introduce a new dependency?
No

#### PR checklist
- [x] The PR title starts with [ENH]
- [x] I've added myself to the list of contributors