### PR TITLE
fix: raise ValueError when SubLOF timedelta window_size used with integer index

### DIFF
--- a/sktime/detection/lof.py
+++ b/sktime/detection/lof.py
@@ -207,6 +207,14 @@ class SubLOF(BaseDetector):
 
         if isinstance(interval_size, int) and not is_integer_index(x):
             interval_size = x.freq * interval_size
+
+        import datetime
+
+        if isinstance(interval_size, datetime.timedelta) and is_integer_index(x):
+            raise ValueError(
+                "window_size is a timedelta but X has an integer index. "
+                "Use an integer window_size when X is indexed by integers."
+            )
         n_intervals = math.floor(x_span / interval_size) + 1
 
         if x_max >= x_min + (n_intervals - 1) * interval_size:

--- a/sktime/detection/tests/test_lof.py
+++ b/sktime/detection/tests/test_lof.py
@@ -93,3 +93,22 @@ def test_sublof_does_not_mutate_input():
     _ = model.fit_transform(X)
 
     pd.testing.assert_frame_equal(X, X_original)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SubLOF),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_sublof_timedelta_window_on_integer_index_raises():
+    """Regression test: timedelta window_size on integer-indexed data raises ValueError.
+
+    SubLOF._split_into_intervals tried to compute x_span / timedelta, where x_span
+    is an int (from a RangeIndex). That raises a raw TypeError deep in the method.
+    The fix adds an early guard that raises a descriptive ValueError instead.
+    """
+    X = pd.DataFrame({"sensor_reading": [0.1, 0.5, 0.2, 100.0, 0.1, 0.0]})
+
+    model = SubLOF(n_neighbors=2, window_size=datetime.timedelta(days=1))
+
+    with pytest.raises(ValueError, match="integer index"):
+        model.fit(X)


### PR DESCRIPTION
Closing - PR #9930 already addresses this issue. Apologies for the duplicate.