### PR TITLE
[ENH] Relax environment and Python version requirements for TimesFMForecaster

### DIFF
--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -151,7 +151,7 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         "authors": ["rajatsen91", "geetu040"],
         # rajatsen91 for google-research/timesfm
         "maintainers": ["geetu040"],
-        "python_version": ">=3.10,<3.11",
+        "python_version": ">=3.10",
         "python_dependencies": [
             "tensorflow",
             "einshape",
@@ -161,7 +161,6 @@ class TimesFMForecaster(_BaseGlobalForecaster):
             "paxml",
             "utilsforecast",
         ],
-        "env_marker": "sys_platform=='linux'",
         # estimator type
         # --------------
         "y_inner_mtype": [


### PR DESCRIPTION
Fixes #8530.

Google's `timesfm` now supports Windows and newer Python versions (like 3.13). This PR removes the restrictive `sys_platform=='linux'` environment marker and relaxes the Python version tag from `>=3.10,<3.11` to `>=3.10`, allowing non-Linux and Python 3.11+ users to run `TimesFMForecaster`.