### PR TITLE
[BUG] add missing raise to ValueError/NotImplementedError in _deprecation_global and benchmarking base

### DIFF
--- a/sktime/benchmarking/base.py
+++ b/sktime/benchmarking/base.py
@@ -116,7 +116,7 @@ class BaseResults:
 
     def save(self):
         """Save results object as master file."""
-        NotImplementedError()
+        raise NotImplementedError()
 
     def _iter(self):
         """Iterate over registry of results object."""

--- a/sktime/forecasting/base/_deprecation_global.py
+++ b/sktime/forecasting/base/_deprecation_global.py
@@ -420,7 +420,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
 
         # handle inputs
         self.check_is_fitted()
@@ -565,7 +565,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
 
         self.check_is_fitted()
         if y is None:
@@ -697,7 +697,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
 
         self.check_is_fitted()
         if y is None:
@@ -825,7 +825,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
         self.check_is_fitted()
         if y is None:
             self._global_forecasting = False
@@ -934,7 +934,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
 
         self.check_is_fitted()
         if y is None:


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10063

#### What does this implement/fix? Explain your changes.

## Summary

Five `ValueError` constructors in `_BaseGlobalForecaster.predict()`, `predict_quantiles()`, `predict_interval()`, `predict_var()`, and `predict_proba()` were called without the `raise` keyword. In each of those methods the guard reads `if not gf and y is not None: ValueError("no global forecasting support!")` — Python evaluates `ValueError(...)` as a standalone expression, creates the exception object, and immediately discards it; execution continues as if no check was performed, silently accepting invalid `y` arguments for forecasters that do not support global forecasting.

A sixth occurrence was found in `BaseResults.save()` in `sktime/benchmarking/base.py`: `NotImplementedError()` was called without `raise`, turning an intended abstract-method guard into a no-op.

The fix adds `raise` in front of all six unraised exception constructors. These are the only changes; no API surface, no tag, no signature is altered.

## Local verification

```
$ cd /tmp/sktime

# Ruff linter passes on touched files
$ ruff check sktime/forecasting/base/_deprecation_global.py sktime/benchmarking/base.py
All checks passed!

# AST scan confirms 0 unraised exception constructors remain in _deprecation_global.py
# and BaseResults.save() now raises NotImplementedError as expected:
$ python3 -c "
from sktime.benchmarking.base import BaseResults
import ast

results = object.__new__(BaseResults)
try:
    results.save()
    print('FAIL')
except NotImplementedError:
    print('PASS: NotImplementedError raised correctly by BaseResults.save()')

with open('sktime/forecasting/base/_deprecation_global.py') as f:
    source = f.read()
tree = ast.parse(source)
count = sum(
    1 for node in ast.walk(tree)
    if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)
    and getattr(getattr(node.value.func, 'id', None) or getattr(node.value.func, 'attr', None), '__eq__', lambda x: False)('ValueError')
)
print(f'PASS: _deprecation_global.py unraised ValueError count: {count} (expected 0)')

for lineno in [423, 568, 700, 828, 937]:
    line = source.splitlines()[lineno - 1].strip()
    status = 'PASS' if line.startswith('raise ValueError') else 'FAIL'
    print(f'{status}: Line {lineno}: {line}')
"
PASS: NotImplementedError raised correctly by BaseResults.save()
PASS: _deprecation_global.py unraised ValueError count: 0 (expected 0)
PASS: Line 423: raise ValueError("no global forecasting support!")
PASS: Line 568: raise ValueError("no global forecasting support!")
PASS: Line 700: raise ValueError("no global forecasting support!")
PASS: Line 828: raise ValueError("no global forecasting support!")
PASS: Line 937: raise ValueError("no global forecasting support!")

# Global-forecaster test suite (14 tests, all pass)
$ python -m pytest sktime/forecasting/tests/test_dummy_global.py \
    --override-ini="addopts=--timeout 60" -q
14 passed in 0.28s

# Benchmarking suite (network-download tests excluded, pre-existing failure)
$ python -m pytest sktime/benchmarking/tests/ \
    --override-ini="addopts=--timeout 60" \
    --ignore=sktime/benchmarking/tests/test_forecasting.py \
    --ignore=sktime/benchmarking/tests/test_classification.py -q
55 passed, 38 skipped in 6.94s
=== LOCAL_TEST_PASSED ===
```

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies.

#### What should a reviewer concentrate their feedback on?

Whether the `_BaseGlobalForecaster` predict-method guards are still needed now that the class itself is deprecated (they are — during the deprecation window, the validation should still fire correctly).

#### Did you add any tests for the change?

The existing `test_dummy_global.py` suite continues to pass. The specific scenario in the issue (calling predict methods with `y` on a non-global forecaster) now correctly raises `ValueError` instead of silently succeeding; a dedicated regression test could be added in a follow-up.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with [BUG].
