### PR TITLE
[ENH] Move weight loading from _fit to __post_init__ for zero-shot models (#10152)

### DIFF
--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -317,6 +317,8 @@ class ChronosForecaster(BaseForecaster):
         "capability:insample": False,
         "capability:pred_int:insample": False,
         "capability:global_forecasting": True,
+        "capability:pretrain": True,
+        "fit_is_empty": True,
         # testing configuration
         # ---------------------
         "tests:vm": True,
@@ -388,6 +390,11 @@ class ChronosForecaster(BaseForecaster):
 
         self._initialize_model_type()
 
+        # Load the model pipeline eagerly at construction time.
+        # Chronos is a zero-shot model: weights are pretrained and immutable,
+        # so loading them once here avoids redundant reloading on every fit().
+        self.model_pipeline = self._load_pipeline()
+
     def _initialize_model_type(self):
         """Initialise model type and configuration based on model's architecture."""
         from transformers import AutoConfig
@@ -418,6 +425,10 @@ class ChronosForecaster(BaseForecaster):
     def _fit(self, y, X=None, fh=None):
         """Fit forecaster to training data.
 
+        For zero-shot models like Chronos, fitting only stores the context
+        window. The model pipeline (pretrained weights) is loaded once in
+        ``__post_init__`` and reused across fit calls.
+
         private _fit containing the core logic, called from fit
 
         Parameters
@@ -433,7 +444,8 @@ class ChronosForecaster(BaseForecaster):
         -------
         self : reference to self
         """
-        self.model_pipeline = self._load_pipeline()
+        # Ensure pipeline is available (e.g., after deserialization)
+        self._ensure_model_pipeline_loaded()
         self._context = y
         return self
 
@@ -471,8 +483,7 @@ class ChronosForecaster(BaseForecaster):
     def _ensure_model_pipeline_loaded(self):
         """Ensure model pipeline is loaded, recreating if needed after unpickling."""
         if not hasattr(self, "model_pipeline") or self.model_pipeline is None:
-            if hasattr(self, "_is_fitted") and self._is_fitted:
-                self.model_pipeline = self._load_pipeline()
+            self.model_pipeline = self._load_pipeline()
 
     def _load_pipeline(self):
         """Load the model pipeline using the multiton pattern.

--- a/sktime/forecasting/chronos2.py
+++ b/sktime/forecasting/chronos2.py
@@ -88,6 +88,8 @@ class Chronos2Forecaster(BaseForecaster):
         "capability:multivariate": True,
         "capability:insample": False,
         "capability:global_forecasting": True,
+        "capability:pretrain": True,
+        "fit_is_empty": True,
         "capability:non_contiguous_X": False,
         "tests:vm": True,
         "tests:skip_by_name": [
@@ -116,7 +118,7 @@ class Chronos2Forecaster(BaseForecaster):
         self.config = config
         self.ignore_deps = ignore_deps
 
-        self.model_pipeline = None
+
 
         if ignore_deps:
             self.set_tags(python_dependencies=[])
@@ -142,6 +144,11 @@ class Chronos2Forecaster(BaseForecaster):
 
         if self.config is not None:
             self._config.update(self.config)
+
+        # Load the model pipeline eagerly at construction time.
+        # Chronos-2 is a zero-shot model: weights are pretrained and immutable,
+        # so loading them once here avoids redundant reloading on every fit().
+        self.model_pipeline = self._load_pipeline()
 
     def __getstate__(self):
         """Return state for pickling, excluding unpickleable model pipeline."""
@@ -174,8 +181,7 @@ class Chronos2Forecaster(BaseForecaster):
     def _ensure_model_pipeline_loaded(self):
         """Reload model pipeline if needed after unpickling."""
         if not hasattr(self, "model_pipeline") or self.model_pipeline is None:
-            if hasattr(self, "_is_fitted") and self._is_fitted:
-                self.model_pipeline = self._load_pipeline()
+            self.model_pipeline = self._load_pipeline()
 
     def _fit(self, y, X=None, fh=None):
         """Fit the forecaster to training data.
@@ -192,7 +198,8 @@ class Chronos2Forecaster(BaseForecaster):
         -------
         self
         """
-        self.model_pipeline = self._load_pipeline()
+        # Ensure pipeline is available (e.g., after deserialization)
+        self._ensure_model_pipeline_loaded()
 
         context_length = self._config["context_length"]
         if context_length is None:

--- a/sktime/forecasting/tests/test_chronos_pretrain.py
+++ b/sktime/forecasting/tests/test_chronos_pretrain.py
@@ -1,0 +1,151 @@
+"""Tests for Chronos zero-shot weight loading migration.
+
+Tests that ChronosForecaster loads model weights at construction time
+(in __post_init__) rather than in _fit(), ensuring:
+1. No redundant weight reloading on repeated fit() calls
+2. The pretrain -> fit -> predict workflow functions correctly
+3. Pipeline persistence across serialization/deserialization
+"""
+
+__author__ = ["Keykyrios"]
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sktime.forecasting.base import ForecastingHorizon
+from sktime.utils.dependencies import _check_estimator_deps
+
+
+@pytest.fixture
+def _check_chronos_deps():
+    """Skip test if Chronos dependencies are not available."""
+    from sktime.forecasting.chronos import ChronosForecaster
+
+    try:
+        _check_estimator_deps(ChronosForecaster, severity="error")
+    except ModuleNotFoundError:
+        pytest.skip("Chronos soft dependencies not available")
+
+
+@pytest.fixture
+def forecaster(_check_chronos_deps):
+    """Create a ChronosForecaster instance."""
+    from sktime.forecasting.chronos import ChronosForecaster
+
+    return ChronosForecaster("amazon/chronos-t5-tiny")
+
+
+@pytest.fixture
+def airline_data():
+    """Load airline dataset split into train/test."""
+    from sktime.datasets import load_airline
+    from sktime.split import temporal_train_test_split
+
+    y = load_airline()
+    return temporal_train_test_split(y)
+
+
+@pytest.fixture
+def panel_data():
+    """Create panel data for pretrain testing."""
+    y_panel = pd.DataFrame(
+        {"y": np.random.default_rng(42).standard_normal(60)},
+        index=pd.MultiIndex.from_arrays(
+            [
+                np.repeat(["ts1", "ts2", "ts3"], 20),
+                np.tile(pd.date_range("2000", periods=20, freq="ME"), 3),
+            ],
+            names=["instance", "time"],
+        ),
+    )
+    return y_panel
+
+
+def test_pipeline_loaded_at_construction(forecaster):
+    """Test that model pipeline is loaded during __post_init__."""
+    assert hasattr(forecaster, "model_pipeline")
+    assert forecaster.model_pipeline is not None
+
+
+def test_fit_does_not_reload_pipeline(forecaster, airline_data):
+    """Test that fit() reuses the pipeline loaded at construction."""
+    y_train, _ = airline_data
+    pipeline_before = id(forecaster.model_pipeline)
+
+    forecaster.fit(y_train)
+
+    pipeline_after = id(forecaster.model_pipeline)
+    assert pipeline_before == pipeline_after, (
+        "Pipeline was reloaded during fit(). "
+        "Zero-shot models should load weights once at construction."
+    )
+
+
+def test_repeated_fit_no_reload(forecaster, airline_data):
+    """Test that repeated fit() calls don't reload the pipeline."""
+    y_train, _ = airline_data
+    pipeline_id_init = id(forecaster.model_pipeline)
+
+    forecaster.fit(y_train)
+    pipeline_id_fit1 = id(forecaster.model_pipeline)
+
+    forecaster.fit(y_train)
+    pipeline_id_fit2 = id(forecaster.model_pipeline)
+
+    assert pipeline_id_init == pipeline_id_fit1 == pipeline_id_fit2
+
+
+def test_pretrain_capability_tag(forecaster):
+    """Test that capability:pretrain tag is set to True."""
+    assert forecaster.get_tag("capability:pretrain") is True
+
+
+def test_pretrain_fit_predict_flow(forecaster, airline_data, panel_data):
+    """Test the full pretrain -> fit -> predict lifecycle."""
+    y_train, y_test = airline_data
+
+    # pretrain on panel data
+    forecaster.pretrain(panel_data)
+    assert forecaster.state == "pretrained"
+    pipeline_after_pretrain = id(forecaster.model_pipeline)
+
+    # fit on single series (should not reload pipeline)
+    forecaster.fit(y_train)
+    assert forecaster.state == "fitted"
+    pipeline_after_fit = id(forecaster.model_pipeline)
+    assert pipeline_after_pretrain == pipeline_after_fit
+
+    # predict
+    fh = ForecastingHorizon(y_test.index, is_relative=False)
+    y_pred = forecaster.predict(fh)
+    assert len(y_pred) == len(y_test)
+
+
+def test_fit_predict_without_pretrain(forecaster, airline_data):
+    """Test that standard fit -> predict still works without pretrain."""
+    y_train, y_test = airline_data
+
+    forecaster.fit(y_train)
+    fh = ForecastingHorizon(y_test.index, is_relative=False)
+    y_pred = forecaster.predict(fh)
+
+    assert len(y_pred) == len(y_test)
+    assert forecaster.state == "fitted"
+
+
+def test_pickle_roundtrip(forecaster, airline_data):
+    """Test that pickling and unpickling restores the pipeline."""
+    import pickle
+
+    y_train, y_test = airline_data
+    forecaster.fit(y_train)
+
+    # Pickle and unpickle
+    pickled = pickle.dumps(forecaster)
+    restored = pickle.loads(pickled)
+
+    # Pipeline should be lazily reloaded
+    fh = ForecastingHorizon(y_test.index, is_relative=False)
+    y_pred = restored.predict(fh)
+    assert len(y_pred) == len(y_test)

--- a/sktime/forecasting/timemoe.py
+++ b/sktime/forecasting/timemoe.py
@@ -130,6 +130,8 @@ class TimeMoEForecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
         "capability:insample": False,
         "capability:pred_int:insample": False,
         "capability:global_forecasting": True,
+        "capability:pretrain": True,
+        "fit_is_empty": True,
         # testing configuration
         # ---------------------
         "tests:vm": True,
@@ -186,8 +188,30 @@ class TimeMoEForecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
         _config.update(self.config if self.config is not None else {})
         self._config = _config
 
+        # Load the model eagerly at construction time.
+        # TimeMoE is a zero-shot model: weights are pretrained and immutable,
+        # so loading them once here avoids redundant reloading on every fit().
+        self.model = self._load_model()
+
+    def _load_model(self):
+        """Load the TimeMoE model using the multiton pattern."""
+        return _CachedTimeMoE(
+            key=self._get_unique_timemoe_key(),
+            timemoe_kwargs=self._get_timemoe_kwargs(),
+            use_source_package=self.use_source_package,
+        ).load_from_checkpoint()
+
+    def _ensure_model_loaded(self):
+        """Ensure model is loaded, reloading if needed after unpickling."""
+        if not hasattr(self, "model") or self.model is None:
+            self.model = self._load_model()
+
     def _fit(self, y, X=None, fh=None):
         """Fit forecaster to training data.
+
+        For zero-shot models like TimeMoE, fitting only stores the context
+        and updates input_size config. The model weights are loaded once in
+        ``__post_init__`` and reused across fit calls.
 
         Parameters
         ----------
@@ -208,11 +232,9 @@ class TimeMoEForecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
         else:
             config["input_size"] = 1
         self._config = config
-        self.model = _CachedTimeMoE(
-            key=self._get_unique_timemoe_key(),
-            timemoe_kwargs=self._get_timemoe_kwargs(),
-            use_source_package=self.use_source_package,
-        ).load_from_checkpoint()
+
+        # Ensure model is available (e.g., after deserialization)
+        self._ensure_model_loaded()
 
         return self
 

--- a/sktime/forecasting/tirex.py
+++ b/sktime/forecasting/tirex.py
@@ -121,6 +121,8 @@ class TiRexForecaster(BaseForecaster):
         # CI and test flags
         # -----------------
         "tests:vm": True,
+        "capability:pretrain": True,
+        "fit_is_empty": True,
     }
 
     def __init__(
@@ -159,10 +161,20 @@ class TiRexForecaster(BaseForecaster):
         license_text = dist.read_text("licenses/LICENSE")
         print(license_text)
 
+    def _ensure_model_loaded(self):
+        """Ensure model is loaded, loading lazily on first access."""
+        if self.model_ is None:
+            key = _tirex_cache_key(self.model, self.device)
+            self.model_ = _cached_TiRex(
+                key=key, model=self.model, device=self.device
+            ).load()
+
     def _fit(self, y, X, fh):
         """Fit forecaster to training data.
 
-        Loads and caches the underlying TiRex model instance (no training).
+        For zero-shot models like TiRex, fitting only stores the context.
+        The model is loaded lazily on first access and cached via the
+        multiton pattern.
 
         Parameters
         ----------
@@ -188,10 +200,7 @@ class TiRexForecaster(BaseForecaster):
         self : TiRexForecaster
             Fitted forecaster (with ``model_`` set).
         """
-        key = _tirex_cache_key(self.model, self.device)
-        self.model_ = _cached_TiRex(
-            key=key, model=self.model, device=self.device
-        ).load()
+        self._ensure_model_loaded()
         return self
 
     def _predict(self, fh, X):


### PR DESCRIPTION
#### Reference Issues/PRs

Part of #10151. Closes #10152.

#### What does this implement/fix? Explain your changes.

Zero-shot foundation models were loading pretrained weights inside `_fit()` on every call. This is wrong. `_fit()` for a zero-shot model should only store the context window. The weights are immutable and should be loaded once.

Migrated models:
- **ChronosForecaster**: `_load_pipeline()` moved to `__post_init__`
- **Chronos2Forecaster**: `_load_pipeline()` moved to `__post_init__`
- **TiRexForecaster**: lazy init via `_ensure_model_loaded()` (license gate in `__init__` prevents eager loading)
- **TimeMoEForecaster**: `_load_model()` moved to `__post_init__`

Tags added to all migrated models:
- `capability:pretrain = True` enables `pretrain()` -> `fit()` -> `predict()` flow
- `fit_is_empty = True` signals fit does no actual learning

The multiton caching already present in these models ensures the same underlying model object survives `reset()` and `clone()` cycles with zero overhead.

Deferred to follow-up PR: TimesFMForecaster (`context_len` depends on `len(y)`), TotoForecaster (loads in `_predict`), MOIRAIForecaster (`prediction_length` depends on `fh`).

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether `fit_is_empty = True` is correct for all four models
- The lazy init pattern for TiRex vs eager `__post_init__` for the others
- Whether deferred models (TimesFM, Toto, MOIRAI) should be noted differently

#### Did you add any tests for the change?

Yes. `sktime/forecasting/tests/test_chronos_pretrain.py` covers:
- Pipeline loaded at construction, not in `fit`
- Repeated `fit()` calls don't reload the pipeline (verified via object ID)
- Full `pretrain()` -> `fit()` -> `predict()` lifecycle
- Pickle roundtrip restores pipeline
- `capability:pretrain` tag is set correctly

#### Any other comments?

Related to the approach proposed by @Sonika-19 in #10151.
