### PR TITLE
Add capability availability notes to optional forecasting methods

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -683,7 +683,12 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         return self.predict(fh=fh, X=X_inner)
 
     def predict_quantiles(self, fh=None, X=None, alpha=None):
-        """Compute/return quantile forecasts.
+        """
+        Availability:
+            Only available if estimator tag `capability:pred_quantiles` is True.
+            Otherwise raises NotImplementedError.
+
+        Compute/return quantile forecasts.
 
         If ``alpha`` is iterable, multiple quantiles will be calculated.
 
@@ -778,7 +783,12 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         return quantiles
 
     def predict_interval(self, fh=None, X=None, coverage=0.90):
-        """Compute/return prediction interval forecasts.
+        """
+        Availability:
+            Only available if estimator tag `capability:pred_int` is True.
+            Otherwise raises NotImplementedError.
+
+        Compute/return prediction interval forecasts.
 
         If ``coverage`` is iterable, multiple intervals will be calculated.
 
@@ -873,7 +883,12 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         return pred_int
 
     def predict_var(self, fh=None, X=None, cov=False):
-        """Compute/return variance forecasts.
+        """
+        Availability:
+            Only available if estimator tag `capability:pred_var` is True.
+            Otherwise raises NotImplementedError.
+
+        Compute/return variance forecasts.
 
         State required:
             Requires state to be "fitted", i.e., ``self.is_fitted=True``.
@@ -954,7 +969,12 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         return pred_var
 
     def predict_proba(self, fh=None, X=None, marginal=True):
-        """Compute/return fully probabilistic forecasts.
+        """
+        Availability:
+            Only available if estimator tag `capability:pred_proba` is True.
+            Otherwise raises NotImplementedError.
+
+        Compute/return fully probabilistic forecasts.
 
         Note:
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -683,13 +683,13 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         return self.predict(fh=fh, X=X_inner)
 
     def predict_quantiles(self, fh=None, X=None, alpha=None):
-        """
+        """Compute/return quantile forecasts.
+
         Availability:
             Only available if estimator tag `capability:pred_quantiles` is True.
             Otherwise raises NotImplementedError.
 
-        Compute/return quantile forecasts.
-
+        
         If ``alpha`` is iterable, multiple quantiles will be calculated.
 
         State required:
@@ -783,12 +783,13 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         return quantiles
 
     def predict_interval(self, fh=None, X=None, coverage=0.90):
-        """
+        """Compute/return prediction interval forecasts.
+
         Availability:
             Only available if estimator tag `capability:pred_int` is True.
             Otherwise raises NotImplementedError.
 
-        Compute/return prediction interval forecasts.
+        
 
         If ``coverage`` is iterable, multiple intervals will be calculated.
 
@@ -883,12 +884,13 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         return pred_int
 
     def predict_var(self, fh=None, X=None, cov=False):
-        """
+        """Compute/return variance forecasts.
+
         Availability:
             Only available if estimator tag `capability:pred_var` is True.
             Otherwise raises NotImplementedError.
 
-        Compute/return variance forecasts.
+        
 
         State required:
             Requires state to be "fitted", i.e., ``self.is_fitted=True``.
@@ -969,12 +971,13 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         return pred_var
 
     def predict_proba(self, fh=None, X=None, marginal=True):
-        """
+        """Compute/return fully probabilistic forecasts.
+        
         Availability:
             Only available if estimator tag `capability:pred_proba` is True.
             Otherwise raises NotImplementedError.
 
-        Compute/return fully probabilistic forecasts.
+        
 
         Note:
 

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -79,7 +79,7 @@ def SlidingWindowSplitter(
 ):
     """Legacy export of Sliding window splitter.
 
-    DEPRECATED - use sktime.split.ExpandingWindowSplitter instead.
+    DEPRECATED - use sktime.split.SlidingWindowSplitter instead.
     """
     from warnings import warn
 

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -79,7 +79,7 @@ def SlidingWindowSplitter(
 ):
     """Legacy export of Sliding window splitter.
 
-    DEPRECATED - use sktime.split.SlidingWindowSplitter instead.
+    DEPRECATED - use sktime.split.ExpandingWindowSplitter instead.
     """
     from warnings import warn
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #6900

#### What does this implement/fix? Explain your changes.
This PR improves documentation clarity for optional forecasting methods such as `predict_interval`.

Currently, these methods are shown in the forecasting API for all estimators, even when they are not actually implemented for a specific estimator. This can lead to confusion when users attempt to call them and receive runtime errors.

This change explicitly documents that such methods are *capability-dependent* and controlled via estimator tags (e.g. `capability:pred_int`).

It clarifies that:
- all forecasters share a unified interface at the base class level
- availability of optional methods depends on capability tags
- if a capability is not supported, calling the method will raise a clear runtime error

This improves consistency between API visibility and actual estimator behavior, and reduces user confusion.

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies introduced.

#### What should a reviewer concentrate their feedback on?
- Clarity and correctness of explanation around capability-based method availability
- Alignment with sktime design philosophy (uniform interface + capability tags)
- Whether the documentation wording is consistent with other optional forecasting methods

#### Did you add any tests for the change?
Not applicable (documentation-only change).

#### Any other comments?
This PR addresses confusion raised in issue #6900 regarding the availability of `predict_interval` in estimators such as ExponentialSmoothing.

The goal is to make capability-based method availability explicit in documentation and reduce mismatch between API reference and runtime behavior.