### PR TITLE
[MNT] chunk estimator VM tests to ensure maximum matrix size of 256 is not exceeded in `test-est`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
           # Load input
           obj_list = json.loads('''${{ needs.detect-changed-classes.outputs.obj_list }}''')
 
-          CHUNK_SIZE = 10  # adjust this!
+          CHUNK_SIZE = 10  # chosen such that this times number of runs is smaller 256
 
           # Split into chunks
           chunks = [obj_list[i:i+CHUNK_SIZE] for i in range(0, len(obj_list), CHUNK_SIZE)]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,39 +193,39 @@ jobs:
           echo "Number of changed classes: $OBJ_LIST_LENGTH"
           echo "Changed classes: $OBJ_LIST"
 
-prepare-chunks:
-  needs: detect-changed-classes
-  runs-on: ubuntu-latest
-  outputs:
-    obj_chunks: ${{ steps.chunk.outputs.obj_chunks }}
+  prepare-chunks:
+    needs: detect-changed-classes
+    runs-on: ubuntu-latest
+    outputs:
+      obj_chunks: ${{ steps.chunk.outputs.obj_chunks }}
 
-  steps:
-    - name: Chunk obj_list
-      id: chunk
-      shell: bash
-      run: |
-        python - <<'EOF'
-        import json
-        import os
+    steps:
+      - name: Chunk obj_list
+        id: chunk
+        shell: bash
+        run: |
+          python - <<'EOF'
+          import json
+          import os
 
-        # Load input
-        obj_list = json.loads('''${{ needs.detect-changed-classes.outputs.obj_list }}''')
+          # Load input
+          obj_list = json.loads('''${{ needs.detect-changed-classes.outputs.obj_list }}''')
 
-        CHUNK_SIZE = 10  # adjust this!
+          CHUNK_SIZE = 10  # adjust this!
 
-        # Split into chunks
-        chunks = [obj_list[i:i+CHUNK_SIZE] for i in range(0, len(obj_list), CHUNK_SIZE)]
+          # Split into chunks
+          chunks = [obj_list[i:i+CHUNK_SIZE] for i in range(0, len(obj_list), CHUNK_SIZE)]
 
-        # Fallback to avoid empty matrix error
-        if not chunks:
-            chunks = [[]]
+          # Fallback to avoid empty matrix error
+          if not chunks:
+              chunks = [[]]
 
-        print(f"Chunks: {len(chunks)}", file=os.sys.stderr)
+          print(f"Chunks: {len(chunks)}", file=os.sys.stderr)
 
-        # Emit output
-        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-            f.write(f"obj_chunks={json.dumps(chunks)}\n")
-        EOF
+          # Emit output
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"obj_chunks={json.dumps(chunks)}\n")
+          EOF
 
   test-est:
     needs: [detect-changed-classes, prepare-chunks, test-nosoftdeps]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,8 @@ jobs:
           if not chunks:
               chunks = [[]]
 
