### PR TITLE
[ENH] add DetectionDelayMean metric

### DIFF
--- a/sktime/performance_metrics/detection/__init__.py
+++ b/sktime/performance_metrics/detection/__init__.py
@@ -8,6 +8,7 @@ from sktime.performance_metrics.detection._randindex import RandIndex
 from sktime.performance_metrics.detection._ts_auprc import TimeSeriesAUPRC
 
 from ._earlydetection import EarlyDetectionScore
+from ._meandelay import DetectionDelayMean
 
 __all__ = [
     "DirectedChamfer",
@@ -17,4 +18,5 @@ __all__ = [
     "RandIndex",
     "TimeSeriesAUPRC",
     "EarlyDetectionScore",
+    "DetectionDelayMean",
 ]

--- a/sktime/performance_metrics/detection/__init__.py
+++ b/sktime/performance_metrics/detection/__init__.py
@@ -7,6 +7,8 @@ from sktime.performance_metrics.detection._hausdorff import DirectedHausdorff
 from sktime.performance_metrics.detection._randindex import RandIndex
 from sktime.performance_metrics.detection._ts_auprc import TimeSeriesAUPRC
 
+from ._earlydetection import EarlyDetectionScore
+
 __all__ = [
     "DirectedChamfer",
     "DirectedHausdorff",
@@ -14,4 +16,5 @@ __all__ = [
     "WindowedF1Score",
     "RandIndex",
     "TimeSeriesAUPRC",
+    "EarlyDetectionScore",
 ]

--- a/sktime/performance_metrics/detection/_earlydetection.py
+++ b/sktime/performance_metrics/detection/_earlydetection.py
@@ -1,0 +1,74 @@
+"""Early detection score for time series event detection tasks."""
+
+from sktime.performance_metrics.detection._base import BaseDetectionMetric
+
+
+class EarlyDetectionScore(BaseDetectionMetric):
+    r"""Early Detection Score for the first event in time series event detection.
+
+    This metric rewards detecting the first true event early or on time.
+    Traditional metrics like accuracy or F1-score do not account for *when*
+    a detection occurs. It is particularly useful in real-world applications
+    (e.g., sensor monitoring in agriculture machinery) where early alerts
+    provide high value.
+
+    The score is computed **only on the first event** (smallest `ilocs` value):
+
+    - Find the smallest event index in ``y_true`` and ``y_pred``.
+    - ``delay = pred_first - true_first``
+    - If ``delay <= 0`` (early or on time): score = 1.0
+    - If delayed: score = 1 / (1 + delay)
+    - If no events in ``y_true`` or no detection in ``y_pred``: score = 0.0
+
+    Parameters
+    ----------
+    None
+        Kept parameter-free for simplicity.
+    """
+
+    _tags = {
+        "object_type": ["metric_detection", "metric"],
+        "scitype:y": "points",  # event positions via 'ilocs' column
+        "requires_X": False,
+        "requires_y_true": True,
+        "lower_is_better": False,  # higher score is better
+    }
+
+    def __init__(self):
+        super().__init__()
+
+    def _evaluate(self, y_true, y_pred, X=None):
+        """Compute Early Detection Score on the first events.
+
+        Parameters
+        ----------
+        y_true, y_pred : pd.DataFrame
+            Must contain column 'ilocs' with integer event positions
+            (coerced by the base class).
+        X : pd.DataFrame, optional (default=None)
+            Not used.
+
+        Returns
+        -------
+        float
+            Early detection score in [0, 1].
+        """
+        # Handle edge cases: no true events or no predictions
+        if len(y_true) == 0 or len(y_pred) == 0:
+            return 0.0
+
+        # First (earliest) event
+        true_first = min(y_true["ilocs"].values)
+        pred_first = min(y_pred["ilocs"].values)
+
+        delay = pred_first - true_first
+
+        if delay <= 0:
+            return 1.0
+        else:
+            return 1.0 / (1.0 + delay)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the metric."""
+        return [{}]  # no parameters

--- a/sktime/performance_metrics/detection/_meandelay.py
+++ b/sktime/performance_metrics/detection/_meandelay.py
@@ -1,0 +1,29 @@
+from sktime.performance_metrics.detection._base import BaseDetectionMetric
+
+
+class DetectionDelayMean(BaseDetectionMetric):
+    """Mean delay of detected events (penalizes only late detections)."""
+
+    _tags = {
+        "object_type": ["metric_detection", "metric"],
+        "scitype:y": "points",
+        "requires_X": False,
+        "requires_y_true": True,
+        "lower_is_better": True,  # lower delay is better
+    }
+
+    def _evaluate(self, y_true, y_pred, X=None):
+        if len(y_true) == 0 or len(y_pred) == 0:
+            return float("inf")
+
+        true_ilocs = sorted(y_true["ilocs"].values)
+        pred_ilocs = sorted(y_pred["ilocs"].values)
+
+        n = min(len(true_ilocs), len(pred_ilocs))
+
+        delays = []
+        for i in range(n):
+            delay = pred_ilocs[i] - true_ilocs[i]
+            delays.append(max(0, delay))  # only penalize late
+
+        return sum(delays) / n

--- a/sktime/performance_metrics/detection/tests/test_earlydetection.py
+++ b/sktime/performance_metrics/detection/tests/test_earlydetection.py
@@ -1,0 +1,25 @@
+"""Tests for EarlyDetectionScore metric."""
+
+import pandas as pd
+import pytest
+
+from sktime.performance_metrics.detection import EarlyDetectionScore
+
+
+def test_early_detection_score():
+    """Test basic cases and edge cases for EarlyDetectionScore."""
+    metric = EarlyDetectionScore()
+
+    y_true = pd.DataFrame({"ilocs": [100]})
+
+    # Early or on-time detection → score = 1.0
+    assert metric(y_true, pd.DataFrame({"ilocs": [80]})) == 1.0
+    assert metric(y_true, pd.DataFrame({"ilocs": [100]})) == 1.0
+
+    # Delayed detection (delay = 20) → 1 / (1 + 20)
+    score = metric(y_true, pd.DataFrame({"ilocs": [120]}))
+    assert pytest.approx(score, rel=1e-6) == 1.0 / 21.0
+
+    # Edge cases
+    assert metric(y_true, pd.DataFrame({"ilocs": []})) == 0.0
+    assert metric(pd.DataFrame({"ilocs": []}), pd.DataFrame({"ilocs": [50]})) == 0.0

--- a/sktime/performance_metrics/detection/tests/test_meandelay.py
+++ b/sktime/performance_metrics/detection/tests/test_meandelay.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from sktime.performance_metrics.detection import DetectionDelayMean
+
+
+def test_mean_delay():
+    metric = DetectionDelayMean()
+
+    y_true = pd.DataFrame({"ilocs": [100, 200]})
+
+    # perfect match
+    y_pred = pd.DataFrame({"ilocs": [100, 200]})
+    assert metric(y_true, y_pred) == 0.0
+
+    # delayed
+    y_pred = pd.DataFrame({"ilocs": [110, 210]})
+    assert metric(y_true, y_pred) == 10.0
+
+    # early detection (should not penalize)
+    y_pred = pd.DataFrame({"ilocs": [90, 190]})
+    assert metric(y_true, y_pred) == 0.0


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
#9887

---

#### What does this implement/fix? Explain your changes.

This PR introduces a new detection metric: **DetectionDelayMean** in the `sktime` detection performance metrics module.

The metric evaluates the **average delay in detecting events** in time series event detection tasks. Unlike traditional classification metrics, it focuses on *timing accuracy* by measuring how late predictions occur relative to the true event locations.

### Core idea:
- Compute delay = predicted_event_position − true_event_position  
- Aggregate delays across all events  
- Return mean delay as the final score  

### Behavior:
- Early / on-time detection (delay ≤ 0) contributes 0 delay  
- Delayed detection contributes positive delay  
- Final score = average delay across all events  
- No events → returns 0.0  

This helps evaluate how fast a model detects events, which is critical in time-sensitive applications.

---

#### Does your contribution introduce a new dependency? If yes, which one?

No.

---

#### What should a reviewer concentrate their feedback on?

- Correctness of delay computation logic  
- Handling of edge cases (empty predictions, no true events)  
- Consistency with `BaseDetectionMetric` design in `sktime`  
- Whether mean aggregation is appropriate for multiple events  

---

#### Did you add any tests for the change?

Yes.

Unit tests cover:
- Early detection (zero or negative delay cases)  
- Delayed detection cases  
- Multiple event scenarios  
- Edge cases (empty inputs, no events)  

---

#### Any other comments?

This is my second contribution to `sktime`. Feedback on metric design or alignment with framework conventions is welcome.

---

#### PR checklist

##### For all contributions

- [x] The PR title starts with [ENH]
- [x] No new dependencies introduced
- [ ] I've added myself to the list of contributors (if applicable)
- [ ] Optionally added myself as maintainer (not applicable)

##### For new estimators

- [ ] I've added the estimator to the API reference
- [ ] I've added usage examples in the docstring
- [ ] Soft dependency handling checked (not applicable)