### PR TITLE
[MNT] Move MCDCNNClassifier test skip config to estimator tags

### DIFF
--- a/sktime/classification/deep_learning/mcdcnn/_mcdcnn_tf.py
+++ b/sktime/classification/deep_learning/mcdcnn/_mcdcnn_tf.py
@@ -86,6 +86,13 @@ class MCDCNNClassifier(BaseDeepClassifier):
         "maintainers": ["james-large"],
         "python_dependencies": "tensorflow",
         # estimator type handled by parent class
+        # test skips, see #6465 and #7958
+        "tests:skip_by_name": [
+            "test_persistence_via_pickle",
+            "test_multioutput",
+            "test_classifier_on_unit_test_data",
+            "test_fit_idempotent",  # due to randomness
+        ],
     }
 
     def __init__(

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -159,12 +159,6 @@ EXCLUDED_TESTS = {
         "test_multioutput",
         "test_classifier_on_unit_test_data",
     ],
-    "MCDCNNClassifier": [
-        "test_persistence_via_pickle",
-        "test_multioutput",
-        "test_classifier_on_unit_test_data",
-        "test_fit_idempotent",  # not part of bug reports but due to randomness
-    ],
     "ARLagOrderSelector": [
         "test_doctest_examples",  # doctest fails, see #8129
     ],


### PR DESCRIPTION
## Reference Issue
Partially addresses #8515

## What does this PR do?

Moves the test skip configuration for `MCDCNNClassifier` from the centralized `sktime/tests/_config.py` to estimator-level `tests:skip_by_name` tag, following the recipe in #8515.

### Changes:
- **`sktime/classification/deep_learning/mcdcnn/_mcdcnn_tf.py`**: Added `"tests:skip_by_name"` tag to `MCDCNNClassifier._tags` with the list of skipped tests
- **`sktime/tests/_config.py`**: Removed `MCDCNNClassifier` entry from `EXCLUDED_TESTS` dict

### Notes:
- Only `MCDCNNClassifier` is handled in this PR (per issue guidance: one estimator per PR)
- The `EXCLUDED_TESTS_BY_TEST` entry for `test_get_test_params_coverage` is left as-is per recipe step 4 (this should be fixed by adding test params, not transferred)
- `MCDCNNRegressor` and `MCDCNNNetwork` entries remain for separate PRs