### PR TITLE
[ENH] Add python_dependencies_recommended tag for optional performance dependencies

### DIFF
--- a/sktime/alignment/base.py
+++ b/sktime/alignment/base.py
@@ -52,9 +52,17 @@ class BaseAligner(BaseEstimator):
 
         super().__init__()
 
-        from sktime.utils.dependencies import _check_estimator_deps
+        from sktime.utils.dependencies import (
+            _check_estimator_deps,
+            _check_soft_dependencies,
+        )
 
         _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
 
     def fit(self, X, Z=None):
         """Fit alignment given series/sequences to align.

--- a/sktime/base/_proba/_base.py
+++ b/sktime/base/_proba/_base.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.base import BaseObject
-from sktime.utils.dependencies import _check_estimator_deps
+from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.pandas import df_map
 
 
@@ -44,6 +44,11 @@ class BaseDistribution(BaseObject):
 
         super().__init__()
         _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
 
     @property
     def loc(self):

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from sktime.base import BasePanelMixin
 from sktime.datatypes import VectorizedDF, check_is_scitype
-from sktime.utils.dependencies import _check_estimator_deps
+from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.sklearn import is_sklearn_transformer
 
 
@@ -104,6 +104,11 @@ class BaseClassifier(BasePanelMixin):
 
         super().__init__()
         _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
 
     def __rmul__(self, other):
         """Magic * method, return concatenated ClassifierPipeline, transformers on left.

--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -10,7 +10,7 @@ import numpy as np
 from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_scitype, convert_to, scitype_to_mtype
 from sktime.datatypes._dtypekind import DtypeKind
-from sktime.utils.dependencies import _check_estimator_deps
+from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.sklearn import is_sklearn_transformer
 from sktime.utils.warnings import warn
 
@@ -51,6 +51,11 @@ class BaseClusterer(BaseEstimator):
 
         super().__init__()
         _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
 
     def __rmul__(self, other):
         """Magic * method, return concatenated ClustererPipeline, transformers on left.

--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -28,7 +28,7 @@ import pandas as pd
 from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_error_msg, check_is_scitype, convert
 from sktime.utils.adapters._safe_call import _method_has_arg
-from sktime.utils.dependencies import _check_estimator_deps
+from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.validation.series import check_series
 
 
@@ -91,6 +91,11 @@ class BaseDetector(BaseEstimator):
     def __init__(self):
         super().__init__()
         _check_estimator_deps(self, severity="warning")
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
 
     def __rmul__(self, other):
         """Magic * method, return (left) concatenated DetectorPipeline.

--- a/sktime/dists_kernels/base/_base.py
+++ b/sktime/dists_kernels/base/_base.py
@@ -63,6 +63,18 @@ class BasePairwiseTransformer(BaseEstimator):
     def __init__(self):
         super().__init__()
 
+        from sktime.utils.dependencies import (
+            _check_estimator_deps,
+            _check_soft_dependencies,
+        )
+
+        _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
+
     def __call__(self, X, X2=None):
         """Compute distance/kernel matrix, call shorthand.
 
@@ -200,6 +212,18 @@ class BasePairwiseTransformerPanel(BaseEstimator):
 
     def __init__(self):
         super().__init__()
+
+        from sktime.utils.dependencies import (
+            _check_estimator_deps,
+            _check_soft_dependencies,
+        )
+
+        _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
 
     def __call__(self, X, X2=None):
         """Compute distance/kernel matrix, call shorthand.

--- a/sktime/dists_kernels/dtw/_dtw_sktime.py
+++ b/sktime/dists_kernels/dtw/_dtw_sktime.py
@@ -125,7 +125,7 @@ class DtwDist(BasePairwiseTransformerPanel):
         # packaging info
         # --------------
         "authors": ["chrisholder", "TonyBagnall", "fkiraly"],
-        "python_dependencies": "numba",
+        "python_dependencies_recommended": "numba",
         # estimator type
         # --------------
         "symmetric": True,  # all the distances are symmetric

--- a/sktime/dists_kernels/edit_dist.py
+++ b/sktime/dists_kernels/edit_dist.py
@@ -117,7 +117,7 @@ class EditDist(BasePairwiseTransformerPanel):
         # packaging info
         # --------------
         "authors": ["chrisholder", "TonyBagnall", "fkiraly"],
-        "python_dependencies": "numba",
+        "python_dependencies_recommended": "numba",
         # estimator type
         # --------------
         "symmetric": True,  # all the distances are symmetric

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -150,6 +150,11 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
 
         super().__init__()
         _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
         self._state = "new"
 
     @classmethod

