### PR TITLE
[DOC] Clarify model weight source parameters for foundation forecasters

### DIFF
--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -197,9 +197,15 @@ class ChronosForecaster(BaseForecaster):
     Parameters
     ----------
     model_path : str
-        Path to the Chronos huggingface model.
+        Chronos weight source passed as ``pretrained_model_name_or_path`` to
+        the upstream ``from_pretrained`` loader. Valid values are a Hugging Face
+        Hub model ID, for example ``"amazon/chronos-t5-tiny"`` or
+        ``"amazon/chronos-bolt-tiny"``, or a local directory accepted by the
+        selected Chronos loader and ``transformers.AutoConfig.from_pretrained``.
+        sktime forwards this value unchanged and does not resolve arbitrary
+        strings, checkpoint files, or alternate model hubs.
 
-    config : dict, optional, default={}
+    config : dict, optional, default=None
         A dictionary specifying the configuration settings for the model.
         The available configuration options include hyperparameters that control
         the prediction behavior, sampling, and hardware preferences. In case of the

--- a/sktime/forecasting/chronos2.py
+++ b/sktime/forecasting/chronos2.py
@@ -24,7 +24,13 @@ class Chronos2Forecaster(BaseForecaster):
     Parameters
     ----------
     model_path : str, default="amazon/chronos-2"
-        Path to the Chronos-2 HuggingFace model.
+        Chronos-2 weight source passed to
+        ``Chronos2Pipeline.from_pretrained`` as
+        ``pretrained_model_name_or_path``. Valid values are a Hugging Face Hub
+        model ID, for example ``"amazon/chronos-2"``, or a local directory
+        accepted by the Chronos-2 ``from_pretrained`` loader. sktime forwards
+        this value unchanged and does not resolve arbitrary strings, checkpoint
+        files, or alternate model hubs.
 
     config : dict, optional, default=None
         Configuration overrides. Supported keys:

--- a/sktime/forecasting/hf_momentfm_forecaster.py
+++ b/sktime/forecasting/hf_momentfm_forecaster.py
@@ -35,8 +35,15 @@ class MomentFMForecaster(_BaseGlobalForecaster):
     For information regarding licensing and use of the momentfm model please visit:
     https://huggingface.co/AutonLab/MOMENT-1-large
 
-    pretrained_model_name_or_path : str
-        Path to the pretrained Momentfm model. Default is AutonLab/MOMENT-1-large
+    Parameters
+    ----------
+    pretrained_model_name_or_path : str, default="AutonLab/MOMENT-1-large"
+        MomentFM weight source passed to ``MOMENTPipeline.from_pretrained``.
+        Valid values are a Hugging Face Hub model ID, for example
+        ``"AutonLab/MOMENT-1-large"``, or a local directory accepted by the
+        MomentFM ``from_pretrained`` loader. sktime forwards this value
+        unchanged and does not resolve arbitrary strings, checkpoint files, or
+        alternate model hubs.
 
     freeze_encoder : bool
         Selection of whether or not to freeze the weights of the encoder

--- a/sktime/forecasting/hf_transformers_forecaster.py
+++ b/sktime/forecasting/hf_transformers_forecaster.py
@@ -31,13 +31,15 @@ class HFTransformersForecaster(BaseForecaster):
     Parameters
     ----------
     model_path : str or PreTrainedModel
-        Path to the huggingface model to use for forecasting. Currently,
-        Informer, Autoformer, and TimeSeriesTransformer are supported.
-        This can be one of the following:
-        - A string specifying the Hugging Face model name or path
-          (e.g., `"huggingface/autoformer-tourism-monthly"`).
-        - An instance of a `PreTrainedModel`, allowing manual initialization
-          and configuration.
+        Forecasting model source. Currently, Informer, Autoformer, and
+        TimeSeriesTransformer are supported. If a string is supplied, it is
+        passed to ``transformers.AutoConfig.from_pretrained`` and the matching
+        Transformers model ``from_pretrained`` loader. Valid string values are
+        a Hugging Face Hub model ID, for example
+        ``"huggingface/autoformer-tourism-monthly"``, or a local directory
+        accepted by those Transformers loaders. A ``PreTrainedModel`` instance
+        is used directly. sktime does not resolve arbitrary strings, checkpoint
+        files, or alternate model hubs.
     fit_strategy : str, default="minimal"
         Strategy to use for fitting (fine-tuning) the model. This can be one of
         the following:

--- a/sktime/forecasting/lagllama.py
+++ b/sktime/forecasting/lagllama.py
@@ -150,8 +150,11 @@ class LagLlamaForecaster(BaseForecaster):
     Parameters
     ----------
     ckpt_path : str, optional (default=None)
