### PR TITLE
[BUG] fix: make_forecasting_scorer compatible with func(y, y_pred) signature

### DIFF
--- a/sktime/performance_metrics/forecasting/_base.py
+++ b/sktime/performance_metrics/forecasting/_base.py
@@ -883,7 +883,11 @@ class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
                 constr_params = set(constr.keys()).intersection(params.keys())
                 params = {key: params[key] for key in constr_params}
 
-        res = func(y_true=y_true, y_pred=y_pred, **params)
+        func_args = list(signature(func).parameters.keys())
+        if func_args and func_args[0] != "y_true":
+            res = func(y_true, y_pred, **params)
+        else:
+            res = func(y_true=y_true, y_pred=y_pred, **params)
         return res
 
 
@@ -990,7 +994,7 @@ def make_forecasting_scorer(
     ----------
     func : callable
         Callable to convert to a forecasting scorer class.
-        Score function (or loss function) with signature ``func(y, y_pred, **kwargs)``.
+        Score function (or loss function) with signature ``func(y_true, y_pred, **kwargs)``.
 
     name : str, default=None
         Name to use for the forecasting scorer loss class.


### PR DESCRIPTION
## Summary

Fixes a bug where `make_forecasting_scorer` would fail when the user-provided 
function used `y` (or any name other than `y_true`) as the first parameter, 
causing a `TypeError` when used with `ForecastingBenchmark`.

## Problem

`_evaluate_func` always called the user function with keyword arguments:
    func(y_true=..., y_pred=...)

But the docstring advertised the signature as `func(y, y_pred, **kwargs)`.
So a function defined as `def my_scorer(y, y_pred)` would raise:
    TypeError: my_scorer() got an unexpected keyword argument 'y_true'

## Changes

- `_base.py` (docstring): corrected the expected signature from 
  `func(y, y_pred, **kwargs)` to `func(y_true, y_pred, **kwargs)`
- `_base.py` (`_evaluate_func`): added a fallback to call the function 
  positionally when its first parameter is not named `y_true`, ensuring 
  backward compatibility with functions using any parameter name

## How to reproduce (before fix)

from sktime.performance_metrics.forecasting import make_forecasting_scorer

def dummy_scorer(y, y_pred):
    return 42

scorer = make_forecasting_scorer(func=dummy_scorer, name="dummy")
scorer.evaluate(y, y_pred)  # raised TypeError

## Related issues

Fixed #9374
