### PR TITLE
[ENH] remove redundant code in `BaseDetector.__init__`

### DIFF
--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -91,14 +91,9 @@ class BaseDetector(BaseEstimator):
         self._is_fitted = False
 
         self._X = None
-        self._Y = None
-
-        task = self.get_tag("task")
-        learning_type = self.get_tag("learning_type")
+        self._y = None
 
         super().__init__()
-
-        self.set_tags(**{"task": task, "learning_type": learning_type})
 
     def __rmul__(self, other):
         """Magic * method, return (left) concatenated DetectorPipeline.

--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -90,9 +90,6 @@ class BaseDetector(BaseEstimator):
     def __init__(self):
         self._is_fitted = False
 
-        self._X = None
-        self._y = None
-
         super().__init__()
 
     def __rmul__(self, other):

--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -28,6 +28,7 @@ import pandas as pd
 from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_error_msg, check_is_scitype, convert
 from sktime.utils.adapters._safe_call import _method_has_arg
+from sktime.utils.dependencies import _check_estimator_deps
 from sktime.utils.validation.series import check_series
 
 
@@ -88,9 +89,8 @@ class BaseDetector(BaseEstimator):
     }
 
     def __init__(self):
-        self._is_fitted = False
-
         super().__init__()
+        _check_estimator_deps(self, severity="warning")
 
     def __rmul__(self, other):
         """Magic * method, return (left) concatenated DetectorPipeline.

--- a/sktime/detection/compose/_pipeline.py
+++ b/sktime/detection/compose/_pipeline.py
@@ -69,13 +69,13 @@ class DetectorPipeline(_HeterogenousMetaEstimator, BaseDetector):
         self.steps = steps
         self.steps_ = self._check_steps(steps, allow_postproc=False)
 
+        super().__init__()
+
         tags_to_clone = ["learning_type", "task"]
         # we do not clone X-y-must-have-same-index, since transformers can
         #   create indices, and that behaviour is not tag-inspectable
         self.clone_tags(self.estimator_, tags_to_clone)
 
-        # init must be called at the end so task is properly set
-        super().__init__()
 
     def __rmul__(self, other):
         """Magic * method, return (left) concatenated DetectorPipeline.

--- a/sktime/detection/compose/_pipeline.py
+++ b/sktime/detection/compose/_pipeline.py
@@ -76,7 +76,6 @@ class DetectorPipeline(_HeterogenousMetaEstimator, BaseDetector):
         #   create indices, and that behaviour is not tag-inspectable
         self.clone_tags(self.estimator_, tags_to_clone)
 
-
     def __rmul__(self, other):
         """Magic * method, return (left) concatenated DetectorPipeline.
 


### PR DESCRIPTION
Removes redundancies in `BaseDetector.__init__`, there is superfluous and dead code:

* setting of `self._Y` which is never used
* get and set tags which are not changed
* added missing `_check_soft_dependencies`
* removed superfluous setting of `_is_fitted`