### PR TITLE
[ENH] Remove slow duplicate ForecastingHorizon tests

### DIFF
--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -635,7 +635,7 @@ def test_frequency_setter(freqstr):
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
     reason="run only if base module has changed or datatypes module has changed",
 )
-def test_auto_ets_case_with_naive():
+def test_auto_ets():
     """Test failure case from #1435.
 
     AutoETS is replaced by NaiveForecaster.
@@ -660,7 +660,7 @@ def test_auto_ets_case_with_naive():
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
     reason="run only if base module has changed or datatypes module has changed",
 )
-def test_exponential_smoothing_case_with_naive():
+def test_exponential_smoothing():
     """Test failure case from #1876.
 
     ExponentialSmoothing is replaced by NaiveForecaster.
@@ -690,7 +690,7 @@ def test_exponential_smoothing_case_with_naive():
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
     reason="run only if base module has changed or datatypes module has changed",
 )
-def test_auto_arima_case_with_naive():
+def test_auto_arima():
     """Test failure case from #805.
 
     AutoARIMA is replaced by NaiveForecaster.

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -13,15 +13,12 @@ from pytest import raises
 
 from sktime.datasets import load_airline
 from sktime.datatypes._utilities import get_cutoff
-from sktime.forecasting.arima import AutoARIMA
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.base._fh import (
     DELEGATED_METHODS,
     _check_freq,
     _extract_freq_from_cutoff,
 )
-from sktime.forecasting.ets import AutoETS
-from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.forecasting.tests._config import (
     INDEX_TYPE_LOOKUP,
@@ -41,7 +38,7 @@ from sktime.utils.datetime import (
     _shift,
     infer_freq,
 )
-from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
+from sktime.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation.series import is_in_valid_index_types, is_integer_index
 
 
@@ -634,31 +631,6 @@ def test_frequency_setter(freqstr):
     assert fh.freq == freqstr
 
 
-# TODO: Replace this long running test with fast unit test
-@pytest.mark.skipif(
-    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
-    or not _check_estimator_deps(AutoETS, severity="none"),
-    reason="run test only if softdeps are present and incrementally (if requested)",
-)
-def test_auto_ets():
-    """Test failure case from #1435.
-
-    https://github.com/sktime/sktime/issues/1435#issue-1000175469
-    """
-    freq = "30T"
-    _y = np.arange(50) + np.random.rand(50) + np.sin(np.arange(50) / 4) * 10
-    t = pd.date_range("2021-09-19", periods=50, freq=freq)
-    y = pd.Series(_y, index=t)
-    y.index = y.index.to_period(freq=freq)
-    forecaster = AutoETS(sp=12, auto=True, n_jobs=-1)
-    forecaster.fit(y)
-    y_pred = forecaster.predict(fh=[1, 2, 3])
-    pd.testing.assert_index_equal(
-        y_pred.index,
-        pd.date_range("2021-09-19", periods=53, freq=freq)[-3:].to_period(freq=freq),
-    )
-
-
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
     reason="run only if base module has changed or datatypes module has changed",
@@ -670,7 +642,7 @@ def test_auto_ets_case_with_naive():
 
     https://github.com/sktime/sktime/issues/1435#issue-1000175469
     """
-    freq = "30T"
+    freq = "30min"
     _y = np.arange(50) + np.random.rand(50) + np.sin(np.arange(50) / 4) * 10
     t = pd.date_range("2021-09-19", periods=50, freq=freq)
     y = pd.Series(_y, index=t)
@@ -681,36 +653,6 @@ def test_auto_ets_case_with_naive():
     pd.testing.assert_index_equal(
         y_pred.index,
         pd.date_range("2021-09-19", periods=53, freq=freq)[-3:].to_period(freq=freq),
-    )
-
-
-# TODO: Replace this long running test with fast unit test
-@pytest.mark.skipif(
-    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
-    or not _check_estimator_deps(ExponentialSmoothing, severity="none"),
-    reason="run test only if softdeps are present and incrementally (if requested)",
-)
-def test_exponential_smoothing():
-    """Test failure case from #1876.
-
-    https://github.com/sktime/sktime/issues/1876#issue-1103752402.
-    """
-    y = load_airline()
-    # Change index to 10 min interval
-    freq = "10Min"
-    time_range = pd.date_range(
-        pd.to_datetime("2019-01-01 00:00"),
-        pd.to_datetime("2019-01-01 23:55"),
-        freq=freq,
-    )
-    # Period Index does not work
-    y.index = time_range.to_period()
-
-    forecaster = ExponentialSmoothing(trend="add", seasonal="multiplicative", sp=12)
-    forecaster.fit(y, fh=[1, 2, 3, 4, 5, 6])
-    y_pred = forecaster.predict()
-    pd.testing.assert_index_equal(
-        y_pred.index, pd.period_range("2019-01-02 00:00", periods=6, freq=freq)
     )
 
 
