### PR TITLE
[ENH] data loaders for detection toy datasets: load_yahoo, load_mitdb, load_seatbelts

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2840,6 +2840,15 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "Michael-ola",
+      "name": "Michael Olaitan Ibitoye",
+      "avatar_url": "https://avatars.githubusercontent.com/Michael-ola",
+      "profile": "https://github.com/Michael-ola",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/sktime/datasets/__init__.py
+++ b/sktime/datasets/__init__.py
@@ -64,6 +64,9 @@ __all__ = [
     "OSULeaf",
     "PLAID",
     "UCRUEADataset",
+    "load_mitdb",
+    "load_seatbelts",
+    "load_yahoo",
 ]
 
 from sktime.datasets._data_io import (
@@ -113,6 +116,9 @@ from sktime.datasets._single_problem_loaders import (
     load_unit_test,
     load_unit_test_tsf,
     load_uschange,
+    load_mitdb,
+    load_seatbelts,
+    load_yahoo,
 )
 from sktime.datasets.base import BaseDataset
 from sktime.datasets.classification import (

--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -40,6 +40,9 @@ __all__ = [
     "load_unit_test_tsf",
     "load_covid_3month",
     "load_tecator",
+    "load_mitdb",
+    "load_seatbelts",
+    "load_yahoo",
 ]
 
 import os
@@ -1746,3 +1749,174 @@ def load_m5(
             inplace=True,
         )
         return sales_train_validation, sell_prices, calendar
+
+
+def load_yahoo(return_mtype: str = None):
+    """Load the Yahoo labeled anomaly detection dataset.
+
+    Parameters
+    ----------
+    return_mtype : str, optional (default=None)
+        The return mtype for the output, a valid sktime Series mtype string.
+        If None, returns pd.Series.
+
+    Returns
+    -------
+    y : pd.Series
+        Anomaly labels (0 or 1) for each time point.
+    X : pd.Series
+        Time series values.
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_yahoo
+    >>> y, X = load_yahoo()
+
+    Notes
+    -----
+    Dimensionality:     univariate
+    Series length:      1422
+    Frequency:          not specified
+
+    This dataset is used to benchmark anomaly detection algorithms. It consists
+    of real and synthetic time series with tagged anomaly points. The dataset
+    tests detection accuracy of various anomaly types including outliers and
+    change points. The synthetic dataset consists of time series with varying
+    trend, noise and seasonality. The real dataset consists of time series
+    representing metrics of various Yahoo services.
+
+    From the TSB-UAD benchmark suite:
+    "TSB-UAD: An End-to-End Benchmark Suite for Univariate Time-Series Anomaly
+    Detection", Paparrizos et al., PVLDB 2022, Volume 15, pages 1697-1711.
+
+    References
+    ----------
+    .. [1] N. Laptev, S. Amizadeh, and Y. Billawala. 2015.
+           S5 - A Labeled Anomaly Detection Dataset, version 1.0(16M).
+           https://webscope.sandbox.yahoo.com/catalog.php?datatype=s&did=70.
+    .. [2] Paparrizos et al. TSB-UAD: An End-to-End Benchmark Suite for
+           Univariate Time-Series Anomaly Detection. PVLDB 2022.
+           https://github.com/TheDatumOrg/TSB-UAD
+    """
+    name = "yahoo"
+    fname = name + ".csv"
+    path = os.path.join(MODULE, DIRNAME, name, fname)
+    data = pd.read_csv(path)
+    y = data["label"]
+    X = data["data"]
+
+    if return_mtype is not None:
+        y = convert(y, from_type="pd.Series", to_type=return_mtype)
+        X = convert(X, from_type="pd.Series", to_type=return_mtype)
+
+    return y, X
+
+
+def load_mitdb(return_mtype: str = None):
+    """Load the MIT-BIH Arrhythmia database dataset.
+
+    Parameters
+    ----------
+    return_mtype : str, optional (default=None)
+        The return mtype for the output, a valid sktime Series mtype string.
+        If None, returns pd.Series.
+
+    Returns
+    -------
+    y : pd.Series
+        Anomaly labels for each time point.
+    X : pd.Series
+        ECG time series values.
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_mitdb
+    >>> y, X = load_mitdb()
+
+    Notes
+    -----
+    Dimensionality:     univariate
+    Frequency:          360 Hz
+
+    The MIT-BIH Arrhythmia database contains 48 half-hour excerpts of
+    two-channel ambulatory ECG recordings, obtained from 47 subjects studied
+    by the BIH Arrhythmia Laboratory between 1975 and 1979.
+
+    From the TSB-UAD benchmark suite:
+    "TSB-UAD: An End-to-End Benchmark Suite for Univariate Time-Series Anomaly
+    Detection", Paparrizos et al., PVLDB 2022, Volume 15, pages 1697-1711.
+
+    References
+    ----------
+    .. [1] George B Moody and Roger G Mark. 1992. MIT-BIH Arrhythmia Database.
+           https://doi.org/10.13026/C2F305
+    .. [2] Paparrizos et al. TSB-UAD: An End-to-End Benchmark Suite for
+           Univariate Time-Series Anomaly Detection. PVLDB 2022.
+           https://github.com/TheDatumOrg/TSB-UAD
+    """
+    name = "mitdb"
+    fname = name + ".csv"
+    path = os.path.join(MODULE, DIRNAME, name, fname)
+    data = pd.read_csv(path)
+    y = data["label"]
+    X = data["data"]
+
+    if return_mtype is not None:
+        y = convert(y, from_type="pd.Series", to_type=return_mtype)
+        X = convert(X, from_type="pd.Series", to_type=return_mtype)
+
+    return y, X
+
+
+def load_seatbelts(return_mtype: str = None):
+    """Load the Seatbelts changepoint detection dataset.
+
+    Parameters
+    ----------
+    return_mtype : str, optional (default=None)
+        The return mtype for the output, a valid sktime Series mtype string.
+        If None, returns pd.Series.
+
+    Returns
+    -------
+    y : pd.Series
+        Changepoint labels for each time point.
+    X : pd.Series
+        Monthly time series of drivers killed or seriously injured (KSI).
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_seatbelts
+    >>> y, X = load_seatbelts()
+
+    Notes
+    -----
+    Dimensionality:     univariate
+    Series length:      192
+    Frequency:          Monthly
+    Time span:          January 1969 to December 1984
+
+    This dataset concerns the number of drivers killed or seriously injured
+    in the UK around the period when seatbelts were introduced. Seatbelts
+    were compulsory equipment in all new cars from 1972 and mandatory to be
+    worn from 1983 onwards.
+
+    References
+    ----------
+    .. [1] G. J. J. Van den Burg and C. K. I. Williams. An Evaluation of
+           Change Point Detection Algorithms. arXiv:2003.06222, 2020.
+           https://github.com/alan-turing-institute/TCPD
+    """
+    name = "seatbelts"
+    fname = name + ".csv"
+    path = os.path.join(MODULE, DIRNAME, name, fname)
+    data = pd.read_csv(path, index_col=0).squeeze("columns")
+    data.index = _coerce_to_monthly_period_index(data.index)
+    y = data["label"]
+    X = data["KSI"]
+
+    if return_mtype is not None:
+        y = convert(y, from_type="pd.Series", to_type=return_mtype)
+        X = convert(X, from_type="pd.Series", to_type=return_mtype)
+
+    return y, X

--- a/sktime/datasets/tests/test_single_problem_loaders.py
+++ b/sktime/datasets/tests/test_single_problem_loaders.py
@@ -14,6 +14,9 @@ from sktime.datasets import (
     load_plaid,
     load_tecator,
     load_unit_test,
+    load_mitdb,
+    load_seatbelts,
+    load_yahoo,
 )
 
 UNIVARIATE_PROBLEMS = [
@@ -73,3 +76,26 @@ def test_load_numpy2d_multivariate_raises(loader):
     """Test that multivariate and/or unequal length raise the correct error."""
     with pytest.raises(ValueError, match="attempting to load into a numpy2d"):
         X, y = loader(return_type="numpy2d")
+
+def test_load_yahoo():
+    """Test that load_yahoo returns two pd.Series objects."""
+    y, X = load_yahoo()
+    assert isinstance(y, pd.Series)
+    assert isinstance(X, pd.Series)
+    assert len(y) == len(X)
+
+
+def test_load_mitdb():
+    """Test that load_mitdb returns two pd.Series objects."""
+    y, X = load_mitdb()
+    assert isinstance(y, pd.Series)
+    assert isinstance(X, pd.Series)
+    assert len(y) == len(X)
+
+
+def test_load_seatbelts():
+    """Test that load_seatbelts returns two pd.Series objects."""
+    y, X = load_seatbelts()
+    assert isinstance(y, pd.Series)
+    assert isinstance(X, pd.Series)
+    assert len(y) == len(X)


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
Closes #7286. See also #7319.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Adds data loader functions for the three toy datasets used in the detection 
notebook (07_detection_anomaly_changepoints.ipynb), which were previously 
loaded via inline pd.read_csv calls with hardcoded paths.

Added load_yahoo(), load_mitdb(), and load_seatbelts() to 
sktime/datasets/_single_problem_loaders.py, exported from 
sktime/datasets/__init__.py. All functions follow existing loader conventions, 
include docstrings with dataset descriptions and references, and support an 
optional return_mtype argument.

This picks up and completes the work started in #7319.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->
NO

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- Correctness of the three loader functions and their return types
- Docstring completeness and formatting
- Test coverage in test_single_problem_loaders.py

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
Yes. Added test_load_yahoo, test_load_mitdb, and test_load_seatbelts to sktime/datasets/tests/test_single_problem_loaders.py, checking that each function returns two pd.Series objects of equal length.

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors]

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
