### PR TITLE
fixes #9933 export show_versions from sktime.utils

### DIFF
--- a/sktime/utils/__init__.py
+++ b/sktime/utils/__init__.py
@@ -1,6 +1,7 @@
 """Utility functionality."""
 
+from sktime.utils._maint._show_versions import show_versions
 from sktime.utils.estimator_checks import check_estimator
 from sktime.utils.plotting import plot_series, plot_windows
 
-__all__ = ["check_estimator", "plot_series", "plot_windows"]
+__all__ = ["check_estimator", "plot_series", "plot_windows", "show_versions"]


### PR DESCRIPTION
#### Reference Issue
Fixes #9933

#### What does this implement/fix? Explain your changes.
`from sktime.utils import show_versions` raised an `ImportError` because
`sktime/utils/__init__.py` did not re-export `show_versions`, even though
`sktime/__init__.py` already did correctly.

Fix: added the import from `sktime.utils._maint._show_versions` and included
`"show_versions"` in `__all__` in `sktime/utils/__init__.py`.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
The two-line change in `sktime/utils/__init__.py` — confirm the import path
`sktime.utils._maint._show_versions` is the intended internal location.

#### Did you add any tests for the change?
No new test added — the fix is verified by running:
`from sktime.utils import show_versions  # previously raised ImportError`

---

**PR Checklist** — check these boxes:
- [x] `[BUG]` prefix in title
- [x] Added yourself to `.all-contributorsrc` with badge `bug` and `code`

