### PR TITLE
[DOC] Remove sklearn versionchanged reference from SubLOF docstring

### DIFF
--- a/sktime/detection/lof.py
+++ b/sktime/detection/lof.py
@@ -81,10 +81,6 @@ class SubLOF(BaseDetector):
           original paper,
         - if a float, the contamination should be in the range (0, 0.5].
 
-        .. versionchanged:: 0.22
-           The default value of ``contamination`` changed from 0.1
-           to ``'auto'``.
-
     novelty : bool, default=False
         By default, LocalOutlierFactor is only meant to be used for outlier
         detection (novelty=False). Set novelty to True if you want to use


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #10019.

#### What does this implement/fix?
Removes the `.. versionchanged:: 0.22` note from the `contamination`
parameter docstring in `SubLOF` (`sktime/detection/lof.py`).

The note refers to **sklearn version 0.22**, not sktime, and is misleading
in sktime's documentation. Removal was explicitly requested by @fkiraly
in the original PR #6524 review:
> "remove 'changed in' references from sklearn, since that follows different versioning"

The fix was not applied before merging.

#### Changes
- Deleted 4 lines from `sktime/detection/lof.py` (lines 84–87)

#### PR checklist
- [x] PR title starts with `[DOC]`
- [x] No new dependencies
- [x] No new tests needed (doc-only change)
