### PR TITLE
[BUG] Fix pandas FutureWarning from "ME" → "M" conversion in ForecastingHorizon

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -411,12 +411,8 @@ class ForecastingHorizon:
                     f"Current: {freq_from_self}, from update: {freq_from_obj}."
                 )
         elif freq_from_obj is not None:  # only freq_from_obj is not None
-            if freq_from_obj == "ME":
-                freq_from_obj = "M"
             self._freq = freq_from_obj
         else:
-            if freq_from_obj == "ME":
-                freq_from_obj = "M"
             # leave self._freq as freq_from_self, or set to None if does not exist yet
             self._freq = freq_from_self
 


### PR DESCRIPTION
#### Reference Issues/PRs
Related to pandas 2.2 deprecation warnings for frequency aliases.

---

#### What does this implement/fix? Explain your changes.

While testing forecasting with a monthly DatetimeIndex, I noticed repeated FutureWarnings from pandas about the "M" frequency being deprecated.

After tracing the issue, I found that ForecastingHorizon was converting the modern "ME" alias back to "M", which causes these warnings and will break in pandas 3.0.

This PR removes that forced conversion so that modern frequency aliases like "ME" are preserved.

---

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies.

---

#### What should a reviewer concentrate their feedback on?

- Whether removing the "ME" → "M" conversion is safe across all use cases
- Any edge cases involving PeriodIndex vs DatetimeIndex

---

#### Did you add any tests for the change?

No new tests yet. I manually verified the fix by reproducing the issue — the warnings are gone after this change.

---

#### Any other comments?

Happy to update this further if needed or add tests based on feedback.

---

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors
- [x] The PR title starts with [BUG]

##### For new estimators
- [x] Not applicable