### PR TITLE
[DOC] Improve TS file reader docstring examples

### DIFF
--- a/sktime/datasets/_readers_writers/ts.py
+++ b/sktime/datasets/_readers_writers/ts.py
@@ -42,26 +42,37 @@ def load_from_tsfile_to_dataframe(
     ----------
     full_file_path_and_name: str
         The full pathname of the .ts file to read.
-    return_separate_X_and_y: bool
-        true if X and Y values should be returned as separate Data Frames (
-        X) and a numpy array (y), false otherwise.
-        This is only relevant for data that
-    replace_missing_vals_with: str
-       The value that missing values in the text file should be replaced
-       with prior to parsing.
-    encoding: str
-        encoding is the name of the encoding used to read file using the open function.
+    return_separate_X_and_y : bool, default=True
+        Whether to return separate ``(X, y)`` outputs. If ``True``, returns
+        a nested pandas ``DataFrame`` ``X`` and a numpy array ``y``.
+        If ``False``, returns a single pandas ``DataFrame`` and, when class labels
+        are present, appends them in a ``"class_vals"`` column.
+    replace_missing_vals_with : str, default="NaN"
+        Value used to replace missing-value markers (``"?"``) before parsing.
+    encoding : str, default="utf-8"
+        Text encoding used when reading the file.
+    y_dtype : str, default="str"
+        Class label dtype to use in the returned ``y``. Accepted values are
+        ``"str"``, ``"int"``, and ``"float"``.
 
     Returns
     -------
-    DataFrame (default) or ndarray (i
-        If return_separate_X_and_y then a tuple containing a DataFrame and a
-        numpy array containing the relevant time-series and corresponding
-        class values.
-    DataFrame
-        If not return_separate_X_and_y then a single DataFrame containing
-        all time-series and (if relevant) a column "class_vals" the
-        associated class values.
+    X : pd.DataFrame
+        Nested dataframe containing the loaded time series.
+    y : np.ndarray
+        Returned only when ``return_separate_X_and_y=True`` and class labels are
+        present in the file.
+    data : pd.DataFrame
+        Returned when ``return_separate_X_and_y=False``; contains all dimensions and,
+        when available, a ``"class_vals"`` column.
+
+    Examples
+    --------
+    >>> from sktime.datasets._readers_writers.ts import load_from_tsfile_to_dataframe
+    >>> X, y = load_from_tsfile_to_dataframe("path/to/data.ts")
+    >>> data = load_from_tsfile_to_dataframe(
+    ...     "path/to/data.ts", return_separate_X_and_y=False
+    ... )
     """
     # Initialize flags and variables used when parsing the file
     metadata_started = False

--- a/sktime/datasets/_readers_writers/ts.py
+++ b/sktime/datasets/_readers_writers/ts.py
@@ -44,11 +44,14 @@ def load_from_tsfile_to_dataframe(
         The full pathname of the .ts file to read.
     return_separate_X_and_y : bool, default=True
         Whether to return separate ``(X, y)`` outputs. If ``True``, returns
-        a nested pandas ``DataFrame`` ``X`` and a numpy array ``y``.
-        If ``False``, returns a single pandas ``DataFrame`` and, when class labels
-        are present, appends them in a ``"class_vals"`` column.
+        a nested pandas ``DataFrame`` ``X`` and a numpy array ``y`` in the
+        ``"nested_univ"`` mtype. If ``False``, returns a single pandas ``DataFrame``
+        and, when class labels are present, appends them in a ``"class_vals"``
+        column (``"nested_univ"`` mtype).
     replace_missing_vals_with : str, default="NaN"
-        Value used to replace missing-value markers (``"?"``) before parsing.
+        Value used to replace missing-value markers (``"?"``) before parsing;
+        if missing-value markers are present, the replacement must be convertible
+        to ``float``.
     encoding : str, default="utf-8"
         Text encoding used when reading the file.
     y_dtype : str, default="str"
@@ -58,13 +61,14 @@ def load_from_tsfile_to_dataframe(
     Returns
     -------
     X : pd.DataFrame
-        Nested dataframe containing the loaded time series.
+        Nested dataframe containing the loaded time series in the
+        ``"nested_univ"`` mtype.
     y : np.ndarray
         Returned only when ``return_separate_X_and_y=True`` and class labels are
         present in the file.
     data : pd.DataFrame
         Returned when ``return_separate_X_and_y=False``; contains all dimensions and,
-        when available, a ``"class_vals"`` column.
+        when available, a ``"class_vals"`` column in the ``"nested_univ"`` mtype.
 
     Examples
     --------


### PR DESCRIPTION
#### Reference Issues/PRs
- N/A (no linked issue)

#### What does this implement/fix?
This PR improves the `load_from_tsfile_to_dataframe` docstring in `sktime/datasets/_readers_writers/ts.py` for clarity and usability.

Changes:
- Clarify parameter behavior for:
  - `return_separate_X_and_y`
  - `replace_missing_vals_with`
  - `encoding`
  - `y_dtype`
- Rewrite/clean up return-value documentation.
- Add concise `Examples` showing both:
  - separate `(X, y)` output
  - combined dataframe output (`return_separate_X_and_y=False`)

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Accuracy and clarity of the revised docstring text.
- Whether examples are concise and consistent with sktime docstring style.
- Whether parameter/return descriptions match actual function behavior.

#### Did you add any tests for the change?
No code behavior changed; this is a documentation-only update.

#### Any other comments?
No functional changes are included in this PR.

#### PR checklist
- [ ] I've added myself to the list of contributors (if applicable)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]