### PR TITLE
[BUG] NaiveForecaster silently accepts sp > len(y) with default window_length

### DIFF
--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -177,21 +177,24 @@ class NaiveForecaster(_BaseWindowForecaster):
         n_timepoints = y.shape[0]
 
         if self.strategy in ("last", "mean"):
-            # check window length is greater than sp for seasonal mean or seasonal last
-            if self.window_length is not None and sp != 1:
-                if self.window_length < sp:
-                    raise ValueError(
+            
+            window = check_window_length(self.window_length, n_timepoints)
+
+            if window is None:
+            # if window is none, len(y) acts as the default window length
+                window = n_timepoints
+
+            # ValueError when window < sp, with default window or given window  
+            if sp != 1 and window < sp:
+                raise ValueError(
                         f"The `window_length`: "
-                        f"{self.window_length} is smaller than "
+                        f"{window} is smaller than "
                         f"`sp`: {sp}."
                     )
-            self.window_length_ = check_window_length(self.window_length, n_timepoints)
+            
+            self.window_length_ = window
             self.sp_ = check_sp(sp)
-
-            #  if not given, set default window length
-            if self.window_length is None:
-                self.window_length_ = len(y)
-
+            
         elif self.strategy == "drift":
             if sp != 1:
                 warn(
@@ -219,11 +222,7 @@ class NaiveForecaster(_BaseWindowForecaster):
 
         # check window length
         if self.window_length_ > len(y):
-            param = "sp" if self.strategy == "last" and sp != 1 else "window_length_"
-            raise ValueError(
-                f"The {param}: {self.window_length_} is larger than "
-                f"the training series."
-            )
+            raise ValueError(f"`window_length` {self.window_length_} is larger than training series length {len(y)}")
 
         return self
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #9969

Issue link: https://github.com/sktime/sktime/issues/9969

#### What does this implement/fix? Explain your changes.

This PR fixes a silent-failure case in `NaiveForecaster._fit` where the validation that `window_length >= sp` was gated behind `window_length is not None`, causing the check to be skipped when the user relied on the default.

As reported in #9969, the following runs without error today, despite `sp=150` exceeding the series length of 144:

```python
y = load_airline()  # length 144
nf = NaiveForecaster(strategy="last", sp=150)
nf.fit(y)
nf.predict(fh=list(range(100)))
```

When `window_length=None`, the forecaster resolves it to `len(y)`, but the existing `window_length < sp` check is gated behind `self.window_length is not None` and therefore skipped. The fit succeeds and the predict call produces NaN-padded output from a seasonal reshape with empty columns. If the user had instead passed `window_length=144` explicitly, the same configuration would have correctly raised `ValueError`.

All validation logic remains in `_fit`, per the sklearn convention that `__init__` must only assign parameters (required for `clone()`, `get_params()`, and `check_estimator`). The resolved value is stored in `self.window_length_` (trailing underscore), leaving `self.window_length` (the user's input) immutable.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

- [ ] Correctness of the `check_window_length` ordering: because `check_window_length` resolves fractional float inputs to integers via `int(np.ceil(frac * n_timepoints))`, the `< sp` comparison must happen *after* resolution, not before. Calling it on the raw `self.window_length` would either spuriously reject valid fractional inputs or crash on type mismatches.
- [ ] Removal of the `param = "sp" if ...` ternary in the series-length guard.
- [ ] The `drift`-branch fix (comparing `self.window_length_` instead of `self.window_length`) — separate latent bug, included here because it's in the same function and follows the same "compare against resolved value" principle.

#### Did you add any tests for the change?

I merely tested the outputs of the new lines, but I haven't added any tests

#### Any other comments?

No

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors.
- [x] The PR title starts with `[BUG]`.