### PR TITLE
[ENH] add random_state to BaseDeepNetworkPyTorch for reproducible training

### DIFF
--- a/sktime/forecasting/base/adapters/_pytorch.py
+++ b/sktime/forecasting/base/adapters/_pytorch.py
@@ -255,7 +255,9 @@ class BaseDeepNetworkPyTorch(BaseForecaster):
         gen = torch.Generator()
         if self.random_state is not None:
             gen.manual_seed(self.random_state)
-        return DataLoader(combined_dataset, self.batch_size, shuffle=True, generator=gen)
+        return DataLoader(
+            combined_dataset, self.batch_size, shuffle=True, generator=gen
+        )
 
     def _get_pretrain_pred_len(self, fh):
         """Get prediction length for pretraining.

--- a/sktime/forecasting/base/adapters/_pytorch.py
+++ b/sktime/forecasting/base/adapters/_pytorch.py
@@ -48,6 +48,7 @@ class BaseDeepNetworkPyTorch(BaseForecaster):
         "capability:pred_int:insample": False,
         "capability:multivariate": True,
         "capability:exogenous": False,
+        "capability:random_state": True,
     }
 
     def __init__(
@@ -60,6 +61,7 @@ class BaseDeepNetworkPyTorch(BaseForecaster):
         optimizer=None,
         optimizer_kwargs=None,
         lr=0.001,
+        random_state=None,
     ):
         self.num_epochs = num_epochs
         self.batch_size = batch_size
@@ -69,6 +71,7 @@ class BaseDeepNetworkPyTorch(BaseForecaster):
         self.optimizer = optimizer
         self.optimizer_kwargs = optimizer_kwargs
         self.lr = lr
+        self.random_state = random_state
 
         super().__init__()
 
@@ -249,7 +252,10 @@ class BaseDeepNetworkPyTorch(BaseForecaster):
         ]
 
         combined_dataset = ConcatDataset(datasets)
-        return DataLoader(combined_dataset, self.batch_size, shuffle=True)
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
+        return DataLoader(combined_dataset, self.batch_size, shuffle=True, generator=gen)
 
     def _get_pretrain_pred_len(self, fh):
         """Get prediction length for pretraining.
@@ -412,7 +418,10 @@ class BaseDeepNetworkPyTorch(BaseForecaster):
                 fh=self.network.pred_len,
             )
 
-        return DataLoader(dataset, self.batch_size, shuffle=True)
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
+        return DataLoader(dataset, self.batch_size, shuffle=True, generator=gen)
 
     def build_pytorch_pred_dataloader(self, y, fh):
         """Build PyTorch DataLoader for prediction."""

--- a/sktime/forecasting/conditional_invertible_neural_network.py
+++ b/sktime/forecasting/conditional_invertible_neural_network.py
@@ -92,6 +92,9 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
         Minimum change in the validation loss to consider as an improvement.
     val_split : float, optional (default=0.2)
         Fraction of the data to use for validation.
+    random_state : int or None, default=None
+        Sets the random seed for the DataLoader shuffle, ensuring reproducible
+        training. If None, results may differ between runs.
 
     References
     ----------
@@ -155,6 +158,7 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
         patience=5,
         delta=0.0001,
         val_split=0.2,
+        random_state=None
     ):
         self.n_coupling_layers = n_coupling_layers
         self.hidden_dim_size = hidden_dim_size
@@ -180,7 +184,8 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
         self.patience = patience
         self.delta = delta
         self.val_split = val_split
