### PR TITLE
[DOC] clarify `_post_init__` contract w.r.t. memory and compute heavy operations

### DIFF
--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -241,6 +241,9 @@ class MyForecaster(BaseForecaster):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         # todo: optional, parameter checking or coercion should happen here
         # if writes derived values to self, should *not* overwrite self.paramc etc

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -153,6 +153,9 @@ class MyForecaster(BaseForecaster):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         # todo: optional, parameter checking or coercion should happen here
         # if writes derived values to self, should *not* overwrite self.parama etc

--- a/extension_templates/forecasting_supersimple.py
+++ b/extension_templates/forecasting_supersimple.py
@@ -112,6 +112,9 @@ class MyForecaster(BaseForecaster):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         # todo: optional, parameter checking or coercion should happen here
         # if writes derived values to self, should *not* overwrite self.parama etc

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -145,6 +145,9 @@ class BaggingForecaster(BaseForecaster):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         bootstrap_transformer = self.bootstrap_transformer
         self.bootstrap_transformer_ = self._check_transformer(bootstrap_transformer)

--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -162,6 +162,9 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         self.current_forecaster_ = None
         self.current_name_ = None

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -124,6 +124,9 @@ class ForecastByLevel(_DelegatedForecaster):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         self.forecaster_ = self.forecaster.clone()
 

--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -66,6 +66,9 @@ class IgnoreX(_DelegatedForecaster):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         self.forecaster_ = self.forecaster.clone()
 

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -2427,6 +2427,9 @@ class RecursiveReductionForecaster(BaseForecaster, _ReducerMixin):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         self._lags = list(range(self.window_length))
 
@@ -2858,6 +2861,9 @@ class YfromX(BaseForecaster, _ReducerMixin):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         estimator = self.estimator
         # self._est_type encodes information what type of estimator is passed

--- a/sktime/forecasting/compose/_skforecast_reduce.py
+++ b/sktime/forecasting/compose/_skforecast_reduce.py
@@ -164,6 +164,9 @@ class SkforecastAutoreg(BaseForecaster):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         self._regressor = None
         self._forecaster = None

--- a/sktime/forecasting/compose/_transform_select_forecaster.py
+++ b/sktime/forecasting/compose/_transform_select_forecaster.py
@@ -137,6 +137,9 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         # saving arguments to object storage
         if self.transformer is not None:

--- a/sktime/forecasting/greykite.py
+++ b/sktime/forecasting/greykite.py
@@ -98,6 +98,9 @@ class GreykiteForecaster(BaseForecaster):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         self._forecaster = None
         self._forecast = None

--- a/sktime/forecasting/mapa.py
+++ b/sktime/forecasting/mapa.py
@@ -171,6 +171,9 @@ class MAPAForecaster(BaseForecaster):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         self._aggregation_levels = (
             self.aggregation_levels if self.aggregation_levels else [1, 2, 4]

--- a/sktime/forecasting/neuralforecast.py
+++ b/sktime/forecasting/neuralforecast.py
@@ -264,6 +264,9 @@ class NeuralForecastRNN(_NeuralForecastAdapter):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         # initiate internal variables to avoid AttributeError in future
         self._trainer_kwargs = None

--- a/sktime/forecasting/scinet.py
+++ b/sktime/forecasting/scinet.py
@@ -202,6 +202,9 @@ class SCINetForecaster(BaseDeepNetworkPyTorch):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         import torch
 

--- a/sktime/forecasting/squaring_residuals.py
+++ b/sktime/forecasting/squaring_residuals.py
@@ -142,6 +142,9 @@ class SquaringResiduals(BaseForecaster):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         assert self.distr in ["norm", "laplace", "t", "cauchy"]
         assert self.strategy in ["square", "abs"]

--- a/sktime/forecasting/var_reduce.py
+++ b/sktime/forecasting/var_reduce.py
@@ -150,6 +150,9 @@ class VARReduce(BaseForecaster):
         * parameter validation
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
         if self.regressor is None:
             from sklearn.linear_model import LinearRegression


### PR DESCRIPTION
This PR adds documentation to clarify the new `_post_init__` contract w.r.t. memory and compute heavy operations, in delineation from `_fit`.

Namely, `_post_init__` should not contain compute or memory heavy operations, these should be localized in `_fit`.