### PR TITLE
[ENH] remove stale `RowTransformer` entries from test config

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -86,10 +86,6 @@ EXCLUDED_TESTS = {
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
     ],
-    # sth is not quite right with the RowTransformer-s changing state,
-    #   but these are anyway on their path to deprecation, see #2370
-    "SeriesToPrimitivesRowTransformer": ["test_methods_do_not_change_state"],
-    "SeriesToSeriesRowTransformer": ["test_methods_do_not_change_state"],
     # Early classifiers intentionally retain information from previous predict calls
     #   for #1.
     # #2 amd #3 are due to predict/predict_proba returning two items and that breaking


### PR DESCRIPTION
## What

Remove stale test exclusion entries for `SeriesToPrimitivesRowTransformer` and `SeriesToSeriesRowTransformer` from `sktime/tests/_config.py`.

## Why

These classes were removed from the codebase but their test exclusion entries remained as dead code. The comment references issue #2370 and notes these were "on their path to deprecation" — they have since been fully removed.

## Changes

`sktime/tests/_config.py`: Remove 4 lines (2 entries + 2 comment lines) for deleted RowTransformer classes.

Part of #4803