-        super().__init__(num_epochs, batch_size, lr=lr)
+        self.random_state = random_state
+        super().__init__(num_epochs, batch_size, lr=lr, random_state=random_state)
 
     def _fit(self, y, fh, X=None):
         """Fit forecaster to training data.
@@ -264,7 +269,12 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
         dataset = self._prepare_data(
             y[:split_index], X[:split_index] if X is not None else None
         )
-        data_loader = DataLoader(dataset, batch_size=self.batch_size, shuffle=True)
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
+        data_loader = DataLoader(
+            dataset, batch_size=self.batch_size, shuffle=True, generator=gen
+        )
 
         val_data_loader_nll = None
         if self.val_split > 0:
@@ -421,8 +431,11 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
 
         self.n_cond_features = n_cond_features
         combined_dataset = ConcatDataset(datasets)
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
         data_loader = DataLoader(
-            combined_dataset, batch_size=self.batch_size, shuffle=True
+            combined_dataset, batch_size=self.batch_size, shuffle=True, generator=gen
         )
 
         self.network = self._build_network(None)
@@ -477,8 +490,11 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
             )
 
         combined_dataset = ConcatDataset(datasets)
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
         data_loader = DataLoader(
-            combined_dataset, batch_size=self.batch_size, shuffle=True
+            combined_dataset, batch_size=self.batch_size, shuffle=True, generator=gen
         )
 
         self.optimizer = self._instantiate_optimizer()
@@ -636,6 +652,7 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
                 "init_param_f_statistic": [1, 1],
                 "deterministic": True,
                 "val_split": 0.5,
+                "random_state": 42,
             },
             {
                 "f_statistic": _test_function,

--- a/sktime/forecasting/conditional_invertible_neural_network.py
+++ b/sktime/forecasting/conditional_invertible_neural_network.py
@@ -158,7 +158,7 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
         patience=5,
         delta=0.0001,
         val_split=0.2,
-        random_state=None
+        random_state=None,
     ):
         self.n_coupling_layers = n_coupling_layers
         self.hidden_dim_size = hidden_dim_size

--- a/sktime/forecasting/es_rnn.py
+++ b/sktime/forecasting/es_rnn.py
@@ -291,7 +291,9 @@ class ESRNNForecaster(BaseDeepNetworkPyTorch):
         gen = torch.Generator()
         if self.random_state is not None:
             gen.manual_seed(self.random_state)
-        return DataLoader(combined_dataset, self.batch_size, shuffle=True, generator=gen)
+        return DataLoader(
+            combined_dataset, self.batch_size, shuffle=True, generator=gen
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/es_rnn.py
+++ b/sktime/forecasting/es_rnn.py
@@ -111,6 +111,9 @@ class ESRNNForecaster(BaseDeepNetworkPyTorch):
         Defines the network output dimension, default=3
     lr : int
         Learning rate for training
+    random_state : int or None, default=None
+        Sets the random seed for the DataLoader shuffle, ensuring reproducible
+        training. If None, results may differ between runs.
 
     References
     ----------
@@ -162,6 +165,7 @@ class ESRNNForecaster(BaseDeepNetworkPyTorch):
         criterion_kwargs=None,
         custom_dataset_train=None,
         custom_dataset_pred=None,
+        random_state=None,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -181,6 +185,7 @@ class ESRNNForecaster(BaseDeepNetworkPyTorch):
         self.custom_dataset_train = custom_dataset_train
         self.custom_dataset_pred = custom_dataset_pred
         self.lr = lr
+        self.random_state = random_state
         if _check_soft_dependencies("torch", severity="none"):
             import torch
 
@@ -241,7 +246,10 @@ class ESRNNForecaster(BaseDeepNetworkPyTorch):
                 stride=self.stride,
             )
 
-        return DataLoader(dataset, self.batch_size, shuffle=True)
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
+        return DataLoader(dataset, self.batch_size, shuffle=True, generator=gen)
 
     def build_pytorch_pred_dataloader(self, y, fh):
         """Build PyTorch DataLoader for prediction."""
@@ -280,7 +288,10 @@ class ESRNNForecaster(BaseDeepNetworkPyTorch):
             for series in all_series
         ]
         combined_dataset = ConcatDataset(datasets)
-        return DataLoader(combined_dataset, self.batch_size, shuffle=True)
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
+        return DataLoader(combined_dataset, self.batch_size, shuffle=True, generator=gen)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -310,6 +321,7 @@ class ESRNNForecaster(BaseDeepNetworkPyTorch):
             "window": 3,
             "pred_len": 3,
             "num_epochs": 1,
+            "random_state": 42,
         }
         params2 = {
             "hidden_size": 10,

--- a/sktime/forecasting/ltsf.py
+++ b/sktime/forecasting/ltsf.py
@@ -124,7 +124,7 @@ class LTSFLinearForecaster(BaseDeepNetworkPyTorch):
             optimizer=optimizer,
             optimizer_kwargs=optimizer_kwargs,
             lr=lr,
-            random_state=random_state
+            random_state=random_state,
         )
 
     def __post_init__(self):
@@ -323,7 +323,9 @@ class LTSFLinearForecaster(BaseDeepNetworkPyTorch):
         gen = torch.Generator()
         if self.random_state is not None:
             gen.manual_seed(self.random_state)
-        return DataLoader(combined_dataset, self.batch_size, shuffle=True, generator=gen)
+        return DataLoader(
+            combined_dataset, self.batch_size, shuffle=True, generator=gen
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -887,7 +889,9 @@ class LTSFNLinearForecaster(BaseDeepNetworkPyTorch):
         gen = torch.Generator()
         if self.random_state is not None:
             gen.manual_seed(self.random_state)
-        return DataLoader(combined_dataset, self.batch_size, shuffle=True, generator=gen)
+        return DataLoader(
+            combined_dataset, self.batch_size, shuffle=True, generator=gen
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -1005,7 +1009,7 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
         Activation function to use. Defaults to relu and otherwise gelu.
     freq : str, optional (default="h")
         Frequency of the input data, relevant only if temporal_encoding is True.
-        
+
     random_state : int or None, default=None
         Sets the random seed for the DataLoader shuffle, ensuring reproducible
         training. If None, results may differ between runs.
@@ -1309,7 +1313,9 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
         gen = torch.Generator()
         if self.random_state is not None:
             gen.manual_seed(self.random_state)
-        return DataLoader(combined_dataset, self.batch_size, shuffle=True, generator=gen)
+        return DataLoader(
+            combined_dataset, self.batch_size, shuffle=True, generator=gen
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/ltsf.py
+++ b/sktime/forecasting/ltsf.py
@@ -43,6 +43,9 @@ class LTSFLinearForecaster(BaseDeepNetworkPyTorch):
         keyword arguments to pass to optimizer
     lr : float, default=0.003
         learning rate to train model with
+    random_state : int or None, default=None
+        Sets the random seed for the DataLoader shuffle, ensuring reproducible
+        training. If None, results may differ between runs.
 
     References
     ----------
@@ -95,6 +98,7 @@ class LTSFLinearForecaster(BaseDeepNetworkPyTorch):
         lr=0.001,
         custom_dataset_train=None,
         custom_dataset_pred=None,
+        random_state=None,
     ):
         self.seq_len = seq_len
         self.pred_len = pred_len
@@ -109,6 +113,7 @@ class LTSFLinearForecaster(BaseDeepNetworkPyTorch):
         self.custom_dataset_train = custom_dataset_train
         self.custom_dataset_pred = custom_dataset_pred
         self.batch_size = batch_size
+        self.random_state = random_state
 
         super().__init__(
             num_epochs=num_epochs,
@@ -119,6 +124,7 @@ class LTSFLinearForecaster(BaseDeepNetworkPyTorch):
             optimizer=optimizer,
             optimizer_kwargs=optimizer_kwargs,
             lr=lr,
+            random_state=random_state
         )
 
     def __post_init__(self):
@@ -312,7 +318,12 @@ class LTSFLinearForecaster(BaseDeepNetworkPyTorch):
         ]
 
         combined_dataset = ConcatDataset(datasets)
-        return DataLoader(combined_dataset, self.batch_size, shuffle=True)
+        import torch
+
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
+        return DataLoader(combined_dataset, self.batch_size, shuffle=True, generator=gen)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -341,6 +352,7 @@ class LTSFLinearForecaster(BaseDeepNetworkPyTorch):
                 # For individual to make a difference
                 # num_channels needs to be > 1
                 "individual": True,
+                "random_state": 42,
             },
             {
                 "seq_len": 3,
@@ -394,6 +406,9 @@ class LTSFDLinearForecaster(BaseDeepNetworkPyTorch):
         keyword arguments to pass to optimizer
     lr : float, default=0.003
         learning rate to train model with
+    random_state : int or None, default=None
+        Sets the random seed for the DataLoader shuffle, ensuring reproducible
+        training. If None, results may differ between runs.
 
     References
     ----------
@@ -446,6 +461,7 @@ class LTSFDLinearForecaster(BaseDeepNetworkPyTorch):
         lr=0.001,
         custom_dataset_train=None,
         custom_dataset_pred=None,
+        random_state=None,
     ):
         self.seq_len = seq_len
         self.pred_len = pred_len
@@ -460,6 +476,7 @@ class LTSFDLinearForecaster(BaseDeepNetworkPyTorch):
         self.custom_dataset_train = custom_dataset_train
         self.custom_dataset_pred = custom_dataset_pred
         self.batch_size = batch_size
+        self.random_state = random_state
 
         super().__init__(
             num_epochs=num_epochs,
@@ -470,6 +487,7 @@ class LTSFDLinearForecaster(BaseDeepNetworkPyTorch):
             optimizer=optimizer,
             optimizer_kwargs=optimizer_kwargs,
             lr=lr,
+            random_state=random_state,
         )
 
     def __post_init__(self):
@@ -535,6 +553,7 @@ class LTSFDLinearForecaster(BaseDeepNetworkPyTorch):
                 # For individual to make a difference
                 # num_channels needs to be > 1
                 "individual": True,
+                "random_state": 42,
             },
             {
                 "seq_len": 2,
@@ -588,6 +607,9 @@ class LTSFNLinearForecaster(BaseDeepNetworkPyTorch):
         keyword arguments to pass to optimizer
     lr : float, default=0.003
         learning rate to train model with
+    random_state : int or None, default=None
+        Sets the random seed for the DataLoader shuffle, ensuring reproducible
+        training. If None, results may differ between runs.
 
     References
     ----------
@@ -640,6 +662,7 @@ class LTSFNLinearForecaster(BaseDeepNetworkPyTorch):
         lr=0.001,
         custom_dataset_train=None,
         custom_dataset_pred=None,
+        random_state=None,
     ):
         self.seq_len = seq_len
         self.pred_len = pred_len
@@ -654,6 +677,7 @@ class LTSFNLinearForecaster(BaseDeepNetworkPyTorch):
         self.custom_dataset_train = custom_dataset_train
         self.custom_dataset_pred = custom_dataset_pred
         self.batch_size = batch_size
+        self.random_state = random_state
 
         super().__init__(
             num_epochs=num_epochs,
@@ -664,6 +688,7 @@ class LTSFNLinearForecaster(BaseDeepNetworkPyTorch):
             optimizer=optimizer,
             optimizer_kwargs=optimizer_kwargs,
             lr=lr,
+            random_state=random_state,
         )
 
     def __post_init__(self):
@@ -857,7 +882,12 @@ class LTSFNLinearForecaster(BaseDeepNetworkPyTorch):
         ]
 
         combined_dataset = ConcatDataset(datasets)
-        return DataLoader(combined_dataset, self.batch_size, shuffle=True)
+        import torch
+
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
+        return DataLoader(combined_dataset, self.batch_size, shuffle=True, generator=gen)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -886,6 +916,7 @@ class LTSFNLinearForecaster(BaseDeepNetworkPyTorch):
                 # For individual to make a difference
                 # num_channels needs to be > 1
                 "individual": True,
+                "random_state": 42,
             },
             {
                 "seq_len": 3,
@@ -974,6 +1005,10 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
         Activation function to use. Defaults to relu and otherwise gelu.
     freq : str, optional (default="h")
         Frequency of the input data, relevant only if temporal_encoding is True.
+        
+    random_state : int or None, default=None
+        Sets the random seed for the DataLoader shuffle, ensuring reproducible
+        training. If None, results may differ between runs.
 
     Examples
     --------
@@ -1028,6 +1063,7 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
         dropout=0.1,
         activation="relu",
         freq="h",
+        random_state=None,
     ):
         self.seq_len = seq_len
         self.context_len = context_len
@@ -1059,6 +1095,7 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
         self.dropout = dropout
         self.activation = activation
         self.freq = freq
+        self.random_state = random_state
 
         super().__init__(
             num_epochs=num_epochs,
@@ -1069,6 +1106,7 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
             optimizer=optimizer,
             optimizer_kwargs=optimizer_kwargs,
             lr=lr,
+            random_state=random_state,
         )
 
     def __post_init__(self):
@@ -1100,6 +1138,7 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
 
     def build_pytorch_train_dataloader(self, y):
         """Build PyTorch DataLoader for training."""
+        import torch
         from torch.utils.data import DataLoader
 
         if self.custom_dataset_train:
@@ -1127,7 +1166,10 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
                 temporal_encoding_type=self.temporal_encoding_type,
             )
 
-        return DataLoader(dataset, self.batch_size, shuffle=True)
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
+        return DataLoader(dataset, self.batch_size, shuffle=True, generator=gen)
 
     def build_pytorch_pred_dataloader(self, y, fh):
         """Build PyTorch DataLoader for prediction."""
@@ -1262,7 +1304,12 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
         ]
 
         combined_dataset = ConcatDataset(datasets)
-        return DataLoader(combined_dataset, self.batch_size, shuffle=True)
+        import torch
+
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
+        return DataLoader(combined_dataset, self.batch_size, shuffle=True, generator=gen)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -1273,7 +1320,6 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
         parameter_set : str, default="default"
             Name of the set of test parameters to return, for use in tests. If no
             special parameters are defined for a value, will return ``"default"`` set.
-
 
         Returns
         -------
@@ -1299,6 +1345,7 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
                 "num_epochs": 1,
                 "batch_size": 1,
                 "lr": 0.008,
+                "random_state": 42,
             },
             {
                 "seq_len": 4,

--- a/sktime/forecasting/rbf_forecaster.py
+++ b/sktime/forecasting/rbf_forecaster.py
@@ -90,6 +90,9 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         ``"gelu"``.
     dropout_rate : float, optional (default=0.1)
         Dropout rate applied after each hidden layer. A value of 0 disables dropout.
+    random_state : int or None, default=None
+        Sets the random seed for the DataLoader shuffle, ensuring reproducible
+        training. If None, results may differ between runs.
     """
 
     _tags = {
@@ -128,6 +131,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         pred_len=None,
         activation="relu",
         dropout_rate=0.1,
+        random_state=None,
     ):
         self.window_length = window_length
         self.hidden_size = hidden_size
@@ -146,11 +150,13 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         self.mode = mode
         self.pred_len = pred_len
         self.device = device
+        self.random_state = random_state
 
         super().__init__(
             batch_size=batch_size,
             optimizer=optimizer,
             lr=lr,
+            random_state=random_state,
         )
 
     def __post_init__(self):
@@ -273,7 +279,12 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         y_tensor = torch.FloatTensor(y_train).to(self._device)
 
         dataset = TensorDataset(X_tensor, y_tensor)
-        dataloader = DataLoader(dataset, batch_size=self.batch_size, shuffle=True)
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
+        dataloader = DataLoader(
+            dataset, batch_size=self.batch_size, shuffle=True, generator=gen
+        )
 
         self._criterion = self._instantiate_criterion()
         self._optimizer = self._instantiate_optimizer()
@@ -443,7 +454,10 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
             datasets.append(TensorDataset(X_tensor, y_tensor))
 
         combined_dataset = ConcatDataset(datasets)
-        return DataLoader(combined_dataset, self.batch_size, shuffle=True)
+        gen = torch.Generator()
+        if self.random_state is not None:
+            gen.manual_seed(self.random_state)
+        return DataLoader(combined_dataset, self.batch_size, shuffle=True, generator=gen)
 
     def _get_pretrain_pred_len(self, fh):
         """Get prediction length for pretraining.
@@ -581,6 +595,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
                 "mode": "ar",
                 "activation": "relu",
                 "dropout_rate": 0.1,
+                "random_state": 42,
             },
             {
                 "window_length": 5,

--- a/sktime/forecasting/rbf_forecaster.py
+++ b/sktime/forecasting/rbf_forecaster.py
@@ -457,7 +457,9 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         gen = torch.Generator()
         if self.random_state is not None:
             gen.manual_seed(self.random_state)
-        return DataLoader(combined_dataset, self.batch_size, shuffle=True, generator=gen)
+        return DataLoader(
+            combined_dataset, self.batch_size, shuffle=True, generator=gen
+        )
 
     def _get_pretrain_pred_len(self, fh):
         """Get prediction length for pretraining.

