### PR TITLE
[BUG] Fix unhandled ModuleNotFoundError for hmmlearn in GaussianHMM

### DIFF
--- a/sktime/detection/hmm_learn/gaussian.py
+++ b/sktime/detection/hmm_learn/gaussian.py
@@ -5,6 +5,7 @@ Please see the original library
 """
 
 from sktime.detection.hmm_learn import BaseHMMLearn
+from sktime.utils.dependencies import _check_soft_dependencies
 
 __author__ = ["miraep8"]
 __all__ = ["GaussianHMM"]
@@ -158,7 +159,6 @@ class GaussianHMM(BaseHMMLearn):
         """
 
         # Intercept missing dependency before the import
-        from sktime.utils.dependencies import _check_soft_dependencies
         _check_soft_dependencies("hmmlearn", severity="error")
 
         # import inside _fit to avoid hard dependency.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9798.


#### What does this implement/fix? Explain your changes.
This PR fixes an unhandled `ModuleNotFoundError` that occurs when a user tries to instantiate and fit `GaussianHMM` without having the `hmmlearn` soft dependency installed.

Previously, the code attempted to import `hmmlearn` directly inside _fit, which bypassed sktime's internal dependency checks and leaked a raw Python traceback to the user. I have added `_check_soft_dependencies("hmmlearn", severity="error")` directly before the import inside `sktime/detection/hmm_learn/gaussian.py` to properly intercept this and raise a clean `MissingSoftDependencyError`.

Output before this PR:

`ModuleNotFoundError: No module named 'hmmlearn'`

Output after this PR:

`ModuleNotFoundError: This functionality requires package 'hmmlearn' to be present in the python environment, but 'hmmlearn' was not found. To install the requirement 'hmmlearn', please run: `pip install hmmlearn`

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

Just verifying the correct placement of the _check_soft_dependencies call inside the _fit method.

#### Any other comments?

Thanks for the help maintaining this!

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.



