### PR TITLE
[ENH] Standardize restrictive licenses checking via tags (#8685)

### DIFF
--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -148,6 +148,8 @@ class TimesFMForecaster(_BaseGlobalForecaster):
     _tags = {
         # packaging info
         # --------------
+                "requires_license_acceptance": True,
+        "license:link": "https://github.com/google-research/timesfm/blob/master/LICENSE",
         "authors": ["rajatsen91", "geetu040"],
         # rajatsen91 for google-research/timesfm
         "maintainers": ["geetu040"],
@@ -187,6 +189,7 @@ class TimesFMForecaster(_BaseGlobalForecaster):
 
     def __init__(
         self,
+        license_accepted=False,
         context_len=None,
         horizon_len=128,
         freq=0,
@@ -248,7 +251,17 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         os.environ["JAX_PLATFORM_NAME"] = backend
         os.environ["JAX_PLATFORMS"] = backend
 
+        self.license_accepted = license_accepted
         super().__init__()
+
+        if self.get_class_tag("requires_license_acceptance", False) and not self.license_accepted:
+            license_link = self.get_class_tag("license:link", "Unknown")
+            raise PermissionError(
+                f"Use of {self.__class__.__name__} is subject to a restrictive license. "
+                f"You must accept the license terms to use this estimator. "
+                f"To accept the license, set the `license_accepted` parameter to True. "
+                f"View the license here: {license_link}"
+            )
 
     def _fit(self, y, X, fh):
         if fh is None and self.horizon_len is None:
@@ -376,6 +389,10 @@ class TimesFMForecaster(_BaseGlobalForecaster):
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
+        return {"license_accepted": True}
+
+    @classmethod
+    def get_test_params_dummy(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/sktime/forecasting/tirex.py
+++ b/sktime/forecasting/tirex.py
@@ -101,6 +101,8 @@ class TiRexForecaster(BaseForecaster):
     """
 
     _tags = {
+        "requires_license_acceptance": True,
+        "license:link": "https://github.com/NX-AI/tirex/blob/main/LICENSE",
         # packaging tags
         # --------------
         "maintainers": ["sinemkilicdere", "martinloretzzz"],
@@ -138,16 +140,13 @@ class TiRexForecaster(BaseForecaster):
         # leave this as is
         super().__init__()
 
-        if not self.license_accepted:
-            raise ValueError(
-                "Use of TiRexForecaster is subject to the license terms of TiRex, "
-                "licensed to third party vendor NXAI GmbH. "
-                "This license is not permissive, and differs from the sktime license. "
-                "You must accept the license terms of TiRex to use TiRexForecaster. "
-                "To accept the license, set the `license_accepted` parameter to True "
-                "to confirm that you have read and accepted the license terms. "
-                "To print and view the license for TiRex, "
-                "call `TiRexForecaster.print_license()`"
+        if self.get_class_tag("requires_license_acceptance", False) and not self.license_accepted:
+            license_link = self.get_class_tag("license:link", "Unknown")
+            raise PermissionError(
+                f"Use of {self.__class__.__name__} is subject to a restrictive license. "
+                f"You must accept the license terms to use this estimator. "
+                f"To accept the license, set the `license_accepted` parameter to True. "
+                f"View the license here: {license_link}"
             )
 
     @classmethod

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -3766,6 +3766,42 @@ ESTIMATOR_TAG_REGISTER = [
 ]
 
 # construct the tag register from all classes in this module
+class requires_license_acceptance(_BaseTag):
+    """Whether the estimator requires explicit license acceptance.
+
+    - String name: ``"requires_license_acceptance"``
+    - Public metadata tag
+    - Values: boolean
+    - Default: ``False``
+    """
+
+    _tags = {
+        "tag_name": "requires_license_acceptance",
+        "parent_type": "object",
+        "tag_type": "bool",
+        "short_descr": "whether the estimator requires explicit license acceptance",
+        "user_facing": True,
+    }
+
+
+class license__link(_BaseTag):
+    """Link to the license for the estimator.
+
+    - String name: ``"license:link"``
+    - Public metadata tag
+    - Values: string
+    - Default: ``None``
+    """
+
+    _tags = {
+        "tag_name": "license:link",
+        "parent_type": "object",
+        "tag_type": "str",
+        "short_descr": "link to the license for the estimator",
+        "user_facing": True,
+    }
+
+
 tag_clses = inspect.getmembers(sys.modules[__name__], inspect.isclass)
 for _, cl in tag_clses:
     # skip the base class
@@ -3783,6 +3819,8 @@ for _, cl in tag_clses:
 
 ESTIMATOR_TAG_TABLE = pd.DataFrame(ESTIMATOR_TAG_REGISTER)
 ESTIMATOR_TAG_LIST = ESTIMATOR_TAG_TABLE[0].tolist()
+
+
 
 
 def check_tag_is_valid(tag_name, tag_value):


### PR DESCRIPTION
Fixes #8685.

This PR formalizes the handling of non-permissive custom licenses in foundation models as discussed in #8685. 

### What this PR does:
1. **Introduces Two New Tags:** 
   - `requires_license_acceptance` (bool): Indicates an estimator requires explicit consent.
   - `license:link` (str): Contains the URL pointing directly to the terms.
2. **Standardizes Parameters & Error Handling:** Foundation models implementing this tag must define `license_accepted=False` in their `__init__`. If `requires_license_acceptance` is True but `license_accepted` is False, a unified `PermissionError` is raised indicating exactly how the user can accept the license.
3. **Applies Pattern to Estimators:** 
   - Refactored `TiRexForecaster` to use this new standardized design (removed its hardcoded `ValueError`).
   - Added the tag and check to `TimesFMForecaster` as it also wraps a model with a potentially restrictive license.