### PR TITLE
[BUG] Chronos2 truncation axis fix and added a regression test

### DIFF
--- a/sktime/forecasting/chronos2.py
+++ b/sktime/forecasting/chronos2.py
@@ -189,7 +189,7 @@ class Chronos2Forecaster(BaseForecaster):
 
         context = y
 
-        if context.shape[1] > context_length:
+        if context.shape[0] > context_length:
             context = context.iloc[-context_length:]
 
         context = context.values.T

--- a/sktime/forecasting/tests/test_chronos2.py
+++ b/sktime/forecasting/tests/test_chronos2.py
@@ -1,0 +1,20 @@
+"""Tests for Chronos2Forecaster."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sktime.forecasting.chronos2 import Chronos2Forecaster
+
+
+def test_chronos2_fit_truncates_context_on_time_axis():
+    """`context_length` truncation should apply to time axis, not feature axis."""
+    pytest.importorskip("torch")
+
+    y = pd.DataFrame(np.arange(300).reshape(100, 3), columns=["a", "b", "c"])
+    forecaster = Chronos2Forecaster(config={"context_length": 10}, ignore_deps=True)
+    forecaster._load_pipeline = lambda: object()
+
+    forecaster._fit(y)
+
+    assert forecaster._context.shape == (3, 10)

--- a/sktime/forecasting/tests/test_chronos2.py
+++ b/sktime/forecasting/tests/test_chronos2.py
@@ -5,8 +5,13 @@ import pandas as pd
 import pytest
 
 from sktime.forecasting.chronos2 import Chronos2Forecaster
+from sktime.utils.dependencies import _check_estimator_deps
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(Chronos2Forecaster, severity="none"),
+    reason="autots not available",
+)
 def test_chronos2_fit_truncates_context_on_time_axis():
     """`context_length` truncation should apply to time axis, not feature axis."""
     pytest.importorskip("torch")


### PR DESCRIPTION
# Reference Issues/PRs
Fixes #9953 
Fixes Chronos2 context truncation bug in sktime/forecasting/chronos2.py (wrong axis used for truncation check).

# What does this implement/fix? Explain your changes.
This PR fixes a bug in Chronos2Forecaster context truncation logic.
Previously, truncation checked context.shape[1] (number of variables/features) but applied truncation on rows/time via context.iloc[-context_length:].
For typical data shaped (n_timepoints, n_vars), this could skip truncation for long histories.

# Changes made:

- Updated truncation condition to check the time axis (context.shape[0] > context_length).
- Kept truncation operation on the most recent context_length rows.
- Added a regression test to verify truncation is applied correctly on the time axis for multivariate input.

#  Does your contribution introduce a new dependency? If yes, which one?
No new dependencies introduced.

# What should a reviewer concentrate their feedback on?
- Correctness of axis selection in truncation condition.
- Whether the new regression test sufficiently covers the bug scenario.
- Any edge cases around context preparation/transposition in Chronos2Forecaster.

# Did you add any tests for the change?
Yes.

Added sktime/forecasting/tests/test_chronos2.py with a focused regression test for time-axis truncation behavior.

# Any other comments?
Targeted local pytest execution was attempted, but pytest was unavailable in the execution environment (No module named pytest).

