### PR TITLE
[ENH] Add WindowedTPR, WindowedFPR, EarlyDetectionTime metrics for sktime.detection

### DIFF
--- a/docs/source/api_reference/detection.rst
+++ b/docs/source/api_reference/detection.rst
@@ -75,6 +75,14 @@ Window-based Anomaly Detection
 
     SubLOF
 
+.. currentmodule:: sktime.detection.isof
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    SubIsolationForest
+
 Foundation Model-based Anomaly Detection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/api_reference/performance_metrics.rst
+++ b/docs/source/api_reference/performance_metrics.rst
@@ -193,6 +193,9 @@ Event detection - anomalies, outliers
     DirectedHausdorff
     DetectionCount
     WindowedF1Score
+    WindowedTPR
+    WindowedFPR
+    EarlyDetectionTime
     TimeSeriesAUPRC
 
 Segment detection

--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -677,23 +677,6 @@ class BaseDetector(BaseEstimator):
         """
         raise NotImplementedError("abstract method")
 
-    def _transform_scores(self, X):
-        """Return scores for predicted labels on test/deployment data.
-
-        core logic
-
-        Parameters
-        ----------
-        X : pd.DataFrame
-            Time series subject to detection, which will be assigned labels or scores.
-
-        Returns
-        -------
-        scores : pd.DataFrame with same index as X
-            Scores for sequence ``X``.
-        """
-        raise NotImplementedError("abstract method")
-
     def _update(self, X, y=None):
         """Update model with new data and optional ground truth labels.
 

