### PR TITLE
[BUG] Fix `TSCOptCV` incorrect base class inheritance

### DIFF
--- a/sktime/classification/model_selection/_hyperactive.py
+++ b/sktime/classification/model_selection/_hyperactive.py
@@ -3,12 +3,12 @@
 
 import numpy as np
 
-from sktime.forecasting.base._delegate import _DelegatedForecaster
+from sktime.classification._delegate import _DelegatedClassifier
 from sktime.utils.dependencies import _placeholder_record
 
 
 @_placeholder_record("hyperactive.integrations.sktime", dependencies="hyperactive>=5")
-class TSCOptCV(_DelegatedForecaster):
+class TSCOptCV(_DelegatedClassifier):
     """Tune an sktime classifier via any optimizer in the hyperactive toolbox.
 
     ``TSCOptCV`` uses any available tuning engine from ``hyperactive``


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #10083

#### What does this implement/fix? Explain your changes.
in the file 
```python
class TSCOptCV(_DelegatedClassifier):
    """Tune an sktime classifier via any optimizer in the hyperactive toolbox.
```
the docstring said they use of a classifier but before it we were usgin forcaster
```python
class TSCOptCV(_DelegatedForecaster):
```
this like its sibling `TSCGridSerchCV` in the same module

the examples read also used `DummyClassifier` not a forcaster
```python
    1. defining the tuned estimator:
    >>> from sktime.classification.dummy import DummyClassifier
    >>> from sklearn.model_selection import KFold
    >>> from hyperactive.integrations.sktime import TSCOptCV
    >>> from hyperactive.opt import GridSearchSk as GridSearch
    >>>
    >>> param_grid = {"strategy": ["most_frequent", "stratified"]}
    >>> tuned_naive = TSCOptCV(
    ...     DummyClassifier(),
    ...     GridSearch(param_grid),
    ...     cv=KFold(n_splits=2, shuffle=False),
    ... )
```

by this fix the registry classification of the fallback stub so now in sktime behaves correctly in environments where hyperactive is not there 