-        Path to LagLlama checkpoint file. If None, automatically downloads
-        from HuggingFace: "time-series-foundation-models/Lag-Llama".
+        Local path to a LagLlama checkpoint file. If ``None`` or if the path
+        does not exist, sktime downloads ``"lag-llama.ckpt"`` from the fixed
+        Hugging Face Hub repository ``"time-series-foundation-models/Lag-Llama"``
+        using ``huggingface_hub.hf_hub_download``. This parameter is not a
+        generic repository ID or alternate hub selector.
     device : str, optional (default=None)
         Device for inference ("cpu", "cuda", "cuda:0", etc.).
         If None, uses CUDA if available, otherwise CPU.

--- a/sktime/forecasting/moirai_forecaster.py
+++ b/sktime/forecasting/moirai_forecaster.py
@@ -17,10 +17,17 @@ class MOIRAIForecaster(_BaseGlobalForecaster):
 
     Parameters
     ----------
-    checkpoint_path : str, default=None
-        Path to the checkpoint of the model. Supported weights are available at [1]_.
+    checkpoint_path : str
+        MOIRAI checkpoint repository identifier. Values starting with
+        ``"Salesforce"`` are passed to ``MoiraiModule.from_pretrained``.
+        Other values are passed as ``repo_id`` to ``huggingface_hub.hf_hub_download``
+        with ``filename="model.ckpt"`` and then loaded via
+        ``MoiraiForecast.load_from_checkpoint``. sktime does not resolve local
+        paths, arbitrary strings, or alternate model hubs here. Supported
+        weights are available at [1]_.
     context_length : int, default=200
-        Length of the context window, time points the model will take as input for inference.
+        Length of the context window, time points the model will take as input
+        for inference.
     patch_size : int, default=32
         Time steps to perform patching with.
     num_samples : int, default=100

--- a/sktime/forecasting/patch_tst.py
+++ b/sktime/forecasting/patch_tst.py
@@ -52,17 +52,15 @@ class PatchTSTForecaster(_BaseGlobalForecaster):
     Parameters
     ----------
     model_path : str or PatchTSTModel, optional
-        Path to the Huggingface model to use for global forecasting. If
-        model_path is passed, the remaining model config parameters will be
-        ignored except for specific training or dataset parameters.
-        This has 3 options:
-
-        - model id to an online pretrained PatchTST Model hosted on HuggingFace
-        - A path or url to a saved configuration JSON file
-        - A path to a *directory* containing a configuration file saved
-
-        using the ``~PretrainedConfig.save_pretrained`` method
-        or the ``~PreTrainedModel.save_pretrained`` method
+        PatchTST weight source or already initialized model. If a string is
+        supplied, it is passed to ``PatchTSTConfig.from_pretrained`` and
+        ``PatchTSTForPrediction.from_pretrained``. Valid string values are a
+        Hugging Face Hub model ID, for example
+        ``"namctin/patchtst_etth1_forecast"``, or a local directory accepted by
+        the Transformers ``from_pretrained`` loaders, such as the output of
+        ``PreTrainedModel.save_pretrained``. A ``PatchTSTModel`` instance is
+        used directly. sktime does not resolve arbitrary strings, checkpoint
+        files, or alternate model hubs.
 
     fit_strategy : str, values = ["full","minimal","zero-shot"], default = "full"
         String to set the fit_strategy of the model.

--- a/sktime/forecasting/timemoe.py
+++ b/sktime/forecasting/timemoe.py
@@ -25,16 +25,15 @@ class TimeMoEForecaster(_BaseGlobalForecaster):
 
     Parameters
     ----------
-    model_path: str
-        Path to the TimeMOE model. This can be:
+    model_path : str
+        TimeMOE weight source passed as ``pretrained_model_name_or_path`` to
+        ``TimeMoeForPrediction.from_pretrained``. Valid values are a Hugging
+        Face Hub model ID, for example ``"Maple728/TimeMoE-50M"``, or a local
+        directory accepted by the TimeMOE/Transformers ``from_pretrained``
+        loader. sktime forwards this value unchanged and does not resolve
+        arbitrary strings, checkpoint files, or alternate model hubs.
 
-        - A model ID from the HuggingFace Hub, e.g., "Maple728/TimeMoE-50M"
-        - A local directory containing the model files, specified as an absolute or
-          relative path to the current working directory
-          The path should point to a directory containing the model weights and
-          configuration files in the format expected by the HuggingFace Transformers
-          library.
-    config: dict, optional
+    config : dict, optional
         A dictionary specifying the configuration of the TimeMOE model.
         The available configuration options include hyperparameters that control
         the prediction behavior, sampling, and hardware utilization.

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -67,8 +67,11 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         although it is recommended to follow these guidelines for optimal results.
 
     repo_id : str, optional (default="google/timesfm-1.0-200m")
