### PR TITLE
[DOC] Remove temporary numpydoc workaround in Sphinx config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -146,8 +146,7 @@ suppress_warnings = [
     "autosectionlabel",
     "ref",
 ]
-# FIXME: Temporary solution until numpydoc issues are fixed
-warnings.filterwarnings("ignore", category=UserWarning, module="numpydoc.docscrape")
+
 show_warning_types = True
 
 # Link to GitHub repo for github_issues extension


### PR DESCRIPTION


#### Reference Issues/PRs
Fixes #9850

#### What does this implement/fix? Explain your changes.
This removes the `numpydoc` user warning suppression in the Sphinx configuration (`docs/source/conf.py`) which was introduced previously as a temporary workaround.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Verifying the local Sphinx builds pass cleanly without getting spammed with unrelated `numpydoc` warnings.

#### Did you add any tests for the change?
No (this is solely a documentation configuration change).

#### Any other comments?
None.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
