### PR TITLE
[MNT] remove module specific tests from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -507,24 +507,6 @@ jobs:
             pyproject:
               - pyproject.toml
 
-  test-base:
-    needs: test-nosoftdeps
-    name: base
-    uses: ./.github/workflows/test_base.yml
-    secrets: inherit
-
-  test-module:
-    needs: test-nosoftdeps
-    name: module
-    uses: ./.github/workflows/test_module.yml
-    secrets: inherit
-
-  test-other:
-    needs: test-nosoftdeps
-    name: other
-    uses: ./.github/workflows/test_other.yml
-    secrets: inherit
-
   test-datasets:
     needs: detect
     name: datasets


### PR DESCRIPTION
This PR removes the module specific tests from the CI.

The tests were originally introduced to manage growing sets of soft dependencies, by sharding them into dependency sets by submodule.

This strategy has been flaky, as tests from submodule B were still running in the setup for submodule A.

Now that tests are managed by the `tests:vm` and the `python_dependencies` tag, we no longer need the submodule test jobs, (except the dataset job which gets extra treatment).