### PR TITLE
[ENH] in forecasting tutorial, make `pandas` calls upwards compatible

### DIFF
--- a/examples/01_forecasting.ipynb
+++ b/examples/01_forecasting.ipynb
@@ -411,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -433,7 +433,8 @@
    ],
    "source": [
     "fh = ForecastingHorizon(\n",
-    "    pd.PeriodIndex(pd.date_range(\"1961-01\", periods=36, freq=\"M\")), is_relative=False\n",
+    "    pd.period_range(\"1961-01\", periods=36, freq=\"M\"),\n",
+    "    is_relative=False,\n",
     ")\n",
     "fh"
    ]
@@ -447,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2756,14 +2757,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# January 1958\n",
     "\n",
     "# new data is observed:\n",
-    "y_1958Jan = y[[-36]]\n",
+    "y_1958Jan = y.iloc[[-36]]\n",
     "\n",
     "# step 5: we update the forecaster with the new data\n",
     "forecaster.update(y_1958Jan)\n",
@@ -2808,7 +2809,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2838,7 +2839,7 @@
    "source": [
     "# plotting predictions and past data\n",
     "plot_series(\n",
-    "    y[:-35],\n",
+    "    y.iloc[:-35],\n",
     "    y_pred_1957Dec,\n",
     "    y_pred_1958Jan,\n",
     "    labels=[\"y_1957Dec\", \"y_pred_1957Dec\", \"y_pred_1958Jan\"],\n",
@@ -2847,14 +2848,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# February 1958\n",
     "\n",
     "# new data is observed:\n",
-    "y_1958Feb = y[[-35]]\n",
+    "y_1958Feb = y.iloc[[-35]]\n",
     "\n",
     "# step 5: we update the forecaster with the new data\n",
     "forecaster.update(y_1958Feb)\n",
@@ -2865,7 +2866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2895,7 +2896,7 @@
    "source": [
     "# plotting predictions and past data\n",
     "plot_series(\n",
-    "    y[:-35],\n",
+    "    y.iloc[:-35],\n",
     "    y_pred_1957Dec,\n",
     "    y_pred_1958Jan,\n",
     "    y_pred_1958Feb,\n",
@@ -2914,7 +2915,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2944,7 +2945,7 @@
     "# March 1958\n",
     "\n",
     "# new data is observed:\n",
-    "y_1958Mar = y[[-34]]\n",
+    "y_1958Mar = y.iloc[[-34]]\n",
     "\n",
     "# step 5&6: update/predict in one step\n",
     "forecaster.update_predict_single(y_1958Mar, fh=fh)"
@@ -2965,7 +2966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2983,7 +2984,7 @@
     "# April 1958\n",
     "\n",
     "# new data is observed:\n",
-    "y_1958Apr = y[[-33]]\n",
+    "y_1958Apr = y.iloc[[-33]]\n",
     "\n",
     "# step 5: perform an update without re-computing the model parameters\n",
     "forecaster.update(y_1958Apr, update_params=False)"
@@ -5445,7 +5446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
in forecasting tutorial, makes `pandas` calls upwards compatible:

* replaces implicit `iloc` calls `[[ix]]` by explicit `.iloc[[ix]]` calls
* replaces period index creation by direct call `pd.period_range`