### PR TITLE
[BUG] Add multivariate capability guard to BaseDetector._check_X

### DIFF
--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -570,10 +570,18 @@ class BaseDetector(BaseEstimator):
         -------
         X : X_inner_mtype
             Data to be transformed
+
+        Raises
+        ------
+        TypeError
+            If ``X`` is not of a supported scitype.
+        ValueError
+            If ``X`` is multivariate and the detector does not support multivariate
+            input, i.e., the tag ``capability:multivariate`` is ``False``.
         """
         ALLOWED_SCITYPES = ["Series", "Panel"]
         X_valid, X_msg, X_metadata = check_is_scitype(
-            X, scitype=ALLOWED_SCITYPES, return_metadata=[]
+            X, scitype=ALLOWED_SCITYPES, return_metadata=["is_univariate"]
         )
         self._X_metadata = X_metadata
         if not X_valid:
@@ -594,6 +602,18 @@ class BaseDetector(BaseEstimator):
                     allowed_msg=allowed_msg,
                     raise_exception=True,
                 )
+
+        # Check multivariate capability: raise a clear error rather than
+        # silently producing incorrect results on multi-column input.
+        # This mirrors the equivalent guard in BaseClassifier._check_capabilities.
+        is_univariate = X_metadata.get("is_univariate", True)
+        if not is_univariate and not self.get_tag("capability:multivariate", False):
+            raise ValueError(
+                f"{type(self).__name__} does not support multivariate time series "
+                f"(detected {X.shape[1] if hasattr(X, 'shape') else '?'} columns). "
+                f"Set the tag 'capability:multivariate' to True in the estimator, "
+                f"or use a multivariate-capable detector."
+            )
 
         X_inner_mtype = self.get_tag("X_inner_mtype")
         X_inner = convert(X, from_type=X_metadata["mtype"], to_type=X_inner_mtype)

--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -581,7 +581,7 @@ class BaseDetector(BaseEstimator):
         """
         ALLOWED_SCITYPES = ["Series", "Panel"]
         X_valid, X_msg, X_metadata = check_is_scitype(
-            X, scitype=ALLOWED_SCITYPES, return_metadata=["is_univariate"]
+            X, scitype=ALLOWED_SCITYPES, return_metadata=["is_univariate", "n_columns"]
         )
         self._X_metadata = X_metadata
         if not X_valid:
@@ -595,22 +595,23 @@ class BaseDetector(BaseEstimator):
                 " See the detection tutorial examples/07_detection.ipynb, or"
                 " the data format tutorial examples/AA_datatypes_and_datasets.ipynb"
             )
-            if not X_valid:
-                check_is_error_msg(
-                    X_msg,
-                    var_name=msg_start,
-                    allowed_msg=allowed_msg,
-                    raise_exception=True,
-                )
+            check_is_error_msg(
+                X_msg,
+                var_name=msg_start,
+                allowed_msg=allowed_msg,
+                raise_exception=True,
+            )
 
         # Check multivariate capability: raise a clear error rather than
         # silently producing incorrect results on multi-column input.
-        # This mirrors the equivalent guard in BaseClassifier._check_capabilities.
-        is_univariate = X_metadata.get("is_univariate", True)
-        if not is_univariate and not self.get_tag("capability:multivariate", False):
+        # Uses metadata from check_is_scitype (not X.shape) per sktime conventions.
+        # Mirrors the equivalent guard in BaseClassifier._check_capabilities.
+        n_columns = X_metadata.get("n_columns", 1)
+        allow_mv = self.get_tag("capability:multivariate", tag_value_default=True)
+        if not allow_mv and n_columns > 1:
             raise ValueError(
                 f"{type(self).__name__} does not support multivariate time series "
-                f"(detected {X.shape[1] if hasattr(X, 'shape') else '?'} columns). "
+                f"(detected {n_columns} columns). "
                 f"Set the tag 'capability:multivariate' to True in the estimator, "
                 f"or use a multivariate-capable detector."
             )
