### PR TITLE
[ENH] move test skip config for SCINetForecaster to estimator tags

### DIFF
--- a/sktime/forecasting/scinet.py
+++ b/sktime/forecasting/scinet.py
@@ -132,6 +132,7 @@ class SCINetForecaster(BaseDeepNetworkPyTorch):
         # "python_dependencies": "pytorch" - inherited from BaseDeepNetworkPyTorch
         # estimator type vars inherited from BaseDeepNetworkPyTorch
         "capability:pretrain": True,
+        "tests:skip_all": True,
     }
 
     def __init__(

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -72,9 +72,8 @@ EXCLUDE_ESTIMATORS = [
     "FreshPRINCE",
     # multiple timeouts and sporadic failures reported related to VARMAX
     # 2997, 3176, 7985
-    "SCINetForecaster",  # known bug #7871
     "MAPAForecaster",  # known bug #8039
-]
+] 
 
 
 # DO NOT ADD ESTIMATORS HERE ANYMORE


### PR DESCRIPTION
Reference Issues/PRs: #8515

What does this implement/fix?
Moves test skip configuration for `SCINetForecaster` from the central 
`tests/_config.py` to the estimator's own `_tags`, as part of the 
test skip config migration initiative.

Changes:
- Removed `SCINetForecaster` from `EXCLUDE_ESTIMATORS` in `sktime/tests/_config.py`
- Added `"tests:skip_all": True` tag to `SCINetForecaster` class in `sktime/forecasting/scinet.py`