### PR TITLE
[BUG] unskip pickle persistence tests for Chronos2Forecaster

### DIFF
--- a/sktime/forecasting/chronos2.py
+++ b/sktime/forecasting/chronos2.py
@@ -114,10 +114,6 @@ class Chronos2Forecaster(BaseForecaster):
         "capability:global_forecasting": True,
         "capability:non_contiguous_X": False,
         "tests:vm": True,
-        "tests:skip_by_name": [
-            "test_persistence_via_pickle",
-            "test_save_estimators_to_file",
-        ],
     }
 
     _default_config = {


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #9869.

#### What does this implement/fix? Explain your changes.

Removes `test_persistence_via_pickle` and `test_save_estimators_to_file` from the `tests:skip_by_name` tag of `Chronos2Forecaster`. The existing `__getstate__` / `__setstate__` / `_ensure_model_pipeline_loaded` methods in `chronos2.py` already handle the unpicklable `model_pipeline` attribute correctly (pattern inherited from the PR #8944 fix to `ChronosForecaster`), but the two pickle tests were preemptively skipped in PR #9823 and never validated. This PR unskips them and verifies that both pass on the full VM matrix.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Whether `__getstate__` / `_ensure_model_pipeline_loaded` as-is is the right abstraction long term, or whether this serialization pattern should move into a shared mixin for zero-shot foundation model forecasters (Chronos, Chronos-2, TimeMoE, TimesFM, TiRex, TimeLLM). Happy to follow up with that refactor in a separate `[ENH]` PR.

#### Did you add any tests for the change?

No new tests. The previously skipped `test_persistence_via_pickle` and `test_save_estimators_to_file` from `test_all_estimators.py` now run for `Chronos2Forecaster` and both pass on all 15 platform combinations on fork CI (Py 3.10 to 3.14, ubuntu/macos/windows).

#### Any other comments?

`ChronosForecaster` has the same stale skip and should receive the same treatment, but its VM tests currently fail on the bolt variant for an unrelated `transformers` incompatibility in vendored `sktime/libs/chronos/chronos_bolt.py` (`T5Stack(encoder_config, self.shared)` no longer matches the current `T5Stack.__init__` signature). Scoping that to a separate `[BUG]` so this PR stays narrow.

#### PR checklist

##### For all contributions
- [x] I've added myself to the list of contributors
- [x] The PR title starts with `[BUG]`