### PR TITLE
[BUG] add univariate tag to GaussianHMM

### DIFF
--- a/sktime/detection/hmm_learn/gaussian.py
+++ b/sktime/detection/hmm_learn/gaussian.py
@@ -104,6 +104,10 @@ class GaussianHMM(BaseHMMLearn):
     >>> labeled_data = model.predict(data) # doctest: +SKIP
     """
 
+    _tags = {
+        "capability:multivariate": False,
+    }
+
     def __init__(
         self,
         n_components: int = 1,


### PR DESCRIPTION
Fixes #9880. Explicitly set capability:multivariate to False.

#### Reference Issues/PRs

Fixes #9880.

#### What does this implement/fix? Explain your changes.

Added the missing `_tags` dictionary to the `GaussianHMM` class to explicitly enforce `capability:multivariate: False`. This prevents downstream pipeline failures when the estimator is inadvertently passed multivariate input data.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- `GaussianHMM` `_tags` definition.

#### Did you add any tests for the change?

No new tests; tag validation is already covered by the core `BaseDetector` test suite.

#### Any other comments?

N/A

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation.
