### PR TITLE
[DOC] Fix typo in forecasting notebook (choic → choice)

### DIFF
--- a/examples/01_forecasting.ipynb
+++ b/examples/01_forecasting.ipynb
@@ -4602,7 +4602,7 @@
     "\n",
     "`sktime` interfaces a number of statistical forecasting algorithms from `statsmodels`: exponential smoothing, theta, and auto-ETS.\n",
     "\n",
-    "For example, to use exponential smoothing with an additive trend component and multiplicative seasonality on the airline data set, we can write the following. Note that since this is monthly data, a good choic for seasonal periodicity (sp) is 12 (= hypothesized periodicity of a year)."
+    "For example, to use exponential smoothing with an additive trend component and multiplicative seasonality on the airline data set, we can write the following. Note that since this is monthly data, a good choice for seasonal periodicity (sp) is 12 (= hypothesized periodicity of a year)."
    ]
   },
   {


### PR DESCRIPTION
## What does this implement/fix?
This PR addresses a typographical error in the forecasting notebook where "choic" was written instead of "choice".

## What should a reviewer concentrate their feedback on?
- Correctness of the typo fix
- No unintended changes

## Reference Issues/PRs
Closes #9966

## PR checklist
- [x] PR title follows contribution guidelines ([DOC])
- [x] Change is limited to documentation only
- [x] No code logic affected
- [x] Verified that the correction is accurate

## Contribution type
- Documentation improvement (doc)