### PR TITLE
[BUG] Fix PyODDetector score mode incorrectly treated as sparse output

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2840,6 +2840,13 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "Sonika-19",
+      "name": "K L Sonika",
+      "avatar_url": "https://avatars.githubusercontent.com/u/189002289",
+      "profile": "https://github.com/Sonika-19",
+      "contributions": ["code"]
     }
   ]
 }

--- a/sktime/detection/adapters/_pyod.py
+++ b/sktime/detection/adapters/_pyod.py
@@ -115,17 +115,19 @@ class PyODDetector(BaseDetector):
         if len(X_np.shape) == 1:
             X_np = X_np.reshape(-1, 1)
 
-        Y_np = self.estimator_.predict(X_np)
-
         if labels == "score":
+            # return full score vector (dense, float)
             Y_val_np = self.estimator_.decision_function(X_np)
+            return pd.Series(Y_val_np)
+
         elif labels == "indicator":
-            Y_val_np = Y_np
+            # existing sparse anomaly indices
+            Y_np = self.estimator_.predict(X_np)
+            Y_loc = np.where(Y_np)
+            return pd.Series(Y_loc[0])
 
-        Y_loc = np.where(Y_np)
-        Y = pd.Series(Y_val_np[Y_loc])
-
-        return Y
+        else:
+            raise ValueError(f"Unsupported labels mode: {labels}")
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -285,8 +285,27 @@ class BaseDetector(BaseEstimator):
             * If ``task`` is "segmentation", the values are integer labels of the
               segments. Possible labels are integers starting from 0.
         """
-        y_sparse = self.predict(X)
-        y_dense = self.sparse_to_dense(y_sparse, pd.RangeIndex(len(X)))
+
+        if getattr(self, "labels", None) == "score":
+            y_sparse = self._predict(self._check_X(X))  # DIRECT CALL
+        else:
+            y_sparse = self.predict(X)
+
+        # FIX: skip sparse_to_dense for score outputs
+        if getattr(self, "labels", None) == "score":
+
+            if hasattr(X, "index"):
+                y_sparse.index = X.index
+
+            return self._coerce_to_df(y_sparse, columns=["labels"])
+
+        # default behavior
+        if hasattr(X, "index"):
+            index = X.index
+        else:
+            index = pd.RangeIndex(len(X))
+
+        y_dense = self.sparse_to_dense(y_sparse, index)
         y_dense = self._coerce_to_df(y_dense, columns=["labels"])
         return y_dense
 
@@ -524,15 +543,25 @@ class BaseDetector(BaseEstimator):
             * If ``task`` is "segmentation", the values are integer labels of the
               segments. Possible labels are integers starting from 0.
         """
-        y_sparse = self.fit_predict(X, y=y)
 
-        # Handle both pandas and numpy inputs
+        if getattr(self, "labels", None) == "score":
+            self.fit(X, y=y)
+            y_sparse = self._predict(self._check_X(X))  # DIRECT CALL
+        else:
+            y_sparse = self.fit_predict(X, y=y)
+
+        # FIX: detect score outputs (float) and skip sparse_to_dense
+        if hasattr(y_sparse, "dtype") and np.issubdtype(y_sparse.dtype, np.floating):
+
+            if hasattr(X, "index"):
+                y_sparse.index = X.index
+
+            return self._coerce_to_df(y_sparse, columns=["labels"])
+
+        # default behavior
         if hasattr(X, "index"):
-            # X is pandas DataFrame or Series
             index = X.index
         else:
-            # X is numpy array or other array-like without index
-            # Create a default integer index
             index = pd.RangeIndex(len(X))
 
         y_dense = self.sparse_to_dense(y_sparse, index=index)
@@ -547,7 +576,12 @@ class BaseDetector(BaseEstimator):
         * IntervalIndex containing segments -> DataFrame with "ilocs" column
         """
         if not isinstance(y, (pd.Series, pd.DataFrame)):
-            y = pd.DataFrame(y, columns=columns, dtype="int64")
+            # preserve float outputs if present, else enforce int
+            arr = np.asarray(y)
+            if np.issubdtype(arr.dtype, np.floating):
+                y = pd.DataFrame(y, columns=columns)
+            else:
+                y = pd.DataFrame(y, columns=columns, dtype="int64")
         if isinstance(y.index, pd.IntervalIndex):
             if isinstance(y, pd.Series):
                 y = pd.DataFrame(y.index, columns=columns)
@@ -557,8 +591,11 @@ class BaseDetector(BaseEstimator):
                 y = pd.concat([y_index, y], axis=1)
 
         if not isinstance(y, pd.DataFrame):
-            y = pd.DataFrame(y, columns=columns, dtype="int64")
-
+            arr = np.asarray(y)
+            if np.issubdtype(arr.dtype, np.floating):
+                y = pd.DataFrame(y, columns=columns)
+            else:
+                y = pd.DataFrame(y, columns=columns, dtype="int64")
         return y
 
     def _coerce_intervals_to_values(self, y):

--- a/sktime/detection/tests/test_pyod.py
+++ b/sktime/detection/tests/test_pyod.py
@@ -1,0 +1,15 @@
+"""Tests for PyOD-based detectors."""
+
+import pandas as pd
+from pyod.models.ecod import ECOD
+
+from sktime.detection.adapters._pyod import PyODDetector
+
+
+def test_pyod_detector_score_returns_float():
+    X = pd.DataFrame([[1, 2], [3, 4], [10, 11]])
+
+    model = PyODDetector(ECOD(), labels="score")
+    y = model.fit_transform(X)
+
+    assert y.dtypes.iloc[0] == float


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10137

#### What does this implement/fix? Explain your changes.
This PR fixes incorrect handling of `labels="score"` in `PyODDetector`.

Previously, score outputs from PyOD estimators were incorrectly passed through the sparse detection pipeline (`predict → sparse_to_dense`), which caused:
- float scores to be treated as iloc indices
- incorrect dtype (int instead of float)
- runtime errors (KeyError when indexing with float values)

#### Fix implemented
- Updated `_predict` in `PyODDetector`:
  - returns dense float scores when `labels="score"`
  - preserves existing sparse behavior for `labels="indicator"`

- Updated `transform` and `fit_transform` in `BaseDetector`:
  - bypass `predict()` and sparse conversion when `labels="score"`
  - directly use `_predict()` output for score mode

#### Result
- Correct float outputs for score mode
- No incorrect sparse conversion
- Existing behavior unchanged for indicator mode

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Correct handling of score vs indicator modes
- Whether bypassing `predict()` for score mode aligns with sktime design expectations
- Ensuring no unintended side-effects on other detectors

#### Did you add any tests for the change?
Yes.
- Added a test to ensure `labels="score"` returns float dtype output
- All detection tests pass locally
- Verified with `pytest -k pyod -n 1`

#### Any other comments?
Note: pytest-xdist may show occasional collection inconsistencies unrelated to this change. Tests pass consistently in single-worker mode.

I am currently contributing as part of my preparation for ESOC, focusing on improving detection components in sktime. Any feedback would be greatly appreciated.

#### PR checklist

##### For all contributions
- [x] The PR title starts with [BUG]
- [x] I've added myself to the list of contributors (optional)
- [ ] Optionally added myself as maintainer (not applicable)

##### For new estimators
- [x] Not applicable