### PR TITLE
MAINT: replace inplace operations in WindowSummarizer to fix pandas FutureWarning (#9640)

### DIFF
--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -295,10 +295,8 @@ class WindowSummarizer(BaseTransformer):
             func_dict, id_vars="index", value_name="window", ignore_index=False
         )
         func_dict.sort_index(inplace=True)
-        func_dict.drop("variable", axis=1, inplace=True)
-        func_dict.rename(
-            columns={"index": "summarizer"},
-            inplace=True,
+        func_dict = func_dict.drop("variable", axis=1)
+        func_dict = func_dict.rename(columns={"index": "summarizer"}
         )
         func_dict = func_dict.dropna(axis=0, how="any")
         # Identify lags (since they can follow special notation)


### PR DESCRIPTION
Replaces `inplace=True` operations with explicit reassignment in
`WindowSummarizer` to resolve pandas FutureWarnings about chained
assignment on DataFrame copies.

Changes in `sktime/transformations/series/summarize.py`:
- `func_dict.drop(..., inplace=True)` → `func_dict = func_dict.drop(...)`
- `func_dict.rename(..., inplace=True)` → `func_dict = func_dict.rename(...)`

This ensures compatibility with pandas 3.0 Copy-on-Write behavior.

Contributes to #9640