### PR TITLE
[DOC] Fix np.darray typo to np.ndarray in docs and comments

### DIFF
--- a/sktime/performance_metrics/forecasting/_base.py
+++ b/sktime/performance_metrics/forecasting/_base.py
@@ -831,8 +831,8 @@ class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
     """Adapter for numpy metrics."""
 
     # all descendants should have a func class attribute
-    #   of signature func(y_true: np.ndarray, y_pred: np.darray, multioutput: bool)
-    #   additional optional args: y_train: np.darray, y_pred_benchmark: np.darray
+    #   of signature func(y_true: np.ndarray, y_pred: np.ndarray, multioutput: bool)
+    #   additional optional args: y_train: np.ndarray, y_pred_benchmark: np.ndarray
     #                       further args that are parameters
     #       all np.ndarray should be 2D
     # func should return 1D np.ndarray if multioutput="raw_values", otherwise float

--- a/sktime/transformations/series/filter.py
+++ b/sktime/transformations/series/filter.py
@@ -103,7 +103,8 @@ class Filter(BaseTransformer):
         """
         from mne import filter
 
-        # np.darray needs to be [anything, ..., time]
+        # np.ndarray needs to be [anything, ..., time]
+
         # so 3D is ok, but we need to flip in 2D case
         if X.ndim == 2:
             X = X.transpose()

--- a/sktime/utils/_testing/panel.py
+++ b/sktime/utils/_testing/panel.py
@@ -35,7 +35,7 @@ def _make_panel(
         number of variables in the time series
     n_timepoints : int, optional, default=20
         number of time points in each series
-    y : None (default), or 1D np.darray or 1D array-like, shape (n_instances, )
+    y : None (default), or 1D np.ndarray or 1D array-like, shape (n_instances, )
         if passed, return will be generated with association to y
     all_positive : bool, optional, default=False
         whether series contain only positive values when generated


### PR DESCRIPTION
#### Reference Issues/PRs
N/A

#### What does this implement/fix? Explain your changes.

Fixes a typo where `np.darray` was used instead of the correct `np.ndarray` in multiple docstrings and comments.

This typo appears in several places and may confuse users, since `np.darray` is not a valid NumPy type.

All occurrences have been updated to `np.ndarray`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether all occurrences of the typo have been correctly updated.

#### Did you add any tests for the change?

Not applicable (documentation-only change).