### PR TITLE
[ENH] Type MLflow sktime model arguments

### DIFF
--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -50,6 +50,7 @@ import pandas as pd
 
 import sktime
 from sktime import utils
+from sktime.base import BaseEstimator
 from sktime.base._serialize import load
 from sktime.utils.dependencies import _check_mlflow_dependencies
 from sktime.utils.multiindex import flatten_multiindex
@@ -121,7 +122,7 @@ def get_default_conda_env(include_cloudpickle=False):
 
 
 def save_model(
-    sktime_model,
+    sktime_model: BaseEstimator,
     path,
     conda_env=None,
     code_paths=None,
@@ -131,12 +132,12 @@ def save_model(
     pip_requirements=None,
     extra_pip_requirements=None,
     serialization_format=SERIALIZATION_FORMAT_PICKLE,
-):  # TODO: can we specify a type for fitted instance of sktime model below?
+):
     """Save a sktime model to a path on the local file system.
 
     Parameters
     ----------
-    sktime_model :
+    sktime_model : BaseEstimator
         Fitted sktime model object.
     path : str
         Local path where the model is to be saved.
@@ -309,7 +310,7 @@ def save_model(
 
 
 def log_model(
-    sktime_model,
+    sktime_model: BaseEstimator,
     artifact_path,
     conda_env=None,
     code_paths=None,
@@ -321,12 +322,12 @@ def log_model(
     extra_pip_requirements=None,
     serialization_format=SERIALIZATION_FORMAT_PICKLE,
     **kwargs,
-):  # TODO: can we specify a type for fitted instance of sktime model below?
+):
     """Log a sktime model as an MLflow artifact for the current run.
 
     Parameters
     ----------
-    sktime_model : fitted sktime model
+    sktime_model : BaseEstimator
         Fitted sktime model object.
     artifact_path : str
         Run-relative artifact path to save the model to.


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #9856.

#### What does this implement/fix? Explain your changes.

Adds `BaseEstimator` type annotations to the `sktime_model` argument of the public MLflow integration functions:

- `save_model`
- `log_model`

The related TODO comments are removed and the parameter docstrings now state `BaseEstimator` explicitly. This is a typing/documentation clarity change only; it does not alter runtime behavior.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Whether `BaseEstimator` is the right public type for fitted sktime model instances accepted by the MLflow flavor entry points.

#### Did you add any tests for the change?

No new tests were added because this only updates annotations and docstrings.

Local validation:

- `python3 -m pytest -o addopts='' sktime/utils/tests/test_mlflow_sktime_model_export.py` - 33 skipped locally because `mlflow` is not installed
- `python3 -m ruff check sktime/utils/mlflow_sktime.py` - passed
- `python3 -m ruff format --check sktime/utils/mlflow_sktime.py` - passed
- Import/annotation check passed for `save_model.__annotations__` and `log_model.__annotations__`

#### Any other comments?

None.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].