### PR TITLE
[MNT] Update CODEOWNERS to active core developers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,4 +11,4 @@
 # Further lookup such as "which algorithms does M maintain"
 # can be carried out using registry.all_estimators
 
-* @benheid @felipeangelimvieira @fkiraly @fnhirwa @geetu040 @pranavvp16 @SaiRevanth25 @XinyuWuu @yarnabrina
+* @benheid @felipeangelimvieira @fkiraly @fnhirwa @geetu040 @jgyasu @marrov @pranavvp16 @SimonBlanke @yarnabrina


### PR DESCRIPTION
Update CODEOWNERS to active core developers - also removes currently inactive developers