### PR TITLE
[ENH] add multivariate and additional detector test scenarios #8896

### DIFF
--- a/sktime/utils/_testing/scenarios_detection.py
+++ b/sktime/utils/_testing/scenarios_detection.py
@@ -57,5 +57,73 @@ class DetectorUnivariateSimple(DetectorTestScenario):
     default_method_sequence = ["fit", "predict", "transform"]
 
 
+class DetectorMultivariateSimple(DetectorTestScenario):
+    """Simple multivariate detector scenario with default settings."""
+
+    _tags = {
+        "is_enabled": True,
+        "scitype": "detector",
+        "X_univariate": False,
+    }
+
+    @property
+    def args(self):
+        Z = _make_series(n_timepoints=20, n_columns=2, random_state=RAND_SD2)
+        return {
+            "fit": {"X": Z},
+            "predict": {"X": Z},
+            "transform": {"X": Z},
+        }
+
+    default_method_sequence = ["fit", "predict", "transform"]
+
+
+class DetectorUnivariateLonger(DetectorTestScenario):
+    """Univariate detector scenario with longer time series."""
+
+    _tags = {
+        "is_enabled": True,
+        "scitype": "detector",
+        "X_univariate": True,
+    }
+
+    @property
+    def args(self):
+        Z = _make_series(n_timepoints=100, random_state=RAND_SD2)
+        return {
+            "fit": {"X": Z},
+            "predict": {"X": Z},
+            "transform": {"X": Z},
+        }
+
+    default_method_sequence = ["fit", "predict", "transform"]
+
+
+class DetectorFitTransformOnly(DetectorTestScenario):
+    """Univariate detector scenario with fit and transform only (no predict)."""
+
+    _tags = {
+        "is_enabled": True,
+        "scitype": "detector",
+        "X_univariate": True,
+    }
+
+    @property
+    def args(self):
+        Z = _make_series(n_timepoints=20, random_state=RAND_SEED)
+        return {
+            "fit": {"X": Z},
+            "predict": {"X": Z},
+            "transform": {"X": Z},
+        }
+
+    default_method_sequence = ["fit", "transform"]
+
+
 # List of scenarios to be imported by tests
-scenarios_detectors = [DetectorUnivariateSimple]
+scenarios_detectors = [
+    DetectorUnivariateSimple,
+    DetectorMultivariateSimple,
+    DetectorUnivariateLonger,
+    DetectorFitTransformOnly,
+]


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #8896.

#### What does this implement/fix? Explain your changes.
This PR addresses issue #8896 by defining comprehensive data scenarios for detector estimators to ensure the testing framework can execute tests for detectors. 

Previously, PR #8914 merged a single univariate test scenario (`DetectorUnivariateSimple`). To provide broader coverage, this PR adds three additional scenarios in `sktime/utils/_testing/scenarios_detection.py`:
1. `DetectorMultivariateSimple`: A scenario with 2 columns to test multivariate capabilities (`"capability:multivariate": True`).
2. `DetectorUnivariateLonger`: A scenario with a longer time series (100 timepoints) and a different random seed to ensure robustness.
3. `DetectorFitTransformOnly`: A scenario that calls `fit` and `transform` but omits `predict`, providing a test path for detectors that are utilized solely as transformers. *(Note: Added `predict` arguments to the scenario to comply with the base estimator test checks while maintaining `["fit", "transform"]` as the default method sequence).*

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- [x] Whether the 3 new detector scenarios cover the required testing surface for detection modules.
- [x] Verification that the `args` defined for `DetectorFitTransformOnly` correctly handle the testing framework's behavior of evaluating all non-state-changing methods (like `predict`).

#### Did you add any tests for the change?
The PR itself *is* adding test scenarios for the framework to run automatically against detector estimators.

#### Any other comments?
All added scenarios are enabled via `"is_enabled": True`. I verified locally that running `python -m pytest sktime/tests/test_all_estimators.py -k "detector"` executes these scenarios properly on detectors.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured dependency isolation.
