### PR TITLE
[ENH] Native bootstrap registry and groundwork

### DIFF
--- a/sktime/bootstrap/__init__.py
+++ b/sktime/bootstrap/__init__.py
@@ -1,0 +1,5 @@
+"""Bootstrap algorithms namespace."""
+
+from sktime.bootstrap.base import BaseBootstrap
+
+__all__ = ["BaseBootstrap"]

--- a/sktime/bootstrap/base.py
+++ b/sktime/bootstrap/base.py
@@ -1,0 +1,16 @@
+"""Base class for bootstrap algorithms."""
+
+from sktime.base import BaseObject
+
+
+class BaseBootstrap(BaseObject):
+    """Base class for bootstrap resampling algorithms."""
+
+    _tags = {
+        "object_type": "bootstrap",
+        "capability:bootstrap_index": True,
+    }
+
+    def clone(self):
+        """Return a clone of self."""
+        return self.__class__(**self.get_params())

--- a/sktime/bootstrap/base.py
+++ b/sktime/bootstrap/base.py
@@ -1,4 +1,10 @@
-"""Base class for bootstrap algorithms."""
+"""Base class for bootstrap algorithms.
+
+copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""
+
+__author__ = ["sunkireddy-Barath"]
+__all__ = ["BaseBootstrap"]
 
 from sktime.base import BaseObject
 
@@ -8,9 +14,5 @@ class BaseBootstrap(BaseObject):
 
     _tags = {
         "object_type": "bootstrap",
-        "capability:bootstrap_index": True,
+        "capability:bootstrap_index": False,
     }
-
-    def clone(self):
-        """Return a clone of self."""
-        return self.__class__(**self.get_params())

--- a/sktime/bootstrap/tests/test_bootstrap_registry.py
+++ b/sktime/bootstrap/tests/test_bootstrap_registry.py
@@ -1,3 +1,11 @@
+"""Tests for bootstrap scitype registry.
+
+copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""
+
+__author__ = ["sunkireddy-Barath"]
+
+from sktime.bootstrap.base import BaseBootstrap
 from sktime.registry._base_classes import (
     get_base_class_for_str,
     get_obj_scitype_list,
@@ -5,9 +13,11 @@ from sktime.registry._base_classes import (
 
 
 def test_bootstrap_scitype_registered():
+    """Test that bootstrap is registered as a scitype."""
     assert "bootstrap" in get_obj_scitype_list()
 
 
 def test_bootstrap_base_class_registered():
+    """Test that the base class for bootstrap can be resolved."""
     cls = get_base_class_for_str("bootstrap")
-    assert cls.__name__ == "BaseBootstrap"
+    assert cls is BaseBootstrap

--- a/sktime/bootstrap/tests/test_bootstrap_registry.py
+++ b/sktime/bootstrap/tests/test_bootstrap_registry.py
@@ -1,0 +1,13 @@
+from sktime.registry._base_classes import (
+    get_base_class_for_str,
+    get_obj_scitype_list,
+)
+
+
+def test_bootstrap_scitype_registered():
+    assert "bootstrap" in get_obj_scitype_list()
+
+
+def test_bootstrap_base_class_registered():
+    cls = get_base_class_for_str("bootstrap")
+    assert cls.__name__ == "BaseBootstrap"

--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -477,6 +477,7 @@ class splitter(_BaseScitypeOfObject):
 
         return TestAllSplitters
 
+
 class bootstrap(_BaseScitypeOfObject):
     """Bootstrap resampling algorithm."""
 

--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -477,6 +477,25 @@ class splitter(_BaseScitypeOfObject):
 
         return TestAllSplitters
 
+class bootstrap(_BaseScitypeOfObject):
+    """Bootstrap resampling algorithm."""
+
+    _tags = {
+        "scitype_name": "bootstrap",
+        "short_descr": "bootstrap resampling algorithm",
+        "parent_scitype": "object",
+    }
+
+    @classmethod
+    def get_base_class(cls):
+        from sktime.bootstrap.base import BaseBootstrap
+
+        return BaseBootstrap
+
+    @classmethod
+    def get_test_class(cls):
+        return None
+
 
 class transformer(_BaseScitypeOfObject):
     """Time series transformer.

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -653,18 +653,6 @@ class capability__missing_values(_BaseTag):
     }
 
 
-class capability__bootstrap_index(_BaseTag):
-    """Whether bootstrap returns sampled indices."""
-
-    _tags = {
-        "tag_name": "capability:bootstrap_index",
-        "parent_type": "bootstrap",
-        "tag_type": "bool",
-        "short_descr": "whether bootstrap returns resampled indices",
-        "user_facing": True,
-    }
-
-
 class capability__feature_importance(_BaseTag):
     """Capability: the estimator can provide feature importance.
 
@@ -2070,7 +2058,7 @@ class capability__bootstrap_index(_BaseTag):
 
     _tags = {
         "tag_name": "capability:bootstrap_index",
-        "parent_type": "transformer",
+        "parent_type": ["transformer", "bootstrap"],
         "tag_type": "bool",
         "short_descr": "can the bootstrap return the index of bootstraped time series?",
         "user_facing": True,

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -653,6 +653,18 @@ class capability__missing_values(_BaseTag):
     }
 
 
+class capability__bootstrap_index(_BaseTag):
+    """Whether bootstrap returns sampled indices."""
+
+    _tags = {
+        "tag_name": "capability:bootstrap_index",
+        "parent_type": "bootstrap",
+        "tag_type": "bool",
+        "short_descr": "whether bootstrap returns resampled indices",
+        "user_facing": True,
+    }
+
+
 class capability__feature_importance(_BaseTag):
     """Capability: the estimator can provide feature importance.
 


### PR DESCRIPTION
Reference
Addresses #9990
Follow-up to the tsbootstrap integration discussion.

What does this implement / fix?
This PR introduces the foundational architecture required to support bootstrap algorithms as first-class objects within sktime.

 Implemented changes:
Added a new top-level package:
sktime/bootstrap/
__init__.py
base.py
Introduced BaseBootstrap in:
sktime/bootstrap/base.py
Registered a new bootstrap scitype in:
sktime/registry/_base_classes.py
Added initial bootstrap capability tag support in:
sktime/registry/_tags.py
Added tests in:
sktime/bootstrap/tests/test_bootstrap_registry.py

 Purpose:
This PR lays the groundwork for making bootstrap algorithms native components of sktime, enabling:
Native bootstrap estimators
Unified API for resampling
Reduced reliance on external libraries like tsbootstrap
This is an architectural step, not a full feature implementation.

Dependencies:
No new dependencies introduced.

What should reviewers focus on?
Bootstrap scitype registration
Design of BaseBootstrap
Registry and tagging integration
Alignment with existing sktime architecture

Tests:
Yes, tests have been added:
Bootstrap scitype registration
Base class registry lookup
All local tests are passing.

Additional comments:
This PR focuses only on object and registry groundwork
Functional bootstrap implementations will be added in future PRs
Supports ongoing efforts to replace or vendor tsbootstrap

 PR Checklist:
For all contributions
PR title starts with [ENH]
Added myself to contributors list