### PR TITLE
[MNT] Shorter CI name for `test-est` workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,6 +230,7 @@ jobs:
 
   test-est:
     name: test-est
+    run-name: test-est
     needs: [detect-changed-classes, prepare-chunks, test-nosoftdeps]
     if: ${{ needs.detect-changed-classes.outputs.obj_list != '[]' }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,7 +230,6 @@ jobs:
 
   test-est:
     name: test-est
-    run-name: test-est
     needs: [detect-changed-classes, prepare-chunks, test-nosoftdeps]
     if: ${{ needs.detect-changed-classes.outputs.obj_list != '[]' }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,6 +229,7 @@ jobs:
           EOF
 
   test-est:
+    name: test-est
     needs: [detect-changed-classes, prepare-chunks, test-nosoftdeps]
     if: ${{ needs.detect-changed-classes.outputs.obj_list != '[]' }}
 

--- a/sktime/forecasting/lagllama.py
+++ b/sktime/forecasting/lagllama.py
@@ -183,7 +183,7 @@ class LagLlamaForecaster(BaseForecaster):
     --------
     **Zero-shot forecasting (default)**
 
-    >>> from sktime.forecasting.lagllama import LagLlamaForecaster  # doctest: +SKIP
+    >>> from sktime.forecasting.lagllama import LagLlamaForecaster
     >>> from sktime.forecasting.base import ForecastingHorizon  # doctest: +SKIP
     >>> from sktime.datasets import load_airline  # doctest: +SKIP
     >>>


### PR DESCRIPTION
Shortens the CI name for the `test-est` workflow to make it more readable.

Contains a minor change to a docstring for triggering the tests.