### PR TITLE
[BUG] Fix missing raise for ValueError in _BaseGlobalForecaster

### DIFF
--- a/sktime/forecasting/base/_deprecation_global.py
+++ b/sktime/forecasting/base/_deprecation_global.py
@@ -420,7 +420,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
 
         # handle inputs
         self.check_is_fitted()
@@ -565,7 +565,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
 
         self.check_is_fitted()
         if y is None:
@@ -697,7 +697,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
 
         self.check_is_fitted()
         if y is None:
@@ -825,7 +825,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
         self.check_is_fitted()
         if y is None:
             self._global_forecasting = False
@@ -934,7 +934,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
 
         self.check_is_fitted()
         if y is None:


### PR DESCRIPTION
Fixes #10200 

## Description

Add the missing `raise` keyword before `ValueError(...)` in 5 methods of
`_BaseGlobalForecaster` in `sktime/forecasting/base/_deprecation_global.py`.

The `ValueError("no global forecasting support!")` was constructed as a bare
expression Python evaluates it but discards the result, so the error was
never actually raised. This caused invalid inputs (passing `y` to a forecaster
without global forecasting support) to silently pass through, potentially
producing incorrect results.

## Affected Methods

| Method | Line |
|--------|------|
| `predict()` | 423 |
| `predict_quantiles()` | 568 |
| `predict_interval()` | 700 |
| `predict_var()` | 828 |
| `predict_proba()` | 937 |

## Changes

- Added `raise` keyword before all 5 bare `ValueError(...)` expressions
- **1 file changed, 5 insertions(+), 5 deletions(-)**

## Testing

- Verified with AST analysis that no bare `ValueError()` expressions remain
- All 5 locations now correctly use `raise ValueError(...)`