--- a/sktime/forecasting/scinet.py
+++ b/sktime/forecasting/scinet.py
@@ -88,6 +88,10 @@ class SCINetForecaster(BaseDeepNetworkPyTorch):
     RIN : bool, default=False
         Flag to enable or disable the use of RevIN (Reversible Instance Normalization).
 
+    random_state : int or None, default=None
+        Sets the random seed for the DataLoader shuffle, ensuring reproducible
+        training. If None, results may differ between runs.
+
     Raises
     ------
     AssertionError
@@ -160,6 +164,7 @@ class SCINetForecaster(BaseDeepNetworkPyTorch):
         positionalE=False,
         modified=True,
         RIN=False,
+        random_state=None,
     ):
         self.seq_len = seq_len
         self.pred_len = pred_len
@@ -184,6 +189,7 @@ class SCINetForecaster(BaseDeepNetworkPyTorch):
         self.positionalE = positionalE
         self.modified = modified
         self.RIN = RIN
+        self.random_state = random_state
 
         super().__init__(
             num_epochs=num_epochs,
@@ -192,6 +198,7 @@ class SCINetForecaster(BaseDeepNetworkPyTorch):
             optimizer=optimizer,
             optimizer_kwargs=optimizer_kwargs,
             lr=lr,
+            random_state=random_state,
         )
 
         from sktime.utils.dependencies import _check_soft_dependencies
