### PR TITLE
fix: remove `duplicate _transform_scores` method in BaseDetector

### DIFF
--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -677,22 +677,6 @@ class BaseDetector(BaseEstimator):
         """
         raise NotImplementedError("abstract method")
 
-    def _transform_scores(self, X):
-        """Return scores for predicted labels on test/deployment data.
-
-        core logic
-
-        Parameters
-        ----------
-        X : pd.DataFrame
-            Time series subject to detection, which will be assigned labels or scores.
-
-        Returns
-        -------
-        scores : pd.DataFrame with same index as X
-            Scores for sequence ``X``.
-        """
-        raise NotImplementedError("abstract method")
 
     def _update(self, X, y=None):
         """Update model with new data and optional ground truth labels.


### PR DESCRIPTION
### 1. Summary

This PR removes an exact duplicate of the `_transform_scores` private method inside `BaseDetector`. 
Previously, `_transform_scores` was defined twice consecutively around lines 660-695. While Python handles shadowing without throwing an error, this poses a danger for future maintenance causing changes applied to only one of the definitions to be silently ignored.
