### PR TITLE
[ENH] update `test_run_test_for_class` to take into account VM-only tests - part 2

### DIFF
--- a/sktime/tests/tests/test_test_utils.py
+++ b/sktime/tests/tests/test_test_utils.py
@@ -169,7 +169,7 @@ def test_run_test_for_class():
 
     if not dep_present:
         assert not run
-        assert reason == "False_required_deps_missing"
+        assert reason in ["False_required_deps_missing", "False_requires_vm"]
     elif not ONLY_CHANGED_MODULES:
         assert run
         assert reason == "True_run_always"
@@ -178,5 +178,5 @@ def test_run_test_for_class():
         assert reason_wdep == reason or reason_nodep == reason
     else:
         assert reason == "False_no_change"
-        assert reason_wdep == "False_no_change"
+        assert reason_wdep in ["False_no_change", "False_requires_vm"]
         assert reason_nodep == "False_no_change"

--- a/sktime/tests/tests/test_test_utils.py
+++ b/sktime/tests/tests/test_test_utils.py
@@ -169,7 +169,7 @@ def test_run_test_for_class():
 
     if not dep_present:
         assert not run
-        assert reason in ["False_required_deps_missing", "False_requires_vm"]
+        assert reason == "False_required_deps_missing"
     elif not ONLY_CHANGED_MODULES:
         assert run
         assert reason == "True_run_always"


### PR DESCRIPTION
Updates the `test_run_test_for_class` to take into account VM-only tests, i.e., the case that an estimator may not be tested because it runs only in a dedicated VM test.

Continuation of #9836 which missed some instances.