### PR TITLE
[BUG] Replace assert with ValueError in VARReduce regressor interface validation

### DIFF
--- a/sktime/forecasting/tests/test_varreduce.py
+++ b/sktime/forecasting/tests/test_varreduce.py
@@ -8,7 +8,7 @@ from sktime.forecasting.var import VAR
 from sktime.forecasting.var_reduce import VARReduce
 from sktime.tests.test_switch import run_test_for_class
 
-__author__ = ["meraldoantonio"]
+__author__ = ["meraldoantonio", "Akanksha Trehun"]
 
 
 @pytest.mark.skipif(
@@ -22,3 +22,37 @@ def test_VAR_against_statsmodels():
     y_var = VAR().fit_predict(y, fh=[1, 2, 3])
     y_varr = VARReduce().fit_predict(y, fh=[1, 2, 3])
     np.testing.assert_allclose(y_var.values, y_varr.values)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class([VARReduce]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_varreduce_invalid_regressor_no_fit_raises():
+    """Regressor without 'fit' must raise ValueError at construction.
+
+    Regression test for bug #10005: bare assert statements were stripped under
+    python -O, so an incompatible regressor was silently accepted.
+    """
+
+    class NoFitRegressor:
+        def predict(self, X):
+            pass
+
+    with pytest.raises(ValueError, match="fit"):
+        VARReduce(regressor=NoFitRegressor())
+
+
+@pytest.mark.skipif(
+    not run_test_for_class([VARReduce]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_varreduce_invalid_regressor_no_predict_raises():
+    """Regressor without 'predict' must raise ValueError at construction."""
+
+    class NoPredict:
+        def fit(self, X, y):
+            pass
+
+    with pytest.raises(ValueError, match="predict"):
+        VARReduce(regressor=NoPredict())

--- a/sktime/forecasting/var_reduce.py
+++ b/sktime/forecasting/var_reduce.py
@@ -147,8 +147,16 @@ class VARReduce(BaseForecaster):
         else:
             self.regressor_ = clone(regressor)
 
-        assert hasattr(self.regressor_, "fit"), "Regressor must have 'fit'"
-        assert hasattr(self.regressor_, "predict"), "Regressor must have 'predict'"
+        if not hasattr(self.regressor_, "fit"):
+            raise ValueError(
+                "regressor must expose a 'fit' method, "
+                f"but {type(self.regressor_)} does not."
+            )
+        if not hasattr(self.regressor_, "predict"):
+            raise ValueError(
+                "regressor must expose a 'predict' method, "
+                f"but {type(self.regressor_)} does not."
+            )
 
         self.coefficients_ = None
         self.intercept_ = None


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10005

#### What does this implement/fix? Explain your changes.

`VARReduce.__init__` validated that the injected `regressor` exposes `fit` and
`predict` using bare `assert` statements:

```python
assert hasattr(self.regressor_, "fit"), "Regressor must have 'fit'"
assert hasattr(self.regressor_, "predict"), "Regressor must have 'predict'"
```

Python's `-O` (optimize) flag strips all `assert` statements at compile time.
Under optimized execution, passing an incompatible object silently bypasses these
checks and only fails later during `_fit` with an uninformative `AttributeError`.

**Fix:** Replace both `assert` statements with explicit `if not hasattr … raise
ValueError(…)` checks that are always enforced.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- The two replaced guard blocks in `var_reduce.py`
- The two new tests in `test_varreduce.py` covering each missing-method scenario

#### Did you add any tests for the change?

Yes — added `test_varreduce_invalid_regressor_no_fit_raises` and
`test_varreduce_invalid_regressor_no_predict_raises` to the existing
`sktime/forecasting/tests/test_varreduce.py`.

#### Any other comments?

Same anti-pattern as `SquaringResiduals` (fixed in PR #10009).

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].