### PR TITLE
[MNT] update the version of lightning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,7 @@ dl = [
   "torch; (sys_platform != 'darwin' or python_version < '3.13')",
   'transformers[torch]<4.41.0; python_version < "3.13"',
   "pytorch-forecasting>=1.0.0,<1.6.0; (sys_platform != 'darwin' or python_version != '3.13') and python_version < '3.14'",
-  "lightning>=2.0,<2.6; (sys_platform != 'darwin' or python_version < '3.13')",
+  "lightning>=2.0; (sys_platform != 'darwin' or python_version < '3.13')",
   'gluonts>=0.14.3; python_version < "3.12"',
   'einops>0.7.0; python_version < "3.12"',
   'huggingface-hub>=0.23.0; python_version < "3.12"',
@@ -247,7 +247,7 @@ notebooks = [
   "prophet",
   "pytorch-forecasting",
   "torch",
-  "lightning>=2.0,<2.6",
+  "lightning>=2.0",
   "skpro",
   "statsforecast",
 ]


### PR DESCRIPTION
found when i ran checks in my PR #9889

updating the `lightning>=2.0,<2.6` as now lightning has now released >=2.6

for this the pr was raised by dependbot #9297 but has merge conflicts

