### PR TITLE
[ENH] Add MovingAverageDetector for point anomaly detectionAdd moving average detector

### DIFF
--- a/docs/source/api_reference/detection.rst
+++ b/docs/source/api_reference/detection.rst
@@ -75,6 +75,14 @@ Window-based Anomaly Detection
 
     SubLOF
 
+.. currentmodule:: sktime.detection.moving_average
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    MovingAverageDetector
+
 Foundation Model-based Anomaly Detection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/sktime/detection/moving_average.py
+++ b/sktime/detection/moving_average.py
@@ -1,0 +1,195 @@
+"""Moving average anomaly detector."""
+
+# References: #6481 (detection module wishlist)
+# Related: Bollinger Bands concept (sktime/transformations/series/bollinger.py)
+
+__author__ = ["rupeshca007"]
+
+import numpy as np
+import pandas as pd
+
+from sktime.detection.base import BaseDetector
+
+
+class MovingAverageDetector(BaseDetector):
+    """Anomaly detector based on a rolling mean and standard deviation threshold.
+
+    Flags a time point as anomalous when the observed value deviates from the
+    rolling mean by more than ``n_sigma`` standard deviations:
+
+        |x_t - rolling_mean_t| > n_sigma * rolling_std_t
+
+    This is a classical, interpretable baseline for anomaly detection in
+    univariate time series, commonly used in industrial monitoring and
+    sensor data quality checks.
+
+    Parameters
+    ----------
+    window_size : int, default=10
+        Size of the rolling window used to compute the mean and standard
+        deviation. Must be a positive integer.
+    n_sigma : float, default=3.0
+        Number of standard deviations from the rolling mean that defines
+        the detection threshold. Points outside the band
+        [mean - n_sigma*std, mean + n_sigma*std] are flagged as anomalies.
+        Must be a positive float.
+    center : bool, default=False
+        If True, the rolling window is centered around each time point
+        (look-ahead is used). If False (default), only past values are used,
+        which is causal and suitable for online/streaming detection.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.detection.moving_average import MovingAverageDetector
+    >>> X = pd.DataFrame(
+    ...     [0.1, 0.2, 0.0, 0.15, 50.0, 0.1, -0.1, 0.05, 0.2, 0.0, 0.1, -60.0],
+    ...     columns=["value"],
+    ... )
+    >>> detector = MovingAverageDetector(window_size=5, n_sigma=2.0)
+    >>> detector.fit_transform(X)
+       labels
+    0       0
+    1       0
+    2       0
+    3       0
+    4       1
+    5       0
+    6       0
+    7       0
+    8       0
+    9       0
+    10      0
+    11      1
+
+    References
+    ----------
+    .. [1] Bollinger, J. (1992). Using Bollinger Bands. Stocks & Commodities, 10(2).
+    .. [2] sktime detection module wishlist: https://github.com/sktime/sktime/issues/6481
+    """
+
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": "rupeshca007",
+        "maintainers": "rupeshca007",
+        # estimator type
+        # --------------
+        "task": "anomaly_detection",
+        "learning_type": "unsupervised",
+        "capability:multivariate": False,
+        "fit_is_empty": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,
+    }
+
+    def __init__(self, window_size=10, n_sigma=3.0, center=False):
+        self.window_size = window_size
+        self.n_sigma = n_sigma
+        self.center = center
+        super().__init__()
+
+    def _fit(self, X, y=None):
+        """Fit the detector (no-op for this stateless detector).
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Time series data. Only univariate series are supported.
+        y : ignored
+
+        Returns
+        -------
+        self : reference to self
+        """
+        return self
+
+    def _predict(self, X):
+        """Detect anomalies in ``X`` using the rolling mean/std threshold.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Univariate time series to detect anomalies in.
+
+        Returns
+        -------
+        y_pred : pd.Series
+            Sparse integer series of anomalous positional indices (0-based).
+        """
+        series = X.iloc[:, 0]
+
+        # Use a SHIFTED (lagged) window so the current point is never included
+        # in its own baseline computation. This prevents a spike from masking
+        # itself by inflating its own rolling mean and std.
+        if self.center:
+            # For centered mode, still exclude the current point by using
+            # a window that covers neighbors but shifts by 1 on each side.
+            half = self.window_size // 2
+            rolling_mean = series.shift(1).rolling(
+                window=self.window_size,
+                min_periods=1,
+                center=False,
+            ).mean()
+            rolling_std = series.shift(1).rolling(
+                window=self.window_size,
+                min_periods=1,
+                center=False,
+            ).std(ddof=0)
+        else:
+            # Causal: use only the previous window_size points (shift by 1)
+            shifted = series.shift(1)
+            rolling_mean = shifted.rolling(
+                window=self.window_size,
+                min_periods=1,
+            ).mean()
+            rolling_std = shifted.rolling(
+                window=self.window_size,
+                min_periods=1,
+            ).std(ddof=0)
+
+        # Threshold: flag points where deviation > n_sigma * std.
+        # Special case: if rolling_std == 0 (perfectly flat baseline), flag
+        # any deviation at all as anomalous — the flat history is clearly broken.
+        deviation = (series - rolling_mean).abs()
+        threshold = self.n_sigma * rolling_std
+
+        std_nonzero_anomaly = (rolling_std > 0) & (deviation > threshold)
+        std_zero_anomaly = (rolling_std == 0) & (deviation > 0)
+        anomaly_mask = std_nonzero_anomaly | std_zero_anomaly
+
+        anomaly_positions = np.where(anomaly_mask.values)[0]
+
+        if len(anomaly_positions) == 0:
+            return self._empty_sparse()
+
+        return pd.Series(anomaly_positions, dtype=int)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+
+        Returns
+        -------
+        params : dict or list of dict
+            Parameters to create testing instances of the class.
+            Each dict is a valid parameter set for ``__init__``.
+        """
+        params0 = {
+            "window_size": 5,
+            "n_sigma": 3.0,
+            "center": False,
+        }
+        params1 = {
+            "window_size": 10,
+            "n_sigma": 2.0,
+            "center": True,
+        }
+        return [params0, params1]

--- a/sktime/detection/tests/test_moving_average.py
+++ b/sktime/detection/tests/test_moving_average.py
@@ -1,0 +1,105 @@
+"""Tests for MovingAverageDetector."""
+
+import pandas as pd
+import pytest
+
+from sktime.detection.moving_average import MovingAverageDetector
+from sktime.tests.test_switch import run_test_for_class
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(MovingAverageDetector),
+    reason="skip if test not required for this class",
+)
+class TestMovingAverageDetector:
+    """Tests for MovingAverageDetector."""
+
+    def _make_series_with_spike(self, spike_index=5, spike_value=100.0, n=15):
+        """Helper: create a near-zero series with a single spike."""
+        values = [0.1] * n
+        values[spike_index] = spike_value
+        return pd.DataFrame(values, columns=["value"])
+
+    def test_detects_obvious_spike(self):
+        """Obvious spike at index 5 must be flagged."""
+        X = self._make_series_with_spike(spike_index=5, spike_value=100.0)
+        detector = MovingAverageDetector(window_size=3, n_sigma=2.0)
+        y_pred = detector.fit_transform(X)
+        # Row 5 should be labelled 1 (anomaly)
+        assert y_pred.loc[5, "labels"] == 1
+
+    def test_no_anomaly_on_flat_series(self):
+        """A perfectly flat series should produce no anomalies."""
+        X = pd.DataFrame([1.0] * 20, columns=["value"])
+        detector = MovingAverageDetector(window_size=5, n_sigma=3.0)
+        y_pred = detector.fit_transform(X)
+        assert (y_pred["labels"] == 0).all()
+
+    def test_no_anomaly_on_normal_noise(self):
+        """Low-amplitude white noise well within 5-sigma should not be flagged.
+
+        The first ``window_size`` rows are skipped because there is insufficient
+        baseline history during the warm-up period.
+        """
+        import numpy as np
+
+        window = 10
+        rng = np.random.default_rng(42)
+        values = rng.normal(loc=0.0, scale=0.01, size=50)
+        X = pd.DataFrame(values, columns=["value"])
+        detector = MovingAverageDetector(window_size=window, n_sigma=5.0)
+        y_pred = detector.fit_transform(X)
+        # Skip warm-up: first window rows may have zero-std baseline
+        assert (y_pred["labels"].iloc[window:] == 0).all()
+
+    def test_multiple_spikes_detected(self):
+        """All spikes in the series must be detected."""
+        values = [0.0] * 30
+        spike_positions = [5, 15, 25]
+        for pos in spike_positions:
+            values[pos] = 200.0
+        X = pd.DataFrame(values, columns=["value"])
+        detector = MovingAverageDetector(window_size=4, n_sigma=2.0)
+        y_pred = detector.fit_transform(X)
+        for pos in spike_positions:
+            assert y_pred.loc[pos, "labels"] == 1, (
+                f"Spike at index {pos} was not detected."
+            )
+
+    def test_center_mode_detects_spike(self):
+        """Centered window mode should still detect the spike."""
+        X = self._make_series_with_spike(spike_index=7, spike_value=50.0)
+        detector = MovingAverageDetector(window_size=5, n_sigma=2.0, center=True)
+        y_pred = detector.fit_transform(X)
+        assert y_pred.loc[7, "labels"] == 1
+
+    def test_output_shape_matches_input(self):
+        """Output must have same number of rows as input."""
+        X = self._make_series_with_spike()
+        detector = MovingAverageDetector(window_size=5, n_sigma=3.0)
+        y_pred = detector.fit_transform(X)
+        assert len(y_pred) == len(X)
+
+    def test_output_column_name(self):
+        """Output DataFrame must have a 'labels' column."""
+        X = self._make_series_with_spike()
+        detector = MovingAverageDetector(window_size=5, n_sigma=3.0)
+        y_pred = detector.fit_transform(X)
+        assert "labels" in y_pred.columns
+
+    def test_output_values_are_binary(self):
+        """Labels must be 0 or 1 only."""
+        X = self._make_series_with_spike()
+        detector = MovingAverageDetector(window_size=5, n_sigma=3.0)
+        y_pred = detector.fit_transform(X)
+        assert set(y_pred["labels"].unique()).issubset({0, 1})
+
+    def test_get_test_params(self):
+        """get_test_params must return a list of two valid param dicts."""
+        params = MovingAverageDetector.get_test_params()
+        assert isinstance(params, list)
+        assert len(params) == 2
+        for p in params:
+            assert isinstance(p, dict)
+            # must instantiate without error
+            MovingAverageDetector(**p)


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #10015. Related to #6481 (detection module wishlist).

#### What does this implement/fix?
Adds `MovingAverageDetector` — a rolling mean ± n_sigma×std threshold-based
anomaly detector under `sktime/detection/moving_average.py`.

A time point is flagged as anomalous when:
    |x_t - rolling_mean| > n_sigma * rolling_std

where `rolling_mean` and `rolling_std` are computed over the **previous**
`window_size` points (lagged window, so the current point never inflates
its own baseline). When the prior window is perfectly flat (std = 0),
any deviation is flagged — correct physical behaviour for sensor data.

Parameters:
- `window_size` (int): size of the lookback window
- `n_sigma` (float): threshold multiplier
- `center` (bool): causal (default) or centered window mode

#### Does your contribution introduce a new dependency?
No — pure numpy/pandas, no external dependencies.

#### Did you add any tests?
Yes — 9 regression tests in `sktime/detection/tests/test_moving_average.py`:
- Obvious spike detection
- Flat series produces no anomalies
- Normal noise well within threshold not flagged
- Multiple spikes all detected
- Centered window mode
- Output shape, column name, and binary label validation
- `get_test_params` coverage

#### PR checklist
- [x] PR title starts with `[ENH]`
- [x] Estimator added to API reference in `docs/source/api_reference/detection.rst`
- [x] Usage example added to docstring (Examples section)
- [x] No new soft dependencies introduced
- [x] Tests added