--- a/sktime/detection/isof.py
+++ b/sktime/detection/isof.py
@@ -1,0 +1,275 @@
+"""Windowed Isolation Forest anomaly detector."""
+
+__author__ = ["rupeshca007"]
+
+import datetime
+import math
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import IsolationForest
+
+from sktime.detection.base import BaseDetector
+
+
+class SubIsolationForest(BaseDetector):
+    """Windowed Isolation Forest anomaly detector for time series.
+
+    Applies scikit-learn's ``IsolationForest`` on non-overlapping windows of
+    a time series, allowing the model to adapt to local temporal structure.
+    This is analogous to ``SubLOF``, but uses the Isolation Forest algorithm,
+    which is especially effective for high-dimensional and large-scale data.
+
+    Parameters
+    ----------
+    window_size : int, float, or datetime.timedelta
+        Size of the non-overlapping windows. If the time series has a
+        ``DatetimeIndex``, ``window_size`` may be a ``timedelta``; otherwise
+        it must be an integer number of observations.
+    n_estimators : int, default=100
+        The number of base estimators in the ensemble.
+    max_samples : int, float, or "auto", default="auto"
+        The number of samples to draw to train each base estimator.
+
+        - If ``int``, then draw ``max_samples`` samples.
+        - If ``float``, then draw ``max(round(n_samples * max_samples), 1)``
+          samples.
+        - If ``"auto"``, then ``max_samples=min(256, n_samples)``.
+
+    contamination : float or "auto", default="auto"
+        The proportion of outliers in the dataset.
+
+        - If ``"auto"``, the threshold is determined as in the original paper.
+        - If a float, it must be in the range ``(0, 0.5]``.
+
+    max_features : int or float, default=1.0
+        The number of features to draw to train each base estimator.
+
+        - If ``int``, then draw ``max_features`` features.
+        - If ``float``, then draw ``max(1, int(max_features * n_features_in_))``
+          features.
+
+    bootstrap : bool, default=False
+        If ``True``, individual trees are fit on random subsets of the training
+        data sampled with replacement. If ``False``, sampling without
+        replacement is performed.
+    random_state : int, RandomState instance or None, default=None
+        Controls the pseudo-randomness of the selection of the feature and
+        split values for each branching step and each tree in the forest.
+    n_jobs : int, default=None
+        The number of jobs to run in parallel for both ``fit`` and ``predict``.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors.
+    verbose : int, default=0
+        Controls the verbosity of the tree building process.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.detection.isof import SubIsolationForest
+    >>> model = SubIsolationForest(window_size=5, n_estimators=10, random_state=42)
+    >>> x = pd.DataFrame([0, 0.5, 100, 0.1, 0, 0, 0, 100, 0, 0, 0.3, -1, 0, 100, 0.2])
+    >>> model.fit_transform(x)
+       labels
+    0       0
+    1       0
+    2       1
+    3       0
+    4       0
+    5       0
+    6       0
+    7       1
+    8       0
+    9       0
+    10      0
+    11      0
+    12      0
+    13      1
+    14      0
+
+    See Also
+    --------
+    SubLOF : Windowed Local Outlier Factor detector.
+    """
+
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": ["rupeshca007"],
+        "maintainers": ["rupeshca007"],
+        # estimator type
+        # --------------
+        "task": "anomaly_detection",
+        "learning_type": "unsupervised",
+        "capability:multivariate": True,
+        "fit_is_empty": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,
+    }
+
+    def __init__(
+        self,
+        window_size,
+        *,
+        n_estimators=100,
+        max_samples="auto",
+        contamination="auto",
+        max_features=1.0,
+        bootstrap=False,
+        random_state=None,
+        n_jobs=None,
+        verbose=0,
+    ):
+        self.window_size = window_size
+        self.n_estimators = n_estimators
+        self.max_samples = max_samples
+        self.contamination = contamination
+        self.max_features = max_features
+        self.bootstrap = bootstrap
+        self.random_state = random_state
+        self.n_jobs = n_jobs
+        self.verbose = verbose
+        self.models_ = None
+        super().__init__()
+
+    def _fit(self, X, y=None):
+        """Fit an IsolationForest model per window.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Training time series data to fit model to.
+        y : ignored
+
+        Returns
+        -------
+        self : reference to self.
+        """
+        model_params = {
+            "n_estimators": self.n_estimators,
+            "max_samples": self.max_samples,
+            "contamination": self.contamination,
+            "max_features": self.max_features,
+            "bootstrap": self.bootstrap,
+            "random_state": self.random_state,
+            "n_jobs": self.n_jobs,
+            "verbose": self.verbose,
+        }
+
+        intervals = self._split_into_intervals(X.index, self.window_size)
+        self.models_ = {
+            interval: IsolationForest(**model_params) for interval in intervals
+        }
+
+        for interval, model in self.models_.items():
+            mask = (X.index >= interval.left) & (X.index < interval.right)
+            X_win = X.loc[mask]
+            if len(X_win) > 0:
+                model.fit(X_win)
+
+        return self
+
+    @staticmethod
+    def _split_into_intervals(x, interval_size):
+        """Split the index range of ``x`` into equally sized intervals.
+
+        Parameters
+        ----------
+        x : pd.Index
+            The time series index to partition.
+        interval_size : int, float, or datetime.timedelta
+            Width of each interval.
+
+        Returns
+        -------
+        pd.IntervalIndex
+            Non-overlapping, left-closed intervals covering the full index range.
+        """
+        from sktime.utils.validation.series import is_integer_index
+
+        x_max = x.max()
+        x_min = x.min()
+        x_span = x_max - x_min
+
+        if isinstance(interval_size, int) and not is_integer_index(x):
+            interval_size = x.freq * interval_size
+        n_intervals = math.floor(x_span / interval_size) + 1
+
+        if x_max >= x_min + (n_intervals - 1) * interval_size:
+            n_intervals += 1
+
+        breaks = [x_min + interval_size * i for i in range(n_intervals)]
+        interval_range = pd.IntervalIndex.from_breaks(breaks, closed="left")
+        return interval_range
+
+    def _predict(self, X):
+        """Detect anomalies on test/deployment data.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Time series to evaluate.
+
+        Returns
+        -------
+        y_pred : pd.Series
+            Sparse anomaly indicator.  Values are integer ``iloc`` indices of
+            anomalous observations in ``X``.
+        """
+        if isinstance(X, pd.Series):
+            X = X.to_frame()
+        X = X.copy()
+        X["__id"] = pd.RangeIndex(len(X))
+
+        y_all = []
+        for interval, model in self.models_.items():
+            X_subset = X.loc[
+                (X.index >= interval.left) & (X.index < interval.right)
+            ]
+
+            if len(X_subset) == 0:
+                continue
+
+            # IsolationForest returns -1 for anomalies, +1 for normal
+            y_subset = model.predict(X_subset.iloc[:, :-1])  # exclude __id col
+            anomaly_indexes = (
+                np.where(y_subset == -1)[0] + X_subset["__id"].iloc[0]
+            )
+            y_all.append(pd.Series(anomaly_indexes))
+
+        if len(y_all) == 0:
+            return self._empty_sparse()
+
+        y_pred = pd.concat(y_all, ignore_index=True).reset_index(drop=True)
+        return y_pred
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the parameter set to return.  If no special parameters are
+            defined for a value, will return the ``"default"`` set.
+
+        Returns
+        -------
+        params : dict or list of dict
+            Parameters to create testing instances of the class.
+            Each ``dict`` is passed as ``**params`` to the constructor.
+        """
+        params0 = {
+            "window_size": datetime.timedelta(days=25),
+            "n_estimators": 10,
+            "random_state": 42,
+        }
+        params1 = {
+            "window_size": 3,
+            "n_estimators": 5,
+            "contamination": 0.1,
+            "bootstrap": True,
+            "random_state": 0,
+        }
+        return [params0, params1]

--- a/sktime/detection/tests/test_isof.py
+++ b/sktime/detection/tests/test_isof.py
@@ -1,0 +1,169 @@
+"""Tests for SubIsolationForest anomaly detector."""
+
+__author__ = ["rupeshca007"]
+
+import datetime
+
+import pandas as pd
+import pytest
+
+from sktime.detection.isof import SubIsolationForest
+from sktime.tests.test_switch import run_test_for_class
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SubIsolationForest),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize(
+    "x,interval_size,expected_intervals",
+    [
+        (
+            pd.Index([1, 2, 3, 4, 5]),
+            1,
+            pd.IntervalIndex.from_breaks([1, 2, 3, 4, 5, 6], closed="left"),
+        ),
+        (
+            pd.Index([0.0, 1.3, 1.5, 2.0, 3.5]),
+            1.5,
+            pd.IntervalIndex.from_breaks([0.0, 1.5, 3.0, 4.5], closed="left"),
+        ),
+        (
+            pd.DatetimeIndex(
+                [
+                    "2024-01-01 00:00:00",
+                    "2024-01-02 00:00:00",
+                    "2024-01-03 00:00:00",
+                    "2024-01-04 00:00:00",
+                    "2024-01-05 00:00:00",
+                ]
+            ),
+            datetime.timedelta(days=1),
+            pd.IntervalIndex.from_breaks(
+                [
+                    "2024-01-01 00:00:00",
+                    "2024-01-02 00:00:00",
+                    "2024-01-03 00:00:00",
+                    "2024-01-04 00:00:00",
+                    "2024-01-05 00:00:00",
+                    "2024-01-06 00:00:00",
+                ],
+                closed="left",
+                dtype="interval[datetime64[ns], left]",
+            ),
+        ),
+    ],
+)
+def test_split_into_intervals(x, interval_size, expected_intervals):
+    """Test that _split_into_intervals produces correct interval partitions."""
+    actual_intervals = SubIsolationForest._split_into_intervals(x, interval_size)
+    assert (actual_intervals == expected_intervals).all()
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SubIsolationForest),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize(
+    "X,expected_ilocs",
+    [
+        (
+            # Points 2, 7, 13 are extreme outliers within their respective windows
+            pd.DataFrame([0, 0, 100, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 100, 0]),
+            [2, 7, 13],
+        ),
+    ],
+)
+def test_predict_detects_outliers(X, expected_ilocs):
+    """Test that SubIsolationForest detects clear point anomalies."""
+    model = SubIsolationForest(
+        window_size=5,
+        n_estimators=10,
+        contamination=0.2,
+        random_state=42,
+    )
+    model.fit(X)
+    y_actual = model.predict(X)
+    detected = set(y_actual["ilocs"].tolist())
+    for iloc in expected_ilocs:
+        assert iloc in detected, (
+            f"Expected anomaly at iloc={iloc} not found in detected={detected}"
+        )
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SubIsolationForest),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_predict_returns_dataframe():
+    """Test that predict() returns a pd.DataFrame with an 'ilocs' column."""
+    X = pd.DataFrame([0, 0.5, 100, 0.1, 0, 0.2, 0.3, 50, 0, 0])
+    model = SubIsolationForest(window_size=3, n_estimators=5, random_state=0)
+    model.fit(X)
+    y = model.predict(X)
+    assert isinstance(y, pd.DataFrame), "predict() should return a pd.DataFrame"
+    assert "ilocs" in y.columns, "predict() result must have an 'ilocs' column"
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SubIsolationForest),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_fit_transform_returns_dense_dataframe():
+    """Test that fit_transform() returns a dense DataFrame with a 'labels' column."""
+    X = pd.DataFrame([0, 0, 100, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 100, 0])
+    model = SubIsolationForest(window_size=5, n_estimators=10, random_state=42)
+    result = model.fit_transform(X)
+    assert isinstance(result, pd.DataFrame)
+    assert "labels" in result.columns
+    assert len(result) == len(X), "fit_transform() output must have same length as X"
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SubIsolationForest),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_does_not_mutate_input():
+    """Test that SubIsolationForest does not modify the input DataFrame."""
+    X = pd.DataFrame([0, 0.5, 100, 0.1, 0, 0.2, 0.3, 50])
+    X_original = X.copy(deep=True)
+
+    model = SubIsolationForest(window_size=2, n_estimators=5, random_state=0)
+    _ = model.fit_transform(X)
+
+    pd.testing.assert_frame_equal(X, X_original)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SubIsolationForest),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_get_test_params():
+    """Test that get_test_params returns valid parameter dicts."""
+    params = SubIsolationForest.get_test_params()
+    assert isinstance(params, list)
+    assert len(params) >= 1
+    for p in params:
+        assert isinstance(p, dict)
+        # Should not raise
+        inst = SubIsolationForest(**p)
+        assert inst is not None
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SubIsolationForest),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_multivariate():
+    """Test that SubIsolationForest handles multivariate time series."""
+    X = pd.DataFrame(
+        {
+            "a": [0, 0, 100, 0, 0, 0, 0, 100, 0, 0],
+            "b": [0, 0, 200, 0, 0, 0, 0, 200, 0, 0],
+        }
+    )
+    model = SubIsolationForest(window_size=5, n_estimators=10, random_state=42)
+    model.fit(X)
+    y = model.predict(X)
+    assert isinstance(y, pd.DataFrame)
+    assert "ilocs" in y.columns

--- a/sktime/performance_metrics/detection/__init__.py
+++ b/sktime/performance_metrics/detection/__init__.py
@@ -5,13 +5,21 @@ from sktime.performance_metrics.detection._count import DetectionCount
 from sktime.performance_metrics.detection._f1score import WindowedF1Score
 from sktime.performance_metrics.detection._hausdorff import DirectedHausdorff
 from sktime.performance_metrics.detection._randindex import RandIndex
+from sktime.performance_metrics.detection._tpr_fpr_adt import (
+    EarlyDetectionTime,
+    WindowedFPR,
+    WindowedTPR,
+)
 from sktime.performance_metrics.detection._ts_auprc import TimeSeriesAUPRC
 
 __all__ = [
     "DirectedChamfer",
     "DirectedHausdorff",
     "DetectionCount",
+    "EarlyDetectionTime",
     "WindowedF1Score",
+    "WindowedFPR",
+    "WindowedTPR",
     "RandIndex",
     "TimeSeriesAUPRC",
 ]

--- a/sktime/performance_metrics/detection/_tpr_fpr_adt.py
+++ b/sktime/performance_metrics/detection/_tpr_fpr_adt.py
@@ -1,0 +1,396 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Event detection metrics: TPR, FPR and advance detection time.
+
+This module implements three metrics specifically designed for evaluating
+event/anomaly detectors on time series:
+
+* ``WindowedTPR`` - True Positive Rate (Recall) with margin-based matching
+* ``WindowedFPR`` - False Positive Rate with margin-based matching
+* ``EarlyDetectionTime`` - Advance detection time: how early a detector fires
+  relative to the true event onset
+
+These metrics are central to the ESoC 2026 agricultural-machinery foreign-object
+detection project, which requires transparent evaluation in terms of TPR, FPR and
+advance detection time.
+
+References
+----------
+.. [1] Talagala, P. D., Hyndman, R. J., & Smith-Miles, K. (2021).
+   Anomaly detection in high-dimensional data. Journal of Computational and
+   Graphical Statistics, 30(2), 360-374.
+"""
+
+__author__ = ["rupeshca007"]
+__all__ = ["WindowedTPR", "WindowedFPR", "EarlyDetectionTime"]
+
+import numpy as np
+import pandas as pd
+
+from sktime.performance_metrics.detection._base import BaseDetectionMetric
+
+
+class WindowedTPR(BaseDetectionMetric):
+    """True Positive Rate (Recall) for event detection with a tolerance window.
+
+    Computes the fraction of true events that have at least one predicted event
+    within ``margin`` time steps (iloc positions).
+
+    A true event at iloc ``t`` is considered *detected* if any predicted event
+    falls in the closed interval ``[t - margin, t + margin]``.
+
+    Each true event can be claimed by at most one predicted event (greedy
+    left-to-right matching), preventing a single prediction from satisfying
+    multiple ground-truth events.
+
+    .. math::
+        \\text{TPR} = \\frac{|\\text{matched true events}|}{|\\text{true events}|}
+
+    Parameters
+    ----------
+    margin : int, default=0
+        Symmetric tolerance in iloc units.  A margin of 0 requires exact matches.
+        A margin of ``k`` allows a predicted event to be up to ``k`` steps away
+        from the true event.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.performance_metrics.detection._tpr_fpr_adt import WindowedTPR
+    >>> y_true = pd.DataFrame({"ilocs": [10, 50, 90]})
+    >>> y_pred = pd.DataFrame({"ilocs": [11, 52, 95]})
+    >>> WindowedTPR(margin=5)(y_true, y_pred)
+    1.0
+    >>> WindowedTPR(margin=0)(y_true, y_pred)
+    0.0
+
+    See Also
+    --------
+    WindowedFPR : False Positive Rate counterpart.
+    EarlyDetectionTime : Measures how early detections are made.
+    WindowedF1Score : F1 score combining precision and recall.
+    """
+
+    _tags = {
+        "authors": ["rupeshca007"],
+        "maintainers": ["rupeshca007"],
+        "object_type": ["metric_detection", "metric"],
+        "scitype:y": "points",
+        "requires_X": False,
+        "requires_y_true": True,
+        "lower_is_better": False,  # higher TPR is better
+    }
+
+    def __init__(self, margin=0):
+        self.margin = margin
+        super().__init__()
+
+    def _evaluate(self, y_true, y_pred, X=None):
+        """Compute TPR under margin-based event matching.
+
+        Parameters
+        ----------
+        y_true : pd.DataFrame
+            Ground truth events with column ``"ilocs"`` (integer iloc indices).
+        y_pred : pd.DataFrame
+            Predicted events with column ``"ilocs"`` (integer iloc indices).
+        X : pd.DataFrame, optional
+            Not used; kept for API compatibility.
+
+        Returns
+        -------
+        float
+            TPR in ``[0, 1]``.  Returns ``1.0`` when both ``y_true`` and
+            ``y_pred`` are empty (no events to miss), and ``0.0`` when
+            ``y_true`` is non-empty but ``y_pred`` is empty.
+        """
+        gt = sorted(y_true["ilocs"].values.tolist())
+        pred = sorted(y_pred["ilocs"].values.tolist())
+
+        if len(gt) == 0 and len(pred) == 0:
+            return 1.0
+        if len(gt) == 0:
+            return 1.0  # no ground-truth events → nothing to miss
+        if len(pred) == 0:
+            return 0.0  # missed everything
+
+        margin = self.margin
+        matched_gt = set()
+        used_pred = set()
+
+        for j, t in enumerate(gt):
+            for i, p in enumerate(pred):
+                if i in used_pred:
+                    continue
+                if abs(p - t) <= margin:
+                    matched_gt.add(j)
+                    used_pred.add(i)
+                    break  # each gt event matched by at most one prediction
+
+        return float(len(matched_gt) / len(gt))
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+
+        Returns
+        -------
+        params : dict or list of dict
+        """
+        return [{}, {"margin": 3}, {"margin": 10}]
+
+
+class WindowedFPR(BaseDetectionMetric):
+    """False Positive Rate for event detection with a tolerance window.
+
+    Computes the fraction of predicted events that do *not* match any true event
+    within ``margin`` iloc steps, normalised by the total number of predicted
+    events.
+
+    .. math::
+        \\text{FPR} = \\frac{|\\text{unmatched predictions}|}{|\\text{predictions}|}
+
+    .. note::
+        This definition treats FPR as *false discovery rate among predictions*,
+        which is the most natural formulation when the number of true negatives
+        (normal time steps) is very large relative to events — exactly the case
+        in anomaly / rare-event detection scenarios.
+
+    Parameters
+    ----------
+    margin : int, default=0
+        Symmetric tolerance in iloc units.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.performance_metrics.detection._tpr_fpr_adt import WindowedFPR
+    >>> y_true = pd.DataFrame({"ilocs": [10, 50, 90]})
+    >>> y_pred = pd.DataFrame({"ilocs": [11, 30, 52]})
+    >>> WindowedFPR(margin=5)(y_true, y_pred)  # 30 is a false alarm
+    0.3333333333333333
+
+    See Also
+    --------
+    WindowedTPR : True Positive Rate counterpart.
+    EarlyDetectionTime : Measures how early detections are made.
+    """
+
+    _tags = {
+        "authors": ["rupeshca007"],
+        "maintainers": ["rupeshca007"],
+        "object_type": ["metric_detection", "metric"],
+        "scitype:y": "points",
+        "requires_X": False,
+        "requires_y_true": True,
+        "lower_is_better": True,  # lower FPR is better
+    }
+
+    def __init__(self, margin=0):
+        self.margin = margin
+        super().__init__()
+
+    def _evaluate(self, y_true, y_pred, X=None):
+        """Compute FPR under margin-based event matching.
+
+        Parameters
+        ----------
+        y_true : pd.DataFrame
+            Ground truth events with column ``"ilocs"``.
+        y_pred : pd.DataFrame
+            Predicted events with column ``"ilocs"``.
+        X : pd.DataFrame, optional
+            Not used; kept for API compatibility.
+
+        Returns
+        -------
+        float
+            FPR in ``[0, 1]``.  Returns ``0.0`` when ``y_pred`` is empty.
+        """
+        gt = sorted(y_true["ilocs"].values.tolist())
+        pred = sorted(y_pred["ilocs"].values.tolist())
+
+        if len(pred) == 0:
+            return 0.0  # no predictions → no false positives
+        if len(gt) == 0:
+            return 1.0  # all predictions are false alarms
+
+        margin = self.margin
+        used_gt = set()
+        true_positives = 0
+
+        for p in pred:
+            for j, t in enumerate(gt):
+                if j in used_gt:
+                    continue
+                if abs(p - t) <= margin:
+                    true_positives += 1
+                    used_gt.add(j)
+                    break
+
+        false_positives = len(pred) - true_positives
+        return float(false_positives / len(pred))
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+
+        Returns
+        -------
+        params : dict or list of dict
+        """
+        return [{}, {"margin": 3}, {"margin": 10}]
+
+
+class EarlyDetectionTime(BaseDetectionMetric):
+    """Advance detection time: how many steps *before* the true event a detector fires.
+
+    For each matched true event, this metric measures the signed difference:
+
+    .. math::
+        \\Delta t = t_{\\text{true}} - t_{\\text{pred}}
+
+    * A **positive** value means the detector fired *before* the true event
+      (early detection, desirable in safety-critical applications).
+    * A **negative** value means the detector fired *after* the true event (late).
+    * Zero means exact match.
+
+    By default (``aggregate="mean"``), the metric returns the mean advance
+    detection time over all matched events.  Unmatched true events are excluded
+    from the average but counted as missed (and optionally penalised via
+    ``missed_penalty``).
+
+    Parameters
+    ----------
+    margin : int, default=0
+        Symmetric tolerance window (in iloc units) for matching predictions to
+        true events.  A prediction must fall within ``[t - margin, t + margin]``
+        to be considered a match.
+    aggregate : str, {"mean", "median", "min", "max"}, default="mean"
+        How to aggregate advance times across matched events.
+    missed_penalty : int or None, default=None
+        Penalty value applied for each unmatched (missed) true event.
+        If ``None``, missed events are excluded from the aggregate.
+        Setting a large negative value (e.g., ``-margin``) penalises misses.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.performance_metrics.detection._tpr_fpr_adt import EarlyDetectionTime
+    >>> y_true = pd.DataFrame({"ilocs": [20, 60, 100]})
+    >>> y_pred = pd.DataFrame({"ilocs": [15, 58, 102]})  # first two early, last late
+    >>> EarlyDetectionTime(margin=10)(y_true, y_pred)
+    1.0
+
+    See Also
+    --------
+    WindowedTPR : True Positive Rate.
+    WindowedFPR : False Positive Rate.
+    """
+
+    _tags = {
+        "authors": ["rupeshca007"],
+        "maintainers": ["rupeshca007"],
+        "object_type": ["metric_detection", "metric"],
+        "scitype:y": "points",
+        "requires_X": False,
+        "requires_y_true": True,
+        "lower_is_better": False,  # higher advance time is better (earlier detection)
+    }
+
+    def __init__(self, margin=0, aggregate="mean", missed_penalty=None):
+        self.margin = margin
+        self.aggregate = aggregate
+        self.missed_penalty = missed_penalty
+        super().__init__()
+
+    def _evaluate(self, y_true, y_pred, X=None):
+        """Compute mean advance detection time.
+
+        Parameters
+        ----------
+        y_true : pd.DataFrame
+            Ground truth events with column ``"ilocs"``.
+        y_pred : pd.DataFrame
+            Predicted events with column ``"ilocs"``.
+        X : pd.DataFrame, optional
+            Not used; kept for API compatibility.
+
+        Returns
+        -------
+        float
+            Aggregated advance detection time (in iloc steps).
+            Positive means early detection; negative means late.
+            Returns ``np.nan`` when there are no ground-truth events.
+        """
+        gt = sorted(y_true["ilocs"].values.tolist())
+        pred = sorted(y_pred["ilocs"].values.tolist())
+
+        if len(gt) == 0:
+            return float("nan")
+
+        margin = self.margin
+        advance_times = []
+        used_pred = set()
+
+        for t in gt:
+            best_match = None
+            best_dt = None
+            for i, p in enumerate(pred):
+                if i in used_pred:
+                    continue
+                if abs(p - t) <= margin:
+                    dt = t - p  # positive = early detection
+                    if best_match is None or abs(dt) < abs(best_dt):
+                        best_match = i
+                        best_dt = dt
+
+            if best_match is not None:
+                used_pred.add(best_match)
+                advance_times.append(best_dt)
+            elif self.missed_penalty is not None:
+                advance_times.append(self.missed_penalty)
+
+        if len(advance_times) == 0:
+            return float("nan")
+
+        arr = np.array(advance_times, dtype=float)
+        agg = self.aggregate
+        if agg == "mean":
+            return float(np.mean(arr))
+        elif agg == "median":
+            return float(np.median(arr))
+        elif agg == "min":
+            return float(np.min(arr))
+        elif agg == "max":
+            return float(np.max(arr))
+        else:
+            raise ValueError(
+                f"aggregate must be one of 'mean', 'median', 'min', 'max'; "
+                f"got {agg!r}"
+            )
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+
+        Returns
+        -------
+        params : dict or list of dict
+        """
+        return [
+            {},
+            {"margin": 5, "aggregate": "median"},
+            {"margin": 10, "aggregate": "mean", "missed_penalty": -10},
+        ]

--- a/sktime/performance_metrics/detection/tests/test_tpr_fpr_adt.py
+++ b/sktime/performance_metrics/detection/tests/test_tpr_fpr_adt.py
@@ -1,0 +1,291 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for WindowedTPR, WindowedFPR, and EarlyDetectionTime metrics."""
+
+__author__ = ["rupeshca007"]
+
+import math
+
+import pandas as pd
+import pytest
+
+from sktime.performance_metrics.detection._tpr_fpr_adt import (
+    EarlyDetectionTime,
+    WindowedFPR,
+    WindowedTPR,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _pts(ilocs):
+    """Create a minimal 'points' DataFrame from a list of iloc indices."""
+    return pd.DataFrame({"ilocs": ilocs})
+
+
+# ===========================================================================
+# WindowedTPR tests
+# ===========================================================================
+
+
+class TestWindowedTPR:
+    """Tests for WindowedTPR."""
+
+    def test_perfect_match_margin0(self):
+        """Exact matches → TPR == 1.0."""
+        y_true = _pts([10, 50, 90])
+        y_pred = _pts([10, 50, 90])
+        assert WindowedTPR(margin=0)(y_true, y_pred) == 1.0
+
+    def test_no_match_margin0(self):
+        """Off-by-one with margin=0 → TPR == 0.0."""
+        y_true = _pts([10, 50, 90])
+        y_pred = _pts([11, 51, 91])
+        assert WindowedTPR(margin=0)(y_true, y_pred) == 0.0
+
+    def test_all_match_within_margin(self):
+        """All events detected within margin → TPR == 1.0."""
+        y_true = _pts([10, 50, 90])
+        y_pred = _pts([11, 52, 95])
+        assert WindowedTPR(margin=5)(y_true, y_pred) == 1.0
+
+    def test_partial_match(self):
+        """Only 2 of 3 events detected → TPR == 2/3."""
+        y_true = _pts([10, 50, 90])
+        y_pred = _pts([10, 50])  # missed 90
+        result = WindowedTPR(margin=0)(y_true, y_pred)
+        assert abs(result - 2 / 3) < 1e-9
+
+    def test_empty_both(self):
+        """Both empty → TPR == 1.0 (convention: nothing to detect)."""
+        assert WindowedTPR()(y_true=_pts([]), y_pred=_pts([])) == 1.0
+
+    def test_empty_pred_nonempty_true(self):
+        """No predictions, events exist → TPR == 0.0."""
+        assert WindowedTPR()(y_true=_pts([10, 20]), y_pred=_pts([])) == 0.0
+
+    def test_empty_true_nonempty_pred(self):
+        """No true events, predictions exist → TPR == 1.0 (nothing to miss)."""
+        assert WindowedTPR()(y_true=_pts([]), y_pred=_pts([5, 15])) == 1.0
+
+    def test_no_double_counting(self):
+        """A single prediction should not satisfy two ground-truth events."""
+        y_true = _pts([10, 12])
+        y_pred = _pts([11])  # within margin=2 of both, but can only match once
+        result = WindowedTPR(margin=2)(y_true, y_pred)
+        assert result == pytest.approx(0.5, abs=1e-9)
+
+    def test_returns_float(self):
+        """Return type must be float."""
+        result = WindowedTPR(margin=1)(y_true=_pts([5]), y_pred=_pts([5]))
+        assert isinstance(result, float)
+
+    @pytest.mark.parametrize("margin", [0, 1, 5, 100])
+    def test_perfect_score_various_margins(self, margin):
+        """Exact predictions always give TPR == 1.0 regardless of margin."""
+        y_true = _pts([20, 40, 60])
+        y_pred = _pts([20, 40, 60])
+        assert WindowedTPR(margin=margin)(y_true, y_pred) == 1.0
+
+    def test_get_test_params(self):
+        """get_test_params returns valid list of dicts."""
+        params = WindowedTPR.get_test_params()
+        assert isinstance(params, list)
+        for p in params:
+            assert isinstance(p, dict)
+            inst = WindowedTPR(**p)
+            assert inst is not None
+
+
+# ===========================================================================
+# WindowedFPR tests
+# ===========================================================================
+
+
+class TestWindowedFPR:
+    """Tests for WindowedFPR."""
+
+    def test_perfect_match_no_false_alarms(self):
+        """All predictions match → FPR == 0.0."""
+        y_true = _pts([10, 50, 90])
+        y_pred = _pts([10, 50, 90])
+        assert WindowedFPR(margin=0)(y_true, y_pred) == 0.0
+
+    def test_all_false_alarms(self):
+        """No prediction matches any true event → FPR == 1.0."""
+        y_true = _pts([10, 50, 90])
+        y_pred = _pts([25, 70])
+        assert WindowedFPR(margin=0)(y_true, y_pred) == 1.0
+
+    def test_partial_false_alarms(self):
+        """One false alarm among three predictions → FPR == 1/3."""
+        y_true = _pts([10, 50, 90])
+        y_pred = _pts([11, 30, 52])   # 30 is a false alarm, margin=5
+        result = WindowedFPR(margin=5)(y_true, y_pred)
+        assert abs(result - 1 / 3) < 1e-9
+
+    def test_empty_pred(self):
+        """No predictions → FPR == 0.0 (no false alarms possible)."""
+        assert WindowedFPR()(y_true=_pts([10, 20]), y_pred=_pts([])) == 0.0
+
+    def test_empty_true_nonempty_pred(self):
+        """No true events, but predictions exist → all are false alarms → FPR == 1.0."""
+        assert WindowedFPR()(y_true=_pts([]), y_pred=_pts([5, 15])) == 1.0
+
+    def test_empty_both(self):
+        """Both empty → FPR == 0.0."""
+        assert WindowedFPR()(y_true=_pts([]), y_pred=_pts([])) == 0.0
+
+    def test_returns_float(self):
+        result = WindowedFPR()(y_true=_pts([10]), y_pred=_pts([10]))
+        assert isinstance(result, float)
+
+    def test_get_test_params(self):
+        params = WindowedFPR.get_test_params()
+        assert isinstance(params, list)
+        for p in params:
+            inst = WindowedFPR(**p)
+            assert inst is not None
+
+
+# ===========================================================================
+# EarlyDetectionTime tests
+# ===========================================================================
+
+
+class TestEarlyDetectionTime:
+    """Tests for EarlyDetectionTime."""
+
+    def test_exact_match_zero_advance(self):
+        """Exact predictions → advance time == 0.0."""
+        y_true = _pts([20, 60, 100])
+        y_pred = _pts([20, 60, 100])
+        result = EarlyDetectionTime(margin=0)(y_true, y_pred)
+        assert result == pytest.approx(0.0, abs=1e-9)
+
+    def test_early_detection_positive(self):
+        """Detector fires 5 steps early → advance time == 5.0."""
+        y_true = _pts([20])
+        y_pred = _pts([15])
+        result = EarlyDetectionTime(margin=10)(y_true, y_pred)
+        assert result == pytest.approx(5.0, abs=1e-9)
+
+    def test_late_detection_negative(self):
+        """Detector fires 3 steps late → advance time == -3.0."""
+        y_true = _pts([20])
+        y_pred = _pts([23])
+        result = EarlyDetectionTime(margin=5)(y_true, y_pred)
+        assert result == pytest.approx(-3.0, abs=1e-9)
+
+    def test_mean_advance_mixed(self):
+        """Two early (5, 5) and one late (-2) → mean == (5+5-2)/3 ≈ 2.67."""
+        y_true = _pts([20, 60, 100])
+        y_pred = _pts([15, 55, 102])  # advances: +5, +5, -2
+        result = EarlyDetectionTime(margin=10, aggregate="mean")(y_true, y_pred)
+        assert result == pytest.approx((5 + 5 - 2) / 3, abs=1e-9)
+
+    def test_median_aggregate(self):
+        """Median of [5, 5, -2] == 5.0."""
+        y_true = _pts([20, 60, 100])
+        y_pred = _pts([15, 55, 102])
+        result = EarlyDetectionTime(margin=10, aggregate="median")(y_true, y_pred)
+        assert result == pytest.approx(5.0, abs=1e-9)
+
+    def test_min_aggregate(self):
+        """Min of [5, 5, -2] == -2.0."""
+        y_true = _pts([20, 60, 100])
+        y_pred = _pts([15, 55, 102])
+        result = EarlyDetectionTime(margin=10, aggregate="min")(y_true, y_pred)
+        assert result == pytest.approx(-2.0, abs=1e-9)
+
+    def test_max_aggregate(self):
+        """Max of [5, 5, -2] == 5.0."""
+        y_true = _pts([20, 60, 100])
+        y_pred = _pts([15, 55, 102])
+        result = EarlyDetectionTime(margin=10, aggregate="max")(y_true, y_pred)
+        assert result == pytest.approx(5.0, abs=1e-9)
+
+    def test_missed_event_excluded_by_default(self):
+        """Missed event (no penalty) is excluded from the aggregate."""
+        y_true = _pts([10, 50])
+        y_pred = _pts([8])  # only matches 10, prediction for 50 is missing
+        result = EarlyDetectionTime(margin=5)(y_true, y_pred)
+        # only advance for event at 10: 10-8=2
+        assert result == pytest.approx(2.0, abs=1e-9)
+
+    def test_missed_event_with_penalty(self):
+        """Missed event applies penalty value to aggregate."""
+        y_true = _pts([10, 50])
+        y_pred = _pts([8])  # matches event at 10 (advance=2), misses 50
+        result = EarlyDetectionTime(margin=5, missed_penalty=-10)(y_true, y_pred)
+        # advances: [2, -10] → mean = -4.0
+        assert result == pytest.approx(-4.0, abs=1e-9)
+
+    def test_empty_true_returns_nan(self):
+        """No true events → nan (undefined)."""
+        result = EarlyDetectionTime(margin=5)(y_true=_pts([]), y_pred=_pts([5]))
+        assert math.isnan(result)
+
+    def test_empty_both_returns_nan(self):
+        """Both empty → nan."""
+        result = EarlyDetectionTime()(y_true=_pts([]), y_pred=_pts([]))
+        assert math.isnan(result)
+
+    def test_invalid_aggregate_raises(self):
+        """Invalid aggregate string → ValueError."""
+        metric = EarlyDetectionTime(margin=5, aggregate="geometric_mean")
+        with pytest.raises(ValueError, match="aggregate must be one of"):
+            metric(y_true=_pts([10]), y_pred=_pts([10]))
+
+    def test_returns_float(self):
+        result = EarlyDetectionTime(margin=2)(y_true=_pts([10]), y_pred=_pts([8]))
+        assert isinstance(result, float)
+
+    def test_get_test_params(self):
+        params = EarlyDetectionTime.get_test_params()
+        assert isinstance(params, list)
+        for p in params:
+            inst = EarlyDetectionTime(**p)
+            assert inst is not None
+
+
+# ===========================================================================
+# Integration: TPR + FPR + ADT together (event detection workflow)
+# ===========================================================================
+
+
+class TestMetricIntegration:
+    """Integration tests simulating a realistic event-detection evaluation."""
+
+    def test_good_detector(self):
+        """A near-perfect detector should have high TPR, low FPR, positive ADT."""
+        # 5 true events; detector fires slightly early for all 5
+        y_true = _pts([100, 200, 300, 400, 500])
+        y_pred = _pts([95, 195, 295, 398, 498])   # all 2-5 steps early
+
+        tpr = WindowedTPR(margin=10)(y_true, y_pred)
+        fpr = WindowedFPR(margin=10)(y_true, y_pred)
+        adt = EarlyDetectionTime(margin=10)(y_true, y_pred)
+
+        assert tpr == 1.0, f"Expected TPR=1.0, got {tpr}"
+        assert fpr == 0.0, f"Expected FPR=0.0, got {fpr}"
+        assert adt > 0.0, f"Expected positive ADT (early detection), got {adt}"
+
+    def test_bad_detector_many_false_alarms(self):
+        """A detector with many false alarms should have high FPR."""
+        y_true = _pts([50])
+        y_pred = _pts([10, 20, 30, 40, 50])  # 4 false alarms
+
+        fpr = WindowedFPR(margin=0)(y_true, y_pred)
+        assert fpr == pytest.approx(4 / 5, abs=1e-9)
+
+    def test_tpr_fpr_complementary(self):
+        """On fixed data, increasing margin should weakly increase TPR."""
+        y_true = _pts([10, 30, 50])
+        y_pred = _pts([13, 33, 54])  # all off by 3-4
+
+        tpr_strict = WindowedTPR(margin=2)(y_true, y_pred)
+        tpr_loose = WindowedTPR(margin=5)(y_true, y_pred)
+
+        assert tpr_loose >= tpr_strict


### PR DESCRIPTION
## Summary

This PR adds **three new evaluation metrics** for time series event/anomaly detection
to `sktime.performance_metrics.detection`, directly addressing the project requirement:

> *"implement transparent performance measures to ensure quality of the developed
> approaches, in terms of TPR, FPR, and advance detection time"*

---

## New Classes

| Class | Description | `lower_is_better` |
|---|---|---|
| `WindowedTPR` | True Positive Rate with margin-based event matching | ❌ (higher = better) |
| `WindowedFPR` | False Positive Rate / False Discovery Rate with margin | ✅ |
| `EarlyDetectionTime` | Mean/median/min/max advance steps before true event onset | ❌ (higher = earlier) |

All three metrics:
- Accept a `margin` parameter (tolerance window in iloc steps) — essential for
  millisecond-granularity sensor data where timing is noisy
- Follow the `BaseDetectionMetric` interface exactly (`_evaluate`, `get_test_params`)
- Work with the standard sktime `"points"` format (`pd.DataFrame` with `"ilocs"` column)
- Are automatically discovered by the sktime estimator registry

---

## Key Design: `EarlyDetectionTime`

Measures how many iloc steps **in advance** a detector fires before the true event:

