### PR TITLE
[DOC] shorten `KalmanFilterTransformerSIMD` to remove `pykalman` dependency

### DIFF
--- a/sktime/transformations/series/kalman_filter/_simdkalman.py
+++ b/sktime/transformations/series/kalman_filter/_simdkalman.py
@@ -116,17 +116,6 @@ class KalmanFilterTransformerSIMD(BaseKalmanFilter, BaseTransformer):
     >>> kf_SIMD = KalmanFilterTransformerSIMD(**kf_params)
     >>> X_SIMD = kf_SIMD.fit_transform(X)
     >>> T_SIMD = time.time() - t0
-    >>>
-    >>> t0 = time.time()
-    >>> kf_PK = KalmanFilterTransformerPK(**kf_params)
-    >>> X_PK = kf_PK.fit_transform(X)
-    >>> T_PK = time.time() - t0
-    >>>
-    >>> print("SIMD Kalman: %.03f s" % T_SIMD)  # doctest: +SKIP
-    SIMD Kalman: 0.260 s
-    >>> print("PyKalman:    %.03f s" % T_PK)  # doctest: +SKIP
-    PyKalman:    13.934 s
-    >>>
     """
 
     _tags = {


### PR DESCRIPTION
The `KalmanFilterTransformerSIMD` docstring was invoking a transformer that depended on `pykalman`, while itself not depending on `pykalman`.

Previously, that was fine, since `pykalman` had been vendored into `sktime` to bridge a maintenance lapse. Now, with `pykalman` restored, the docstring causes soft dependency errors since it does not expect `pykalman` to be installed - this is solved by removing the (somewhat extraneous) reference to `pykalman`.