### PR TITLE
[ENH] add second parameter set for `TimeSeriesKernelKMeans`

### DIFF
--- a/sktime/clustering/kernel_k_means.py
+++ b/sktime/clustering/kernel_k_means.py
@@ -173,7 +173,7 @@ class TimeSeriesKernelKMeans(_TslearnAdapter, BaseClusterer):
             "max_iter": 2,
             "tol": 0.001,
             "kernel_params": {"sigma": 0.5},
-            "verbose": True,
+            "verbose": False,
             "n_jobs": None,
             "random_state": 42,
         }

--- a/sktime/clustering/kernel_k_means.py
+++ b/sktime/clustering/kernel_k_means.py
@@ -154,7 +154,7 @@ class TimeSeriesKernelKMeans(_TslearnAdapter, BaseClusterer):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
-        return {
+        params0 = {
             "n_clusters": 2,
             "kernel": "gak",
             "n_init": 1,
@@ -165,6 +165,19 @@ class TimeSeriesKernelKMeans(_TslearnAdapter, BaseClusterer):
             "n_jobs": 1,
             "random_state": 1,
         }
+
+        params1 = {
+            "n_clusters": 3,
+            "kernel": "gak",
+            "n_init": 2,
+            "max_iter": 2,
+            "tol": 0.001,
+            "kernel_params": {"sigma": 0.5},
+            "verbose": True,
+            "n_jobs": None,
+            "random_state": 42,
+        }
+        return [params0, params1]
 
     def _score(self, X, y=None) -> float:
         return np.abs(self.inertia_)

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -246,7 +246,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "TapNetNetwork",
         "TemporalDictionaryEnsemble",
         "TimeSeriesKMedoids",
-        "TimeSeriesKernelKMeans",
         "WEASEL",
         # The below estimators need to have their name removed from EXCLUDE_SOFT_DEPS
         # too after adding test parameters to them


### PR DESCRIPTION
adds a second parameter set for `TimeSeriesKernelKMeans`.

This estimator is a `tests:core` estimator, so would fail on standard testing.