### PR TITLE
[BUG] Fix NaiveForecaster.predict_var(cov=True) returning all-NaN

### DIFF
--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -599,9 +599,8 @@ class NaiveForecaster(_BaseWindowForecaster):
         fh_idx = fh.to_absolute_index(self.cutoff)
         if cov:
             fh_size = len(fh)
-            cov_matrix = np.fill_diagonal(
-                np.zeros(shape=(fh_size, fh_size)), marginal_vars
-            )
+            cov_matrix = np.zeros(shape=(fh_size, fh_size))
+            np.fill_diagonal(cov_matrix, marginal_vars)
             pred_var = pd.DataFrame(cov_matrix, columns=fh_idx, index=fh_idx)
         else:
             pred_var = pd.DataFrame(marginal_vars, index=fh_idx)


### PR DESCRIPTION
Fixes #9634.

`np.fill_diagonal` modifies the array in-place and returns `None`. The current code assigns its return value to `cov_matrix`, so `pd.DataFrame(None, ...)` produces all NaN.

Fix: allocate the zeros matrix first, then call `np.fill_diagonal` separately.

```diff
-            cov_matrix = np.fill_diagonal(
-                np.zeros(shape=(fh_size, fh_size)), marginal_vars
-            )
+            cov_matrix = np.zeros(shape=(fh_size, fh_size))
+            np.fill_diagonal(cov_matrix, marginal_vars)
```