### PR TITLE
[BUG] Imputer: fix falsy zero missing_values check and method equality test

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -535,6 +535,13 @@
       "contributions": ["tutorial"]
     },
     {
+      "login": "magic-peach",
+      "name": "Akanksha Trehun",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/47450591?v=4",
+      "profile": "https://github.com/magic-peach",
+      "contributions": ["doc", "bug","code"]
+    },
+    {
       "login": "Multivin12",
       "name": "Multivin12",
       "avatar_url": "https://avatars3.githubusercontent.com/u/36476633?v=4",

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -160,7 +160,7 @@ class Imputer(BaseTransformer):
                 }
             )
 
-        if method in "forecaster":
+        if method == "forecaster":
             self.set_tags(**{"y_inner_mtype": ["pd.DataFrame"]})
 
     def _fit(self, X, y=None):
@@ -224,7 +224,7 @@ class Imputer(BaseTransformer):
         X = X.copy()
 
         # replace missing_values with np.nan
-        if self.missing_values:
+        if self.missing_values is not None:
             X = X.replace(to_replace=self.missing_values, value=np.nan)
 
         if not _has_missing_values(X):

--- a/sktime/transformations/series/tests/test_imputer.py
+++ b/sktime/transformations/series/tests/test_imputer.py
@@ -3,6 +3,7 @@
 """Unit tests of Imputer functionality."""
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from sktime.datatypes import get_examples
@@ -101,6 +102,28 @@ def test_impute_multiindex(method):
     imp_tbl = TransformByLevel(Imputer(method=method))
     df_imp_tbl = imp_tbl.fit_transform(df)
     assert np.array_equal(df_imp, df_imp_tbl, equal_nan=True)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(Imputer),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_imputer_missing_values_zero():
+    """Imputer with missing_values=0 must replace zeros, not silently skip them.
+
+    Regression test for GH #10017: ``if self.missing_values:`` was falsy for
+    integer zero, so zeros were never marked as NaN and never imputed.
+    """
+    idx = pd.date_range("2000", periods=5, freq="ME")
+    y = pd.DataFrame({"a": [1.0, 0.0, 3.0, 0.0, 5.0]}, index=idx)
+
+    imp = Imputer(method="mean", missing_values=0)
+    y_imp = imp.fit_transform(y)
+
+    assert not (y_imp == 0).any().any(), (
+        "zeros should have been replaced but are still present in the output"
+    )
+    assert not y_imp.isna().any().any(), "imputed output must not contain NaN"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

Fixes #10017

Two bugs in `Imputer`:

**Bug 1 (high impact): `missing_values=0` silently skipped**

In `_transform`, the guard was:
```python
if self.missing_values:
    X = X.replace(to_replace=self.missing_values, value=np.nan)
```
Integer `0`, float `0.0`, and `False` all evaluate as falsy, so `Imputer(missing_values=0)` never actually called `replace()`. Zeros in the input were never treated as missing values and never imputed.

Fix:
```python
if self.missing_values is not None:
    X = X.replace(to_replace=self.missing_values, value=np.nan)
```

**Bug 2 (low impact): substring test instead of equality in `__init__`**

```python
# before – Python substring test, not equality!
if method in "forecaster":
    self.set_tags(**{"y_inner_mtype": ["pd.DataFrame"]})

# after
if method == "forecaster":
    self.set_tags(**{"y_inner_mtype": ["pd.DataFrame"]})
```
For all current valid method values this happened to behave correctly, but the intent is clearly equality and the substring form is fragile against future method additions.

## Changes

| File | Change |
|------|--------|
| `sktime/transformations/series/impute.py` | Fix falsy check and substring test |
| `sktime/transformations/series/tests/test_imputer.py` | Add `test_imputer_missing_values_zero` regression test |
| `.all-contributorsrc` | Add contributor entry for magic-peach |

## Testing

Added `test_imputer_missing_values_zero`: constructs a series with literal zeros, runs `Imputer(method="mean", missing_values=0)`, and asserts that the output contains neither zeros nor NaN.

---

_Please also review the `.all-contributorsrc` change — this adds the contributor entry for Akanksha Trehun (magic-peach)._