### PR TITLE
[ENH] Add input validation for benchmarking tasks

### DIFF
--- a/sktime/benchmarking/tasks.py
+++ b/sktime/benchmarking/tasks.py
@@ -31,7 +31,26 @@ class BaseTask(BaseObject):
     """
 
     def __init__(self, target, features=None, metadata=None):
-        # TODO input checks on target and feature args
+        if not isinstance(target, str) or target == "":
+            raise ValueError(
+                f"target must be a non-empty string, but found {target!r}"
+            )
+
+        if features is not None:
+            if isinstance(features, str):
+                raise TypeError(
+                    "features must be a list-like of strings, but found a string"
+                )
+            features_index = pd.Index(features)
+            if len(features_index) > 0 and not features_index.map(
+                lambda x: isinstance(x, str) and x != ""
+            ).all():
+                raise ValueError("all feature names must be non-empty strings")
+            if features_index.has_duplicates:
+                raise ValueError("features must not contain duplicate column names")
+            if target in features_index:
+                raise ValueError("target must not also be included in features")
+
         self._target = target
         self._features = features if features is None else pd.Index(features)
 

--- a/sktime/benchmarking/tests/test_tasks.py
+++ b/sktime/benchmarking/tests/test_tasks.py
@@ -65,3 +65,22 @@ def check_set_metadata(task, target, metadata):
 def test_set_metadata_supervised(task):
     """Test check_set_metadata."""
     check_set_metadata(task, "class_val", gunpoint)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
+def test_invalid_task_init_inputs():
+    """Test constructor validation for invalid target/features inputs."""
+    with raises(ValueError, match="target must be a non-empty string"):
+        BaseTask(target="")
+
+    with raises(TypeError, match="features must be a list-like of strings"):
+        BaseTask(target="class_val", features="dim_0")
+
+    with raises(ValueError, match="must not contain duplicate"):
+        BaseTask(target="class_val", features=["dim_0", "dim_0"])
+
+    with raises(ValueError, match="must not also be included in features"):
+        BaseTask(target="class_val", features=["dim_0", "class_val"])


### PR DESCRIPTION
#### Reference Issues/PRs
- N/A (no linked issue)

#### What does this implement/fix? 
This PR adds lightweight input validation to benchmarking task construction so invalid task definitions fail fast with clear errors.

Changes:
- Add `BaseTask` constructor validation for:
  - non-empty string `target`
  - list-like `features` (reject plain string input)
  - non-empty string feature names
  - duplicate feature names
  - `target` appearing inside `features`
- Add focused regression tests for invalid initialization inputs in `sktime/benchmarking/tests/test_tasks.py`.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Whether these constructor-level validations are the right constraints for `BaseTask`.
- Whether error messages are clear and consistent with project expectations.
- Whether test coverage is sufficient for invalid-input behavior.

#### Did you add any tests for the change?
Yes.
- Added `test_invalid_task_init_inputs` in `sktime/benchmarking/tests/test_tasks.py`.

#### PR checklist
- [ ] I've added myself to the list of contributors (if applicable)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]