### PR TITLE
[BUG] Fix ValueError in STRAY when input size n < k+1

### DIFF
--- a/sktime/detection/stray.py
+++ b/sktime/detection/stray.py
@@ -158,15 +158,15 @@ class STRAY(BaseTransformer):
         -------
         dict of index of outliers and the outlier scores
         """
+        n_neighbors = n if self.k >= n else self.k + 1
         if len(X.shape) == 1:
-            nbrs = NearestNeighbors(n_neighbors=self.k + 1).fit(X.reshape(-1, 1))
-            distances, _ = nbrs.kneighbors(X.reshape(-1, 1))
-        else:
-            nbrs = NearestNeighbors(
-                n_neighbors=n if self.k >= n else self.k + 1,
-                algorithm=self.knn_algorithm,
-            ).fit(X)
-            distances, _ = nbrs.kneighbors(X)
+            X = X.reshape(-1, 1)
+
+        nbrs = NearestNeighbors(
+            n_neighbors=n_neighbors,
+            algorithm=self.knn_algorithm,
+        ).fit(X)
+        distances, _ = nbrs.kneighbors(X)
 
         if self.k == 1:
             d = distances[:, 1]

--- a/sktime/detection/tests/test_stray.py
+++ b/sktime/detection/tests/test_stray.py
@@ -316,3 +316,24 @@ def test_2D_score_with_standardize():
     fitted_model = model.fit(X)
     y_scores_actual = fitted_model.score_
     assert np.allclose(y_scores_actual, y_scores_expected)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(STRAY),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_stray_small_input():
+    """Test STRAY with input smaller than k+1.
+
+    This is a regression test for #9905.
+    """
+    # Use a small dataset where n < k+1 (default k=10)
+    X = np.array([1, 2, 1, 2, 1, 2, 100]).reshape(-1, 1)
+    stray = STRAY(k=10)
+    y = stray.fit_transform(X)
+
+    assert len(y) == len(X)
+    assert y.dtype == bool
+    # Ensure it doesn't crash and returns expected types
+    # At least the outlier 100 should be detected or at least the code finished
+    assert isinstance(y, np.ndarray)


### PR DESCRIPTION
Reference Issues/PRs
Fixes #9905.

What does this implement/fix? Explain your changes.
This PR resolves a ValueError in the STRAY anomaly detection algorithm that occurred when the number of input samples $n$ was less than the requested number of neighbors $k + 1$.

Key Changes:

Robust n_neighbors Calculation: Updated the score_ method in sktime/detection/stray.py to ensure n_neighbors never exceeds the available sample size.
Unified Logic: Refactored the scoring logic to consistently handle both univariate and multivariate data, simplifying the code and ensuring the fix applies to both input formats.
Regression Test: Added test_stray_small_input in sktime/detection/tests/test_stray.py which specifically tests STRAY with a dataset smaller than the default $k+1$ to prevent future regressions.
Does your contribution introduce a new dependency? If yes, which one?
No.

What should a reviewer concentrate their feedback on?
The logic for capping n_neighbors in the score_ method.
The consistency of the refactored scoring logic for univariate vs. multivariate inputs.
Did you add any tests for the change?
Yes, I added a regression test test_stray_small_input in sktime/detection/tests/test_stray.py.

Any other comments?
None.
