### PR TITLE
[BUG] fix copy-paste error in ESRNNForecaster pred dataloader using train dataset

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2810,7 +2810,7 @@
       "name": "Param Sureliya",
       "avatar_url": "https://avatars.githubusercontent.com/u/paramsureliya",
       "profile": "https://github.com/paramsureliya",
-      "contributions": ["code"]
+      "contributions": ["code", "bug"]
     },
     {
       "login": "priyanshuharshbodhi1",

--- a/sktime/forecasting/base/adapters/_pytorch.py
+++ b/sktime/forecasting/base/adapters/_pytorch.py
@@ -422,8 +422,8 @@ class BaseDeepNetworkPyTorch(BaseForecaster):
             if hasattr(self.custom_dataset_pred, "build_dataset") and callable(
                 self.custom_dataset_pred.build_dataset
             ):
-                self.custom_dataset_train.build_dataset(y)
-                dataset = self.custom_dataset_train
+                self.custom_dataset_pred.build_dataset(y)
+                dataset = self.custom_dataset_pred
             else:
                 raise NotImplementedError(
                     "Custom Dataset `build_dataset` method is not available. Please"

--- a/sktime/forecasting/es_rnn.py
+++ b/sktime/forecasting/es_rnn.py
@@ -251,8 +251,8 @@ class ESRNNForecaster(BaseDeepNetworkPyTorch):
             if hasattr(self.custom_dataset_pred, "build_dataset") and callable(
                 self.custom_dataset_pred.build_dataset
             ):
-                self.custom_dataset_train.build_dataset(y)
-                dataset = self.custom_dataset_train
+                self.custom_dataset_pred.build_dataset(y)
+                dataset = self.custom_dataset_pred
             else:
                 raise NotImplementedError(
                     "Custom Dataset `build_dataset` method is not available. Please"

--- a/sktime/forecasting/ltsf.py
+++ b/sktime/forecasting/ltsf.py
@@ -1137,8 +1137,8 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
             if hasattr(self.custom_dataset_pred, "build_dataset") and callable(
                 self.custom_dataset_pred.build_dataset
             ):
-                self.custom_dataset_train.build_dataset(y)
-                dataset = self.custom_dataset_train
+                self.custom_dataset_pred.build_dataset(y)
+                dataset = self.custom_dataset_pred
             else:
                 raise NotImplementedError(
                     "Custom Dataset `build_dataset` method is not available. Please"

--- a/sktime/forecasting/tests/test_es_rnn.py
+++ b/sktime/forecasting/tests/test_es_rnn.py
@@ -1,4 +1,4 @@
-﻿"""Tests for ESRNNForecaster."""
+"""Tests for ESRNNForecaster."""
 
 import pytest
 

--- a/sktime/forecasting/tests/test_es_rnn.py
+++ b/sktime/forecasting/tests/test_es_rnn.py
@@ -1,0 +1,52 @@
+﻿"""Tests for ESRNNForecaster."""
+
+import pytest
+
+from sktime.utils.dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("torch", severity="none"),
+    reason="skip if torch not installed",
+)
+def test_esrnn_pred_dataloader_uses_pred_dataset_not_train():
+    """Regression test: build_pytorch_pred_dataloader must use custom_dataset_pred.
+
+    Previously, build_pytorch_pred_dataloader incorrectly called
+    custom_dataset_train.build_dataset() and set dataset = custom_dataset_train
+    when a user passed custom_dataset_pred. This meant the custom prediction
+    dataset was silently ignored and the training dataset was used instead,
+    producing wrong predictions with no error raised.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import numpy as np
+    import pandas as pd
+
+    from sktime.forecasting.es_rnn import ESRNNForecaster
+
+    y = pd.Series(
+        np.arange(20, dtype=float),
+        index=pd.date_range("2000-01", periods=20, freq="M"),
+    )
+
+    mock_train = MagicMock()
+    mock_pred = MagicMock()
+
+    forecaster = ESRNNForecaster(
+        custom_dataset_train=mock_train,
+        custom_dataset_pred=mock_pred,
+    )
+
+    with patch("torch.utils.data.DataLoader") as mock_dataloader:
+        forecaster.build_pytorch_pred_dataloader(y, fh=[1, 2, 3])
+
+    mock_pred.build_dataset.assert_called_once_with(y)
+    mock_train.build_dataset.assert_not_called()
+
+    mock_dataloader.assert_called_once()
+    first_arg = mock_dataloader.call_args[0][0]
+    assert first_arg is mock_pred, (
+        "DataLoader was given custom_dataset_train instead of "
+        "custom_dataset_pred - copy-paste bug in pred dataloader"
+    )


### PR DESCRIPTION
Fixes #10048

#### What does this implement/fix?

The same copy-paste bug existed in three files. In all three,
`build_pytorch_pred_dataloader` correctly checks `custom_dataset_pred`
but then calls `custom_dataset_train.build_dataset(y)` and sets
`dataset = custom_dataset_train`. The custom prediction dataset is
silently ignored and the training dataset is used for prediction instead
— wrong results, no error, no warning raised.

Files fixed:
- `sktime/forecasting/es_rnn.py` lines 254-255
- `sktime/forecasting/ltsf.py` lines 1140-1141
- `sktime/forecasting/base/adapters/_pytorch.py` lines 425-426

The base class fix (`_pytorch.py`) is the most impactful as it affects
all forecasters inheriting from `BaseDeepNetworkPyTorch` that use the
default `build_pytorch_pred_dataloader`.

#### Does your contribution introduce a new dependency?

No.

#### What should a reviewer concentrate their feedback on?

- Two-line fix in each of the three files
- Regression test in `sktime/forecasting/tests/test_es_rnn.py`

#### Did you add any tests?

Yes. Added `sktime/forecasting/tests/test_es_rnn.py` with a regression
test using MagicMock to verify `custom_dataset_pred.build_dataset` is
called during prediction and `custom_dataset_train` is never touched.

#### PR checklist
- [x] I've added myself to the list of contributors with `code` and `bug` badges
- [x] The PR title starts with [BUG]