### PR TITLE
[ENH] move dynamic tag setting to dedicated `__dynamic_tags__` method

### DIFF
--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -216,6 +216,21 @@ class MyForecaster(BaseForecaster):
         # do not put anything else in __init__,
         # use __post_init__ for any further initialization logic
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the incstance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
+
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 
@@ -237,16 +252,6 @@ class MyForecaster(BaseForecaster):
         else:
             # estimators should be cloned to avoid side effects
             self._paramc = self.paramc.clone()
-
-        # todo: if tags of estimator depend on component tags, set these here
-        #  only needed if estimator is a composite
-        #  tags set in the constructor apply to the object and override the class
-        #
-        # example 1: conditional setting of a tag
-        # if est.foo == 42:
-        #   self.set_tags(handles-missing-data=True)
-        # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _fit(self, y, X, fh):

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -224,7 +224,7 @@ class MyForecaster(BaseForecaster):
         """
         # todo: if tags of estimator depend on component tags, set these here
         #  typically only needed if estimator is a composite
-        #  tags set here apply to the incstance, and override the class tags
+        #  tags set here apply to the instance, and override the class tags
         #
         # example 1: conditional setting of a tag based on parameter foo
         # if self.foo == 42:

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -216,6 +216,7 @@ class MyForecaster(BaseForecaster):
         # do not put anything else in __init__,
         # use __post_init__ for any further initialization logic
 
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
     def __dynamic_tags__(self):
         """Dynamic tag setter logic for setting tag values condition on parameters.
 
@@ -231,6 +232,7 @@ class MyForecaster(BaseForecaster):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -238,7 +238,6 @@ class MyForecaster(BaseForecaster):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -151,7 +151,6 @@ class MyForecaster(BaseForecaster):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -144,6 +144,7 @@ class MyForecaster(BaseForecaster):
         # do not put anything else in __init__,
         # use __post_init__ for any further initialization logic
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/forecasting_supersimple.py
+++ b/extension_templates/forecasting_supersimple.py
@@ -111,7 +111,6 @@ class MyForecaster(BaseForecaster):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -197,6 +197,13 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
 
         return deep_equals(self_params, other_params)
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        pass
+
     @classmethod
     def _get_set_config_doc(cls):
         """Create docstring for set_config from self._config_doc.

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -175,6 +175,10 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         """,
     }
 
