### PR TITLE
[DO NOT MERGE] Util to collect and install soft dependencies from estimators

### DIFF
--- a/sktime/utils/dependencies/__init__.py
+++ b/sktime/utils/dependencies/__init__.py
@@ -14,6 +14,7 @@ from sktime.utils.dependencies._dependencies import (
 )
 from sktime.utils.dependencies._isinstance import _isinstance_by_name
 from sktime.utils.dependencies._placeholder import _placeholder_record
+from sktime.utils.dependencies.get_soft_dependencies import get_soft_dependencies
 
 __all__ = [
     "_check_dl_dependencies",
@@ -25,4 +26,5 @@ __all__ = [
     "_isinstance_by_name",
     "_placeholder_record",
     "_safe_import",
+    "get_soft_dependencies",
 ]

--- a/sktime/utils/dependencies/get_soft_dependencies.py
+++ b/sktime/utils/dependencies/get_soft_dependencies.py
@@ -8,6 +8,8 @@ from collections.abc import Iterable
 
 from sktime.registry import all_estimators
 
+__all__ = ["get_soft_dependencies"]
+
 
 def _normalize_dependencies(deps: str | Iterable | None) -> set[str]:
     """Return a normalized set of dependency strings.

--- a/sktime/utils/dependencies/get_soft_dependencies.py
+++ b/sktime/utils/dependencies/get_soft_dependencies.py
@@ -1,0 +1,172 @@
+"""Util to collect and install soft dependencies from estimators."""
+
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from collections.abc import Iterable
+
+from sktime.registry import all_estimators
+
+
+def _normalize_dependencies(deps: str | Iterable | None) -> set[str]:
+    """Return a normalized set of dependency strings.
+
+    Parameters
+    ----------
+    deps : str or iterable of str or iterable of iterable of str or None
+        Dependency specification. Supported formats include a single string,
+        a flat iterable of strings, nested iterables of strings, or None.
+
+    Returns
+    -------
+    set of str
+        Flattened set of dependency strings. Invalid or non-string entries
+        are ignored.
+    """
+    normalized: set[str] = set()
+
+    if deps is None:
+        return normalized
+
+    if isinstance(deps, str):
+        normalized.add(deps)
+        return normalized
+
+    if isinstance(deps, (list, tuple, set)):
+        for item in deps:
+            if isinstance(item, str):
+                normalized.add(item)
+            elif isinstance(item, (list, tuple, set)):
+                for sub in item:
+                    if isinstance(sub, str):
+                        normalized.add(sub)
+            # silently ignore anything else
+
+    return normalized
+
+
+def get_soft_dependencies(
+    install: bool = False,
+    verbose: bool = False,
+) -> set[str]:
+    """Collect soft dependencies declared by all sktime estimators.
+
+    Optionally installs the collected dependencies using pip.
+
+    Parameters
+    ----------
+    install : bool, default=False
+        If True, install the collected dependencies.
+    verbose : bool, default=False
+        If True, print progress information and warnings.
+
+    Returns
+    -------
+    set of str
+        Unique dependency specifications collected from estimator tags.
+    """
+    dependencies: set[str] = set()
+
+    estimators = all_estimators()
+
+    for name, Estimator in estimators:
+        try:
+            deps = Estimator.get_class_tags().get("python_dependencies", None)
+            normalized = _normalize_dependencies(deps)
+            dependencies.update(normalized)
+
+        except Exception as e:
+            if verbose:
+                print(f"[WARN] Skipping {name}: {e}")
+
+    if verbose:
+        print(f"\nCollected {len(dependencies)} unique dependencies.")
+
+    if install and dependencies:
+        _install_packages(dependencies, verbose=verbose)
+
+    return dependencies
+
+
+def _parse_package_spec(spec: str):
+    """Split a package specification into name and version specifier.
+
+    Parameters
+    ----------
+    spec : str
+        Package specification string, e.g., ``"numpy>=1.20"`` or ``"pandas"``.
+
+    Returns
+    -------
+    tuple of str
+        A tuple ``(name, version_specifier)`` where the version specifier
+        may be an empty string if not provided.
+    """
+    match = re.match(r"^([a-zA-Z0-9_\-]+)(.*)$", spec)
+    if match:
+        return match.group(1), match.group(2)
+    return spec, ""
+
+
+def _merge_dependencies(packages):
+    """Merge multiple specifications of the same package.
+
+    For duplicate packages, a heuristic is used to keep the most restrictive
+    version constraint by selecting the longest specifier string.
+
+    Parameters
+    ----------
+    packages : iterable of str
+        Collection of package specification strings.
+
+    Returns
+    -------
+    list of str
+        Sorted list of merged package specifications.
+    """
+    merged = defaultdict(list)
+
+    for pkg in packages:
+        name, spec = _parse_package_spec(pkg)
+        merged[name].append(spec)
+
+    final = []
+
+    for name, specs in merged.items():
+        # pick the "most restrictive" spec (heuristic: longest string)
+        best_spec = max(specs, key=len) if specs else ""
+        final.append(name + best_spec)
+
+    return sorted(final)
+
+
+def _install_packages(packages, verbose=True):
+    """Install packages using pip.
+
+    Parameters
+    ----------
+    packages : iterable of str
+        Package specification strings to install.
+    verbose : bool, default=True
+        If True, print installation progress and errors.
+
+    Returns
+    -------
+    None
+        This function installs packages as a side effect.
+    """
+    merged_packages = _merge_dependencies(packages)
+
+    if verbose:
+        print(f"\nInstalling {len(merged_packages)} merged packages...\n")
+
+    for pkg in merged_packages:
+        try:
+            if verbose:
+                print(f"[INSTALL] {pkg}")
+
+            subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])  # noqa: S603
+
+        except subprocess.CalledProcessError as e:
+            print(f"[ERROR] Failed to install {pkg}: {e}")

--- a/sktime/utils/dependencies/get_soft_dependencies.py
+++ b/sktime/utils/dependencies/get_soft_dependencies.py
@@ -1,10 +1,12 @@
 """Util to collect and install soft dependencies from estimators."""
 
-import re
 import subprocess
 import sys
 from collections import defaultdict
 from collections.abc import Iterable
+
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
 
 from sktime.registry import all_estimators
 
@@ -91,56 +93,75 @@ def get_soft_dependencies(
     return dependencies
 
 
-def _parse_package_spec(spec: str):
-    """Split a package specification into name and version specifier.
-
-    Parameters
-    ----------
-    spec : str
-        Package specification string, e.g., ``"numpy>=1.20"`` or ``"pandas"``.
-
-    Returns
-    -------
-    tuple of str
-        A tuple ``(name, version_specifier)`` where the version specifier
-        may be an empty string if not provided.
-    """
-    match = re.match(r"^([a-zA-Z0-9_\-]+)(.*)$", spec)
-    if match:
-        return match.group(1), match.group(2)
-    return spec, ""
-
-
-def _merge_dependencies(packages):
+def _merge_dependencies(packages, verbose=True, strategy="strict"):
     """Merge multiple specifications of the same package.
 
-    For duplicate packages, a heuristic is used to keep the most restrictive
-    version constraint by selecting the longest specifier string.
+    This implementation uses proper parsing via ``packaging`` and attempts
+    to compute the intersection of version constraints.
 
     Parameters
     ----------
     packages : iterable of str
         Collection of package specification strings.
+    verbose : bool, default=True
+        If True, print warnings for conflicts.
+    strategy : {"strict", "permissive"}, default="strict"
+        Strategy to handle conflicting constraints:
+        - "strict": skip packages with incompatible constraints
+        - "permissive": fall back to a heuristic (longest specifier)
 
     Returns
     -------
     list of str
         Sorted list of merged package specifications.
     """
-    merged = defaultdict(list)
+    grouped = defaultdict(list)
 
+    # group by package name
     for pkg in packages:
-        name, spec = _parse_package_spec(pkg)
-        merged[name].append(spec)
+        try:
+            req = Requirement(pkg)
+            grouped[req.name].append(req.specifier)
+        except Exception:
+            # fallback for non-standard strings
+            grouped[pkg].append(SpecifierSet(""))
 
-    final = []
+    merged = []
 
-    for name, specs in merged.items():
-        # pick the "most restrictive" spec (heuristic: longest string)
-        best_spec = max(specs, key=len) if specs else ""
-        final.append(name + best_spec)
+    for name, specifiers in grouped.items():
+        # compute intersection
+        combined = SpecifierSet()
+        for spec in specifiers:
+            combined &= spec
 
-    return sorted(final)
+        combined_str = str(combined)
+
+        # detect potential conflict (empty intersection heuristic)
+        if not combined_str:
+            if len(specifiers) > 1:
+                if verbose:
+                    print(
+                        f"[WARN] Conflicting requirements for {name}: "
+                        f"{[str(s) for s in specifiers]}"
+                    )
+
+                if strategy == "strict":
+                    # skip conflicting package
+                    continue
+
+                elif strategy == "permissive":
+                    # fallback: pick longest original spec
+                    fallback = max(
+                        (str(s) for s in specifiers),
+                        key=len,
+                        default="",
+                    )
+                    merged.append(name + fallback)
+                    continue
+
+        merged.append(name + combined_str)
+
+    return sorted(merged)
 
 
 def _install_packages(packages, verbose=True):


### PR DESCRIPTION
Adds a utility to collect soft dependencies from all the sktime estimators and then install them. I needed this script for quick use, but I will be iterating over this to add it as a general utility.