@@ -618,6 +619,7 @@ class BaseDetector(BaseEstimator):
         X_inner_mtype = self.get_tag("X_inner_mtype")
         X_inner = convert(X, from_type=X_metadata["mtype"], to_type=X_inner_mtype)
         return X_inner
+
 
     def _fit(self, X, y=None):
         """Fit to training data.

--- a/sktime/detection/base/tests/test_multivariate_check.py
+++ b/sktime/detection/base/tests/test_multivariate_check.py
@@ -1,58 +1,112 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Tests for multivariate capability guard in BaseDetector._check_X."""
+"""Tests for multivariate capability guard in BaseDetector._check_X.
+
+Covers all four combinations of detector capability vs input dimensionality,
+as requested in https://github.com/sktime/sktime/issues/9943
+"""
 
 __author__ = ["rupeshca007"]
 
 import pandas as pd
 import pytest
 
+from sktime.detection.base import BaseDetector
 from sktime.detection.dummy import DummyRegularAnomalies
 from sktime.tests.test_switch import run_test_for_class
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures: minimal detector stubs
+# ---------------------------------------------------------------------------
+
+
+class _UnivariateDummy(BaseDetector):
+    """Minimal detector that declares capability:multivariate = False."""
+
+    _tags = {
+        "task": "anomaly_detection",
+        "learning_type": "unsupervised",
+        "capability:multivariate": False,
+        "fit_is_empty": True,
+    }
+
+    def __init__(self):
+        super().__init__()
+
+    def _predict(self, X):
+        return self._empty_sparse()
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        return {}
+
+
+class _MultivariateDummy(BaseDetector):
+    """Minimal detector that declares capability:multivariate = True."""
+
+    _tags = {
+        "task": "anomaly_detection",
+        "learning_type": "unsupervised",
+        "capability:multivariate": True,
+        "fit_is_empty": True,
+    }
+
+    def __init__(self):
+        super().__init__()
+
+    def _predict(self, X):
+        return self._empty_sparse()
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        return {}
+
+
+# Shared data
+X_univariate = pd.DataFrame({"sensor_a": [1.0, 2.0, 3.0, 4.0, 5.0]})
+X_multivariate = pd.DataFrame(
+    {
+        "vibration": [1.0, 2.0, 3.0, 4.0, 5.0],
+        "acoustics": [5.0, 4.0, 3.0, 2.0, 1.0],
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Combo 1: univariate detector + univariate input → OK
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.skipif(
     not run_test_for_class(DummyRegularAnomalies),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-def test_multivariate_input_raises_for_univariate_detector():
-    """Univariate detectors should raise ValueError on multivariate input.
-
-    Before this fix, passing a 2-column DataFrame to a detector with
-    ``capability:multivariate=False`` would silently produce wrong results.
-    After the fix, a clear ValueError is raised immediately, guiding the user
-    to switch to a multivariate-capable detector.
-
-    This is especially important for multi-sensor time series (e.g., vibration,
-    acoustics, mechanics) where users may inadvertently pass all sensor channels
-    to a univariate-only algorithm.
-    """
-    # DummyRegularAnomalies has capability:multivariate = True — use a
-    # minimal subclass that sets it to False to test the guard properly.
-    from sktime.detection.base import BaseDetector
-
-    class _UnivariateDummy(BaseDetector):
-        """Minimal detector that only supports univariate input."""
-
-        _tags = {
-            "task": "anomaly_detection",
-            "learning_type": "unsupervised",
-            "capability:multivariate": False,  # univariate only
-            "fit_is_empty": True,
-        }
-
-        def __init__(self):
-            super().__init__()
-
-        def _predict(self, X):
-            return self._empty_sparse()
-
-        @classmethod
-        def get_test_params(cls, parameter_set="default"):
-            return {}
-
-    X_multivariate = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+def test_univariate_detector_univariate_input_ok():
+    """Combo 1: univariate-only detector accepts single-column input without error."""
     detector = _UnivariateDummy()
+    # Should not raise
+    detector.fit(X_univariate)
+    result = detector.predict(X_univariate)
+    assert isinstance(result, pd.DataFrame)
 
+
+# ---------------------------------------------------------------------------
+# Combo 2: univariate detector + multivariate input → ValueError  ← core fix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DummyRegularAnomalies),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_univariate_detector_multivariate_input_raises():
+    """Combo 2: univariate-only detector raises ValueError on multi-column input.
+
+    Before the fix, this silently produced incorrect results.
+    After the fix, a clear ValueError is raised immediately at fit() time,
+    guiding the user to switch to a multivariate-capable detector.
+    """
+    detector = _UnivariateDummy()
     with pytest.raises(ValueError, match="does not support multivariate"):
         detector.fit(X_multivariate)
 
@@ -61,25 +115,70 @@ def test_multivariate_input_raises_for_univariate_detector():
     not run_test_for_class(DummyRegularAnomalies),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-def test_multivariate_input_accepted_for_multivariate_detector():
-    """Multivariate detectors must accept multi-column DataFrames without error."""
-    X_multivariate = pd.DataFrame({"a": [1, 2, 3, 4, 5], "b": [5, 4, 3, 2, 1]})
-    # DummyRegularAnomalies sets capability:multivariate = True
-    detector = DummyRegularAnomalies(step_size=2)
-    # Should not raise
-    detector.fit(X_multivariate)
-    result = detector.predict(X_multivariate)
-    assert isinstance(result, pd.DataFrame)
+def test_univariate_detector_multivariate_input_raises_on_predict():
+    """Combo 2b: guard also fires at predict() time if fit was with univariate."""
+    detector = _UnivariateDummy()
+    detector.fit(X_univariate)  # fit on univariate — OK
+    with pytest.raises(ValueError, match="does not support multivariate"):
+        detector.predict(X_multivariate)  # predict on multivariate — should raise
+
+
+# ---------------------------------------------------------------------------
+# Combo 3: multivariate detector + univariate input → OK
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.skipif(
     not run_test_for_class(DummyRegularAnomalies),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-def test_univariate_input_accepted_for_univariate_detector():
-    """Univariate detector must still accept single-column DataFrames."""
-    X_univariate = pd.DataFrame({"a": [1, 2, 3, 4, 5]})
-    detector = DummyRegularAnomalies(step_size=2)
+def test_multivariate_detector_univariate_input_ok():
+    """Combo 3: multivariate-capable detector accepts single-column input."""
+    detector = _MultivariateDummy()
     detector.fit(X_univariate)
     result = detector.predict(X_univariate)
     assert isinstance(result, pd.DataFrame)
+
+
+# ---------------------------------------------------------------------------
+# Combo 4: multivariate detector + multivariate input → OK
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DummyRegularAnomalies),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_multivariate_detector_multivariate_input_ok():
+    """Combo 4: multivariate-capable detector accepts multi-column input."""
+    detector = _MultivariateDummy()
+    detector.fit(X_multivariate)
+    result = detector.predict(X_multivariate)
+    assert isinstance(result, pd.DataFrame)
+
+
+# ---------------------------------------------------------------------------
+# Error message quality
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DummyRegularAnomalies),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_error_message_contains_column_count():
+    """ValueError message should include the detected column count."""
+    detector = _UnivariateDummy()
+    with pytest.raises(ValueError, match="2"):
+        detector.fit(X_multivariate)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DummyRegularAnomalies),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_error_message_contains_class_name():
+    """ValueError message should include the detector class name."""
+    detector = _UnivariateDummy()
+    with pytest.raises(ValueError, match="_UnivariateDummy"):
+        detector.fit(X_multivariate)

--- a/sktime/detection/base/tests/test_multivariate_check.py
+++ b/sktime/detection/base/tests/test_multivariate_check.py
@@ -1,0 +1,85 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for multivariate capability guard in BaseDetector._check_X."""
+
+__author__ = ["rupeshca007"]
+
+import pandas as pd
+import pytest
+
+from sktime.detection.dummy import DummyRegularAnomalies
+from sktime.tests.test_switch import run_test_for_class
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DummyRegularAnomalies),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_multivariate_input_raises_for_univariate_detector():
+    """Univariate detectors should raise ValueError on multivariate input.
+
+    Before this fix, passing a 2-column DataFrame to a detector with
+    ``capability:multivariate=False`` would silently produce wrong results.
+    After the fix, a clear ValueError is raised immediately, guiding the user
+    to switch to a multivariate-capable detector.
+
+    This is especially important for multi-sensor time series (e.g., vibration,
+    acoustics, mechanics) where users may inadvertently pass all sensor channels
+    to a univariate-only algorithm.
+    """
+    # DummyRegularAnomalies has capability:multivariate = True — use a
+    # minimal subclass that sets it to False to test the guard properly.
+    from sktime.detection.base import BaseDetector
+
+    class _UnivariateDummy(BaseDetector):
+        """Minimal detector that only supports univariate input."""
+
+        _tags = {
+            "task": "anomaly_detection",
+            "learning_type": "unsupervised",
+            "capability:multivariate": False,  # univariate only
+            "fit_is_empty": True,
+        }
+
+        def __init__(self):
+            super().__init__()
+
+        def _predict(self, X):
+            return self._empty_sparse()
+
+        @classmethod
+        def get_test_params(cls, parameter_set="default"):
+            return {}
+
+    X_multivariate = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    detector = _UnivariateDummy()
+
+    with pytest.raises(ValueError, match="does not support multivariate"):
+        detector.fit(X_multivariate)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DummyRegularAnomalies),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_multivariate_input_accepted_for_multivariate_detector():
+    """Multivariate detectors must accept multi-column DataFrames without error."""
+    X_multivariate = pd.DataFrame({"a": [1, 2, 3, 4, 5], "b": [5, 4, 3, 2, 1]})
+    # DummyRegularAnomalies sets capability:multivariate = True
+    detector = DummyRegularAnomalies(step_size=2)
+    # Should not raise
+    detector.fit(X_multivariate)
+    result = detector.predict(X_multivariate)
+    assert isinstance(result, pd.DataFrame)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DummyRegularAnomalies),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_univariate_input_accepted_for_univariate_detector():
+    """Univariate detector must still accept single-column DataFrames."""
+    X_univariate = pd.DataFrame({"a": [1, 2, 3, 4, 5]})
+    detector = DummyRegularAnomalies(step_size=2)
+    detector.fit(X_univariate)
+    result = detector.predict(X_univariate)
+    assert isinstance(result, pd.DataFrame)


### PR DESCRIPTION
## Summary
Fixes #9943 
`BaseDetector._check_X` had no check for the `capability:multivariate` tag.
This meant that passing a **multi-column (multivariate) DataFrame** to a
univariate-only detector would **silently produce incorrect results** instead
of raising a clear, actionable error.

This is a real-world footgun especially for **multi-sensor datasets** (e.g.,
vibration + acoustics + mechanics), where users naturally pass all channels
together into a detector that only supports univariate input.

---

## Root Cause

`BaseClassifier._check_capabilities` already performs this guard:
```python
if not self.get_tag("capability:multivariate") and not is_univariate:
    raise ValueError(...)
```
Before:
```python
detector = MyUnivariateDetector()
detector.fit(pd.DataFrame({"vibration": [...], "acoustics": [...]}))

```

After:
```python
detector = MyUnivariateDetector()
detector.fit(pd.DataFrame({"vibration": [...], "acoustics": [...]}))
```
## Checklist
- [x] Bug fix (no breaking changes for correctly-used detectors)
- [x] Mirrors established pattern in BaseClassifier._check_capabilities
- [x] Tests added covering positive and negative cases
- [x] Docstring updated with Raises section