### PR TITLE
[MNT] simplify `all_extras` soft dependency set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,29 +78,15 @@ dependencies = [
 #
 # all_extras soft dependencies must be compatible with pandas 2
 all_extras = [
-  'arch>=5.6,<7.1.0; python_version < "3.13"',
   'cloudpickle; python_version < "3.13"',
-  'dash!=2.9.0; python_version < "3.13"',
-  'dask<2025.2.1,>2024.8.2; extra == "dataframe" and python_version < "3.13"',
-  'gluonts>=0.9; python_version < "3.13"',
-  'h5py; python_version < "3.12"',
-  'hmmlearn>=0.2.7; python_version < "3.11"',
   'holidays; python_version < "3.13"',
   'matplotlib!=3.9.1,>=3.3.2; python_version < "3.13"',
   'numba<0.63,>=0.53; python_version < "3.14"',
-  'optuna<4.5',
   'pmdarima!=1.8.1,<3.0.0,>=1.8',
   'polars[pandas]>=0.20,<2.0; python_version < "3.13"',
-  'pyod>=0.8; python_version < "3.11"',
-  'ray >=2.40.0; python_version < "3.13"',
-  'scikit_posthocs>=0.6.5; python_version < "3.13"',
   'seaborn>=0.11; python_version < "3.13"',
-  'skforecast<0.19,>=0.12.1; python_version < "3.14"',
-  "skpro>=2,<2.12.0",
-  'statsforecast<2.1.0,>=1.0.0; python_version < "3.13"',
+  "skpro>=2,<2.13.0",
   'statsmodels>=0.12.1; python_version < "3.13"',
-  'tensorflow<2.20,>=2.15; python_version < "3.13"',
-  'tsfresh>=0.17; python_version < "3.12"',
   'xarray; python_version < "3.13"',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
 # users can install via "pip install sktime[all_extras]"
 #
 # * all_extras soft dependencies must be compatible with pandas 2, numpy 2
-# * estimator specific soft dependences should be handled
+# * estimator specific soft dependencies should be handled
 #   via python_dependencies tag instead, do not add here
 all_extras = [
   'cloudpickle',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ all_extras = [
   'holidays',
   'matplotlib!=3.9.1,>=3.3.2',
   'numba<0.63,>=0.53; python_version < "3.14"',
-  'pmdarima!=1.8.1,<3.0.0,>=1.8',
   'polars[pandas]>=0.20,<2.0',
   'seaborn>=0.11',
   "skpro>=2,<2.13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,14 @@ dependencies = [
 # but are required by popular estimators, e.g., prophet, tbats, etc.
 
 # curated set of all_extras
+# soft dependencies for the framework layer
 # these are not all soft dependencies, but only common ones
 #
 # users can install via "pip install sktime[all_extras]"
 #
-# all_extras soft dependencies must be compatible with pandas 2
+# * all_extras soft dependencies must be compatible with pandas 2, numpy 2
+# * estimator specific soft dependences should be handled
+#   via python_dependencies tag instead, do not add here
 all_extras = [
   'cloudpickle',
   'holidays',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ all_extras = [
   'matplotlib!=3.9.1,>=3.3.2',
   'numba<0.63,>=0.53; python_version < "3.14"',
   'pmdarima!=1.8.1,<3.0.0,>=1.8',
-  'polars[pandas]>=0.20,<2.0; python_version < "3.13"',
+  'polars[pandas]>=0.20,<2.0',
   'seaborn>=0.11',
   "skpro>=2,<2.13.0",
   'statsmodels>=0.12.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,16 +78,15 @@ dependencies = [
 #
 # all_extras soft dependencies must be compatible with pandas 2
 all_extras = [
-  'cloudpickle; python_version < "3.13"',
-  'holidays; python_version < "3.13"',
-  'matplotlib!=3.9.1,>=3.3.2; python_version < "3.13"',
+  'cloudpickle',
+  'holidays',
+  'matplotlib!=3.9.1,>=3.3.2',
   'numba<0.63,>=0.53; python_version < "3.14"',
   'pmdarima!=1.8.1,<3.0.0,>=1.8',
   'polars[pandas]>=0.20,<2.0; python_version < "3.13"',
-  'seaborn>=0.11; python_version < "3.13"',
+  'seaborn>=0.11',
   "skpro>=2,<2.13.0",
-  'statsmodels>=0.12.1; python_version < "3.13"',
-  'xarray; python_version < "3.13"',
+  'statsmodels>=0.12.1',
 ]
 
 # single-task dependencies, e.g., forecasting, classification, etc.

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -35,6 +35,7 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
         # CI and test flags
         # -----------------
         "tests:libs": ["sktime.forecasting.base.adapters._generalised_statsforecast"],
+        "tests:vm": True,
     }
 
     def __init__(self):

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -24,6 +24,9 @@ class _PmdArimaAdapter(BaseForecaster):
         "requires-fh-in-fit": False,
         "capability:missing_values": True,
         "python_dependencies": ["pmdarima"],
+        # CI and testing tags
+        # -------------------
+        "tests:vm": True,
     }
 
     def __init__(self):

--- a/sktime/forecasting/base/adapters/_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_statsforecast.py
@@ -28,6 +28,9 @@ class _StatsForecastAdapter(BaseForecaster):
         "capability:pred_int": True,  # does forecaster implement predict_quantiles?
         "capability:pred_int:insample": True,
         "python_dependencies": "statsforecast",
+        # CI and test dependencies
+        # ------------------------
+        "tests:vm": True,
     }
 
     def __init__(self):


### PR DESCRIPTION
Simplifies the `all_extras` soft dependency set in preparation for the 1.0 release.

Changes the philosophy from being a collection of popular estimator soft dependencies to be only framework soft dependencies.
Estimator soft dependencies are now managed in the `python_dependencies` tag of the estimator.

* remove estimator specific dependencies
* remove `<3.13` condition on framework soft dependencies