### PR TITLE
[BUG] Fix ScaledLogitTransformer: zero-valued bound causes wrong transform branch

### DIFF
--- a/sktime/transformations/series/scaledlogit.py
+++ b/sktime/transformations/series/scaledlogit.py
@@ -151,7 +151,7 @@ class ScaledLogitTransformer(BaseTransformer):
                 obj=self,
             )
 
-        if self.upper_bound and self.lower_bound:
+        if self.upper_bound is not None and self.lower_bound is not None:
             X_transformed = np.log((X - self.lower_bound) / (self.upper_bound - X))
         elif self.upper_bound is not None:
             X_transformed = -np.log(self.upper_bound - X)
@@ -178,7 +178,7 @@ class ScaledLogitTransformer(BaseTransformer):
         -------
         inverse transformed version of X
         """
-        if self.upper_bound and self.lower_bound:
+        if self.upper_bound is not None and self.lower_bound is not None:
             X_inv_transformed = (self.upper_bound * np.exp(X) + self.lower_bound) / (
                 np.exp(X) + 1
             )

--- a/sktime/transformations/series/tests/test_scaledlogit.py
+++ b/sktime/transformations/series/tests/test_scaledlogit.py
@@ -1,7 +1,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """ScaledLogit transform unit tests."""
 
-__author__ = ["ltsaprounis"]
+__author__ = ["ltsaprounis", "Akanksha Trehun"]
 
 import numpy as np
 import pytest
@@ -62,3 +62,31 @@ def test_scaledlogit_bound_errors(lower, upper, message):
     with pytest.warns(RuntimeWarning):
         ScaledLogitTransformer(lower, upper).fit_transform(y)
         warn(message, RuntimeWarning)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ScaledLogitTransformer),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize(
+    "lower, upper",
+    [
+        (0, 70),   # lower_bound=0 is falsy — triggered the bug
+        (0, 1),    # probability scale, lower=0
+        (-10, 0),  # upper_bound=0 is falsy — triggered the bug
+    ],
+)
+def test_scaledlogit_zero_bound_uses_scaled_logit(lower, upper):
+    """Regression test: zero-valued bounds must use the scaled-logit branch.
+
+    Failure case in bug #10003: `if self.upper_bound and self.lower_bound` was
+    falsy when either bound was 0, causing the wrong transform branch to execute.
+    """
+    X = np.linspace(lower + 1e-3, upper - 1e-3, 10).reshape(1, -1)
+    t = ScaledLogitTransformer(lower_bound=lower, upper_bound=upper)
+    Xt = t.fit_transform(X)
+    expected = np.log((X - lower) / (upper - X))
+    np.testing.assert_allclose(Xt, expected, atol=1e-10)
+
+    X_inv = t.inverse_transform(Xt)
+    np.testing.assert_allclose(X_inv, X, atol=1e-10)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10003

#### What does this implement/fix? Explain your changes.

`ScaledLogitTransformer._transform` and `_inverse_transform` both checked whether
two bounds were provided using Python truthiness:

```python
if self.upper_bound and self.lower_bound:
    # scaled logit branch
```

When either bound is `0` — a perfectly valid value (e.g., `lower_bound=0` for a
probability or count scale, which is the docstring's own usage example
`ScaledLogitTransformer(0, 650)`) — the condition evaluates to `False` and the
code falls through to the single-bound branch, silently applying the wrong formula.

**Fix:** replace both occurrences of the truthy check with explicit `is not None`
comparisons in `_transform` and `_inverse_transform`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- The two one-line changes in `scaledlogit.py` (lines 154 and 181)
- The new parametrized test `test_scaledlogit_zero_bound_uses_scaled_logit`
  which covers `lower=0`, `upper=0`, and both together

#### Did you add any tests for the change?

Yes — `test_scaledlogit_zero_bound_uses_scaled_logit` checks three zero-bound
scenarios: verifies the transform output matches `log((x-a)/(b-x))` and that the
round-trip `inverse_transform(transform(X))` recovers the original data.

#### Any other comments?

The existing `test_scaledlogit_transform` parametrize list does not include a
zero-bound case, so the bug was undetected by the test suite.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].