--- a/sktime/networks/base.py
+++ b/sktime/networks/base.py
@@ -19,9 +19,17 @@ class BaseDeepNetwork(BaseObject):
     def __init__(self):
         super().__init__()
 
-        from sktime.utils.dependencies import _check_estimator_deps
+        from sktime.utils.dependencies import (
+            _check_estimator_deps,
+            _check_soft_dependencies,
+        )
 
         _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
 
     @abstractmethod
     def build_network(self, input_shape, **kwargs):

--- a/sktime/param_est/base.py
+++ b/sktime/param_est/base.py
@@ -31,7 +31,7 @@ from sktime.datatypes import (
 )
 from sktime.datatypes._dtypekind import DtypeKind
 from sktime.utils.adapters._safe_call import _safe_call
-from sktime.utils.dependencies import _check_estimator_deps
+from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.sklearn import is_sklearn_transformer
 from sktime.utils.warnings import warn
 
@@ -89,6 +89,11 @@ class BaseParamFitter(BaseEstimator):
 
         super().__init__()
         _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
 
     def __mul__(self, other):
         """Magic * method, for estimators on the right.

--- a/sktime/performance_metrics/base/_base.py
+++ b/sktime/performance_metrics/base/_base.py
@@ -23,9 +23,17 @@ class BaseMetric(BaseObject):
     def __init__(self):
         super().__init__()
 
-        from sktime.utils.dependencies import _check_estimator_deps
+        from sktime.utils.dependencies import (
+            _check_estimator_deps,
+            _check_soft_dependencies,
+        )
 
         _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
 
     def __call__(self, y_true, y_pred, **kwargs):
         """Calculate metric value using underlying metric function.

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -299,6 +299,76 @@ class python_dependencies(_BaseTag):
     }
 
 
+class python_dependencies_recommended(_BaseTag):
+    """Recommended (optional) Python package dependencies for the object (PEP 440).
+
+    Part of packaging metadata for the object.
+
+    - String name: ``"python_dependencies_recommended"``
+    - Private tag, developer and framework facing
+    - Values: str or list of str, each str a PEP 440 compliant dependency specifier
+    - Example: ``"numba"``
+    - Example 2: ``["numba>=0.55", "joblib"]``
+    - Default: no recommended dependencies (``None``)
+
+    ``sktime`` manages objects and estimators like mini-packages,
+    with their own dependencies and compatibility requirements.
+    Dependencies are specified in the tags:
+
+    - ``"python_version"``: Python version specifier (PEP 440) for the object,
+    - ``"python_dependencies"``: list of required Python packages (PEP 440)
+    - ``"python_dependencies_recommended"``: list of recommended Python packages
+      (PEP 440)
+    - ``"env_marker"``: environment marker for the object (PEP 508)
+    - ``"requires_cython"``: whether the object requires a C compiler present
+
+    The ``python_dependencies_recommended`` tag of an object is a string or list of
+    strings, each string a PEP 440 compliant version specifier,
+    specifying recommended but optional Python dependencies of the object.
+
+    Unlike ``python_dependencies``, missing recommended dependencies do not prevent
+    the estimator from being instantiated or used. Instead, a ``UserWarning`` is
+    raised at construction time to inform the user that installing the listed
+    packages would improve performance (e.g., via JIT compilation).
+
+    Use this tag for estimators that have a pure-Python fallback but run
+    significantly faster when an optional package such as ``numba`` is available.
+
+    If passed as a list, conditions are combined with logical AND.
+    Optionally, lists within a list can be used to combine conditions with logical OR.
+
+    The tag is used internally to check for recommended dependencies in the
+    build environment, and raise informative warnings if they are absent.
+
+    Valid dependency specifications with plain English descriptions:
+
+    * ``"numba"``: ``numba`` is recommended
+    * ``"numba>=0.55"``: ``numba`` version 0.55 or higher is recommended
+    * ``["numba>=0.55", "joblib"]``: both ``numba`` version 0.55 or higher
+      and ``joblib`` are recommended
+
+    Developers should note that package names in the PEP 440 specifier strings
+    that should be provided
+    are identical with the package names used in ``pip install`` commands or on PyPI,
+    which in general is not the same as the import name of the package,
+    e.g., ``"scikit-learn"`` as in ``pip install scikit-learn``,
+    and not ``"sklearn"``, as in ``import sklearn``.
+
+    Developers can use ``_check_soft_dependencies`` from ``skbase.utils.dependencies``
+    with ``severity="warning"`` to check recommended dependencies of the object
+    manually, or rely on the base class ``__init__`` to issue the warning
+    automatically via the tag.
+    """
+
+    _tags = {
+        "tag_name": "python_dependencies_recommended",
+        "parent_type": "object",
+        "tag_type": ("list", "str"),
+        "short_descr": "recommended soft dependencies as str or list of str (PEP 440)",
+        "user_facing": False,
+    }
+
+
 class env_marker(_BaseTag):
     """Environment marker requirement for the object (PEP 508).
 

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from sktime.base import BasePanelMixin
 from sktime.datatypes import VectorizedDF
-from sktime.utils.dependencies import _check_estimator_deps
+from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.sklearn import is_sklearn_transformer
 
 
@@ -95,6 +95,11 @@ class BaseRegressor(BasePanelMixin):
 
         super().__init__()
         _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
 
     def __rmul__(self, other):
         """Magic * method, return concatenated RegressorPipeline, transformers on left.

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -114,9 +114,17 @@ class BaseSplitter(BaseObject):
 
         super().__init__()
 
