### PR TITLE
Fix: preserve input index in BaseDetector.transform

### DIFF
--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -286,8 +286,10 @@ class BaseDetector(BaseEstimator):
               segments. Possible labels are integers starting from 0.
         """
         y_sparse = self.predict(X)
+        index = X.index if hasattr(X, "index") else pd.RangeIndex(len(X))
         y_dense = self.sparse_to_dense(y_sparse, pd.RangeIndex(len(X)))
         y_dense = self._coerce_to_df(y_dense, columns=["labels"])
+        y_dense.index = index
         return y_dense
 
     def transform_scores(self, X):

--- a/sktime/detection/base/tests/test_base.py
+++ b/sktime/detection/base/tests/test_base.py
@@ -1,6 +1,7 @@
 """Tests for base change point detection class."""
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from sktime.tests.test_switch import run_test_module_changed
@@ -26,3 +27,24 @@ def test_fit_transform_numpy():
     # also test fit alone
     model = SubLOF(3, window_size=5, novelty=True)
     model.fit(data)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection"),
+    reason="module not changed",
+)
+def test_transform_preserves_index():
+    """Test that transform preserves input index.
+
+    Regression test for issue: BaseDetector.transform drops original time index.
+    """
+    from sktime.detection.naive import ThresholdDetector
+
+    rng = pd.date_range("2024-01-01", periods=5, freq="D")
+    X = pd.Series([1, 2, 10, 2, 1], index=rng)
+
+    model = ThresholdDetector(upper=5)
+    model.fit(X)
+    y_pred = model.transform(X)
+
+    assert all(y_pred.index == X.index)


### PR DESCRIPTION
## Summary
Fixes `BaseDetector.transform` to preserve the input time series index in output.

## Problem
`BaseDetector.transform` was not preserving the input's index (e.g., DatetimeIndex) and always returned results with a generic RangeIndex. This breaks downstream workflows that depend on aligned time indices. #10138

## Solution
Capture the input index before processing and apply it to the final output DataFrame. The fix:
- Extracts X.index if available, otherwise defaults to RangeIndex
- Applies this index to the transformed output

## Changes
- Modified `BaseDetector.transform` in `sktime/detection/base/_base.py`
- Added regression test `test_transform_preserves_index` in test_base.py

## Testing
- Added test with DatetimeIndex input to verify index preservation
- Existing tests continue to pass

fixes - #10138