@@ -259,6 +266,7 @@ class SCINetForecaster(BaseDeepNetworkPyTorch):
                 "optimizer": "Adam",
                 "batch_size": 1,
                 "num_epochs": 1,
+                "random_state": 42,
             },
             {
                 "seq_len": 16,

--- a/sktime/forecasting/tests/test_base_deep_network_pytorch_random_state.py
+++ b/sktime/forecasting/tests/test_base_deep_network_pytorch_random_state.py
@@ -1,0 +1,304 @@
+"""Tests for random_state support in BaseDeepNetworkPyTorch and subclasses.
+
+Regression tests verifying that:
+- All 8 affected forecasters accept random_state and store it correctly
+- build_pytorch_train_dataloader seeds torch.Generator when random_state is set
+- ESRNNForecaster's own overridden dataloader also seeds the generator
+- LTSFTransformerForecaster's own overridden dataloader also seeds the generator
+- random_state=0 is correctly treated as a valid seed (not falsy)
+- random_state=None does not call manual_seed at all
+"""
+
+import pytest
+
+from sktime.utils.dependencies import _check_soft_dependencies
+
+_torch_not_installed = not _check_soft_dependencies("torch", severity="none")
+
+
+# ---------------------------------------------------------------------------
+# Parametrized: verify all 8 forecasters accept random_state in __init__
+# ---------------------------------------------------------------------------
+
+def _cinn_f_statistic(x, params):
+    """Minimal f_statistic for CINNForecaster tests."""
+    return x
+
+
+_FORECASTER_PARAMS = [
+    (
+        "sktime.forecasting.scinet",
+        "SCINetForecaster",
+        {"seq_len": 8, "pred_len": 3},
+    ),
+    (
+        "sktime.forecasting.es_rnn",
+        "ESRNNForecaster",
+        {"window": 3, "pred_len": 3, "num_epochs": 1},
+    ),
+    (
+        "sktime.forecasting.ltsf",
+        "LTSFLinearForecaster",
+        {"seq_len": 8, "pred_len": 3, "num_epochs": 1},
+    ),
+    (
+        "sktime.forecasting.ltsf",
+        "LTSFDLinearForecaster",
+        {"seq_len": 8, "pred_len": 3, "num_epochs": 1},
+    ),
+    (
+        "sktime.forecasting.ltsf",
+        "LTSFNLinearForecaster",
+        {"seq_len": 8, "pred_len": 3, "num_epochs": 1},
+    ),
+    (
+        "sktime.forecasting.ltsf",
+        "LTSFTransformerForecaster",
+        {"seq_len": 8, "pred_len": 3, "num_epochs": 1},
+    ),
+    (
+        "sktime.forecasting.rbf_forecaster",
+        "RBFForecaster",
+        {"window_length": 5, "epochs": 1},
+    ),
+    (
+        "sktime.forecasting.conditional_invertible_neural_network",
+        "CINNForecaster",
+        {
+            "num_epochs": 1,
+            "window_size": 2,
+            "sample_dim": 5,
+            "f_statistic": _cinn_f_statistic,
+            "init_param_f_statistic": [1, 1],
+        },
+    ),
+]
+
+
+@pytest.mark.skipif(_torch_not_installed, reason="skip if torch not installed")
+@pytest.mark.parametrize("module,cls_name,params", _FORECASTER_PARAMS)
+def test_forecaster_accepts_random_state(module, cls_name, params):
+    """All 8 forecasters must accept random_state and store it on self.
+
+    Verifies that random_state=None was added to each forecaster's __init__
+    signature and that self.random_state is set correctly. Without this,
+    passing random_state would raise TypeError: unexpected keyword argument.
+    """
+    import importlib
+
+    mod = importlib.import_module(module)
+    cls = getattr(mod, cls_name)
+
+    forecaster = cls(**params, random_state=42)
+    assert forecaster.random_state == 42, (
+        f"{cls_name}.random_state should be 42 but got {forecaster.random_state}"
+    )
+
+    forecaster_none = cls(**params, random_state=None)
+    assert forecaster_none.random_state is None, (
+        f"{cls_name}.random_state should be None but got {forecaster_none.random_state}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Base class dataloader seeding (SCINetForecaster uses base class directly)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(_torch_not_installed, reason="skip if torch not installed")
+def test_base_train_dataloader_seeds_generator():
+    """Regression test: build_pytorch_train_dataloader in base class seeds generator.
+
+    BaseDeepNetworkPyTorch.build_pytorch_train_dataloader must pass a seeded
+    torch.Generator to DataLoader when random_state is set. Without this, the
+    DataLoader shuffle order is different every run producing non-reproducible results.
+
+    SCINetForecaster uses the base class dataloader without overriding it,
+    so it is used here as the representative test case for the base class path.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import numpy as np
+    import pandas as pd
+
+    from sktime.forecasting.scinet import SCINetForecaster
+
+    y = pd.Series(
+        np.arange(50, dtype=float),
+        index=pd.date_range("2000-01", periods=50, freq="M"),
+    )
+
+    forecaster = SCINetForecaster(seq_len=8, random_state=42)
+
+    with patch("torch.Generator") as mock_gen_class:
+        mock_gen = MagicMock()
+        mock_gen_class.return_value = mock_gen
+
+        with patch("torch.utils.data.DataLoader"):
+            forecaster.network = MagicMock()
+            forecaster.network.seq_len = 8
+            forecaster.network.pred_len = 3
+            forecaster.build_pytorch_train_dataloader(y)
+
+    mock_gen.manual_seed.assert_called_once_with(42)
+
+
+@pytest.mark.skipif(_torch_not_installed, reason="skip if torch not installed")
+def test_base_train_dataloader_random_state_zero_seeds_generator():
+    """Regression test: random_state=0 must seed the generator.
+
+    0 is a valid seed value. The guard must use ``if self.random_state is not None``
+    not ``if self.random_state`` because 0 evaluates as falsy in Python and would
+    be silently skipped by the latter form.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import numpy as np
+    import pandas as pd
+
+    from sktime.forecasting.scinet import SCINetForecaster
+
+    y = pd.Series(
+        np.arange(50, dtype=float),
+        index=pd.date_range("2000-01", periods=50, freq="M"),
+    )
+
+    forecaster = SCINetForecaster(seq_len=8, random_state=0)
+
+    with patch("torch.Generator") as mock_gen_class:
+        mock_gen = MagicMock()
+        mock_gen_class.return_value = mock_gen
+
+        with patch("torch.utils.data.DataLoader"):
+            forecaster.network = MagicMock()
+            forecaster.network.seq_len = 8
+            forecaster.network.pred_len = 3
+            forecaster.build_pytorch_train_dataloader(y)
+
+    mock_gen.manual_seed.assert_called_once_with(0)
+
+
+@pytest.mark.skipif(_torch_not_installed, reason="skip if torch not installed")
+def test_base_train_dataloader_none_does_not_seed():
+    """Regression test: random_state=None must NOT call manual_seed.
+
+    When no seed is requested, the generator must be left unseeded so that
+    PyTorch's default random behaviour is preserved.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import numpy as np
+    import pandas as pd
+
+    from sktime.forecasting.scinet import SCINetForecaster
+
+    y = pd.Series(
+        np.arange(50, dtype=float),
+        index=pd.date_range("2000-01", periods=50, freq="M"),
+    )
+
+    forecaster = SCINetForecaster(seq_len=8, random_state=None)
+
+    with patch("torch.Generator") as mock_gen_class:
+        mock_gen = MagicMock()
+        mock_gen_class.return_value = mock_gen
+
+        with patch("torch.utils.data.DataLoader"):
+            forecaster.network = MagicMock()
+            forecaster.network.seq_len = 8
+            forecaster.network.pred_len = 3
+            forecaster.build_pytorch_train_dataloader(y)
+
+    mock_gen.manual_seed.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# ESRNN: has its own overridden build_pytorch_train_dataloader
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(_torch_not_installed, reason="skip if torch not installed")
+def test_esrnn_train_dataloader_seeds_generator():
+    """Regression test: ESRNNForecaster's overridden dataloader seeds generator.
+
+    ESRNNForecaster overrides build_pytorch_train_dataloader with its own
+    implementation using ESRNNTrainDataset. The base class fix alone is not
+    enough — this override must also seed the torch.Generator.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import numpy as np
+    import pandas as pd
+
+    from sktime.forecasting.es_rnn import ESRNNForecaster
+
+    y = pd.Series(
+        np.arange(50, dtype=float),
+        index=pd.date_range("2000-01", periods=50, freq="M"),
+    )
+
+    forecaster = ESRNNForecaster(
+        window=5,
+        pred_len=3,
+        num_epochs=1,
+        random_state=42,
+    )
+
+    with patch("torch.Generator") as mock_gen_class:
+        mock_gen = MagicMock()
+        mock_gen_class.return_value = mock_gen
+
+        with patch("torch.utils.data.DataLoader"):
+            forecaster.network = MagicMock()
+            forecaster.network.pred_len = 3
+            forecaster.build_pytorch_train_dataloader(y)
+
+    mock_gen.manual_seed.assert_called_once_with(42)
+
+
+# ---------------------------------------------------------------------------
+# LTSFTransformer: has its own overridden build_pytorch_train_dataloader
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(_torch_not_installed, reason="skip if torch not installed")
+def test_ltsf_transformer_train_dataloader_seeds_generator():
+    """Regression test: LTSFTransformerForecaster's overridden dataloader seeds generator.
+
+    LTSFTransformerForecaster overrides build_pytorch_train_dataloader with its
+    own implementation using PytorchFormerDataset. The base class fix alone is
+    not enough — this override must also seed the torch.Generator.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import numpy as np
+    import pandas as pd
+
+    from sktime.forecasting.ltsf import LTSFTransformerForecaster
+
+    y = pd.Series(
+        np.arange(50, dtype=float),
+        index=pd.date_range("2000-01", periods=50, freq="M"),
+    )
+
+    forecaster = LTSFTransformerForecaster(
+        seq_len=8,
+        pred_len=3,
+        num_epochs=1,
+        random_state=42,
+    )
+
+    # Set internal state normally written during fit
+    forecaster._pred_len = 3
+    forecaster._temporal_encoding = False
+    forecaster.temporal_encoding_type = "linear"
+    forecaster.freq = "M"
+
+    with patch("torch.Generator") as mock_gen_class:
+        mock_gen = MagicMock()
+        mock_gen_class.return_value = mock_gen
+
+        with patch("torch.utils.data.DataLoader"):
+            with patch(
+                "sktime.networks.ltsf.data.dataset.PytorchFormerDataset"
+            ):
+                forecaster.build_pytorch_train_dataloader(y)
+
+    mock_gen.manual_seed.assert_called_once_with(42)

--- a/sktime/forecasting/tests/test_base_deep_network_pytorch_random_state.py
+++ b/sktime/forecasting/tests/test_base_deep_network_pytorch_random_state.py
@@ -215,6 +215,7 @@ def test_base_train_dataloader_none_does_not_seed():
 # ESRNN: has its own overridden build_pytorch_train_dataloader
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.skipif(_torch_not_installed, reason="skip if torch not installed")
 def test_esrnn_train_dataloader_seeds_generator():
     """Regression test: ESRNNForecaster's overridden dataloader seeds generator.
@@ -258,6 +259,7 @@ def test_esrnn_train_dataloader_seeds_generator():
 # LTSFTransformer: has its own overridden build_pytorch_train_dataloader
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.skipif(_torch_not_installed, reason="skip if torch not installed")
 def test_ltsf_transformer_train_dataloader_seeds_generator():
     """Regression test: LTSFTransformerForecaster's overridden dataloader seeds generator.
@@ -296,9 +298,7 @@ def test_ltsf_transformer_train_dataloader_seeds_generator():
         mock_gen_class.return_value = mock_gen
 
         with patch("torch.utils.data.DataLoader"):
-            with patch(
-                "sktime.networks.ltsf.data.dataset.PytorchFormerDataset"
-            ):
+            with patch("sktime.networks.ltsf.data.dataset.PytorchFormerDataset"):
                 forecaster.build_pytorch_train_dataloader(y)
 
     mock_gen.manual_seed.assert_called_once_with(42)

--- a/sktime/forecasting/tests/test_base_deep_network_pytorch_random_state.py
+++ b/sktime/forecasting/tests/test_base_deep_network_pytorch_random_state.py
@@ -55,7 +55,7 @@ _FORECASTER_PARAMS = [
     (
         "sktime.forecasting.ltsf",
         "LTSFTransformerForecaster",
-        {"seq_len": 8, "pred_len": 3, "num_epochs": 1},
+        {"seq_len": 8, "pred_len": 3, "num_epochs": 1, "context_len": 8},
     ),
     (
         "sktime.forecasting.rbf_forecaster",
@@ -126,7 +126,7 @@ def test_base_train_dataloader_seeds_generator():
 
     y = pd.Series(
         np.arange(50, dtype=float),
-        index=pd.date_range("2000-01", periods=50, freq="M"),
+        index=pd.date_range("2000-01", periods=50, freq="ME"),
     )
 
     forecaster = SCINetForecaster(seq_len=8, random_state=42)
@@ -161,7 +161,7 @@ def test_base_train_dataloader_random_state_zero_seeds_generator():
 
     y = pd.Series(
         np.arange(50, dtype=float),
-        index=pd.date_range("2000-01", periods=50, freq="M"),
+        index=pd.date_range("2000-01", periods=50, freq="ME"),
     )
 
     forecaster = SCINetForecaster(seq_len=8, random_state=0)
@@ -195,7 +195,7 @@ def test_base_train_dataloader_none_does_not_seed():
 
     y = pd.Series(
         np.arange(50, dtype=float),
-        index=pd.date_range("2000-01", periods=50, freq="M"),
+        index=pd.date_range("2000-01", periods=50, freq="ME"),
     )
 
     forecaster = SCINetForecaster(seq_len=8, random_state=None)
@@ -235,7 +235,7 @@ def test_esrnn_train_dataloader_seeds_generator():
 
     y = pd.Series(
         np.arange(50, dtype=float),
-        index=pd.date_range("2000-01", periods=50, freq="M"),
+        index=pd.date_range("2000-01", periods=50, freq="ME"),
     )
 
     forecaster = ESRNNForecaster(
@@ -279,11 +279,12 @@ def test_ltsf_transformer_train_dataloader_seeds_generator():
 
     y = pd.Series(
         np.arange(50, dtype=float),
-        index=pd.date_range("2000-01", periods=50, freq="M"),
+        index=pd.date_range("2000-01", periods=50, freq="ME"),
     )
 
     forecaster = LTSFTransformerForecaster(
         seq_len=8,
+        context_len=8,
         pred_len=3,
         num_epochs=1,
         random_state=42,

--- a/sktime/forecasting/tests/test_base_deep_network_pytorch_random_state.py
+++ b/sktime/forecasting/tests/test_base_deep_network_pytorch_random_state.py
@@ -20,6 +20,7 @@ _torch_not_installed = not _check_soft_dependencies("torch", severity="none")
 # Parametrized: verify all 8 forecasters accept random_state in __init__
 # ---------------------------------------------------------------------------
 
+
 def _cinn_f_statistic(x, params):
     """Minimal f_statistic for CINNForecaster tests."""
     return x
@@ -103,6 +104,7 @@ def test_forecaster_accepts_random_state(module, cls_name, params):
 # ---------------------------------------------------------------------------
 # Base class dataloader seeding (SCINetForecaster uses base class directly)
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.skipif(_torch_not_installed, reason="skip if torch not installed")
 def test_base_train_dataloader_seeds_generator():
@@ -262,7 +264,7 @@ def test_esrnn_train_dataloader_seeds_generator():
 
 @pytest.mark.skipif(_torch_not_installed, reason="skip if torch not installed")
 def test_ltsf_transformer_train_dataloader_seeds_generator():
-    """Regression test: LTSFTransformerForecaster's overridden dataloader seeds generator.
+    """Regression test: LTSFTransformerForecaster overridden dataloader seed generator.
 
     LTSFTransformerForecaster overrides build_pytorch_train_dataloader with its
     own implementation using PytorchFormerDataset. The base class fix alone is


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #10056

#### What does this implement/fix? Explain your changes.

All 8 deep learning forecasters inheriting from `BaseDeepNetworkPyTorch` produced
non-reproducible results because `DataLoader` was called with `shuffle=True` but no
seeded `torch.Generator`. Calling `.fit()` twice with identical data gave different
predictions every time.

This PR fixes reproducibility by:

- Adding `random_state=None` to `BaseDeepNetworkPyTorch.__init__` and seeding a
  `torch.Generator` in `build_pytorch_train_dataloader` and `_build_panel_dataloader`
- Adding `"capability:random_state": True` to the base class `_tags`
- Using `if self.random_state is not None` (not `if self.random_state`) so `random_state=0`
  is treated as a valid seed
- Propagating `random_state` to all 8 child forecasters' `__init__` signatures
- Fixing all overridden dataloader methods in child classes that bypass the base class:
  `ESRNNForecaster`, `LTSFTransformerForecaster`, `LTSFLinearForecaster`,
  `LTSFDLinearForecaster`, `LTSFNLinearForecaster`, `RBFForecaster`, `CINNForecaster`

The pattern is lifted from `ConvTimeNetForecaster` which had already solved this locally.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- The `if self.random_state is not None` guard in every seeded DataLoader call
- Child class overrides  each one that bypasses the base class must seed its own generator
- The new test file `sktime/forecasting/tests/test_base_deep_network_pytorch_random_state.py`

#### Did you add any tests for the change?

Yes. Added `sktime/forecasting/tests/test_base_deep_network_pytorch_random_state.py` with 6 tests:

- All 8 forecasters accept `random_state` and store it correctly (parametrized)
- Base class dataloader seeds the generator when `random_state` is set
- `random_state=0` is treated as a valid seed (not falsy)
- `random_state=None` does not call `manual_seed`
- `ESRNNForecaster`'s overridden dataloader seeds the generator
- `LTSFTransformerForecaster`'s overridden dataloader seeds the generator

#### Any other comments?

None.

#### PR checklist

##### For all contributions
- [ ] I've had already added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with code badge 
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.