### PR TITLE
[ENH] Replace production assert statements with explicit exceptions

### DIFF
--- a/sktime/detection/datagen.py
+++ b/sktime/detection/datagen.py
@@ -96,29 +96,58 @@ def piecewise_normal_multivariate(
     L, N = np.array(means).shape
 
     rng = check_random_state(random_state)
-    assert len(lengths) == L
+    if len(lengths) != L:
+        raise ValueError(
+            f"`lengths` must have the same length as `means` ({L}), "
+            f"but found {len(lengths)}."
+        )
 
     # if no covariance is specified, build it from variance
     # assuming independent random variables
     if covariances is None:
-        assert variances is not None
+        if variances is None:
+            raise ValueError(
+                "`variances` must not be None when `covariances` is None."
+            )
 
         # variances van be specified as a float, make 1D array, repeat L times
         if isinstance(variances, (float, int)):
             variances = np.repeat(variances, N)
             variances = np.tile(variances, (L, 1))
 
-        assert np.array(variances).shape == (L, N)
+        if np.array(variances).shape != (L, N):
+            raise ValueError(
+                f"`variances` must have shape ({L}, {N}), "
+                f"but found {np.array(variances).shape}."
+            )
 
         # get covariance matrices from variance arrays
         covariances = [get_covariances(var) for var in variances]
 
     else:
-        assert all(np.allclose(np.array(cov), np.array(cov).T) for cov in covariances)
-        assert all(np.all(np.linalg.eigvals(cov) >= 0) for cov in covariances)
+        if not all(
+            np.allclose(np.array(cov), np.array(cov).T) for cov in covariances
+        ):
+            raise ValueError(
+                "All covariance matrices must be symmetric."
+            )
+        if not all(
+            np.all(np.linalg.eigvals(cov) >= 0) for cov in covariances
+        ):
+            raise ValueError(
+                "All covariance matrices must be positive semi-definite."
+            )
 
-    assert np.array(covariances).shape[0] == L
-    assert np.array(covariances).shape[1] == N
+    if np.array(covariances).shape[0] != L:
+        raise ValueError(
+            f"Number of covariance matrices must match number of segments "
+            f"({L}), but found {np.array(covariances).shape[0]}."
+        )
+    if np.array(covariances).shape[1] != N:
+        raise ValueError(
+            f"Covariance matrix dimensions must match number of series "
+            f"({N}), but found {np.array(covariances).shape[1]}."
+        )
 
     return np.concatenate(
         [
@@ -175,12 +204,20 @@ def piecewise_normal(
         2.53658231, 2.53427025, 3.24196227, 1.08671976])
     """
     rng = check_random_state(random_state)
-    assert len(means) == len(lengths)
+    if len(means) != len(lengths):
+        raise ValueError(
+            f"`means` and `lengths` must have the same length, "
+            f"but found {len(means)} and {len(lengths)}."
+        )
 
     if isinstance(std_dev, (float, int)):
         std_dev = np.repeat(std_dev, len(means))
 
-    assert len(std_dev) == len(means)
+    if len(std_dev) != len(means):
+        raise ValueError(
+            f"`std_dev` and `means` must have the same length, "
+            f"but found {len(std_dev)} and {len(means)}."
+        )
 
     segments_data = [
         rng.normal(loc=mean, scale=sd, size=[length])
@@ -302,7 +339,11 @@ def piecewise_poisson(
     """
     rng = check_random_state(random_state)
 
-    assert len(lambdas) == len(lengths)
+    if len(lambdas) != len(lengths):
+        raise ValueError(
+            f"`lambdas` and `lengths` must have the same length, "
+            f"but found {len(lambdas)} and {len(lengths)}."
+        )
 
     try:
         segments_data = [
@@ -310,7 +351,9 @@ def piecewise_poisson(
             for lams, length in zip(lambdas, lengths)
         ]
     except ValueError:
-        raise Exception("Size mismatch")
+        raise ValueError(
+            "Size mismatch between `lambdas` and `lengths` parameters."
+        )
 
     return np.concatenate(tuple(segments_data))
 

--- a/sktime/forecasting/ardl.py
+++ b/sktime/forecasting/ardl.py
@@ -281,7 +281,10 @@ class ARDL(_StatsModelsAdapter):
         self.maxorder = maxorder
 
         if not self.auto_ardl:
-            assert self.lags is not None
+            if self.lags is None:
+                raise ValueError(
+                    "`lags` must be specified when `auto_ardl` is False."
+                )
 
         if self.auto_ardl and self.lags is not None:
             raise ValueError("lags should not be specified if auto_ardl is True")

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -479,7 +479,8 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         _check_estimator_deps(self)
 
         # check y is not None
-        assert y is not None, "y cannot be None, but found None"
+        if y is None:
+            raise ValueError("y cannot be None, but found None")
 
         # if fit is called, estimator is reset, including fitted state
         if not self._state == "pretrained":
@@ -2690,7 +2691,12 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         if method in ["predict", "predict_var"]:
             return featnames
         else:
-            assert method in ["predict_interval", "predict_quantiles"]
+            if method not in ["predict_interval", "predict_quantiles"]:
+                raise ValueError(
+                    f"`method` must be one of 'predict', 'predict_var', "
+                    f"'predict_interval', or 'predict_quantiles', "
+                    f"but found: {method!r}"
+                )
 
         if method == "predict_interval":
             coverage = kwargs.get("coverage", None)

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -986,11 +986,24 @@ def _check_cutoff(cutoff, index):
     if cutoff is None:
         raise ValueError("`cutoff` must be given, but found none.")
     if isinstance(index, pd.PeriodIndex):
-        assert isinstance(cutoff, (pd.Period, pd.PeriodIndex))
-        assert index.freqstr == cutoff.freqstr
+        if not isinstance(cutoff, (pd.Period, pd.PeriodIndex)):
+            raise TypeError(
+                f"`cutoff` must be a pd.Period or pd.PeriodIndex when index "
+                f"is a pd.PeriodIndex, but found: {type(cutoff)}"
+            )
+        if index.freqstr != cutoff.freqstr:
+            raise ValueError(
+                f"`cutoff` frequency must match index frequency, but found "
+                f"cutoff.freqstr={cutoff.freqstr} and "
+                f"index.freqstr={index.freqstr}"
+            )
 
     if isinstance(index, pd.DatetimeIndex):
-        assert isinstance(cutoff, (pd.Timestamp, pd.DatetimeIndex))
+        if not isinstance(cutoff, (pd.Timestamp, pd.DatetimeIndex)):
+            raise TypeError(
+                f"`cutoff` must be a pd.Timestamp or pd.DatetimeIndex when "
+                f"index is a pd.DatetimeIndex, but found: {type(cutoff)}"
+            )
 
 
 def _coerce_to_period(x, freq=None):

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -60,8 +60,16 @@ def _concat_y_X(y, X):
 
 def _check_fh(fh):
     """Check fh prior to sliding-window transform."""
-    assert fh.is_relative
-    assert fh.is_all_out_of_sample()
+    if not fh.is_relative:
+        raise ValueError(
+            "Forecasting horizon `fh` must be relative for sliding-window "
+            "transform, but found absolute `fh`."
+        )
+    if not fh.is_all_out_of_sample():
+        raise ValueError(
+            "Forecasting horizon `fh` must be all out-of-sample for "
+            "sliding-window transform."
+        )
     return fh.to_indexer().to_numpy()
 
 
@@ -143,8 +151,16 @@ def _sliding_window_transform(
     if scitype == "tabular-regressor" and transformers is None:
         Xt = Xt.reshape(Xt.shape[0], -1)
 
-    assert Xt.ndim == 2 or Xt.ndim == 3
-    assert yt.ndim == 2
+    if Xt.ndim not in (2, 3):
+        raise ValueError(
+            f"Sliding-window transform X output must be 2d or 3d, "
+            f"but found {Xt.ndim}d array."
+        )
+    if yt.ndim != 2:
+        raise ValueError(
+            f"Sliding-window transform y output must be 2d, "
+            f"but found {yt.ndim}d array."
+        )
 
     return yt, Xt
 

--- a/sktime/forecasting/squaring_residuals.py
+++ b/sktime/forecasting/squaring_residuals.py
@@ -146,11 +146,22 @@ class SquaringResiduals(BaseForecaster):
         IMPORTANT: no significant compute or memory use should happen in __post_init__,
         memory and compute intensive operations should be in _fit, not __post_init__.
         """
-        assert self.distr in ["norm", "laplace", "t", "cauchy"]
-        assert self.strategy in ["square", "abs"]
-        assert self.initial_window >= 1, (
-            "Initial window should be larger or equal to one"
-        )
+        valid_distr = ["norm", "laplace", "t", "cauchy"]
+        if self.distr not in valid_distr:
+            raise ValueError(
+                f"`distr` must be one of {valid_distr}, but found: {self.distr!r}"
+            )
+        valid_strategy = ["square", "abs"]
+        if self.strategy not in valid_strategy:
+            raise ValueError(
+                f"`strategy` must be one of {valid_strategy}, "
+                f"but found: {self.strategy!r}"
+            )
+        if self.initial_window < 1:
+            raise ValueError(
+                f"`initial_window` should be >= 1, "
+                f"but found: {self.initial_window}"
+            )
 
         if self.forecaster is None:
             self._forecaster = NaiveForecaster()


### PR DESCRIPTION
Fixes #10202 

## Description

Replace production `assert` statements with explicit exception handling in core
forecasting and validation modules.

Python removes `assert` statements when running with optimization enabled
(`python -O`), meaning important runtime validation checks were silently skipped
in production environments.

This PR converts those assertions into explicit `ValueError` / `TypeError`
checks to ensure validation always executes.

## Affected Files

| File | Changes |
|------|------|
| `_base.py` | Replace `assert y is not None` |
| `_fh.py` | Replace cutoff/index validation asserts |
| `squaring_residuals.py` | Replace strategy/distribution asserts |
| `_reduce.py` | Replace forecasting horizon and ndim asserts |
| `datagen.py` | Replace input validation asserts |
| `ardl.py` | Replace lags validation assert |

## Example

Before:

```python
assert y is not None, "y cannot be None"
````

After:

```python
if y is None:
    raise ValueError("y cannot be None")
```

## Why this change is needed

`assert` is intended for debugging and internal invariants, not production
input validation.

Under optimized execution:

```bash
python -O
```

all assertions are skipped entirely.

Replacing them with explicit exceptions ensures:

* consistent runtime validation
* reliable error handling
* predictable behavior in production environments

## Changes

* Replaced production-facing asserts with explicit exceptions
* Improved error messages for invalid inputs
* Preserved existing validation behavior while ensuring checks always execute

## Testing

* Verified all replaced assertions now execute under optimized mode
* Confirmed invalid inputs correctly raise exceptions
* Existing functionality remains unchanged for valid inputs