### PR TITLE
DOC: add Examples section to GreedyGaussianSegmentation docstring

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2830,6 +2830,15 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "keerthana-ar",
+      "name": "Keerthana A R",
+      "avatar_url": "https://avatars.githubusercontent.com/u/145217290?v=4",
+      "profile": "https://github.com/keerthana-ar",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/sktime/detection/ggs.py
+++ b/sktime/detection/ggs.py
@@ -30,6 +30,20 @@ References
    "Greedy Gaussian segmentation of multivariate time series.",
     Adv Data Anal Classif 13, 727-751 (2019).
     https://doi.org/10.1007/s11634-018-0335-0
+
+Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from sktime.detection.ggs import GreedyGaussianSegmentation
+    >>> np.random.seed(42)
+    >>> X = pd.DataFrame(
+    ...     np.concatenate(
+    ...         [np.random.normal(0, 1, (50, 2)), np.random.normal(5, 1, (50, 2))]
+    ...     )
+    ... )
+    >>> detector = GreedyGaussianSegmentation(k_max=2, lamb=1.0)
+    >>> y_pred = detector.fit_predict(X)
 """
 
 import logging


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #4264

#### What does this implement/fix? Explain your changes.
Adds an `Examples` section to the `GreedyGaussianSegmentation` docstring in `sktime/detection/ggs.py`.

The example demonstrates basic usage of the estimator for multivariate time series segmentation using `fit_predict` on a synthetic dataset with two distinct Gaussian segments.

The doctest passes locally.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- The `Examples` section added to the `GreedyGaussianSegmentation` class docstring
- Correctness and clarity of the example

#### Did you add any tests for the change?
No new tests — this is a documentation-only change. The example itself serves as a doctest.

#### Any other comments?
Note: AI tools were used to assist in writing this PR.

#### PR checklist
##### For all contributions
- [x] I've added myself to the list of contributors with badge `doc`.
- [ ] Optionally, for added estimators: N/A
- [x] The PR title starts with [DOC].

##### For new estimators
N/A