### PR TITLE
[BUG] NaiveForecaster silently accepting sp > len(y)

### DIFF
--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -177,20 +177,20 @@ class NaiveForecaster(_BaseWindowForecaster):
         n_timepoints = y.shape[0]
 
         if self.strategy in ("last", "mean"):
-            # check window length is greater than sp for seasonal mean or seasonal last
-            if self.window_length is not None and sp != 1:
-                if self.window_length < sp:
-                    raise ValueError(
-                        f"The `window_length`: "
-                        f"{self.window_length} is smaller than "
-                        f"`sp`: {sp}."
-                    )
             self.window_length_ = check_window_length(self.window_length, n_timepoints)
             self.sp_ = check_sp(sp)
 
-            #  if not given, set default window length
+            # if not given, set default window length
             if self.window_length is None:
                 self.window_length_ = len(y)
+
+            # check window length is greater than sp for seasonal mean or seasonal last
+            if self.sp_ != 1 and self.window_length_ < self.sp_:
+                raise ValueError(
+                    f"The `window_length`: "
+                    f"{self.window_length_} is smaller than "
+                    f"`sp`: {self.sp_}."
+                )
 
         elif self.strategy == "drift":
             if sp != 1:


### PR DESCRIPTION
Fixes #9970. Validation for window_length vs sp was being bypassed when window_length=None. Moved the check after the default fallback sets window_length_ = len(y).

#### Reference Issues/PRs

Fixes #9970.

#### What does this implement/fix? Explain your changes.

The validation check for `window_length < sp` was previously bypassed when `window_length` defaulted to `None`. 

Moved the validation block to occur *after* the fallback assigns `window_length_ = len(y)`, ensuring `sp` can never exceed the training data length silently.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Core validation logic in `_fit` of `NaiveForecaster`.

#### Did you add any tests for the change?

No new tests added; existing test suite covers `NaiveForecaster` validation logic natively.

#### Any other comments?

N/A

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [x] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation.
