### PR TITLE
[BUG] Mutable default argument in RBFForecaster.__init__ leads to shared state

### DIFF
--- a/sktime/forecasting/rbf_forecaster.py
+++ b/sktime/forecasting/rbf_forecaster.py
@@ -57,7 +57,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         - "gaussian": :math:`\exp(-\gamma (t - c)^2)`
         - "multiquadric": :math:`\sqrt{1 + \gamma (t - c)^2}`
         - "inverse_multiquadric": :math:`\frac{1}{\sqrt{1 + \gamma (t - c)^2}}`
-    hidden_layers : list of int, optional (default=[64, 32])
+    hidden_layers : tuple or list of int, optional (default=(64, 32))
         Sizes of linear layers following the RBF layer.
     optimizer : {"adam", "sgd", "rmsprop"}, optional (default="adam")
         Type of optimizer to use.
@@ -114,7 +114,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         centers=None,
         gamma=1.0,
         rbf_type="gaussian",
-        hidden_layers=[64, 32],
+        hidden_layers=(64, 32),
         optimizer="adam",
         lr=0.01,
         epochs=100,
@@ -554,7 +554,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
                 "batch_size": 16,
                 "gamma": 1.0,
                 "rbf_type": "gaussian",
-                "hidden_layers": [16],
+                "hidden_layers": (16,),
                 "epochs": 3,
                 "lr": 0.01,
                 "stride": 1,
@@ -570,7 +570,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
                 "batch_size": 32,
                 "gamma": 0.5,
                 "rbf_type": "gaussian",
-                "hidden_layers": [64, 32],
+                "hidden_layers": (64, 32),
                 "epochs": 3,
                 "lr": 0.005,
                 "stride": 1,


### PR DESCRIPTION
Fixes #9971 by changing the mutable list default [64, 32] to an immutable tuple (64, 32) in RBFForecaster, preventing cross-instance state leakage and adhering to scikit-learn API design.

#### Reference Issues/PRs

Fixes #9971.

#### What does this implement/fix? Explain your changes.

Changed the mutable list default `[64, 32]` to an immutable tuple `(64, 32)` in `RBFForecaster.__init__` and `get_test_params`. This prevents cross-instance state leakage and aligns the estimator with standard scikit-learn/sktime API design principles regarding mutable defaults.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- `RBFForecaster` initialization arguments and `get_test_params` structures.

#### Did you add any tests for the change?

No new tests; the fix is structural and existing tests in `test_rbf_forecaster.py` cover runtime execution.

#### Any other comments?

N/A

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation.
