### PR TITLE
[ENH] skip `StatsForecastMSTL` testing on negative data with multiplicative seasonality

### DIFF
--- a/sktime/forecasting/statsforecast.py
+++ b/sktime/forecasting/statsforecast.py
@@ -873,7 +873,7 @@ class StatsForecastMSTL(_GeneralisedStatsForecastAdapter):
         # CI and test flags
         # -----------------
         "tests:skip_by_name": ["test_update_with_exogenous_variables"],
-        # multiplicative test case does not work on negative valued data
+        # multiplicative test case does not work on negative valued data, see #9808
     }
 
     def __init__(


### PR DESCRIPTION
Some test cases for `StatsForecastMSTL` run it on negative data with multiplicative seasonality.

The estimator does not allow for this (since some recent version), hence tests fail.

This PR adds a test skip to avoid this case.