-        from sktime.utils.dependencies import _check_estimator_deps
+        from sktime.utils.dependencies import (
+            _check_estimator_deps,
+            _check_soft_dependencies,
+        )
 
         _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
 
     def split(self, y: ACCEPTED_Y_TYPES) -> SPLIT_GENERATOR_TYPE:
         """Get iloc references to train/test splits of `y`.

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -65,7 +65,7 @@ from sktime.datatypes import (
 )
 from sktime.datatypes._dtypekind import DtypeKind
 from sktime.datatypes._series_as_panel import convert_to_scitype
-from sktime.utils.dependencies import _check_estimator_deps
+from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.sklearn import (
     is_sklearn_classifier,
     is_sklearn_clusterer,
@@ -214,6 +214,11 @@ class BaseTransformer(BaseEstimator):
 
         super().__init__()
         _check_estimator_deps(self)
+        recommended = self.get_class_tag(
+            "python_dependencies_recommended", tag_value_default=None
+        )
+        if recommended is not None:
+            _check_soft_dependencies(recommended, severity="warning", obj=self)
 
     def _is_transformer(self, other):
         """Check whether other is a transformer - sklearn or sktime.


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #9810 
Follow up to the edge case identified during review of PR #9805 (relating to Issue #9798).

#### What does this implement/fix? Explain your changes.

This PR implements the python_dependencies_recommended tag to support optional soft dependencies that improve performance but are not strictly required for execution. 
Previously, estimators with pure-Python fallbacks (like DtwDist and EditDist which optionally use numba via an njit passthrough) were forced to use the strict python_dependencies tag. This resulted in a hard ModuleNotFoundError during _check_estimator_deps at construction time.

Changes made include:

1. Registry: Added the python_dependencies_recommended tag definition to sktime/registry/_tags.py
2. Framework Support: Updated the __init__ methods of all core base classes (BaseAligner, BaseClassifier, BaseClusterer, BaseDetector, BaseDistribution, BaseForecaster, BaseDeepNetwork, BaseParamFitter, BaseMetric, BaseRegressor, BaseSplitter, BaseTransformer, and    BasePairwiseTransformer/Panel) to check for the new tag using      _check_soft_dependencies(..., severity="warning").
3. Estimator Migration: Swapped "python_dependencies": "numba" to "python_dependencies_recommended": "numba" in the DtwDist and EditDist pairwise transformers.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?
 - Verification that the tag definition in _tags.py is accurate.
 - Verify that all ```__init__``` methods are covered for all core base classes and none are missed.

#### Did you add any tests for the change?

As discussed in #9805, we wanted to avoid complicating the global CI test framework (test_all_estimators) with dynamic uninstallation of numba to test the fallback path, since the CI already tests the "fast path" (with numba installed) by default.

I have tested this locally using  ```unittest.mock.patch.dict("sys.modules", {"numba": None})``` to simulate the absence of numba during import. The tests successfully verified that:
   1. The ```UserWarning``` is triggered correctly at construction time.
   2. ```No ModuleNotFoundError``` is raised.
   3. The ```.transform()``` method successfully completes execution using the native Python fallback.

If maintainers prefer to have this mock test committed to the test suite  (e.g. in dists_kernels/tests), I am happy to add it!

#### Any other comments?
Note: While reviewing the codebase to apply these base class checks, I noticed that InformationGainSegmentation (sktime/detection/igts.py) inherits directly from BaseEstimator rather than BaseDetector, causing it to miss out on standard detector base class boilerplate (including the new recommended dependency check). I can open a separate [MNT] issue to track
  refactoring that estimator to conform to the BaseDetector API.

#### PR checklist
##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

