### PR TITLE
[ENH] follow-up detector scenario coverage improvements (#8896)

### DIFF
--- a/sktime/detection/tests/test_scenarios.py
+++ b/sktime/detection/tests/test_scenarios.py
@@ -1,0 +1,18 @@
+"""Scenario definitions for detector tests."""
+
+from sktime.utils._testing.scenarios_getter import retrieve_scenarios
+
+
+def test_detector_scenarios_defined():
+    """At least one detector scenario should be available via the scenario getter."""
+    scenarios = retrieve_scenarios("detector")
+
+    assert len(scenarios) > 0
+    assert all(scenario.get_tag("scitype") == "detector" for scenario in scenarios)
+
+
+def test_detector_multivariate_scenario_defined():
+    """A multivariate detector scenario should be available for capable detectors."""
+    scenarios = retrieve_scenarios("detector", filter_tags={"X_univariate": False})
+
+    assert len(scenarios) > 0

--- a/sktime/utils/_testing/scenarios_detection.py
+++ b/sktime/utils/_testing/scenarios_detection.py
@@ -57,5 +57,26 @@ class DetectorUnivariateSimple(DetectorTestScenario):
     default_method_sequence = ["fit", "predict", "transform"]
 
 
+class DetectorMultivariateSimple(DetectorTestScenario):
+    """Simple multivariate detector scenario with default settings."""
+
+    _tags = {
+        "is_enabled": True,
+        "scitype": "detector",
+        "X_univariate": False,
+    }
+
+    @property
+    def args(self):
+        Z = _make_series(n_timepoints=20, n_columns=2, random_state=RAND_SD2)
+        return {
+            "fit": {"X": Z},
+            "predict": {"X": Z},
+            "transform": {"X": Z},
+        }
+
+    default_method_sequence = ["fit", "predict", "transform"]
+
+
 # List of scenarios to be imported by tests
-scenarios_detectors = [DetectorUnivariateSimple]
+scenarios_detectors = [DetectorUnivariateSimple, DetectorMultivariateSimple]


### PR DESCRIPTION

#### Reference Issues/PRs

- Refs #8896.  
- Follow-up to #8914 (baseline detector scenario setup).

#### What does this implement/fix? Explain your changes.
This PR adds follow-up detector scenario coverage improvements in the test framework:

- adds a multivariate detector scenario in `sktime/utils/_testing/scenarios_detection.py`
- adds focused detector scenario tests in `sktime/detection/tests/test_scenarios.py`

The goal is to strengthen detector scenario coverage beyond the baseline univariate setup and add regression checks for scenario discovery/filtering.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- whether adding multivariate detector scenario coverage is appropriate as follow-up to #8896
- whether test scope/location (`detection/tests/test_scenarios.py`) aligns with repo conventions
- whether scenario retrieval/filter assertions are clear and minimal

#### Did you add any tests for the change?
Yes.

Added:
- `sktime/detection/tests/test_scenarios.py`
  - `test_detector_scenarios_defined`
  - `test_detector_multivariate_scenario_defined`

Ran locally:
```bash
pytest -v sktime/detection/tests/test_scenarios.py --maxfail=1
pytest -v sktime/utils/_testing/tests/test_testscenario_getter.py --maxfail=1
pre-commit run --files sktime/utils/_testing/scenarios_detection.py sktime/detection/tests/test_scenarios.py (passed)
```



#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


