### PR TITLE
[BUG] Fix multivariate detection in SubLOF and missing raise in DetectorPipeline

### DIFF
--- a/sktime/detection/compose/_pipeline.py
+++ b/sktime/detection/compose/_pipeline.py
@@ -181,7 +181,7 @@ class DetectorPipeline(_HeterogenousMetaEstimator, BaseDetector):
         ann_ind = self._get_first_detector_index(estimator_tuples)
 
         if not allow_postproc and ann_ind != len(estimators) - 1:
-            TypeError(
+            raise TypeError(
                 f"in {self_name}, last estimator must be a time series detector, "
                 f"but found a transformer"
             )

--- a/sktime/detection/lof.py
+++ b/sktime/detection/lof.py
@@ -241,7 +241,7 @@ class SubLOF(BaseDetector):
             if len(X_subset) == 0:
                 continue
 
-            y_subset = model.predict(X_subset.iloc[:, [0]])
+            y_subset = model.predict(X_subset.drop(columns=["__id"]))
             anomaly_indexes = np.where(y_subset == -1)[0] + X_subset["__id"].iloc[0]
             y_all.append(pd.Series(anomaly_indexes))
 

--- a/sktime/detection/tests/test_lof.py
+++ b/sktime/detection/tests/test_lof.py
@@ -93,3 +93,25 @@ def test_sublof_does_not_mutate_input():
     _ = model.fit_transform(X)
 
     pd.testing.assert_frame_equal(X, X_original)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SubLOF),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_sublof_multivariate_prediction():
+    """Check that SubLOF uses all columns for predictions."""
+    X1 = pd.DataFrame({0: [0, 0, 100, 0, 0, 0, 0], 1: [0, 0, 0, 0, 0, 0, 0], 2: [0, 0, 0, 0, 0, 0, 0]})
+    X2 = pd.DataFrame({0: [0, 0, 0, 0, 0, 0, 0], 1: [0, 0, 100, 0, 0, 0, 0], 2: [0, 0, 0, 0, 0, 0, 0]})
+
+    model1 = SubLOF(n_neighbors=2, window_size=3, novelty=True)
+    model1.fit(X1)
+    y1 = model1.predict(X1)
+
+    model2 = SubLOF(n_neighbors=2, window_size=3, novelty=True)
+    model2.fit(X2)
+    y2 = model2.predict(X2)
+
+    assert len(y1) > 0, "Model 1 should detect anomaly"
+    assert len(y2) > 0, "Model 2 should detect anomaly, proving column 1 is used"
+    pd.testing.assert_frame_equal(y1, y2)

--- a/sktime/detection/tests/test_pipeline.py
+++ b/sktime/detection/tests/test_pipeline.py
@@ -1,0 +1,18 @@
+"""Tests for detector pipelines."""
+
+import pytest
+
+from sktime.detection.compose import DetectorPipeline
+from sktime.detection.lof import SubLOF
+from sktime.transformations.series.detrend import Detrender
+
+
+def test_pipeline_raises_type_error_for_transformer_last():
+    """Test that placing a transformer after a detector raises TypeError."""
+    with pytest.raises(TypeError, match="last estimator must be a time series detector"):
+        DetectorPipeline(
+            steps=[
+                ("det", SubLOF(n_neighbors=2, window_size=2)),
+                ("trafo", Detrender()),
+            ]
+        )


### PR DESCRIPTION
## Description

This PR addresses two critical bugs in the detection module related to multivariate support and pipeline validation:

1. **`SubLOF` Multivariate Prediction Fix**
   - **Bug:** Even though `SubLOF` has the tag `"capability:multivariate": True` and fits on all columns, the `_predict` method incorrectly hardcoded `y_subset = model.predict(X_subset.iloc[:, [0]])`, causing it to silently ignore all sensor columns except the first during inference.
   - **Fix:** Updated the prediction logic to use `X_subset.drop(columns=["__id"])` ensuring all original multivariate channels are correctly passed to the LOF model.
   - **Test:** Added `test_sublof_multivariate_prediction` in `test_lof.py` to explicitly assert that non-primary columns influence the anomaly detection output.

2. **`DetectorPipeline` TypeError missing `raise`**
   - **Bug:** In `_check_steps`, when an invalid pipeline sequence was constructed (e.g., placing a transformer after a detector with `allow_postproc=False`), a `TypeError` object was instantiated but never actually raised, allowing invalid pipelines to fail silently later.
   - **Fix:** Added the missing `raise` keyword before the `TypeError`.
   - **Test:** Added `test_pipeline_raises_type_error_for_transformer_last` in a newly created `test_pipeline.py` file to prevent future regressions.
