### PR TITLE
[MNT] in `test-est` CI, ensure all dependencies are resolved at once

### DIFF
--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -38,12 +38,15 @@ jobs:
         shell: pwsh
         run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
 
-      - name: Install dependencies for ${{ matrix.flag }}
-        run: |
-          uv run --with ".[dev]" python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" | tee deps.txt
-          pip install .[dev] -r deps.txt
+      - name: Install sktime with dev dependencies
+        run: uv pip install .[dev]
         env:
           UV_SYSTEM_PYTHON: 1
+
+      - name: Install dependencies for ${{ matrix.flag }}
+        run: |
+          python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" > deps.txt
+          uv pip install --no-upgrade -r deps.txt
         continue-on-error: true
 
       - name: Show dependencies

--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -40,12 +40,8 @@ jobs:
 
       - name: Install dependencies for ${{ matrix.flag }}
         run: |
-          uv pip install .
-          python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" > deps.txt
-        continue-on-error: true
-
-      - name: Install dependencies for ${{ matrix.flag }}
-        run: uv pip install .[dev] -r deps.txt
+          uv run --with ".[dev]" python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" > deps.txt
+          pip install .[dev] -r deps.txt
         env:
           UV_SYSTEM_PYTHON: 1
         continue-on-error: true

--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies for ${{ matrix.flag }}
         run: |
-          uv run --with ".[dev]" python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" > deps.txt
+          uv run --with ".[dev]" python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" | tee deps.txt
           pip install .[dev] -r deps.txt
         env:
           UV_SYSTEM_PYTHON: 1

--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -47,9 +47,9 @@ jobs:
         run: |
           python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" > deps.txt
           uv pip install --no-upgrade -r deps.txt
-        continue-on-error: true
         env:
           UV_SYSTEM_PYTHON: 1
+        continue-on-error: true
 
       - name: Show dependencies
         run: uv pip list

--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -38,15 +38,12 @@ jobs:
         shell: pwsh
         run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
 
-      - name: Install sktime with dev dependencies
-        run: uv pip install .[dev]
-        env:
-          UV_SYSTEM_PYTHON: 1
-
       - name: Install dependencies for ${{ matrix.flag }}
         run: |
           python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" > deps.txt
-          uv pip install -r deps.txt
+          uv pip install .[dev] -r deps.txt
+        env:
+          UV_SYSTEM_PYTHON: 1
         continue-on-error: true
 
       - name: Show dependencies

--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -40,8 +40,12 @@ jobs:
 
       - name: Install dependencies for ${{ matrix.flag }}
         run: |
+          uv pip install .
           python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" > deps.txt
-          uv pip install .[dev] -r deps.txt
+        continue-on-error: true
+
+      - name: Install dependencies for ${{ matrix.flag }}
+        run: uv pip install .[dev] -r deps.txt
         env:
           UV_SYSTEM_PYTHON: 1
         continue-on-error: true

--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -48,6 +48,8 @@ jobs:
           python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" > deps.txt
           uv pip install --no-upgrade -r deps.txt
         continue-on-error: true
+        env:
+          UV_SYSTEM_PYTHON: 1
 
       - name: Show dependencies
         run: uv pip list

--- a/sktime/forecasting/patch_tst.py
+++ b/sktime/forecasting/patch_tst.py
@@ -240,6 +240,20 @@ class PatchTSTForecaster(_BaseGlobalForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": [
+            "julian-fong",
+            "geetu040",
+            "Yuqi Nie",
+            "Nam H. Nguyen",
+            "Phanwadee Sinthong",
+            "Jayant Kalagnanam",
+        ],
+        "maintainers": ["julian-fong"],
+        "python_dependencies": ["transformers<4.41.0", "torch", "accelerate"],
+        # estimator type
+        # --------------
         "X_inner_mtype": [
             "pd.DataFrame",
             "pd-multiindex",
@@ -259,17 +273,9 @@ class PatchTSTForecaster(_BaseGlobalForecaster):
         "capability:insample": False,
         "capability:pred_int": False,
         "capability:pred_int:insample": False,
-        "authors": [
-            "julian-fong",
-            "geetu040",
-            "Yuqi Nie",
-            "Nam H. Nguyen",
-            "Phanwadee Sinthong",
-            "Jayant Kalagnanam",
-        ],
-        "maintainers": ["julian-fong"],
-        "python_dependencies": ["transformers<4.41.0", "torch", "accelerate"],
         "capability:global_forecasting": True,
+        # Tests and CI tags
+        # -----------------
         "tests:vm": True,
     }
 


### PR DESCRIPTION
Fixes an unreported bug in the CI.
Previously, the `test-est` CI step installed dependencies twice, once `sktime` and its deps, and then the estimator specific deps.

This could lead to silent failure of tests if the estimator specific deps were incompatible with the previously installed `sktime` deps.

This PR fixes the above problem by using the same env, and including `no-upgrade` in the second installation step, 

Includes minor changes for `PatchTSTForecaster` to trigger the `test-est` CI.