@@ -727,7 +669,7 @@ def test_exponential_smoothing_case_with_naive():
     """
     y = load_airline()
     # Change index to 10 min interval
-    freq = "10Min"
+    freq = "10min"
     time_range = pd.date_range(
         pd.to_datetime("2019-01-01 00:00"),
         pd.to_datetime("2019-01-01 23:55"),
@@ -741,54 +683,6 @@ def test_exponential_smoothing_case_with_naive():
     y_pred = forecaster.predict()
     pd.testing.assert_index_equal(
         y_pred.index, pd.period_range("2019-01-02 00:00", periods=6, freq=freq)
-    )
-
-
-# TODO: Replace this long running test with fast unit test
-@pytest.mark.skipif(
-    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
-    or not _check_estimator_deps(AutoARIMA, severity="none"),
-    reason="run only if base module has changed or datatypes module has changed",
-)
-def test_auto_arima():
-    """Test failure case from #805.
-
-    https://github.com/sktime/sktime/issues/805#issuecomment-891848228.
-    """
-    time_index = pd.date_range("January 1, 2021", periods=8, freq="1D")
-    X = pd.DataFrame(
-        np.random.randint(0, 4, 24).reshape(8, 3),
-        columns=["First", "Second", "Third"],
-        index=time_index,
-    )
-    y = pd.Series([1, 3, 2, 4, 5, 2, 3, 1], index=time_index)
-
-    fh_ = ForecastingHorizon(X.index[5:], is_relative=False)
-
-    a_clf = AutoARIMA(start_p=2, start_q=2, max_p=5, max_q=5)
-    clf = a_clf.fit(X=X[:5], y=y[:5])
-    y_pred_sk = clf.predict(fh=fh_, X=X[5:])
-
-    pd.testing.assert_index_equal(
-        y_pred_sk.index, pd.date_range("January 6, 2021", periods=3, freq="1D")
-    )
-
-    time_index = pd.date_range("January 1, 2021", periods=8, freq="2D")
-    X = pd.DataFrame(
-        np.random.randint(0, 4, 24).reshape(8, 3),
-        columns=["First", "Second", "Third"],
-        index=time_index,
-    )
-    y = pd.Series([1, 3, 2, 4, 5, 2, 3, 1], index=time_index)
-
-    fh = ForecastingHorizon(X.index[5:], is_relative=False)
-
-    a_clf = AutoARIMA(start_p=2, start_q=2, max_p=5, max_q=5)
-    clf = a_clf.fit(X=X[:5], y=y[:5])
-    y_pred_sk = clf.predict(fh=fh, X=X[5:])
-
-    pd.testing.assert_index_equal(
-        y_pred_sk.index, pd.date_range("January 11, 2021", periods=3, freq="2D")
     )
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #9698.

#### What does this implement/fix? Explain your changes.

Removes three long-running ForecastingHorizon regression tests that instantiate heavy forecasters solely to assert prediction index behavior:

- `test_auto_ets`
- `test_exponential_smoothing`
- `test_auto_arima`

The file already contains equivalent `NaiveForecaster` regression cases for the same index assertions, so this keeps the ForecastingHorizon coverage while avoiding expensive estimator setup and soft dependency checks. The now-unused imports are removed as well.

I also updated the remaining minute-frequency aliases in these fast cases to pandas 3-compatible names (`30min`, `10min`).

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the remaining `NaiveForecaster` cases preserve the intended ForecastingHorizon/index coverage for the three linked historical failures.
- Whether removing the soft dependency gated variants is acceptable for CI speed and maintenance.

#### Did you add any tests for the change?

No new tests were added; this removes duplicated slow tests while preserving the fast equivalents already present in the same file.

Local validation:

- `python3 -m pytest -o addopts='' sktime/forecasting/base/tests/test_fh.py -k 'auto_ets_case_with_naive or exponential_smoothing_case_with_naive or auto_arima_case_with_naive'` - 3 passed, 356 deselected
- `python3 -m ruff check sktime/forecasting/base/tests/test_fh.py` - passed
- `python3 -m ruff format --check sktime/forecasting/base/tests/test_fh.py` - passed

#### Any other comments?

None.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].