-        The identifier for the model repository.
-        The default model is the 200M parameter version.
+        TimesFM repository identifier passed as ``repo_id`` to
+        ``TimesFm.load_from_checkpoint``. The default model is the 200M
+        parameter version, ``"google/timesfm-1.0-200m"``. sktime forwards this
+        value unchanged and does not resolve arbitrary strings, local
+        checkpoint files, or alternate model hubs.
     input_patch_len : int, optional (default=32)
         The fixed length of input patches that the model processes.
         This parameter is fixed to 1280 for the 200M model and should not be changed.

--- a/sktime/forecasting/tirex.py
+++ b/sktime/forecasting/tirex.py
@@ -71,7 +71,10 @@ class TiRexForecaster(BaseForecaster):
     Parameters
     ----------
     model : str (default = "NX-AI/TiRex")
-        "Model identifier to load via the vendored TiRex loader"
+        Model identifier passed to ``tirex.load_model``. The default is
+        ``"NX-AI/TiRex"``. sktime forwards this value unchanged and does not
+        resolve arbitrary strings, local checkpoint files, or alternate model
+        hubs.
     device : {"cpu", "cuda", ...}, default="cpu"
         Compute device used by the underlying TiRex model.
     license_accepted : bool, default=False

--- a/sktime/forecasting/toto.py
+++ b/sktime/forecasting/toto.py
@@ -55,8 +55,13 @@ class TotoForecaster(BaseForecaster):
         Whether to stabilize the model with global context.
     use_memory_efficient_attention : boolean, optional (default=True)
         Whether to use memory-efficient attention mechanisms using Xformers.
-    model_path : string, optional (default='Datadog/Toto-Open-Base-1.0')
-        Path to the Toto huggingface model.
+    model_path : str, optional (default='Datadog/Toto-Open-Base-1.0')
+        Toto weight source passed as ``pretrained_model_name_or_path`` to
+        ``Toto.from_pretrained``. Valid values are a Hugging Face Hub model ID,
+        for example ``"Datadog/Toto-Open-Base-1.0"``, or a local directory
+        accepted by the Toto ``from_pretrained`` loader. sktime forwards this
+        value unchanged and does not resolve arbitrary strings, checkpoint
+        files, or alternate model hubs.
     device : string, optional (default=None)
         Specifies the device on which to run the model on ('cpu' or 'cuda').
 

--- a/sktime/forecasting/ttm.py
+++ b/sktime/forecasting/ttm.py
@@ -96,20 +96,19 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     Parameters
     ----------
     model_path : str, default="ibm/TTM"
-        Path to the Huggingface model to use for forecasting.
-        This can be either:
+        TinyTimeMixer weight source passed to
+        ``TinyTimeMixerConfig.from_pretrained`` and
+        ``TinyTimeMixerForPrediction.from_pretrained``. Valid values are a
+        Hugging Face Hub model ID, for example ``"ibm/TTM"``, or a local
+        directory accepted by those ``from_pretrained`` loaders. sktime forwards
+        this value unchanged and does not resolve arbitrary strings, checkpoint
+        files, or alternate model hubs.
 
-        - The name of a Huggingface repository (e.g., "ibm/TTM")
+        If this parameter is ``None``, ``fit_strategy`` must be ``"full"`` to
+        allow full fine tuning of the model loaded from pretrained/provided
+        config; otherwise, ``ValueError`` is raised.
 
-        - A local path to a folder containing model files in a format supported
-          by transformers. In this case, ensure that the directory contains all
-          necessary files (e.g., configuration, tokenizer, and model weights).
-
-        - If this parameter is *None*, fit_strategy should be *full* to allow
-          full fine tuning of the model loaded from pretrained/provided config,
-          else ValueError is raised.
-
-    revision: str, default="main"
+    revision : str, default="main"
         Revision of the model to use:
 
         - "main": For loading model with context_length of 512


### PR DESCRIPTION
#### Reference Issues/PRs

Partially addresses #7249.

#### What does this implement/fix? Explain your changes.

This PR clarifies documentation for model weight source parameters in pretrained and foundation forecasting estimators.

The updated docstrings describe whether a parameter is passed to an upstream loader such as `from_pretrained`, `hf_hub_download`, `load_from_checkpoint`, or `tirex.load_model`. The wording also avoids implying support for arbitrary strings, arbitrary checkpoint files, or alternate model hubs where that behavior is not currently implemented.

This is intentionally documentation-only and does not add new loading behavior.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the documented accepted values accurately match the existing loader behavior for each estimator.
- Whether any wording still overstates support for local files, arbitrary paths, or alternate model hubs.

#### Did you add any tests for the change?

No. This is a documentation-only change to existing docstrings.

#### Any other comments?

This is scoped as a partial documentation improvement for #7249.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [x] Optionally, for added estimators: not applicable.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [x] Not applicable.
