### PR TITLE
[DOC] Fix docstring typos, broken examples, and parameter name mismatches

### DIFF
--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -1636,7 +1636,7 @@ def load_m5(
             value_name="sales",
         ).dropna()
 
-        # add calender info
+        # add calendar info
         df2 = df1.merge(cal, left_on="day", right_on="d", how="left")
 
         # select useful columns

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -658,6 +658,9 @@ def from_3d_numpy_to_multi_index(
     time_index : str
         Name of multi-index level corresponding to DataFrame's timepoints
 
+    column_names : list, optional
+        Optional list of column names to use for the DataFrame columns.
+
 
     Returns
     -------
@@ -730,7 +733,7 @@ def from_multi_index_to_nested(
     multi_ind_dataframe : pd.DataFrame
         Input multi-indexed pandas DataFrame
 
-    instance_index_name : int or str, default=0 (first level = 0-th index)
+    instance_index : int or str, default=None (first level = 0-th index)
         Index or name of multi-index level corresponding to the DataFrame's instances
 
     cells_as_numpy : bool, default = False
@@ -894,7 +897,7 @@ def from_nested_to_3d_numpy(X):
 
     Returns
     -------
-    X_3d : np.ndarrray
+    X_3d : np.ndarray
         3-dimensional NumPy array
     """
     # n_columns = X.shape[1]

--- a/sktime/transformations/series/filter.py
+++ b/sktime/transformations/series/filter.py
@@ -93,7 +93,7 @@ class Filter(BaseTransformer):
 
         Parameters
         ----------
-        X : 2D or 3D numpy array, sktime format np.darray or numpy3D
+        X : 2D or 3D numpy array, sktime format np.ndarray or numpy3D
         y : not used, passed only for interface conformance
 
         Returns

--- a/sktime/transformations/series/peak.py
+++ b/sktime/transformations/series/peak.py
@@ -24,7 +24,7 @@ class PeakTimeFeature(BaseTransformer):
         the frequency of the time series given by ts_freq.
         E.g., if daily data is provided and ts_freq = ("D"), it does not make
         sense to derive PeakTimeFeature with higher frequency like hourly features. So,
-        the outpul must exclude is_peak_hour and will be is_peak_day, is_peak_week,
+        the output must exclude is_peak_hour and will be is_peak_day, is_peak_week,
         is_peak_month, is_peak_quarter, is_peak_year.
         Only supports the following frequencies:
         {"Y": year, "Q": quarter, "M": month, "W": week, "D": day, "H": hour}
@@ -119,7 +119,7 @@ class PeakTimeFeature(BaseTransformer):
 
     2- Example for two peak intervals: peak_hour_start=[6, 16], peak_hour_end=[9, 20]
     means we have two peak hour intervals where the first peak starts at 6 am
-    and ends at 9 am. The second peak starts at 16 am and ends at 20. we can
+    and ends at 9 am. The second peak starts at 16 (4 PM) and ends at 20. we can
     have more than two intervals.
 
     3- Example for one working interval: working_hour_start=[8], working_hour_end=[16]
@@ -134,7 +134,7 @@ class PeakTimeFeature(BaseTransformer):
     Examples
     --------
     >>> from sktime.transformations.series.peak import PeakTimeFeature  # doctest: +SKIP
-    >>> from sktime.datasets import   # doctest: +SKIP
+    >>> from sktime.datasets import load_solar  # doctest: +SKIP
     >>> y = load_solar()  # doctest: +SKIP
     >>> y = y.tz_localize(None)  # doctest: +SKIP
     >>> y = y.asfreq("H")  # doctest: +SKIP


### PR DESCRIPTION
#### Reference Issues/PRs
No linked issue found during codebase review.

#### What does this implement/fix? Explain your changes.

Fixes multiple documentation issues across the codebase:

**Broken docstring example:**
- `sktime/transformations/series/peak.py` (line 137): The docstring
  example had an incomplete import statement
  (`from sktime.datasets import   # doctest: +SKIP` — missing `load_solar`)

**Typos:**
- `peak.py` (line 27): `outpul` → `output`
- `peak.py` (line 122): `16 am` → `16 (4 PM)` (24-hour time doesn't use AM/PM)
- `filter.py` (line 96): `np.darray` → `np.ndarray`
- `_convert.py` (line 897): `np.ndarrray` → `np.ndarray` (triple 'r')
- `_single_problem_loaders.py` (line 1639): `calender` → `calendar`

**Parameter name mismatches:**
- `_convert.py` (line 733): Docstring says `instance_index_name` but actual
  parameter is `instance_index`

**Missing parameter documentation:**
- `_convert.py`: `from_3d_numpy_to_multi_index()` has `column_names` parameter
  in its signature but it was not documented in the docstring

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### Any other comments?
Documentation-only changes, no code logic affected.
