### PR TITLE
[ENH] add RangeBasedPrecision and RangeBasedRecall detection metrics

### DIFF
--- a/sktime/performance_metrics/detection/__init__.py
+++ b/sktime/performance_metrics/detection/__init__.py
@@ -6,6 +6,10 @@ from sktime.performance_metrics.detection._f1score import WindowedF1Score
 from sktime.performance_metrics.detection._hausdorff import DirectedHausdorff
 from sktime.performance_metrics.detection._randindex import RandIndex
 from sktime.performance_metrics.detection._ts_auprc import TimeSeriesAUPRC
+from sktime.performance_metrics.detection._range_based_precision_recall import (
+    RangeBasedPrecision,
+    RangeBasedRecall,
+)
 
 __all__ = [
     "DirectedChamfer",
@@ -13,5 +17,7 @@ __all__ = [
     "DetectionCount",
     "WindowedF1Score",
     "RandIndex",
+    "RangeBasedPrecision",
+    "RangeBasedRecall",
     "TimeSeriesAUPRC",
 ]

--- a/sktime/performance_metrics/detection/_range_based_precision_recall.py
+++ b/sktime/performance_metrics/detection/_range_based_precision_recall.py
@@ -1,0 +1,324 @@
+"""Range-based Precision and Recall for advance event detection."""
+
+from sktime.performance_metrics.detection._base import BaseDetectionMetric
+
+
+class RangeBasedPrecision(BaseDetectionMetric):
+    r"""Range-based Precision for event detection with positional bias.
+
+    Extends classical Precision to range-based events with a customizable
+    positional bias function. With ``bias="front"``, detections earlier
+    in the true event range receive higher scores, directly rewarding
+    advance detection.
+
+    Based on Tatbul et al., NeurIPS 2018.
+    https://arxiv.org/abs/1803.03639
+
+    Parameters
+    ----------
+    bias : str, default="flat"
+        Positional bias function. One of "flat", "front", "back".
+        "flat"  - all positions within a range are equally weighted.
+        "front" - earlier positions in a range receive higher weight,
+                  rewarding advance/early detection.
+        "back"  - later positions in a range receive higher weight.
+    alpha : float, default=0.0
+        Weight for existence reward (0 to 1). Default 0 means
+        the score is purely based on overlap.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.performance_metrics.detection._range_based_precision_recall import (
+    ...     RangeBasedPrecision,
+    ... )
+    >>> y_true = pd.DataFrame({"ilocs": [10, 11, 12, 13, 14]})
+    >>> y_pred = pd.DataFrame({"ilocs": [10, 11]})
+    >>> metric = RangeBasedPrecision(bias="front")
+    >>> metric(y_true, y_pred)  # doctest: +SKIP
+    """
+
+    _tags = {
+        "object_type": ["metric_detection", "metric"],
+        "scitype:y": "points",
+        "requires_X": False,
+        "requires_y_true": True,
+        "lower_is_better": False,  # higher precision is better
+    }
+
+    def __init__(self, bias="flat", alpha=0.0):
+        self.bias = bias
+        self.alpha = alpha
+        super().__init__()
+
+    def _positional_bias(self, position, length):
+        """Compute positional weight for a detection within a range.
+
+        Parameters
+        ----------
+        position : int
+            Position within the range (0-indexed from start).
+        length : int
+            Total length of the range.
+
+        Returns
+        -------
+        float
+            Weight for this position.
+        """
+        if length <= 1:
+            return 1.0
+
+        if self.bias == "flat":
+            return 1.0
+        elif self.bias == "front":
+            # linearly decreasing: earlier positions get higher weight
+            return float(length - position) / length
+        elif self.bias == "back":
+            # linearly increasing: later positions get higher weight
+            return float(position + 1) / length
+        else:
+            raise ValueError(
+                f"Unknown bias '{self.bias}'. Choose from 'flat', 'front', 'back'."
+            )
+
+    def _overlap_score(self, pred_iloc, true_ilocs_set, true_start, true_end):
+        """Compute overlap score for a single predicted point.
+
+        Parameters
+        ----------
+        pred_iloc : int
+            The predicted event position.
+        true_ilocs_set : set
+            Set of all true event positions.
+        true_start : int
+            Start of the true event range.
+        true_end : int
+            End of the true event range (inclusive).
+
+        Returns
+        -------
+        float
+            Overlap score between 0 and 1.
+        """
+        if pred_iloc not in true_ilocs_set:
+            return 0.0
+
+        range_length = true_end - true_start + 1
+        position = pred_iloc - true_start
+        weight = self._positional_bias(position, range_length)
+
+        # normalize weights across the range
+        total_weight = sum(
+            self._positional_bias(p, range_length) for p in range(range_length)
+        )
+        if total_weight == 0:
+            return 0.0
+
+        return weight / total_weight
+
+    def _evaluate(self, y_true, y_pred, X=None):
+        """Evaluate Range-based Precision on given inputs.
+
+        Parameters
+        ----------
+        y_true : pd.DataFrame
+            Ground truth events in "points" format with column 'ilocs'.
+        y_pred : pd.DataFrame
+            Predicted events in "points" format with column 'ilocs'.
+        X : pd.DataFrame, optional
+            Unused, part of signature.
+
+        Returns
+        -------
+        float
+            Range-based Precision score between 0.0 and 1.0.
+        """
+        true_ilocs = sorted(y_true["ilocs"].values.tolist())
+        pred_ilocs = sorted(y_pred["ilocs"].values.tolist())
+
+        if len(pred_ilocs) == 0 and len(true_ilocs) == 0:
+            return 1.0
+        if len(pred_ilocs) == 0:
+            return 0.0
+        if len(true_ilocs) == 0:
+            return 0.0
+
+        true_ilocs_set = set(true_ilocs)
+        true_start = min(true_ilocs)
+        true_end = max(true_ilocs)
+
+        total_score = 0.0
+        for pred in pred_ilocs:
+            # existence reward: does any true event exist?
+            existence = 1.0 if len(true_ilocs) > 0 else 0.0
+            # overlap reward
+            overlap = self._overlap_score(pred, true_ilocs_set, true_start, true_end)
+            total_score += self.alpha * existence + (1 - self.alpha) * overlap
+
+        return total_score / len(pred_ilocs)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default={}
+            Parameters to create testing instances of the class.
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
+            instance.
+            ``create_test_instance`` uses the first (or only) dictionary in ``params``.
+        """
+        param1 = {}
+        param2 = {"bias": "front"}
+        param3 = {"bias": "back", "alpha": 0.1}
+        return [param1, param2, param3]
+
+
+class RangeBasedRecall(BaseDetectionMetric):
+    r"""Range-based Recall for event detection with positional bias.
+
+    Extends classical Recall to range-based events with a customizable
+    positional bias function. With ``bias="front"``, detections earlier
+    in the true event range contribute more to recall, directly rewarding
+    advance/early detection.
+
+    Based on Tatbul et al., NeurIPS 2018.
+    https://arxiv.org/abs/1803.03639
+
+    Parameters
+    ----------
+    bias : str, default="flat"
+        Positional bias function. One of "flat", "front", "back".
+        "flat"  - all positions within a range are equally weighted.
+        "front" - earlier positions in a range receive higher weight,
+                  rewarding advance/early detection.
+        "back"  - later positions in a range receive higher weight.
+    alpha : float, default=0.0
+        Weight for existence reward (0 to 1).
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.performance_metrics.detection._range_based_precision_recall import (
+    ...     RangeBasedRecall,
+    ... )
+    >>> y_true = pd.DataFrame({"ilocs": [10, 11, 12, 13, 14]})
+    >>> y_pred = pd.DataFrame({"ilocs": [10, 11]})
+    >>> metric = RangeBasedRecall(bias="front")
+    >>> metric(y_true, y_pred)  # doctest: +SKIP
+    """
+
+    _tags = {
+        "object_type": ["metric_detection", "metric"],
+        "scitype:y": "points",
+        "requires_X": False,
+        "requires_y_true": True,
+        "lower_is_better": False,  # higher recall is better
+    }
+
+    def __init__(self, bias="flat", alpha=0.0):
+        self.bias = bias
+        self.alpha = alpha
+        super().__init__()
+
+    def _positional_bias(self, position, length):
+        """Compute positional weight for a detection within a range."""
+        if length <= 1:
+            return 1.0
+
+        if self.bias == "flat":
+            return 1.0
+        elif self.bias == "front":
+            return float(length - position) / length
+        elif self.bias == "back":
+            return float(position + 1) / length
+        else:
+            raise ValueError(
+                f"Unknown bias '{self.bias}'. Choose from 'flat', 'front', 'back'."
+            )
+
+    def _evaluate(self, y_true, y_pred, X=None):
+        """Evaluate Range-based Recall on given inputs.
+
+        Parameters
+        ----------
+        y_true : pd.DataFrame
+            Ground truth events in "points" format with column 'ilocs'.
+        y_pred : pd.DataFrame
+            Predicted events in "points" format with column 'ilocs'.
+        X : pd.DataFrame, optional
+            Unused, part of signature.
+
+        Returns
+        -------
+        float
+            Range-based Recall score between 0.0 and 1.0.
+        """
+        true_ilocs = sorted(y_true["ilocs"].values.tolist())
+        pred_ilocs = sorted(y_pred["ilocs"].values.tolist())
+
+        if len(true_ilocs) == 0 and len(pred_ilocs) == 0:
+            return 1.0
+        if len(true_ilocs) == 0:
+            return 0.0
+        if len(pred_ilocs) == 0:
+            return 0.0
+
+        pred_ilocs_set = set(pred_ilocs)
+        true_start = min(true_ilocs)
+        true_end = max(true_ilocs)
+        range_length = true_end - true_start + 1
+
+        # existence reward
+        existence = 1.0 if len(pred_ilocs) > 0 else 0.0
+
+        # overlap reward: sum weighted contributions of true events that are detected
+        total_weight = sum(
+            self._positional_bias(t - true_start, range_length) for t in true_ilocs
+        )
+
+        if total_weight == 0:
+            return 0.0
+
+        overlap_score = 0.0
+        for true in true_ilocs:
+            if true in pred_ilocs_set:
+                position = true - true_start
+                weight = self._positional_bias(position, range_length)
+                overlap_score += weight / total_weight
+
+        recall = self.alpha * existence + (1 - self.alpha) * overlap_score
+        return recall
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default={}
+            Parameters to create testing instances of the class.
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
+            instance.
+            ``create_test_instance`` uses the first (or only) dictionary in ``params``.
+        """
+        param1 = {}
+        param2 = {"bias": "front"}
+        param3 = {"bias": "back", "alpha": 0.1}
+        return [param1, param2, param3]

--- a/sktime/performance_metrics/detection/tests/test_range_based_precision_recall.py
+++ b/sktime/performance_metrics/detection/tests/test_range_based_precision_recall.py
@@ -1,0 +1,157 @@
+"""Tests for Range-based Precision and Recall detection metrics."""
+
+import pandas as pd
+import pytest
+
+from sktime.performance_metrics.detection._range_based_precision_recall import (
+    RangeBasedPrecision,
+    RangeBasedRecall,
+)
+from sktime.tests.test_switch import run_test_for_class
+
+
+@pytest.mark.skipif(
+    not run_test_for_class([RangeBasedPrecision, RangeBasedRecall]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_range_based_precision_flat():
+    """Test RangeBasedPrecision with flat (default) positional bias.
+
+    Setup
+    -----
+    y_true ilocs: [0, 2, 3]  -> true event range [0, 3], length 4
+    y_pred ilocs: [0, 1, 3, 4, 5]
+
+    With flat bias, each position in the range has equal weight 1/4.
+    Predicted points 0 and 3 are in the true set; 1, 4, 5 are not.
+    overlap contribution per hit = 1/4 (one position out of 4, equally weighted).
+    Total score = (1/4 + 0 + 1/4 + 0 + 0) / 5 = 0.5 / 5 = 0.1
+    """
+    y_true = pd.DataFrame({"ilocs": [0, 2, 3]})
+    y_pred = pd.DataFrame({"ilocs": [0, 1, 3, 4, 5]})
+
+    metric = RangeBasedPrecision()
+
+    loss = metric(y_true, y_pred)
+    assert isinstance(loss, float)
+    assert abs(loss - 0.1) < 1e-9
+
+
+@pytest.mark.skipif(
+    not run_test_for_class([RangeBasedPrecision, RangeBasedRecall]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_range_based_recall_flat():
+    """Test RangeBasedRecall with flat (default) positional bias.
+
+    Setup
+    -----
+    y_true ilocs: [0, 2, 3]  -> true event range [0, 3], length 4
+    y_pred ilocs: [0, 1, 3, 4, 5]
+
+    With flat bias, total weight = 3 (one per true point: 0, 2, 3).
+    Detected true points: 0 (weight 1/4) and 3 (weight 1/4).
+    Recall = (1/4 + 1/4) / (3 * 1/4) = 0.5 / 0.75 = 0.6667
+    """
+    y_true = pd.DataFrame({"ilocs": [0, 2, 3]})
+    y_pred = pd.DataFrame({"ilocs": [0, 1, 3, 4, 5]})
+
+    metric = RangeBasedRecall()
+
+    loss = metric(y_true, y_pred)
+    assert isinstance(loss, float)
+    assert abs(loss - 2 / 3) < 1e-9
+
+
+@pytest.mark.skipif(
+    not run_test_for_class([RangeBasedPrecision, RangeBasedRecall]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_range_based_recall_front_bias():
+    """Test RangeBasedRecall rewards earlier detections with front bias.
+
+    Setup
+    -----
+    y_true ilocs: [0, 2, 3]  -> true event range [0, 3], length 4
+    y_pred ilocs: [0, 1, 3, 4, 5]
+
+    Front bias weights for length 4: pos0=1.0, pos1=0.75, pos2=0.5, pos3=0.25
+    True points at positions: 0 (weight 1.0), 2 (weight 0.5), 3 (weight 0.25)
+    Total weight = 1.75
+    Detected: 0 (1.0/1.75) and 3 (0.25/1.75)
+    Recall = (1.0 + 0.25) / 1.75 = 1.25 / 1.75 ~= 0.7143
+
+    Front bias gives higher recall than flat (0.7143 > 0.6667) because the
+    earliest detection at position 0 is rewarded more.
+    """
+    y_true = pd.DataFrame({"ilocs": [0, 2, 3]})
+    y_pred = pd.DataFrame({"ilocs": [0, 1, 3, 4, 5]})
+
+    metric_front = RangeBasedRecall(bias="front")
+    metric_flat = RangeBasedRecall(bias="flat")
+
+    recall_front = metric_front(y_true, y_pred)
+    recall_flat = metric_flat(y_true, y_pred)
+
+    assert isinstance(recall_front, float)
+    assert abs(recall_front - 5 / 7) < 1e-9
+    # front bias should reward early detection more than flat
+    assert recall_front > recall_flat
+
+
+@pytest.mark.skipif(
+    not run_test_for_class([RangeBasedPrecision, RangeBasedRecall]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_range_based_perfect_prediction():
+    """Test that perfect prediction gives Precision=0.25 and Recall=1.0 (flat bias).
+
+    When y_pred == y_true == [0, 2, 3], range length is 4.
+    Precision: each of the 3 predicted points hits a true point.
+    Each contributes weight 1/4 (flat). Total = 3*(1/4) / 3 = 1/4 = 0.25.
+    Recall: all 3 true points detected. Total weight = 3*(1/4) = 0.75. Score = 1.0.
+    """
+    y_true = pd.DataFrame({"ilocs": [0, 2, 3]})
+    y_pred = pd.DataFrame({"ilocs": [0, 2, 3]})
+
+    prec = RangeBasedPrecision()(y_true, y_pred)
+    rec = RangeBasedRecall()(y_true, y_pred)
+
+    assert isinstance(prec, float)
+    assert isinstance(rec, float)
+    assert abs(prec - 0.25) < 1e-9
+    assert abs(rec - 1.0) < 1e-9
+
+
+@pytest.mark.skipif(
+    not run_test_for_class([RangeBasedPrecision, RangeBasedRecall]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_range_based_no_overlap():
+    """Test that non-overlapping predictions give score 0.0."""
+    y_true = pd.DataFrame({"ilocs": [0, 2, 3]})
+    y_pred = pd.DataFrame({"ilocs": [10, 11, 12]})
+
+    prec = RangeBasedPrecision()(y_true, y_pred)
+    rec = RangeBasedRecall()(y_true, y_pred)
+
+    assert prec == 0.0
+    assert rec == 0.0
+
+
+@pytest.mark.skipif(
+    not run_test_for_class([RangeBasedPrecision, RangeBasedRecall]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_range_based_empty_inputs():
+    """Test edge cases: both empty returns 1.0, one empty returns 0.0."""
+    empty = pd.DataFrame({"ilocs": []})
+    y = pd.DataFrame({"ilocs": [1, 2, 3]})
+
+    # both empty -> 1.0
+    assert RangeBasedPrecision()(empty, empty) == 1.0
+    assert RangeBasedRecall()(empty, empty) == 1.0
+
+    # pred empty, true not -> 0.0
+    assert RangeBasedPrecision()(y, empty) == 0.0
+    assert RangeBasedRecall()(y, empty) == 0.0


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #9887

#### What does this implement/fix?
Implements `RangeBasedPrecision` and `RangeBasedRecall` detection metrics based on Tatbul et al., NeurIPS 2018 (https://arxiv.org/abs/1803.03639).

These metrics extend classical Precision and Recall to range-based events with a customizable positional bias:
- `bias="flat"` — all positions equally weighted (default)
- `bias="front"` — earlier positions weighted higher, directly rewarding advance/early detection
- `bias="back"` — later positions weighted higher
- `alpha` parameter controls existence reward weight (default 0.0)

#### Does your contribution introduce a new dependency?
No.

#### Did you add any tests for the change?
Yes : 6 tests in `test_range_based_precision_recall.py`, each with hand-computed expected values documented in the docstring, covering flat bias precision and recall, front bias recall, perfect prediction, no overlap, and empty inputs.

#### PR checklist
- [x] The PR title starts with [ENH]
- [x] I've added one or more illustrative usage examples to the docstring