### PR TITLE
[BUG] fix falsy random_state check in ConvTimeNetForecaster dataloader

### DIFF
--- a/sktime/forecasting/convtimenet.py
+++ b/sktime/forecasting/convtimenet.py
@@ -352,7 +352,7 @@ class ConvTimeNetForecaster(_pytorch.BaseDeepNetworkPyTorch):
             and dataset_len % self.batch_size == 1
         )
         gen = torch.Generator()
-        if self.random_state:
+        if self.random_state is not None:
             gen.manual_seed(self.random_state)
         if drop_last:
             warnings.warn(
@@ -406,7 +406,7 @@ class ConvTimeNetForecaster(_pytorch.BaseDeepNetworkPyTorch):
         )
 
         gen = torch.Generator()
-        if self.random_state:
+        if self.random_state is not None:
             gen.manual_seed(self.random_state)
 
         return DataLoader(

--- a/sktime/forecasting/tests/test_convtimenet.py
+++ b/sktime/forecasting/tests/test_convtimenet.py
@@ -19,7 +19,7 @@ def test_convtimenet_random_state_zero_sets_seed():
 
     Fix: changed to `if self.random_state is not None:` so seed 0 is applied.
     """
-    from unittest.mock import MagicMock, call, patch
+    from unittest.mock import MagicMock, patch
 
     import numpy as np
     import pandas as pd

--- a/sktime/forecasting/tests/test_convtimenet.py
+++ b/sktime/forecasting/tests/test_convtimenet.py
@@ -28,13 +28,14 @@ def test_convtimenet_random_state_zero_sets_seed():
 
     y = pd.Series(
         np.arange(50, dtype=float),
-        index=pd.date_range("2000-01", periods=50, freq="M"),
+        index=pd.date_range("2000-01", periods=50, freq="ME"),
     )
 
-    forecaster = ConvTimeNetForecaster(
-        context_window=10,
-        random_state=0,
-    )
+    params = ConvTimeNetForecaster.get_test_params()
+    if isinstance(params, list):
+        params = params[0]
+    params["random_state"] = 0
+    forecaster = ConvTimeNetForecaster(**params)
 
     with patch("torch.Generator") as mock_generator_class:
         mock_gen = MagicMock()

--- a/sktime/forecasting/tests/test_convtimenet.py
+++ b/sktime/forecasting/tests/test_convtimenet.py
@@ -1,0 +1,47 @@
+"""Tests for ConvTimeNetForecaster."""
+
+import pytest
+
+from sktime.utils.dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("torch", severity="none"),
+    reason="skip if torch not installed",
+)
+def test_convtimenet_random_state_zero_sets_seed():
+    """Regression test: random_state=0 must set the generator seed.
+
+    Previously, build_pytorch_train_dataloader and the pred dataloader used
+    `if self.random_state:` which evaluates random_state=0 as falsy.
+    This meant seed 0 was silently ignored and results were not reproducible
+    even though the user explicitly passed random_state=0.
+
+    Fix: changed to `if self.random_state is not None:` so seed 0 is applied.
+    """
+    from unittest.mock import MagicMock, call, patch
+
+    import numpy as np
+    import pandas as pd
+
+    from sktime.forecasting.convtimenet import ConvTimeNetForecaster
+
+    y = pd.Series(
+        np.arange(50, dtype=float),
+        index=pd.date_range("2000-01", periods=50, freq="M"),
+    )
+
+    forecaster = ConvTimeNetForecaster(
+        context_window=10,
+        random_state=0,
+    )
+
+    with patch("torch.Generator") as mock_generator_class:
+        mock_gen = MagicMock()
+        mock_generator_class.return_value = mock_gen
+
+        with patch("torch.utils.data.DataLoader"):
+            forecaster.build_pytorch_train_dataloader(y)
+
+    # manual_seed must have been called with 0
+    mock_gen.manual_seed.assert_called_once_with(0)

--- a/sktime/forecasting/tests/test_convtimenet.py
+++ b/sktime/forecasting/tests/test_convtimenet.py
@@ -37,12 +37,19 @@ def test_convtimenet_random_state_zero_sets_seed():
     params["random_state"] = 0
     forecaster = ConvTimeNetForecaster(**params)
 
+    # self.network is only set after fit(), so mock it directly
+    forecaster.network = MagicMock()
+    forecaster.network.seq_len = params.get("context_window", 10)
+    forecaster.network.pred_len = params.get("pred_len", 3)
+
     with patch("torch.Generator") as mock_generator_class:
         mock_gen = MagicMock()
         mock_generator_class.return_value = mock_gen
 
         with patch("torch.utils.data.DataLoader"):
-            forecaster.build_pytorch_train_dataloader(y)
-
+            with patch(
+                "sktime.forecasting.base.adapters._pytorch.PyTorchTrainDataset"
+            ):
+                forecaster.build_pytorch_train_dataloader(y)
     # manual_seed must have been called with 0
     mock_gen.manual_seed.assert_called_once_with(0)

--- a/sktime/forecasting/tests/test_convtimenet.py
+++ b/sktime/forecasting/tests/test_convtimenet.py
@@ -47,9 +47,7 @@ def test_convtimenet_random_state_zero_sets_seed():
         mock_generator_class.return_value = mock_gen
 
         with patch("torch.utils.data.DataLoader"):
-            with patch(
-                "sktime.forecasting.base.adapters._pytorch.PyTorchTrainDataset"
-            ):
+            with patch("sktime.forecasting.base.adapters._pytorch.PyTorchTrainDataset"):
                 forecaster.build_pytorch_train_dataloader(y)
     # manual_seed must have been called with 0
     mock_gen.manual_seed.assert_called_once_with(0)


### PR DESCRIPTION
Fixes #10052

#### What does this implement/fix?

`ConvTimeNetForecaster.build_pytorch_train_dataloader` and its pred
dataloader both used `if self.random_state:` to decide whether to seed
the PyTorch Generator. This is a falsy check  `random_state=0`
evaluates to False, so seed 0 is silently ignored and results are not
reproducible even though the user explicitly passed `random_state=0`.

Fixed by changing both checks on lines 355 and 409 to
`if self.random_state is not None:`.

Note: the network class and classification base already use the correct
`is not None` pattern  this fix makes the forecaster consistent with
the rest of the codebase.

#### Does your contribution introduce a new dependency?

No.

#### What should a reviewer concentrate their feedback on?

- Lines 355 and 409 in `sktime/forecasting/convtimenet.py`
- Regression test in `sktime/forecasting/tests/test_convtimenet.py`

#### Did you add any tests?

Yes. Added `sktime/forecasting/tests/test_convtimenet.py` with a
regression test that patches `torch.Generator` and verifies
`manual_seed` is called with 0 when `random_state=0` is passed.

#### PR checklist
- [x] The PR title starts with [BUG]