### PR TITLE
[BUG] Replace assert with ValueError in SquaringResiduals parameter validation

### DIFF
--- a/sktime/forecasting/squaring_residuals.py
+++ b/sktime/forecasting/squaring_residuals.py
@@ -118,11 +118,20 @@ class SquaringResiduals(BaseForecaster):
         self.distr_kwargs = distr_kwargs
         super().__init__()
 
-        assert self.distr in ["norm", "laplace", "t", "cauchy"]
-        assert self.strategy in ["square", "abs"]
-        assert self.initial_window >= 1, (
-            "Initial window should be larger or equal to one"
-        )
+        if self.distr not in ["norm", "laplace", "t", "cauchy"]:
+            raise ValueError(
+                f"distr must be one of 'norm', 'laplace', 't', 'cauchy', "
+                f"but found: {self.distr!r}"
+            )
+        if self.strategy not in ["square", "abs"]:
+            raise ValueError(
+                f"strategy must be one of 'square', 'abs', "
+                f"but found: {self.strategy!r}"
+            )
+        if self.initial_window < 1:
+            raise ValueError(
+                f"initial_window must be >= 1, but found: {self.initial_window}"
+            )
 
         if self.forecaster is None:
             self.forecaster = NaiveForecaster()

--- a/sktime/forecasting/tests/test_squaring_residuals.py
+++ b/sktime/forecasting/tests/test_squaring_residuals.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3 -u
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for SquaringResiduals parameter validation."""
+
+__author__ = ["Akanksha Trehun"]
+
+import pytest
+
+from sktime.forecasting.squaring_residuals import SquaringResiduals
+from sktime.utils.dependencies import _check_estimator_deps
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(SquaringResiduals, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+@pytest.mark.parametrize("bad_distr", ["gaussian", "uniform", 42, None])
+def test_squaring_residuals_invalid_distr_raises(bad_distr):
+    """Invalid distr must raise ValueError at construction, not silently pass.
+
+    Regression test for bug #10004: bare assert statements were stripped under
+    python -O, so invalid arguments were silently accepted.
+    """
+    with pytest.raises(ValueError, match="distr"):
+        SquaringResiduals(distr=bad_distr)
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(SquaringResiduals, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+@pytest.mark.parametrize("bad_strategy", ["cube", "log", 1, None])
+def test_squaring_residuals_invalid_strategy_raises(bad_strategy):
+    """Invalid strategy must raise ValueError at construction."""
+    with pytest.raises(ValueError, match="strategy"):
+        SquaringResiduals(strategy=bad_strategy)
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(SquaringResiduals, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+@pytest.mark.parametrize("bad_window", [0, -1, -100])
+def test_squaring_residuals_invalid_initial_window_raises(bad_window):
+    """initial_window < 1 must raise ValueError at construction."""
+    with pytest.raises(ValueError, match="initial_window"):
+        SquaringResiduals(initial_window=bad_window)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10004

#### What does this implement/fix? Explain your changes.

`SquaringResiduals.__init__` validated three constructor parameters using bare
`assert` statements:

```python
assert self.distr in ["norm", "laplace", "t", "cauchy"]
assert self.strategy in ["square", "abs"]
assert self.initial_window >= 1, "Initial window should be larger or equal to one"
```

Python's `-O` (optimize) flag compiles away all `assert` statements, so under
`python -O` these checks are silently skipped. An invalid argument like
`distr="my_dist"` passes construction without error and only fails later inside
`_predict_interval` with a hard-to-diagnose `KeyError`.

**Fix:** Replace all three `assert` statements with explicit `if … raise ValueError`
blocks that remain active regardless of interpreter optimization flags.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- The three replaced guard blocks in `squaring_residuals.py`
- The new test file `sktime/forecasting/tests/test_squaring_residuals.py`
  (no prior test file existed for this estimator)

#### Did you add any tests for the change?

Yes — `test_squaring_residuals.py` adds three parametrized tests that each verify
a `ValueError` is raised at construction for invalid `distr`, `strategy`, and
`initial_window` values.

#### Any other comments?

This is the same anti-pattern as `assert` usage in `var_reduce.py` (see #10005),
filed separately.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].