### PR TITLE
[ENH] remove deprecated `scipy` Kulsinski distance from tests

### DIFF
--- a/sktime/dists_kernels/tests/test_scipy_dist.py
+++ b/sktime/dists_kernels/tests/test_scipy_dist.py
@@ -1,4 +1,5 @@
 """Tests for scipy interface."""
+import warnings
 
 import numpy as np
 import pytest
@@ -55,30 +56,42 @@ def X2_df():
         panel=False,
     )
 
+def _scipy_available(metric):
+    """
+    Return
+        True if scipy accepts metric
+        False if not
+    """
+    from scipy.spatial.distance import cdist
+
+    x = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cdist(x, x, metric=metric)
+    except ValueError:
+        return False
+
+    return True
+
 
 def _get_kul_name():
     """Get name of kul... distance.
 
     Utility to bridge deprecation of kulsinski distance in scipy.
     Name pre-1.11.0 is kulsinski, and from 1.11.0 it is kulczynski1.
-
-    Returns
-    -------
-    name : str
-        one of "kulsinski" (if scipy < 1.11.0) and "kulczynski1" (if scipy >= 1.11.0)
+    From 1.17.0 none of them is available returns None in that case.
     """
-    try:
-        from scipy.spatial.distance import kulczynski1  # noqa: F401
+    distance = ["kulczynski1", "kulsinski"]
+    for name in distance:
+        if _scipy_available(name):
+            return name
 
-        name = "kulczynski1"
-    except Exception:
-        name = "kulsinski"
-
-    return name
+    return None
 
 
 # potential parameters
-METRIC_VALUES = [
+_METRIC_CANDIDATES = [
     "braycurtis",
     "canberra",
     "chebyshev",
@@ -90,7 +103,7 @@ METRIC_VALUES = [
     "hamming",
     "jaccard",
     "jensenshannon",
-    _get_kul_name(),
+    *filter(None, [_get_kul_name()]),
     "mahalanobis",
     "matching",
     "minkowski",
@@ -102,6 +115,10 @@ METRIC_VALUES = [
     "sqeuclidean",
     "yule",
 ]
+METRIC_VALUES = [
+    metric for metric in _METRIC_CANDIDATES if _scipy_available(metric)
+]
+
 P_VALUES = [1, 2, 5, 10]
 COLALIGN_VALUES = ["intersect", "force-align", "none"]
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10190

#### What does this implement/fix? Explain your changes.
the scipy new version did not support the importing of `kulsinski` and `kulczynski1` due to this the wrong import happend that lead to failing test and raise valueError.

to fix this i made a fall back function `_scipy_available()` that we can use in `_get_Kul()` and test whether the metric name is there or not.

then added `_METRIC_CANDIDATES` that has filter function that maps the input to `None` if the metric name is not there in the `get_kul()` function
therefore `METRIC_VALUES` uses it and only the metrics available will be used 

this will lead to the test case to pass

tests pass locally
<img width="1919" height="354" alt="Screenshot 2026-05-06 103456" src="https://github.com/user-attachments/assets/a9ff2cda-79c2-4935-8d5e-3ffe47ceeb99" />