### PR TITLE
[BUG] Fix SeasonalityACFqstat: reject_cand logic inverted for p_adjust='none'

### DIFF
--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -380,7 +380,7 @@ class SeasonalityACFqstat(BaseParamFitter):
             self.pvalues_adjusted_ = pvals_adj
         else:
             self.pvalues_adjusted_ = pvalues_cand
-            reject_cand = pvalues_cand > p_threshold
+            reject_cand = pvalues_cand <= p_threshold
 
         sorting = np.argsort(pvalues_cand)
         reject_ordered = reject_cand[sorting]

--- a/sktime/param_est/tests/test_seasonality.py
+++ b/sktime/param_est/tests/test_seasonality.py
@@ -1,7 +1,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Tests for seasonality parameter estimators."""
 
-__author__ = ["fkiraly"]
+__author__ = ["fkiraly", "Akanksha Trehun"]
 
 import numpy as np
 import pytest
@@ -57,3 +57,25 @@ def test_seasonality_acf_qstat():
     actual = sp_est.get_fitted_params()["sp_significant"]
     expected = np.array([12, 7, 3])
     np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(SeasonalityACFqstat, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+def test_seasonality_acf_qstat_p_adjust_none_consistent():
+    """Test SeasonalityACFqstat p_adjust='none' returns significant periods.
+
+    Regression test for bug #10002: reject_cand was inverted when p_adjust='none',
+    causing non-significant periods to be selected as seasonal periods.
+    """
+    X = load_airline().diff()[1:]
+    sp_est_adj = SeasonalityACFqstat(candidate_sp=[3, 7, 12], p_adjust="fdr_bh")
+    sp_est_none = SeasonalityACFqstat(candidate_sp=[3, 7, 12], p_adjust="none")
+    sp_est_adj.fit(X)
+    sp_est_none.fit(X)
+
+    # Both variants should agree that period 12 is strongly seasonal
+    assert 12 in sp_est_none.sp_significant_
+    # p_adjust='none' primary sp should match adjusted variant on clear seasonal data
+    assert sp_est_none.sp_ == sp_est_adj.sp_


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10002

#### What does this implement/fix? Explain your changes.

`SeasonalityACFqstat._fit` detects seasonal periods by checking whether Q-statistic
p-values are significant. When `p_adjust != "none"`, `multipletests` is used and
its `reject` array follows the standard convention: `True` = null hypothesis
rejected = **period is significant**.

However, in the `else` branch (`p_adjust == "none"`), the code computed:

```python
reject_cand = pvalues_cand > p_threshold
```

This is the opposite convention: `True` = p > threshold = **period is NOT
significant**. The subsequent selection `sp_significant = sp_ordered[reject_ordered]`
then returned non-significant periods as detected seasonal periods.

**Fix:** change `>` to `<=` so both branches use the same `True`=significant
convention.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- The one-character change on line 383 of `seasonality.py`
- The new consistency test `test_seasonality_acf_qstat_p_adjust_none_consistent`

#### Did you add any tests for the change?

Yes — `test_seasonality_acf_qstat_p_adjust_none_consistent` verifies that
`p_adjust="none"` and `p_adjust="fdr_bh"` agree on the primary seasonal period
for airline data (which has a clear period-12 signal).

#### Any other comments?

`SeasonalityACF` (without qstat) is not affected — it uses a confidence-interval
lower-bound comparison and the logic there is correct.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.