-          print(f"Chunks: {len(chunks)}", file=os.sys.stderr)
+          print(f"Number of chunks: {len(chunks)}", file=os.sys.stderr)
+          print(f"Chunks: {chunks}"")
 
           # Emit output
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,7 @@ jobs:
               chunks = [[]]
 
           print(f"Number of chunks: {len(chunks)}", file=os.sys.stderr)
-          print(f"Chunks: {chunks}"")
+          print(f"Chunks: {chunks}")
 
           # Emit output
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,60 +193,52 @@ jobs:
           echo "Number of changed classes: $OBJ_LIST_LENGTH"
           echo "Changed classes: $OBJ_LIST"
 
+prepare-chunks:
+  needs: detect-changed-classes
+  runs-on: ubuntu-latest
+  outputs:
+    obj_chunks: ${{ steps.chunk.outputs.obj_chunks }}
+
+  steps:
+    - name: Chunk obj_list
+      id: chunk
+      shell: bash
+      run: |
+        python - <<'EOF'
+        import json
+        import os
+
+        # Load input
+        obj_list = json.loads('''${{ needs.detect-changed-classes.outputs.obj_list }}''')
+
+        CHUNK_SIZE = 10  # adjust this!
+
+        # Split into chunks
+        chunks = [obj_list[i:i+CHUNK_SIZE] for i in range(0, len(obj_list), CHUNK_SIZE)]
+
+        # Fallback to avoid empty matrix error
+        if not chunks:
+            chunks = [[]]
+
+        print(f"Chunks: {len(chunks)}", file=os.sys.stderr)
+
+        # Emit output
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            f.write(f"obj_chunks={json.dumps(chunks)}\n")
+        EOF
+
   test-est:
-    needs: [detect-changed-classes, test-nosoftdeps]
+    needs: [detect-changed-classes, prepare-chunks, test-nosoftdeps]
     if: ${{ needs.detect-changed-classes.outputs.obj_list != '[]' }}
 
     strategy:
       fail-fast: false
       matrix:
-        flag: ${{ fromJson(needs.detect-changed-classes.outputs.obj_list) }}
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        chunk: ${{ fromJson(needs.prepare-chunks.outputs.obj_chunks) }}
 
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install OSX packages
-        run: ./.github/scripts/install_osx_dependencies.sh
-
-      - name: Force non-GUI Matplotlib backend (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
-        shell: pwsh
-        run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
-
-      - name: Install sktime with dev dependencies
-        run: uv pip install .[dev]
-        env:
-          UV_SYSTEM_PYTHON: 1
-
-      - name: Install dependencies for ${{ matrix.flag }}
-        run: |
-          python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" > deps.txt
-          pip install -r deps.txt
-        continue-on-error: true
-
-      - name: Show dependencies
-        run: uv pip list
-
-      - name: Run tests with ${{ matrix.flag }}
-        env:
-          FLAG: ${{ matrix.flag }}
-        shell: bash
-        run: python -c "from sktime.tests._test_vm import run_test_vm; run_test_vm('${{ matrix.flag }}')"
+    uses: ./.github/workflows/test_est.yml
+    with:
+      flags: ${{ toJson(matrix.chunk) }}
 
   detect-package-change:
     needs: code-quality

--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -1,0 +1,59 @@
+on:
+  workflow_call:
+    inputs:
+      flags:
+        required: true
+        type: string
+
+jobs:
+  test-est-inner:
+    strategy:
+      fail-fast: false
+      matrix:
+        flag: ${{ fromJson(inputs.flags) }}
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install OSX packages
+        run: ./.github/scripts/install_osx_dependencies.sh
+
+      - name: Force non-GUI Matplotlib backend (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
+
+      - name: Install sktime with dev dependencies
+        run: uv pip install .[dev]
+        env:
+          UV_SYSTEM_PYTHON: 1
+
+      - name: Install dependencies for ${{ matrix.flag }}
+        run: |
+          python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" > deps.txt
+          pip install -r deps.txt
+        continue-on-error: true
+
+      - name: Show dependencies
+        run: uv pip list
+
+      - name: Run tests with ${{ matrix.flag }}
+        env:
+          FLAG: ${{ matrix.flag }}
+        shell: bash
+        run: python -c "from sktime.tests._test_vm import run_test_vm; run_test_vm('${{ matrix.flag }}')"

--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -6,7 +6,7 @@ on:
         type: string
 
 jobs:
-  test-est-inner:
+  test-est:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies for ${{ matrix.flag }}
         run: |
           python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" > deps.txt
-          pip install -r deps.txt
+          uv pip install -r deps.txt
         continue-on-error: true
 
       - name: Show dependencies


### PR DESCRIPTION
Currently, the `test-est` job to test individual estimators can fail if a too large number of estimators are tested - namely, 18.

This is due to 3 operating systems, and five python versions, leading to 18*3*5 runs exceeding the matrix limit of 256.

This PR adds chunking to ensure the matrix limit is not exceeded.