### PR TITLE
BF: fix PyODDetector labels='score' returning partial float scores

### DIFF
--- a/sktime/detection/adapters/_pyod.py
+++ b/sktime/detection/adapters/_pyod.py
@@ -122,10 +122,22 @@ class PyODDetector(BaseDetector):
         elif labels == "indicator":
             Y_val_np = Y_np
 
-        Y_loc = np.where(Y_np)
-        Y = pd.Series(Y_val_np[Y_loc])
+        if labels == "score":
+            Y = pd.Series(Y_val_np, index=X.index)
+        else:
+            Y_loc = np.where(Y_np)
+            Y = pd.Series(Y_val_np[Y_loc], index=X.index[Y_loc[0]])
 
         return Y
+
+
+    def predict(self, X):
+        """Override predict to handle labels='score' without int64 coercion."""
+        if self.labels == "score":
+            self.check_is_fitted()
+            X_inner = self._check_X(X)
+            return self._predict(X=X_inner)
+        return super().predict(X)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10137

#### What does this implement/fix?
When `labels="score"` was passed to `PyODDetector` two bugs occurred:

- Only scores at anomaly positions were returned instead of the full series
- The base class `_coerce_to_df` forced dtype to `int64` causing a `ValueError` on float scores

Fixed by:
- In `_predict`: when `labels="score"` return full series with correct index instead of partial anomaly-position scores
- In `predict`: override base class to skip `int64` coercion when `labels="score"`

#### Does your contribution introduce a new dependency?
No

#### What should a reviewer concentrate their feedback on?
- The `predict` override in `PyODDetector` to bypass `_coerce_to_df` for the score case
- Whether the `indicator` case still behaves correctly after the `_predict` changes

#### Did you add any tests for the change?
No dedicated test file exists for `PyODDetector` currently. Verified manually that `labels="score"` now returns correct length, correct index and float dtype, and that `labels="indicator"` still works as before.