### PR TITLE
BUG: remove eval from FhPlexForecaster parameter lookup

### DIFF
--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -486,10 +486,7 @@ class FhPlexForecaster(BaseForecaster):
         # naive_m = ["last", "mean", "drift"]
 
         naive_m = ["last", "last", "last"]
-        naive_list = [{"strategy": x} for x in naive_m * 20]
-        naive_dict = {k: naive_list[k % 3] for k in range(-50, 10)}
-
-        naive_str = "lambda ix: {'strategy': ['last', 'last', 'last'][ix % 3]}"
+        naive_callable = lambda ix: {"strategy": ["last", "last", "last"][ix % 3]}
 
         f = NaiveForecaster()
 
@@ -498,6 +495,9 @@ class FhPlexForecaster(BaseForecaster):
             "forecaster": f,
             "fh_params": naive_dict,
             "fh_lookup": "relative",
+            "fh_contiguous": True,
+        }
+        params3 = {"forecaster": f, "fh_params": naive_callable
             "fh_contiguous": True,
         }
         params3 = {"forecaster": f, "fh_params": naive_str, "fh_lookup": "relative"}

--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -489,8 +489,6 @@ class FhPlexForecaster(BaseForecaster):
         naive_list = [{"strategy": x} for x in naive_m * 20]
         naive_dict = {k: naive_list[k % 3] for k in range(-50, 10)}
 
-        naive_callable = lambda ix: {"strategy": ["last", "last", "last"][ix % 3]}
-
         f = NaiveForecaster()
 
         params1 = {"forecaster": f, "fh_params": naive_list}
@@ -500,10 +498,5 @@ class FhPlexForecaster(BaseForecaster):
             "fh_lookup": "relative",
             "fh_contiguous": True,
         }
-        params3 = {
-            "forecaster": f,
-            "fh_params": naive_callable,
-            "fh_lookup": "relative",
-        }
 
-        return [params1, params2, params3]
+        return [params1, params2]

--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -500,6 +500,10 @@ class FhPlexForecaster(BaseForecaster):
             "fh_lookup": "relative",
             "fh_contiguous": True,
         }
-        params3 = {"forecaster": f, "fh_params": naive_callable, "fh_lookup": "relative"}
+        params3 = {
+            "forecaster": f,
+            "fh_params": naive_callable,
+            "fh_lookup": "relative",
+        }
 
         return [params1, params2, params3]

--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -26,12 +26,11 @@ class FhPlexForecaster(BaseForecaster):
     Parameters
     ----------
     forecaster : sktime compatible forecaster
-    fh_params : dict, list, callable, or str that eval-defines a callable
+    fh_params : dict, list, or callable, optional (default=None)
         specifies forecaster to use per fh element
         dict: keys = fh elements, values = param dict for forecaster
         list: i-th entry is forecaster param dict for i-th fh element
         callable: maps fh element to forecaster param dict
-        str: eval(fh_params) must define a lambda that maps fh element to param dict
         param dict need not be complete, only overrides for ``forecaster`` params
     fh_lookup : str, one of "relative" (default), "absolute", or "as-is"
         specifies fh elements used in dict or callable
@@ -126,7 +125,11 @@ class FhPlexForecaster(BaseForecaster):
                 return fh_params[ix]
 
         elif isinstance(fh_params, str):
-            ret_param = eval(fh_params)
+            raise TypeError(
+                f"fh_params must be dict, list, or callable, not str. "
+                f"Received str: {fh_params!r}. "
+                f"Pass a callable directly, e.g., lambda x: {...} instead of a string."
+            )
         else:
             ret_param = fh_params
 

--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -486,6 +486,9 @@ class FhPlexForecaster(BaseForecaster):
         # naive_m = ["last", "mean", "drift"]
 
         naive_m = ["last", "last", "last"]
+        naive_list = [{"strategy": x} for x in naive_m * 20]
+        naive_dict = {k: naive_list[k % 3] for k in range(-50, 10)}
+
         naive_callable = lambda ix: {"strategy": ["last", "last", "last"][ix % 3]}
 
         f = NaiveForecaster()
@@ -497,9 +500,6 @@ class FhPlexForecaster(BaseForecaster):
             "fh_lookup": "relative",
             "fh_contiguous": True,
         }
-        params3 = {"forecaster": f, "fh_params": naive_callable
-            "fh_contiguous": True,
-        }
-        params3 = {"forecaster": f, "fh_params": naive_str, "fh_lookup": "relative"}
+        params3 = {"forecaster": f, "fh_params": naive_callable, "fh_lookup": "relative"}
 
         return [params1, params2, params3]


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #10034

#### What does this implement/fix? Explain your changes.
This PR removes eval-based string execution in FhPlexForecaster parameter lookup and replaces it with safe type validation.

Summary of changes:
- Updated _fhplex.py
- Removed eval usage in the _plexfun property
- Kept existing behavior for valid inputs:
  - dict
  - list
  - callable
- Added explicit TypeError for string inputs with a clear migration message to pass a callable directly instead of a string expression
- Updated parameter documentation to remove the string-eval option

This hardens the implementation against code-injection style misuse while preserving intended functionality.

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependency introduced.

#### What should a reviewer concentrate their feedback on?
- [x] Correctness of _plexfun behavior for dict/list/callable inputs
- [x] Error handling and clarity of TypeError message for string inputs
- [x] Backward compatibility for valid existing usage patterns
- [x] Docstring consistency with implemented behavior

#### Did you add any tests for the change?
No repository test file was added in this commit.

Validation performed locally:
- dict-based fh_params works as expected
- callable-based fh_params works as expected
- string-based fh_params now raises intended TypeError with migration guidance

If preferred, I can add a focused unit test in a follow-up commit.

#### Any other comments?
This is part of the ongoing eval-hardening effort across sktime to remove dynamic execution entry points in user-facing parameter paths.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the maintainers tag
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]

##### For new estimators
- [ ] I've added the estimator to the API reference
- [ ] I've added one or more illustrative usage examples to the docstring
- [ ] If the estimator relies on a soft dependency, I've set the python_dependencies tag and ensured dependency isolation