### PR TITLE
[MNT] make `test-est` CI element require `test-nosoftdeps`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,7 +194,7 @@ jobs:
           echo "Changed classes: $OBJ_LIST"
 
   test-est:
-    needs: detect-changed-classes
+    needs: [detect-changed-classes, test-nosoftdeps]
     if: ${{ needs.detect-changed-classes.outputs.obj_list != '[]' }}
 
     strategy:


### PR DESCRIPTION
Changes the main CI so that the `test-est` CI element requires `test-nosoftdeps`.

This is to avoid unnecessary testing when the superficial API conformance checks fail.