### PR TITLE
[ENH] add SoftEDF1Score metric for advance event detection

### DIFF
--- a/docs/source/api_reference/performance_metrics.rst
+++ b/docs/source/api_reference/performance_metrics.rst
@@ -192,6 +192,7 @@ Event detection - anomalies, outliers
     DirectedChamfer
     DirectedHausdorff
     DetectionCount
+    SoftEDF1Score
     WindowedF1Score
     TimeSeriesAUPRC
 

--- a/sktime/performance_metrics/detection/__init__.py
+++ b/sktime/performance_metrics/detection/__init__.py
@@ -5,6 +5,7 @@ from sktime.performance_metrics.detection._count import DetectionCount
 from sktime.performance_metrics.detection._f1score import WindowedF1Score
 from sktime.performance_metrics.detection._hausdorff import DirectedHausdorff
 from sktime.performance_metrics.detection._randindex import RandIndex
+from sktime.performance_metrics.detection._softed import SoftEDF1Score
 from sktime.performance_metrics.detection._ts_auprc import TimeSeriesAUPRC
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     "DetectionCount",
     "WindowedF1Score",
     "RandIndex",
+    "SoftEDF1Score",
     "TimeSeriesAUPRC",
 ]

--- a/sktime/performance_metrics/detection/_softed.py
+++ b/sktime/performance_metrics/detection/_softed.py
@@ -1,0 +1,148 @@
+"""SoftED detection metric for soft/temporal-tolerant event evaluation.
+
+Reference
+---------
+Salles, R., Escobar, L., Baroni, L., Zorrilla, R., Ziviani, A., Kreischer, V.,
+Delicato, F., Pires, P. F., Maia, L., Coutinho, R., Assis, L., Ogasawara, E.
+(2024). SoftED: Metrics for Soft Evaluation of Time Series Event Detection.
+Computers & Industrial Engineering, 198, 109890.
+https://doi.org/10.1016/j.cie.2024.109890
+arXiv:2304.00439
+"""
+
+import numpy as np
+
+from sktime.performance_metrics.detection._base import BaseDetectionMetric
+
+
+class SoftEDF1Score(BaseDetectionMetric):
+    """SoftED F1 score for event detection with temporal tolerance.
+
+    Computes a soft F1 score between predicted and true event iloc positions.
+    Each prediction's contribution is a soft-membership value in ``[0, 1]``
+    based on its distance to the nearest unmatched true event, within a
+    tolerance window. A prediction farther than ``tolerance`` iloc units
+    from every true event contributes zero.
+
+    For true event ``t_i`` and predicted event ``p_j`` with
+    ``d = |t_i - p_j|`` and ``T = tolerance``:
+
+    * ``membership="linear"``: ``mu(d) = max(0, 1 - d / T)``
+    * ``membership="rectangular"``: ``mu(d) = 1 if d <= T else 0``
+
+    Soft precision and recall follow Salles et al. (2024) via greedy
+    one-to-one matching of each prediction to its nearest unused true event
+    within tolerance. F1 is the harmonic mean of soft precision and recall.
+
+    Parameters
+    ----------
+    tolerance : int, optional (default=5)
+        Half-width of the soft-membership window, in iloc units.
+        Must be a non-negative integer.
+    membership : {"linear", "rectangular"}, optional (default="linear")
+        Soft-membership function mapping distance to a score in ``[0, 1]``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.performance_metrics.detection import SoftEDF1Score
+    >>> y_true = pd.DataFrame({"ilocs": [10, 50, 90]})
+    >>> y_pred = pd.DataFrame({"ilocs": [12, 51, 200]})
+    >>> metric = SoftEDF1Score(tolerance=5, membership="linear")
+    >>> score = metric(y_true, y_pred)
+    >>> 0.0 < score <= 1.0
+    True
+    """
+
+    _tags = {
+        "object_type": ["metric_detection", "metric"],
+        "scitype:y": "points",
+        "requires_X": False,
+        "requires_y_true": True,
+        "lower_is_better": False,
+    }
+
+    def __init__(self, tolerance=5, membership="linear"):
+        self.tolerance = tolerance
+        self.membership = membership
+        super().__init__()
+
+    def _evaluate(self, y_true, y_pred, X=None):
+        """Compute SoftED F1 between true and predicted events.
+
+        Parameters
+        ----------
+        y_true : pd.DataFrame
+            Ground-truth events in "points" format. Must have column ``ilocs``.
+        y_pred : pd.DataFrame
+            Predicted events in "points" format. Must have column ``ilocs``.
+        X : pd.DataFrame, optional (default=None)
+            Unused; kept for interface parity.
+
+        Returns
+        -------
+        float
+            Soft F1 score in ``[0, 1]``. Higher is better.
+        """
+        gt = np.sort(np.asarray(y_true["ilocs"].values, dtype=float))
+        pred = np.sort(np.asarray(y_pred["ilocs"].values, dtype=float))
+
+        if len(gt) == 0 and len(pred) == 0:
+            return 1.0
+        if len(gt) == 0 or len(pred) == 0:
+            return 0.0
+
+        tol = float(self.tolerance)
+        if tol < 0:
+            raise ValueError(f"tolerance must be non-negative, got {self.tolerance!r}")
+
+        membership = self.membership
+        if membership not in ("linear", "rectangular"):
+            raise ValueError(
+                f"membership must be 'linear' or 'rectangular', got {membership!r}"
+            )
+
+        # Greedy one-to-one match each prediction to its nearest unused true
+        # event within tolerance. Accumulate soft-membership contributions.
+        used = np.zeros(len(gt), dtype=bool)
+        soft_matches = 0.0
+        for p in pred:
+            d_all = np.abs(gt - p)
+            d_all[used] = np.inf
+            j = int(np.argmin(d_all))
+            d = float(d_all[j])
+            if d > tol:
+                continue
+            if membership == "linear":
+                soft_matches += max(0.0, 1.0 - d / tol) if tol > 0 else float(d == 0)
+            else:  # rectangular
+                soft_matches += 1.0
+            used[j] = True
+
+        soft_precision = soft_matches / len(pred)
+        soft_recall = soft_matches / len(gt)
+
+        if soft_precision + soft_recall == 0:
+            return 0.0
+        return 2.0 * soft_precision * soft_recall / (soft_precision + soft_recall)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return. Unused here; kept
+            for interface parity with the sktime test framework.
+
+        Returns
+        -------
+        list of dict
+            Parameter dicts for automated test-instance construction.
+        """
+        return [
+            {},
+            {"tolerance": 10, "membership": "linear"},
+            {"tolerance": 3, "membership": "rectangular"},
+        ]

--- a/sktime/performance_metrics/detection/tests/test_softed.py
+++ b/sktime/performance_metrics/detection/tests/test_softed.py
@@ -1,0 +1,97 @@
+"""Tests for the SoftED F1 detection metric."""
+
+import pandas as pd
+import pytest
+
+from sktime.performance_metrics.detection._softed import SoftEDF1Score
+from sktime.tests.test_switch import run_test_for_class
+
+
+@pytest.fixture
+def true_events():
+    """Three ground-truth events at ilocs 10, 50, 90."""
+    return pd.DataFrame({"ilocs": [10, 50, 90]})
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SoftEDF1Score),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_softed_perfect_match(true_events):
+    """Identical predictions to ground truth score exactly 1.0."""
+    metric = SoftEDF1Score(tolerance=5, membership="linear")
+    assert metric(true_events, true_events) == pytest.approx(1.0)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SoftEDF1Score),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_softed_all_outside_tolerance(true_events):
+    """Predictions outside tolerance contribute nothing, score 0.0."""
+    y_pred = pd.DataFrame({"ilocs": [200, 300, 400]})
+    metric = SoftEDF1Score(tolerance=5, membership="linear")
+    assert metric(true_events, y_pred) == 0.0
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SoftEDF1Score),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_softed_rectangular_hard_cutoff(true_events):
+    """Rectangular membership is a hard step function at tolerance."""
+    y_pred_in = pd.DataFrame({"ilocs": [10, 50, 90]})
+    # all 6 iloc away, tolerance=5
+    y_pred_out = pd.DataFrame({"ilocs": [16, 56, 96]})
+    metric = SoftEDF1Score(tolerance=5, membership="rectangular")
+    assert metric(true_events, y_pred_in) == pytest.approx(1.0)
+    assert metric(true_events, y_pred_out) == 0.0
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SoftEDF1Score),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_softed_linear_decay(true_events):
+    """Linear membership at distance 2 with tolerance 5 gives mu = 1 - 2/5 = 0.6.
+
+    All three predictions are 2 iloc away from their matched true event,
+    so soft_matches = 3 * 0.6 = 1.8, soft_precision = soft_recall = 0.6,
+    and F1 = 0.6.
+    """
+    y_pred = pd.DataFrame({"ilocs": [12, 52, 92]})
+    metric = SoftEDF1Score(tolerance=5, membership="linear")
+    assert metric(true_events, y_pred) == pytest.approx(0.6)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SoftEDF1Score),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_softed_empty_both_returns_one():
+    """No true events and no predictions is a trivial perfect score."""
+    empty = pd.DataFrame({"ilocs": []})
+    metric = SoftEDF1Score()
+    assert metric(empty, empty) == 1.0
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SoftEDF1Score),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_softed_invalid_membership_raises(true_events):
+    """An unknown membership string raises ValueError."""
+    metric = SoftEDF1Score(membership="quadratic")
+    with pytest.raises(ValueError, match="linear.*rectangular"):
+        metric(true_events, true_events)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SoftEDF1Score),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_softed_negative_tolerance_raises(true_events):
+    """A negative tolerance raises ValueError."""
+    metric = SoftEDF1Score(tolerance=-1)
+    with pytest.raises(ValueError, match="non-negative"):
+        metric(true_events, true_events)


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #9887. This PR implements **SoftED** (Salles et al. 2024, [arXiv:2304.00439](https://arxiv.org/abs/2304.00439) / [doi:10.1016/j.cie.2024.109890](https://doi.org/10.1016/j.cie.2024.109890)), the one metric from the #9887 list that is not yet covered by an open PR.

Related in-flight metric PRs (none overlap with this one semantically):

| PR | Metric | Matching semantics |
|----|--------|-------------------|
| #9877 / #9895 / #9913 | `DetectionDelayMean` | mean signed delay (symmetric) |
| #9911 | `NormalizedAdvanceWarningScore` (NAB-like) | sigmoid window, binary match |
| #9912 | `PHMScore` (Saxena 2008) | asymmetric exponential cost |
| #9939 | `MultiChannelDetectionDelay` | per-channel delay |
| #9942 | `WindowedTPR` / `WindowedFPR` / `EarlyDetectionTime` | windowed binary counts |
| #9945 | `Temporal Bias` (Escobar 2021) | a priori / a posteriori distances |
| **this PR** | `SoftEDF1Score` | **fuzzy soft-membership F1 over a tolerance window** |

Scope was pre-announced on the issue: https://github.com/sktime/sktime/issues/9887#issuecomment-4283450312

#### What does this implement/fix? Explain your changes.

Adds `SoftEDF1Score` as a new detection metric under `sktime.performance_metrics.detection`. Implements Salles et al. (2024), Algorithm 1 — a soft/fuzzy F1 score for point-event detection with a temporal tolerance window.

For true event `t_i` and predicted event `p_j` with `d = |t_i - p_j|` and tolerance `T`:

- `membership="linear"`: `mu(d) = max(0, 1 - d/T)`
- `membership="rectangular"`: `mu(d) = 1 if d <= T else 0`

Greedy one-to-one matching: each prediction claims its nearest unused true event within tolerance; contributions are summed and normalised to soft-precision and soft-recall; the final score is their harmonic mean. Runtime is `O(|pred| · |true|)`, appropriate for typical event-detection scales.

Files changed:

- `sktime/performance_metrics/detection/_softed.py` — new `SoftEDF1Score(BaseDetectionMetric)` class.
- `sktime/performance_metrics/detection/__init__.py` — register the class and add to `__all__`.
- `sktime/performance_metrics/detection/tests/test_softed.py` — explicit unit tests.
- `docs/source/api_reference/performance_metrics.rst` — entry under event-detection metrics.

#### Does your contribution introduce a new dependency? If yes, which one?

No. Uses only `numpy` and `pandas`, both already in the core dependency set. `pyproject.toml` is unchanged.

#### What should a reviewer concentrate their feedback on?

- [x] Class structure mirrors `WindowedF1Score` in `_f1score.py` (tags, `_evaluate` signature, `get_test_params`). Please flag any deviation from the preferred pattern.
- [x] Matching strategy: greedy one-to-one within tolerance. Happy to add `matching="optimal"` (Hungarian) as a follow-up option if preferred.
- [x] Parameter validation is raised inside `_evaluate`, not `__init__`, to keep `__init__` side-effect-free per sktime convention. Confirm this matches your preference.
- [x] Naming: `SoftEDF1Score` vs. splitting into `SoftEDPrecision` + `SoftEDRecall` + `SoftEDF1Score` — Salles et al. define all three. I chose the single F1 class for a focused first contribution; trivial to split if you prefer.
- [x] `get_test_params` returns three parameter sets (defaults, linear wide, rectangular narrow). Let me know if you want a different coverage.

#### Did you add any tests for the change?

Yes, at two layers.

1. **Explicit unit tests** in `sktime/performance_metrics/detection/tests/test_softed.py` — 7 cases covering: perfect match, all predictions out of tolerance, rectangular hard cutoff, linear-decay numeric assertion, empty-both edge case, invalid `membership` value, invalid `tolerance` value. Gated by `run_test_for_class(SoftEDF1Score)` matching the project's convention (see `test_chamfer.py`).
2. **Framework-level tests** via `get_test_params`. `check_estimator(SoftEDF1Score)` exercises all three parameter sets across the metric test suite.

Local verification (Windows 10, Python 3.13.13, editable install from `main`):

```
$ pytest sktime/performance_metrics/detection/tests/test_softed.py --only_changed_modules False -q
7 passed in 0.31s

$ python -c "from sktime.utils.estimator_checks import check_estimator; \
    from sktime.performance_metrics.detection import SoftEDF1Score; \
    check_estimator(SoftEDF1Score, raise_exceptions=True)"
All 40 tests PASSED

$ python -m pytest --doctest-modules sktime/performance_metrics/detection/_softed.py
1 passed in 0.11s

$ pre-commit run --files \
    sktime/performance_metrics/detection/_softed.py \
    sktime/performance_metrics/detection/__init__.py \
    sktime/performance_metrics/detection/tests/test_softed.py \
    docs/source/api_reference/performance_metrics.rst
all hooks PASSED
```

#### Any other comments?

- Motivation: I am applying to ESoC 2026 Batch 2 for the **Predictive Sensor** project, whose card explicitly names *"advance detection time"* as a required metric. SoftED is directly on-scope. Not requesting any special treatment — flagging only so the scope alignment is visible.
- Happy to respond fast to review feedback and iterate. If the scope needs to be split or reshaped (e.g. three separate metric classes), I can restructure in this PR rather than a follow-up.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with [ENH].

##### For new estimators
- [x] I've added the estimator to the API reference — `docs/source/api_reference/performance_metrics.rst`.
- [x] I've added an illustrative usage example to the docstring, in a pydocstyle-compliant `Examples` section (runnable as doctest).
- [x] No soft dependency required (pure `numpy` + `pandas`); `python_dependencies` tag not set.