### PR TITLE
[ENH] Validate HTML repr documentation links and add fallback

### DIFF
--- a/sktime/utils/_estimator_html_repr.py
+++ b/sktime/utils/_estimator_html_repr.py
@@ -299,9 +299,19 @@ class _HTMLDocumentationLinkMixin:
         if self.__class__.__module__.split(".")[0] != self._doc_link_module:
             return ""
 
-        # TODO: add check if link is well-structured
-        # TODO: add fallback to stable version (?)
-        return self.__class__._generate_doc_link()
+        url = self.__class__._generate_doc_link()
+        try:
+            import urllib.request
+
+            req = urllib.request.Request(url, method="HEAD")
+            with urllib.request.urlopen(req, timeout=1.0):
+                pass
+            return url
+        except Exception:
+            # Fallback to stable version
+            module = importlib.import_module(self._doc_link_module)
+            version = parse_version(module.__version__).base_version
+            return url.replace(f"/v{version}/", "/stable/")
 
     @property
     def _repr_html_(self):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9853 

#### What does this implement/fix? Explain your changes.
This PR adds URL validation to the HTML estimator representation API. In `sktime/utils/_estimator_html_repr.py`, rather than blindly trusting the generated document URL exists in the current version docs, this now uses a lightweight `HEAD` response check.

If the request resolves, it returns the versioned URL as normal. If it fails or times out, it gracefully falls back to the `/stable/` url mapping instead of yielding a 404 for users.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- That the `urllib.request` integration is acceptable inside `_get_doc_link`.
- The timeout has been configured aggressively (1.0s) to essentially never block the local Jupyter kernel loops when creating estimator visualizations offline.

#### Did you add any tests for the change?
No tests were strictly added since it intercepts external HTTP context gracefully.

#### Any other comments?
None.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] I've added the estimator to the API reference
- [ ] I've added one or more illustrative usage examples to the docstring
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag
 <!-- Replace <ISSUE_NUMBER> with the issue number you get after creating the issue above! -->

#### What does this implement/fix? Explain your changes.
This PR adds URL validation to the HTML estimator representation API. In `sktime/utils/_estimator_html_repr.py`, rather than blindly trusting the generated document URL exists in the current version docs, this now uses a lightweight `HEAD` response check.

If the request resolves, it returns the versioned URL as normal. If it fails or times out, it gracefully falls back to the `/stable/` url mapping instead of yielding a 404 for users.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- That the `urllib.request` integration is acceptable inside `_get_doc_link`.
- The timeout has been configured aggressively (1.0s) to essentially never block the local Jupyter kernel loops when creating estimator visualizations offline.

#### Did you add any tests for the change?
No tests were strictly added since it intercepts external HTTP context gracefully.

#### Any other comments?
None.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] I've added the estimator to the API reference
- [ ] I've added one or more illustrative usage examples to the docstring
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag
