### PR TITLE
[BUG] Fix HierarchicalProphet python_dependencies version bounds

### DIFF
--- a/sktime/forecasting/prophetverse.py
+++ b/sktime/forecasting/prophetverse.py
@@ -274,7 +274,7 @@ class HierarchicalProphet(_DelegatedForecaster):
         # --------------
         "authors": "felipeangelimvieira",
         "maintainers": "felipeangelimvieira",
-        "python_dependencies": "prophetverse",
+        "python_dependencies": "prophetverse>=0.8.0,<0.11.0",	
         # estimator type
         # --------------
         "capability:multivariate": False,


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10083

#### What does this implement/fix? Explain your changes.
While investigating the failing forecasters from #10083, I found that HierarchicalProphet had no version bounds on its python_dependencies tag. The Prophetverse class right above it already had prophetverse>=0.8.0,<0.11.0 both on its decorator and in its tags, but HierarchicalProphet just had "prophetverse" with no bounds at all.

Since prophetverse 0.11.0 introduced breaking changes, this was causing the forecaster to fail when a newer version was installed.

Before:
```python
"python_dependencies": "prophetverse",
```

After:
```python
"python_dependencies": "prophetverse>=0.8.0,<0.11.0",
```

One-line fix - updated the python_dependencies tag in HierarchicalProphet to match the bounds already set in its decorator: prophetverse>=0.8.0,<0.11.0.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
The one-line change in sktime/forecasting/prophetverse.py - just checking the version bounds make sense given the decorator already in place.

#### Did you add any tests for the change?
No new tests added - the existing CI tests for prophetverse cover this.

#### PR checklist
- [ ] I've added myself to the list of contributors with any new badges I've earned
- [x] The PR title starts with [BUG]