+    def __init__(self):
+        self.__dynamic_tags__()
+        super().__init__()
+
     def __eq__(self, other):
         """Equality dunder. Checks equal class and parameters.
 

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -176,8 +176,8 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
     }
 
     def __init__(self):
-        self.__dynamic_tags__()
         super().__init__()
+        self.__dynamic_tags__()
 
     def __eq__(self, other):
         """Equality dunder. Checks equal class and parameters.

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -81,7 +81,11 @@ class BaggingForecaster(BaseForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
         "authors": ["fkiraly", "ltsaprounis"],
+        # estimator type
+        # --------------
         "capability:multivariate": True,  # which y are fine? True/False
         "capability:exogenous": True,  # does estimator ignore the exogeneous X?
         "capability:missing_values": True,  # can estimator handle missing data?

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -111,23 +111,37 @@ class BaggingForecaster(BaseForecaster):
         self.sp = sp
         self.random_state = random_state
 
-        if bootstrap_transformer is None:
+        super().__init__()
+
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        if self.bootstrap_transformer is None:
             # if the transformer is None, this uses the statsmodels dependent
             # sktime.transformations.bootstrap.STLBootstrapTransformer
             #
             # done before the super call to trigger exceptions
             self.set_tags(**{"python_dependencies": "statsmodels"})
 
-        super().__init__()
-
         # set the tags based on forecaster
         tags_to_clone = [
             "requires-fh-in-fit",  # is forecasting horizon already required in fit?
             "enforce_index_type",
         ]
-        if forecaster is not None:
+        if self.forecaster is not None:
             self.clone_tags(self.forecaster, tags_to_clone)
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
         self.bootstrap_transformer_ = self._check_transformer(bootstrap_transformer)
         self.forecaster_ = self._check_forecaster(forecaster)
 

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -142,8 +142,9 @@ class BaggingForecaster(BaseForecaster):
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
         """
+        bootstrap_transformer = self.bootstrap_transformer
         self.bootstrap_transformer_ = self._check_transformer(bootstrap_transformer)
-        self.forecaster_ = self._check_forecaster(forecaster)
+        self.forecaster_ = self._check_forecaster(self.forecaster)
 
     def _check_transformer(self, transformer):
         """Check if the transformer is a valid transformer for BaggingForecaster.

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -91,7 +91,11 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
     """
 
     _tags = {
+        # packaging info
+        # --------------
         "authors": ["GuzalBulatova", "mloning", "fkiraly"],
+        # estimator type
+        # --------------
         "capability:multivariate": True,
         "capability:exogenous": True,
         "y_inner_mtype": PANDAS_MTYPES,

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -31,13 +31,15 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
     Parameters
     ----------
     forecasters : sktime forecaster, or list of tuples (str, estimator, int or pd.index)
-        if tuples, with name = str, estimator is forecaster, index as int or index
-        if last element is index, it must be int, str, or pd.Index coercible
-        if last element is int x, and is not in columns, is interpreted as x-th column
-        all columns must be present in an index
 
-        If forecaster, clones of forecaster are applied to all columns.
-        If list of tuples, forecaster in tuple is applied to column with int/str index
+        * if tuples, with name = str, estimator is forecaster, index as int or index
+        * if last element is index, it must be int, str, or pd.Index coercible
+        * if last element is int x, and is not in columns, is interpreted as x-th column
+
+        All columns must be present in an index
+
+        * If forecaster, clones of forecaster are applied to all columns.
+        * If list of tuples, forecaster in tuple is applied to column with int/str index
 
     Examples
     --------
@@ -119,17 +121,22 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
 
         super().__init__(forecasters=None)
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         # set requires-fh-in-fit depending on forecasters
-        if isinstance(forecasters, BaseForecaster):
+        if isinstance(self.forecasters, BaseForecaster):
             tags_to_clone = [
                 "requires-fh-in-fit",
                 "capability:pred_int",
                 "capability:exogenous",
                 "capability:missing_values",
             ]
-            self.clone_tags(forecasters, tags_to_clone)
+            self.clone_tags(self.forecasters, tags_to_clone)
         else:
-            l_forecasters = [(x[0], x[1]) for x in forecasters]
+            l_forecasters = [(x[0], x[1]) for x in self.forecasters]
             self._anytagis_then_set("requires-fh-in-fit", True, False, l_forecasters)
             self._anytagis_then_set("capability:pred_int", False, True, l_forecasters)
             self._anytagis_then_set("capability:exogenous", True, False, l_forecasters)

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -106,7 +106,11 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
         "authors": ["mloning", "GuzalBulatova", "aiwalter", "RNKuhns", "AnH0ang"],
+        # estimator type
+        # --------------
         "capability:exogenous": True,
         "requires-fh-in-fit": False,
         "capability:missing_values": False,

--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -131,21 +131,39 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     _steps_fitted_attr = "forecasters_"
 
     def __init__(self, forecasters, verbose=False, nan_predict_policy="ignore"):
+        self.forecasters = forecasters
+        self.verbose = verbose
+        self.nan_predict_policy = nan_predict_policy
+
         super().__init__()
 
-        self.forecasters = forecasters
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        self._anytagis_then_set("requires-fh-in-fit", True, False, self._forecasters)
+        self._anytagis_then_set("capability:pred_int", False, True, self._forecasters)
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
         self.current_forecaster_ = None
         self.current_name_ = None
-        self.verbose = verbose
-        self.nan_predict_policy = _check_nan_policy_option(nan_predict_policy)
+
+        self.nan_predict_policy = _check_nan_policy_option(self.nan_predict_policy)
 
         self._forecasters = self._check_estimators(
             forecasters, "forecasters", clone_ests=False
         )
         self.forecasters_ = self._check_estimators(forecasters, "forecasters")
 
-        self._anytagis_then_set("requires-fh-in-fit", True, False, self._forecasters)
-        self._anytagis_then_set("capability:pred_int", False, True, self._forecasters)
 
     def _validate_y_pred(self, y_pred):
         if self.nan_predict_policy in ("warn", "raise"):

--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -160,10 +160,9 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
         self.nan_predict_policy = _check_nan_policy_option(self.nan_predict_policy)
 
         self._forecasters = self._check_estimators(
-            forecasters, "forecasters", clone_ests=False
+            self.forecasters, "forecasters", clone_ests=False
         )
-        self.forecasters_ = self._check_estimators(forecasters, "forecasters")
-
+        self.forecasters_ = self._check_estimators(self.forecasters, "forecasters")
 
     def _validate_y_pred(self, y_pred):
         if self.nan_predict_policy in ("warn", "raise"):

--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -108,8 +108,12 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
         "authors": ["ninedigits", "RikStarmans"],
         "maintainers": ["ninedigits"],
+        # estimator type
+        # --------------
         "capability:missing_values": True,
         "capability:multivariate": True,
         "y_inner_mtype": ALL_TIME_SERIES_MTYPES,

--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -142,6 +142,11 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
 
         This method should be used for setting dynamic tags only.
         """
+        # writing self._forecasters early to allow tag setting
+        self._forecasters = self._check_estimators(
+            self.forecasters, "forecasters", clone_ests=False
+        )
+
         self._anytagis_then_set("requires-fh-in-fit", True, False, self._forecasters)
         self._anytagis_then_set("capability:pred_int", False, True, self._forecasters)
 
@@ -159,9 +164,6 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
 
         self.nan_predict_policy = _check_nan_policy_option(self.nan_predict_policy)
 
-        self._forecasters = self._check_estimators(
-            self.forecasters, "forecasters", clone_ests=False
-        )
         self.forecasters_ = self._check_estimators(self.forecasters, "forecasters")
 
     def _validate_y_pred(self, y_pred):

--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -28,22 +28,30 @@ class FhPlexForecaster(BaseForecaster):
     forecaster : sktime compatible forecaster
     fh_params : dict, list, callable, or str that eval-defines a callable
         specifies forecaster to use per fh element
-        dict: keys = fh elements, values = param dict for forecaster
-        list: i-th entry is forecaster param dict for i-th fh element
-        callable: maps fh element to forecaster param dict
-        str: eval(fh_params) must define a lambda that maps fh element to param dict
+        
+        * dict: keys = fh elements, values = param dict for forecaster
+        * list: i-th entry is forecaster param dict for i-th fh element
+        * callable: maps fh element to forecaster param dict
+        * str: eval(fh_params) must define a lambda that maps fh element to param dict
+
         param dict need not be complete, only overrides for ``forecaster`` params
+
     fh_lookup : str, one of "relative" (default), "absolute", or "as-is"
         specifies fh elements used in dict or callable
-        if "relative", fh will be coerced to relative ForecastingHorizon
-        if "absolute", fh will be coerced to absolute ForecastingHorizon
-        if "as-is", fh will be coerced to ForecastingHorizon (but not relative/absolute)
+
+        * if "relative", fh will be coerced to relative ``ForecastingHorizon``
+        * if "absolute", fh will be coerced to absolute ``ForecastingHorizon``
+        * if "as-is", fh will be coerced to ``ForecastingHorizon``
+          (but not relative/absolute)
+
     fh_contiguous : bool, default=False
         whether fh in inner loops are enforced to be contiguous
-        False: forecaster with fh_params[fN] is asked to forecast fN and only fN
-        True: forecaster with fh_params[fN] is asked to forecast 1, 2, ..., fN
-            and the output is then subset to the forecast of fN
-            this is required if the forecaster can only forecast contiguous horizons
+
+        * False: forecaster with fh_params[fN] is asked to forecast fN and only fN
+        * True: forecaster with fh_params[fN] is asked to forecast 1, 2, ..., fN
+          and the output is then subset to the forecast of fN
+          this is required if the forecaster can only forecast contiguous horizons
+
         CAUTION: if using grid search inside, then ``True`` will cause the
         tuning metric to be evaluated on horizons 1, 2, ..., fN, not just fN
 

--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -91,7 +91,11 @@ class FhPlexForecaster(BaseForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
         "authors": "fkiraly",
+        # estimator type
+        # --------------
         "requires-fh-in-fit": True,
         "capability:missing_values": True,
         "capability:multivariate": True,

--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -28,7 +28,7 @@ class FhPlexForecaster(BaseForecaster):
     forecaster : sktime compatible forecaster
     fh_params : dict, list, callable, or str that eval-defines a callable
         specifies forecaster to use per fh element
-        
+
         * dict: keys = fh elements, values = param dict for forecaster
         * list: i-th entry is forecaster param dict for i-th fh element
         * callable: maps fh element to forecaster param dict

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -112,11 +112,6 @@ class ForecastByLevel(_DelegatedForecaster):
         self.set_tags(**{"y_inner_mtype": mtypes})
         self.set_tags(**{"X_inner_mtype": mtypes})
 
-    def __dynamic_tags__(self):
-        """Dynamic tag setter logic for setting tag values condition on parameters.
-
-        This method should be used for setting dynamic tags only.
-        """
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -81,13 +81,17 @@ class ForecastByLevel(_DelegatedForecaster):
         self.forecaster = forecaster
         self.groupby = groupby
 
-        self.forecaster_ = forecaster.clone()
-
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         self._set_delegated_tags(self.forecaster_)
         self.set_tags(**{"fit_is_empty": False})
 
+        groupby = self.groupby
         if groupby == "local":
             scitypes = ["Series"]
         elif groupby == "global":
@@ -107,6 +111,22 @@ class ForecastByLevel(_DelegatedForecaster):
         # but vectorization/broadcasting happens at the level of groupby
         self.set_tags(**{"y_inner_mtype": mtypes})
         self.set_tags(**{"X_inner_mtype": mtypes})
+
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        self.forecaster_ = forecaster.clone()
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -126,7 +126,7 @@ class ForecastByLevel(_DelegatedForecaster):
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
         """
-        self.forecaster_ = forecaster.clone()
+        self.forecaster_ = self.forecaster.clone()
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -88,7 +88,7 @@ class ForecastByLevel(_DelegatedForecaster):
 
         This method should be used for setting dynamic tags only.
         """
-        self._set_delegated_tags(self.forecaster_)
+        self._set_delegated_tags(self.forecaster)
         self.set_tags(**{"fit_is_empty": False})
 
         groupby = self.groupby

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -60,7 +60,11 @@ class ForecastByLevel(_DelegatedForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
         "authors": ["fkiraly"],
+        # estimator type
+        # --------------
         "requires-fh-in-fit": False,
         "capability:missing_values": True,
         "capability:multivariate": True,

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -173,6 +173,7 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
 
         This method should be used for setting dynamic tags only.
         """
+        forecasters = self.forecasters
         if isinstance(forecasters, BaseForecaster):
             tags_to_clone = [
                 "requires-fh-in-fit",

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -140,8 +140,12 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
         "authors": ["VyomkeshVyas", "sanskarmodi8"],
         "maintainers": ["VyomkeshVyas"],
+        # estimator type
+        # --------------
         "capability:multivariate": True,
         "capability:exogenous": True,
         "y_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -168,6 +168,11 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
         self.backend_params = backend_params
         super().__init__(forecasters=None)
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         if isinstance(forecasters, BaseForecaster):
             tags_to_clone = [
                 "requires-fh-in-fit",

--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -36,6 +36,8 @@ class IgnoreX(_DelegatedForecaster):
     _delegate_name = "forecaster_"
 
     _tags = {
+        # estimator type
+        # --------------
         "capability:exogenous": True,
         # CI and test flags
         # -----------------

--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -48,13 +48,24 @@ class IgnoreX(_DelegatedForecaster):
 
         super().__init__()
 
-        self.forecaster_ = forecaster.clone()
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
 
+        This method should be used for setting dynamic tags only.
+        """
         self._set_delegated_tags(self.forecaster_)
-        self.set_tags(**{"capability:exogenous": True})
+        self.set_tags(**{"capability:exogenous": not self.ignore_x})
 
-        if ignore_x:
-            self.set_tags(**{"capability:exogenous": False})
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        self.forecaster_ = forecaster.clone()
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -65,7 +76,6 @@ class IgnoreX(_DelegatedForecaster):
         parameter_set : str, default="default"
             Name of the set of test parameters to return, for use in tests. If no
             special parameters are defined for a value, will return ``"default"`` set.
-
 
         Returns
         -------

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -114,23 +114,37 @@ class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
         forecasters: list,
         selected_forecaster=None,
     ):
-        super().__init__()
         self.selected_forecaster = selected_forecaster
-
         self.forecasters = forecasters
-        self._check_estimators(
-            forecasters,
-            attr_name="forecasters",
-            cls_type=BaseForecaster,
-            clone_ests=False,
-        )
-        self._set_forecaster()
+        super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         self._set_delegated_tags()
         self.set_tags(**{"fit_is_empty": False})
         # this ensures that we convert in the inner estimator, not in the multiplexer
         self.set_tags(**{"y_inner_mtype": ALL_TIME_SERIES_MTYPES})
         self.set_tags(**{"X_inner_mtype": ALL_TIME_SERIES_MTYPES})
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        self._check_estimators(
+            self.forecasters,
+            attr_name="forecasters",
+            cls_type=BaseForecaster,
+            clone_ests=False,
+        )
+        self._set_forecaster()
 
     @property
     def _forecasters(self):

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -81,7 +81,11 @@ class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
         "authors": ["kkoralturk", "aiwalter", "fkiraly", "miraep8"],
+        # estimator type
+        # --------------
         "requires-fh-in-fit": False,
         "capability:missing_values": False,
         "capability:multivariate": True,

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -123,21 +123,7 @@ class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
 
         This method should be used for setting dynamic tags only.
         """
-        self._set_delegated_tags()
-        self.set_tags(**{"fit_is_empty": False})
-        # this ensures that we convert in the inner estimator, not in the multiplexer
-        self.set_tags(**{"y_inner_mtype": ALL_TIME_SERIES_MTYPES})
-        self.set_tags(**{"X_inner_mtype": ALL_TIME_SERIES_MTYPES})
-
-    def __post_init__(self):
-        """Post-init constructor logic, can be used by inheriting classes.
-
-        This method should be used for:
-
-        * parameter validation
-        * initialization logic beyond self.param = param
-        * any soft dependency imports in the constructor
-        """
+        # setting forecaster early to allow tag setting
         self._check_estimators(
             self.forecasters,
             attr_name="forecasters",
@@ -145,6 +131,12 @@ class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
             clone_ests=False,
         )
         self._set_forecaster()
+
+        self._set_delegated_tags()
+        self.set_tags(**{"fit_is_empty": False})
+        # this ensures that we convert in the inner estimator, not in the multiplexer
+        self.set_tags(**{"y_inner_mtype": ALL_TIME_SERIES_MTYPES})
+        self.set_tags(**{"X_inner_mtype": ALL_TIME_SERIES_MTYPES})
 
     @property
     def _forecasters(self):

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -433,8 +433,13 @@ class ForecastingPipeline(_Pipeline):
 
     def __init__(self, steps):
         self.steps = steps
-        self.steps_ = self._check_steps(steps, allow_postproc=False)
         super().__init__()
+
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         tags_to_clone = [
             "capability:exogenous",  # does estimator ignore the exogeneous X?
             "capability:pred_int",  # can the estimator produce prediction intervals?
@@ -447,6 +452,17 @@ class ForecastingPipeline(_Pipeline):
         #   create indices, and that behaviour is not tag-inspectable
         self.clone_tags(self.forecaster_, tags_to_clone)
         self._anytagis_then_set("fit_is_empty", False, True, self.steps_)
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        self.steps_ = self._check_steps(self.steps, allow_postproc=False)
 
     @property
     def forecaster_(self):
@@ -884,9 +900,13 @@ class TransformedTargetForecaster(_Pipeline):
 
     def __init__(self, steps):
         self.steps = steps
-        self.steps_ = self._check_steps(steps, allow_postproc=True)
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         # set the tags based on forecaster
         tags_to_clone = [
             "capability:exogenous",  # does estimator ignore the exogeneous X?
@@ -915,6 +935,17 @@ class TransformedTargetForecaster(_Pipeline):
 
         if any_t_use_y:
             self.set_tags(**{"capability:exogenous": True})
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        self.steps_ = self._check_steps(self.steps, allow_postproc=True)
 
     @property
     def forecaster_(self):

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -876,8 +876,12 @@ class TransformedTargetForecaster(_Pipeline):
     """
 
     _tags = {
+        # packaging info
+        # --------------
         "authors": ["mloning", "fkiraly", "aiwalter"],
         "capability:multivariate": True,
+        # estimator type
+        # --------------
         "y_inner_mtype": SUPPORTED_MTYPES,
         "X_inner_mtype": SUPPORTED_MTYPES,
         "capability:exogenous": True,

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -440,6 +440,9 @@ class ForecastingPipeline(_Pipeline):
 
         This method should be used for setting dynamic tags only.
         """
+        # setting self.steps_ early to allow self.forecaster_ property etc
+        self.steps_ = self._check_steps(self.steps, allow_postproc=False)
+
         tags_to_clone = [
             "capability:exogenous",  # does estimator ignore the exogeneous X?
             "capability:pred_int",  # can the estimator produce prediction intervals?
@@ -452,17 +455,6 @@ class ForecastingPipeline(_Pipeline):
         #   create indices, and that behaviour is not tag-inspectable
         self.clone_tags(self.forecaster_, tags_to_clone)
         self._anytagis_then_set("fit_is_empty", False, True, self.steps_)
-
-    def __post_init__(self):
-        """Post-init constructor logic, can be used by inheriting classes.
-
-        This method should be used for:
-
-        * parameter validation
-        * initialization logic beyond self.param = param
-        * any soft dependency imports in the constructor
-        """
-        self.steps_ = self._check_steps(self.steps, allow_postproc=False)
 
     @property
     def forecaster_(self):
@@ -907,6 +899,9 @@ class TransformedTargetForecaster(_Pipeline):
 
         This method should be used for setting dynamic tags only.
         """
+        # setting self.steps_ early to allow self.forecaster_ property etc
+        self.steps_ = self._check_steps(self.steps, allow_postproc=True)
+
         # set the tags based on forecaster
         tags_to_clone = [
             "capability:exogenous",  # does estimator ignore the exogeneous X?
@@ -935,17 +930,6 @@ class TransformedTargetForecaster(_Pipeline):
 
         if any_t_use_y:
             self.set_tags(**{"capability:exogenous": True})
-
-    def __post_init__(self):
-        """Post-init constructor logic, can be used by inheriting classes.
-
-        This method should be used for:
-
-        * parameter validation
-        * initialization logic beyond self.param = param
-        * any soft dependency imports in the constructor
-        """
-        self.steps_ = self._check_steps(self.steps, allow_postproc=True)
 
     @property
     def forecaster_(self):

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1987,6 +1987,11 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         self._lags = list(range(window_length))
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         if pooling == "local":
             mtypes = "pd.DataFrame"
         elif pooling == "global":
@@ -2384,7 +2389,6 @@ class RecursiveReductionForecaster(BaseForecaster, _ReducerMixin):
         self.estimator = estimator
         self.impute_method = impute_method
         self.pooling = pooling
-        self._lags = list(range(window_length))
         super().__init__()
 
         warn(
@@ -2393,6 +2397,12 @@ class RecursiveReductionForecaster(BaseForecaster, _ReducerMixin):
             "https://github.com/alan-turing-institute/sktime/issues/3224"
         )
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        pooling = self.pooling
         if pooling == "local":
             mtypes = "pd.DataFrame"
         elif pooling == "global":
@@ -2408,6 +2418,18 @@ class RecursiveReductionForecaster(BaseForecaster, _ReducerMixin):
         self.set_tags(**{"X_inner_mtype": mtypes})
         self.set_tags(**{"y_inner_mtype": mtypes})
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        self._lags = list(range(self.window_length))
+
+        impute_method = self.impute_method
         if isinstance(impute_method, str):
             from sktime.transformations.series.impute import Imputer
 
@@ -2796,23 +2818,22 @@ class YfromX(BaseForecaster, _ReducerMixin):
         self.pooling = pooling
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        estimator = self.estimator
         # self._est_type encodes information what type of estimator is passed
         if hasattr(estimator, "get_tags"):
             _est_type = estimator.get_tag("object_type", "regressor", False)
         else:
             _est_type = "regressor"
 
-        if _est_type not in ["regressor", "regressor_proba"]:
-            raise TypeError(
-                "error in YfromX, estimator must be either an sklearn compatible "
-                "regressor, or an skpro probabilistic regressor."
-            )
-
         # has probabilistic mode iff the estimator is of type regressor_proba
         self.set_tags(**{"capability:pred_int": _est_type == "regressor_proba"})
 
-        self._est_type = _est_type
-
+        pooling = self.pooling
         if pooling == "local":
             mtypes = "pd.DataFrame"
         elif pooling == "global":
@@ -2827,6 +2848,29 @@ class YfromX(BaseForecaster, _ReducerMixin):
             )
         self.set_tags(**{"X_inner_mtype": mtypes})
         self.set_tags(**{"y_inner_mtype": mtypes})
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        # self._est_type encodes information what type of estimator is passed
+        if hasattr(estimator, "get_tags"):
+            _est_type = estimator.get_tag("object_type", "regressor", False)
+        else:
+            _est_type = "regressor"
+
+        if _est_type not in ["regressor", "regressor_proba"]:
+            raise TypeError(
+                "error in YfromX, estimator must be either an sklearn compatible "
+                "regressor, or an skpro probabilistic regressor."
+            )
+
+        self._est_type = _est_type
 
     def _fit(self, y, X, fh):
         """Fit forecaster to training data.

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1992,6 +1992,7 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
 
         This method should be used for setting dynamic tags only.
         """
+        pooling = self.pooling
         if pooling == "local":
             mtypes = "pd.DataFrame"
         elif pooling == "global":
@@ -2858,6 +2859,7 @@ class YfromX(BaseForecaster, _ReducerMixin):
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
         """
+        estimator = self.estimator
         # self._est_type encodes information what type of estimator is passed
         if hasattr(estimator, "get_tags"):
             _est_type = estimator.get_tag("object_type", "regressor", False)

--- a/sktime/forecasting/compose/_skforecast_reduce.py
+++ b/sktime/forecasting/compose/_skforecast_reduce.py
@@ -21,9 +21,9 @@ class SkforecastAutoreg(BaseForecaster):
     lags : int, list, numpy ndarray, range
         Lags used as predictors. Index starts at 1, so lag 1 is equal to t-1.
 
-            - ``int``: include lags from 1 to ``lags`` (included).
-            - ``list``, ``1d numpy ndarray`` or ``range``: include only lags present in
-            ``lags``, all elements must be int.
+        - ``int``: include lags from 1 to ``lags`` (included).
+        - ``list``, ``1d numpy ndarray`` or ``range``: include only lags present in
+          ``lags``, all elements must be int.
 
     transformer_y : object transformer (preprocessor), default ``None``
         An instance of a transformer (preprocessor) compatible with the scikit-learn
@@ -156,6 +156,15 @@ class SkforecastAutoreg(BaseForecaster):
 
         super().__init__()
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
         self._regressor = None
         self._forecaster = None
         self._transformer_y = None

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -77,6 +77,11 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
 
         super().__init__(forecasters=forecasters, n_jobs=n_jobs)
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         self._anytagis_then_set("capability:exogenous", True, False, forecasters)
         self._anytagis_then_set("capability:missing_values", False, True, forecasters)
         self._anytagis_then_set("fit_is_empty", False, True, forecasters)

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -82,6 +82,7 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
 
         This method should be used for setting dynamic tags only.
         """
+        forecasters = self._get_forecaster_list()
         self._anytagis_then_set("capability:exogenous", True, False, forecasters)
         self._anytagis_then_set("capability:missing_values", False, True, forecasters)
         self._anytagis_then_set("fit_is_empty", False, True, forecasters)

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -77,13 +77,6 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
 
         super().__init__(forecasters=forecasters, n_jobs=n_jobs)
 
-    def __dynamic_tags__(self):
-        """Dynamic tag setter logic for setting tag values condition on parameters.
-
-        This method should be used for setting dynamic tags only.
-        """
-        self._initialize_forecaster_tuples(self.forecasters)
-        forecasters = self._get_forecaster_list()
         self._anytagis_then_set("capability:exogenous", True, False, forecasters)
         self._anytagis_then_set("capability:missing_values", False, True, forecasters)
         self._anytagis_then_set("fit_is_empty", False, True, forecasters)

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -82,6 +82,7 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
 
         This method should be used for setting dynamic tags only.
         """
+        self._initialize_forecaster_tuples()
         forecasters = self._get_forecaster_list()
         self._anytagis_then_set("capability:exogenous", True, False, forecasters)
         self._anytagis_then_set("capability:missing_values", False, True, forecasters)

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -82,7 +82,7 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
 
         This method should be used for setting dynamic tags only.
         """
-        self._initialize_forecaster_tuples()
+        self._initialize_forecaster_tuples(self.forecasters)
         forecasters = self._get_forecaster_list()
         self._anytagis_then_set("capability:exogenous", True, False, forecasters)
         self._anytagis_then_set("capability:missing_values", False, True, forecasters)

--- a/sktime/forecasting/compose/_transform_select_forecaster.py
+++ b/sktime/forecasting/compose/_transform_select_forecaster.py
@@ -124,23 +124,35 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
 
         super().__init__()
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
         # saving arguments to object storage
-        if transformer is not None:
-            self.transformer = transformer
+        if self.transformer is not None:
+            transformer = self.transformer
         else:
             from sktime.transformations.series.adi_cv import ADICVTransformer
 
-            self.transformer = ADICVTransformer(features=["class"])
+            transformer = ADICVTransformer(features=["class"])
 
-        self.transformer_ = coerce_scitype(self.transformer, "transformer").clone()
+        self.transformer_ = coerce_scitype(transformer, "transformer").clone()
 
-        for forecaster in forecasters.values():
+        for forecaster in self.forecasters.values():
             assert isinstance(forecaster, BaseForecaster)
 
-        self.forecasters_ = {k: f.clone() for k, f in forecasters.items()}
+        self.forecasters_ = {k: f.clone() for k, f in self.forecasters.items()}
 
-        # All checks OK!
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
 
+        This method should be used for setting dynamic tags only.
+        """
         # Assigning all capabilities on the basis of the capabilities
         # of the passed forecasters
         true_if_all_tags = {
@@ -168,6 +180,7 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
                     break
 
             # Perform this check for the fallback forecaster too
+            fallback_forecaster = self.fallback_forecaster
             if fallback_forecaster is not None and (
                 tag not in fallback_forecaster.get_tags()
                 or fallback_forecaster.get_tags()[tag] is False
@@ -195,13 +208,6 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
 
         # Update the tags
         self.set_tags(**true_if_all_tags)
-
-        # Finally, dynamically adding implementation of probabilistic
-        # functions depending on the tags set.
-        if self.get_tag("capability:pred_int"):
-            self._predict_interval = _predict_interval
-            self._predict_var = _predict_var
-            self._predict_proba = _predict_proba
 
     @property
     def _steps(self):
@@ -437,114 +443,111 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
             else:
                 self.fallback_forecaster = forecaster
 
+    def _predict_interval(self, fh, X, coverage):
+        """Compute/return prediction quantiles for a forecast.
 
-# Function implementations that will be added dynamically
-# if the conditions are met. explained further above!
-def _predict_interval(self, fh, X, coverage):
-    """Compute/return prediction quantiles for a forecast.
+        private _predict_interval containing the core logic,
+            called from predict_interval and possibly predict_quantiles
 
-    private _predict_interval containing the core logic,
-        called from predict_interval and possibly predict_quantiles
+        State required:
+            Requires state to be "fitted".
 
-    State required:
-        Requires state to be "fitted".
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
 
-    Accesses in self:
-        Fitted model attributes ending in "_"
-        self.cutoff
-
-    Parameters
-    ----------
-    fh : guaranteed to be ForecastingHorizon
-        The forecasting horizon with the steps ahead to predict.
-    X :  sktime time series object, optional (default=None)
-        guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
-        Exogeneous time series for the forecast
-    coverage : list of float (guaranteed not None and floats in [0,1] interval)
-        nominal coverage(s) of predictive interval(s)
-
-    Returns
-    -------
-    pred_int : pd.DataFrame
-        Column has multi-index: first level is variable name from y in fit,
-            second level coverage fractions for which intervals were computed.
-                in the same order as in input `coverage`.
-            Third level is string "lower" or "upper", for lower/upper interval end.
-        Row index is fh, with additional (upper) levels equal to instance levels,
-            from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
-        Entries are forecasts of lower/upper interval end,
-            for var in col index, at nominal coverage in second col index,
-            lower/upper depending on third col index, for the row index.
-            Upper/lower interval end forecasts are equivalent to
-            quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
-    """
-    # Call this function for the chosen forecaster
-    return self.chosen_forecaster_.predict_interval(fh=fh, X=X, coverage=coverage)
-
-
-def _predict_var(self, fh, X=None, cov=False):
-    """Forecast variance at future horizon.
-
-    private _predict_var containing the core logic, called from predict_var
-
-    Parameters
-    ----------
-    fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
-        The forecasting horizon with the steps ahead to predict.
-        If not passed in _fit, guaranteed to be passed here
-    X :  sktime time series object, optional (default=None)
-        guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
-        Exogeneous time series for the forecast
-    cov : bool, optional (default=False)
-        if True, computes covariance matrix forecast.
-        if False, computes marginal variance forecasts.
-
-    Returns
-    -------
-    pred_var : pd.DataFrame, format dependent on `cov` variable
-        If cov=False:
-            Column names are exactly those of `y` passed in `fit`/`update`.
-                For nameless formats, column index will be a RangeIndex.
-            Row index is fh, with additional levels equal to instance levels,
-                from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
-            Entries are variance forecasts, for var in col index.
-            A variance forecast for given variable and fh index is a predicted
-                variance for that variable and index, given observed data.
-        If cov=True:
-            Column index is a multiindex: 1st level is variable names (as above)
-                2nd level is fh.
-            Row index is fh, with additional levels equal to instance levels,
-                from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
-            Entries are (co-)variance forecasts, for var in col index, and
-                covariance between time index in row and col.
-            Note: no covariance forecasts are returned between different variables.
-    """
-    return self.chosen_forecaster_.predict_var(fh=fh, X=X, cov=cov)
-
-
-def _predict_proba(self, fh, X, marginal=True):
-    """Compute/return fully probabilistic forecasts.
-
-    private _predict_proba containing the core logic, called from predict_proba
-
-    Parameters
-    ----------
-    fh : int, list, np.array or ForecastingHorizon (not optional)
-        The forecasting horizon encoding the time stamps to forecast at.
-        if has not been passed in fit, must be passed, not optional
-    X : sktime time series object, optional (default=None)
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon
+            The forecasting horizon with the steps ahead to predict.
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
             Exogeneous time series for the forecast
-        Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
-        if self.get_tag("X-y-must-have-same-index"),
-            X.index must contain fh.index and y.index both
-    marginal : bool, optional (default=True)
-        whether returned distribution is marginal by time index
+        coverage : list of float (guaranteed not None and floats in [0,1] interval)
+            nominal coverage(s) of predictive interval(s)
 
-    Returns
-    -------
-    pred_dist : sktime BaseDistribution
-        predictive distribution
-        if marginal=True, will be marginal distribution by time point
-        if marginal=False and implemented by method, will be joint
-    """
-    return self.chosen_forecaster_.predict_proba(fh=fh, X=X, marginal=marginal)
+        Returns
+        -------
+        pred_int : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+                second level coverage fractions for which intervals were computed.
+                    in the same order as in input `coverage`.
+                Third level is string "lower" or "upper", for lower/upper interval end.
+            Row index is fh, with additional (upper) levels equal to instance levels,
+                from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+            Entries are forecasts of lower/upper interval end,
+                for var in col index, at nominal coverage in second col index,
+                lower/upper depending on third col index, for the row index.
+                Upper/lower interval end forecasts are equivalent to
+                quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
+        """
+        # Call this function for the chosen forecaster
+        return self.chosen_forecaster_.predict_interval(fh=fh, X=X, coverage=coverage)
+
+
+    def _predict_var(self, fh, X=None, cov=False):
+        """Forecast variance at future horizon.
+
+        private _predict_var containing the core logic, called from predict_var
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to predict.
+            If not passed in _fit, guaranteed to be passed here
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series for the forecast
+        cov : bool, optional (default=False)
+            if True, computes covariance matrix forecast.
+            if False, computes marginal variance forecasts.
+
+        Returns
+        -------
+        pred_var : pd.DataFrame, format dependent on `cov` variable
+            If cov=False:
+                Column names are exactly those of `y` passed in `fit`/`update`.
+                    For nameless formats, column index will be a RangeIndex.
+                Row index is fh, with additional levels equal to instance levels,
+                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+                Entries are variance forecasts, for var in col index.
+                A variance forecast for given variable and fh index is a predicted
+                    variance for that variable and index, given observed data.
+            If cov=True:
+                Column index is a multiindex: 1st level is variable names (as above)
+                    2nd level is fh.
+                Row index is fh, with additional levels equal to instance levels,
+                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+                Entries are (co-)variance forecasts, for var in col index, and
+                    covariance between time index in row and col.
+                Note: no covariance forecasts are returned between different variables.
+        """
+        return self.chosen_forecaster_.predict_var(fh=fh, X=X, cov=cov)
+
+
+    def _predict_proba(self, fh, X, marginal=True):
+        """Compute/return fully probabilistic forecasts.
+
+        private _predict_proba containing the core logic, called from predict_proba
+
+        Parameters
+        ----------
+        fh : int, list, np.array or ForecastingHorizon (not optional)
+            The forecasting horizon encoding the time stamps to forecast at.
+            if has not been passed in fit, must be passed, not optional
+        X : sktime time series object, optional (default=None)
+                Exogeneous time series for the forecast
+            Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
+            if self.get_tag("X-y-must-have-same-index"),
+                X.index must contain fh.index and y.index both
+        marginal : bool, optional (default=True)
+            whether returned distribution is marginal by time index
+
+        Returns
+        -------
+        pred_dist : sktime BaseDistribution
+            predictive distribution
+            if marginal=True, will be marginal distribution by time point
+            if marginal=False and implemented by method, will be joint
+        """
+        return self.chosen_forecaster_.predict_proba(fh=fh, X=X, marginal=marginal)

--- a/sktime/forecasting/compose/_transform_select_forecaster.py
+++ b/sktime/forecasting/compose/_transform_select_forecaster.py
@@ -484,7 +484,6 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         # Call this function for the chosen forecaster
         return self.chosen_forecaster_.predict_interval(fh=fh, X=X, coverage=coverage)
 
-
     def _predict_var(self, fh, X=None, cov=False):
         """Forecast variance at future horizon.
 
@@ -523,7 +522,6 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
                 Note: no covariance forecasts are returned between different variables.
         """
         return self.chosen_forecaster_.predict_var(fh=fh, X=X, cov=cov)
-
 
     def _predict_proba(self, fh, X, marginal=True):
         """Compute/return fully probabilistic forecasts.

--- a/sktime/forecasting/compose/_transform_select_forecaster.py
+++ b/sktime/forecasting/compose/_transform_select_forecaster.py
@@ -97,15 +97,20 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["shlok191"],
+        "maintainers": ["shlok191"],
+        "python_version": None,
+        # estimator type
+        # --------------
         "y_inner_mtype": "pd.DataFrame",
         "X_inner_mtype": "pd.DataFrame",
         "capability:multivariate": True,
         "capability:exogenous": True,
+        "capability:pred_int": True,
         "requires-fh-in-fit": False,
         "enforce_index_type": None,
-        "authors": ["shlok191"],
-        "maintainers": ["shlok191"],
-        "python_version": None,
         "visual_block_kind": "parallel",
         # CI and test flags
         # -----------------


### PR DESCRIPTION
This PR adds a `__dynamic_tags__` entrypoint for all dynamic tag setting.

This helps structure tag setting logic better, and control the exact point in initialization when this occurs - this was inconsistent in the current code base prior this PR.

The PR also moves dynamic tag setting in composites to the new `__dynamic_tags__` entrypoint.