### PR TITLE
[BUG] Validate TSF return_type and align docs

### DIFF
--- a/sktime/datasets/_readers_writers/tsf.py
+++ b/sktime/datasets/_readers_writers/tsf.py
@@ -130,11 +130,12 @@ def load_tsf_to_dataframe(
     value_column_name: str, default="series_value"
         Any name that is preferred to have as the name of the column containing series
         values in the returning dataframe.
-    return_type : str - "pd_multiindex_hier" (default), "tsf_default", or valid sktime
+    return_type : str - "pd_multiindex_hier" (default), "default_tsf", or valid sktime
         mtype string for in-memory data container format specification of the
         return type:
         - "pd_multiindex_hier" = pd.DataFrame of sktime type ``pd_multiindex_hier``
-        - "tsf_default" = container that faithfully mirrors tsf format from the original
+        - "default_tsf" = container that faithfully mirrors tsf format from the
+            original
             implementation in: https://github.com/rakshitha123/TSForecasting/
             blob/master/utils/data_loader.py.
         - other valid mtype strings are Panel or Hierarchical mtypes in
@@ -152,6 +153,20 @@ def load_tsf_to_dataframe(
         "frequency", "forecast_horizon", "contain_missing_values",
         "contain_equal_length"
     """
+    if not isinstance(return_type, str):
+        raise TypeError(
+            f"return_type must be a str, but found type {type(return_type)}"
+        )
+
+    valid_return_types = {"default_tsf", "pd_multiindex_hier"}.union(
+        set(MTYPE_LIST_HIERARCHICAL)
+    )
+    if return_type not in valid_return_types:
+        raise ValueError(
+            f"return_type must be one of {sorted(valid_return_types)}, "
+            f"but found {return_type}"
+        )
+
     col_names = []
     col_types = []
     all_data = {}

--- a/sktime/datasets/tests/test_readers_writers.py
+++ b/sktime/datasets/tests/test_readers_writers.py
@@ -1188,6 +1188,17 @@ def test_load_tsf_to_dataframe(input_path, return_type, output_df):
         assert check_is_mtype(obj=df, mtype=return_type, msg_return_dict="list")
 
 
+def test_load_tsf_to_dataframe_invalid_return_type():
+    """Test load_tsf_to_dataframe raises on unsupported return_type values."""
+    data_path = os.path.join(
+        os.path.dirname(sktime.__file__),
+        "datasets/data/UnitTest/UnitTest_Tsf_Loader.tsf",
+    )
+
+    with pytest.raises(ValueError, match="return_type must be one of"):
+        load_tsf_to_dataframe(data_path, return_type="tsf_default")
+
+
 @pytest.mark.parametrize("freq", [None, "YS"])
 def test_convert_tsf_to_multiindex(freq):
     input_df = pd.DataFrame(


### PR DESCRIPTION
# Reference Issues/PRs
- N/A (no linked issue)

#### What does this implement/fix?
This PR fixes an inconsistency in the TSF loader docs and adds explicit input validation for `return_type` in `load_tsf_to_dataframe`.

Changes:
- Align docstring wording to use the canonical `default_tsf` return type.
- Add a `TypeError` when `return_type` is not a string.
- Add a `ValueError` when `return_type` is unsupported, with a clear message listing valid values.
- Add a regression test to ensure unsupported alias values (e.g., `tsf_default`) fail clearly.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Whether `default_tsf` is the right canonical name to enforce in this loader.
- Whether the new `return_type` validation behavior/error messaging is appropriate.
- Whether the regression test coverage is sufficient for alias rejection.

#### Did you add any tests for the change?
Yes.
- Added a regression test in `sktime/datasets/tests/test_readers_writers.py`:
  - `test_load_tsf_to_dataframe_invalid_return_type`
