### PR TITLE
 [ENH] Replace generic raise Exception with specific exception types

### DIFF
--- a/sktime/benchmarking/critical_difference.py
+++ b/sktime/benchmarking/critical_difference.py
@@ -370,7 +370,9 @@ def plot_critical_difference(
             ]
             #
         else:
-            raise Exception("alpha must be 0.01, 0.05 or 0.1")
+            raise ValueError(
+                f"`alpha` must be 0.01, 0.05, or 0.1, but found: {alpha}"
+            )
 
         if cliques is None:
             # calculate critical difference with Nemenyi

--- a/sktime/benchmarking/evaluation.py
+++ b/sktime/benchmarking/evaluation.py
@@ -609,7 +609,9 @@ class Evaluator:
                       3.846]
             # fmt: on
         else:
-            raise Exception("alpha must be 0.01, 0.05 or 0.1")
+            raise ValueError(
+                f"`alpha` must be 0.01, 0.05, or 0.1, but found: {alpha}"
+            )
 
         cd = qalpha[n_strategies - 1] * np.sqrt(
             n_strategies * (n_strategies + 1) / (6 * n_datasets)

--- a/sktime/benchmarking/experiments.py
+++ b/sktime/benchmarking/experiments.py
@@ -301,7 +301,7 @@ def run_classification_experiment(
          train probabilities, the classifier will be built but no file will be output.
     """
     if not test_file and not train_file:
-        raise Exception(
+        raise ValueError(
             "Both test_file and train_file are set to False. "
             "At least one must be output."
         )

--- a/sktime/classification/compose/_multiplexer.py
+++ b/sktime/classification/compose/_multiplexer.py
@@ -120,7 +120,7 @@ class MultiplexClassifier(_HeterogenousMetaEstimator, _DelegatedClassifier):
         component_names = self._get_estimator_names(self._classifiers, make_unique=True)
         selected = self.selected_classifier
         if selected is not None and selected not in component_names:
-            raise Exception(
+            raise ValueError(
                 f"Invalid selected_classifier parameter value provided, "
                 f" found: {self.selected_classifier}. Must be one of these"
                 f" valid selected_classifier parameter values: {component_names}."

--- a/sktime/detection/datagen.py
+++ b/sktime/detection/datagen.py
@@ -310,7 +310,9 @@ def piecewise_poisson(
             for lams, length in zip(lambdas, lengths)
         ]
     except ValueError:
-        raise Exception("Size mismatch")
+        raise ValueError(
+            "Size mismatch between `lambdas` and `lengths` parameters."
+        )
 
     return np.concatenate(tuple(segments_data))
 

--- a/sktime/detection/eagglo.py
+++ b/sktime/detection/eagglo.py
@@ -401,7 +401,7 @@ class EAgglo(BaseTransformer):
                 self.distances[K + 1, k] = val
                 self.distances[k, K + 1] = val
 
-    def _get_penalty_func(self) -> Callable:  # sourcery skip: raise-specific-error
+    def _get_penalty_func(self) -> Callable:
         """Define penalty function given (possibly string) input."""
         PENALTIES = {"len_penalty": len_penalty, "mean_diff_penalty": mean_diff_penalty}
 
@@ -412,8 +412,9 @@ class EAgglo(BaseTransformer):
             if self.penalty in PENALTIES:
                 return PENALTIES[self.penalty]
 
-        raise Exception(
-            f"'penalty' must be callable or {PENALTIES.keys()}, got {self.penalty}"
+        raise ValueError(
+            f"'penalty' must be callable or one of {list(PENALTIES.keys())}, "
+            f"got {self.penalty!r}"
         )
 
     @classmethod

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -155,7 +155,7 @@ class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
         component_names = self._get_estimator_names(self._forecasters, make_unique=True)
         selected = self.selected_forecaster
         if selected is not None and selected not in component_names:
-            raise Exception(
+            raise ValueError(
                 f"Invalid selected_forecaster parameter value provided, "
                 f" found: {self.selected_forecaster}. Must be one of these"
                 f" valid selected_forecaster parameter values: {component_names}."

--- a/sktime/regression/compose/_multiplexer.py
+++ b/sktime/regression/compose/_multiplexer.py
@@ -119,7 +119,7 @@ class MultiplexRegressor(_HeterogenousMetaEstimator, _DelegatedRegressor):
         component_names = self._get_estimator_names(self._regressors, make_unique=True)
         selected = self.selected_regressor
         if selected is not None and selected not in component_names:
-            raise Exception(
+            raise ValueError(
                 f"Invalid selected_regressor parameter value provided, "
                 f" found: {self.selected_regressor}. Must be one of these"
                 f" valid selected_regressor parameter values: {component_names}."

--- a/sktime/transformations/compose/_multiplex.py
+++ b/sktime/transformations/compose/_multiplex.py
@@ -150,7 +150,7 @@ class MultiplexTransformer(_HeterogenousMetaEstimator, _DelegatedTransformer):
         )
         selected = self.selected_transformer
         if selected is not None and selected not in component_names:
-            raise Exception(
+            raise ValueError(
                 f"Invalid selected_transformer parameter value provided, "
                 f" found: {selected}. Must be one of these"
                 f" valid selected_transformer parameter values: {component_names}."


### PR DESCRIPTION
### Reference Issues/PRs

Fixes #10204 

### What does this implement/fix? Explain your changes.

Replaces bare `raise Exception(...)` with `raise ValueError(...)` across 9 production code files. 
Using generic `Exception` prevents callers from catching specific error types, violating Python best 
practices (PEP 8) and making error handling unreliable in downstream code.

### Changes by module

**Detection:**
- `detection/eagglo.py`: `Exception` → `ValueError` for invalid penalty parameter. Also removed 
  stale `# sourcery skip: raise-specific-error` comment.
- `detection/datagen.py`: `Exception` → `ValueError` for size mismatch.

**Multiplexer pattern (4 files):**
- `transformations/compose/_multiplex.py`
- `regression/compose/_multiplexer.py`
- `forecasting/compose/_multiplexer.py`
- `classification/compose/_multiplexer.py`
All four: `Exception` → `ValueError` for invalid selected estimator parameter.

**Benchmarking:**
- `benchmarking/experiments.py`: `Exception` → `ValueError` for invalid config.
- `benchmarking/evaluation.py`: `Exception` → `ValueError` for invalid alpha.
- `benchmarking/critical_difference.py`: `Exception` → `ValueError` for invalid alpha.

### Verification

- ✅ Zero `raise Exception(` remaining in all 9 modified files
- ✅ All files pass `ast.parse()` syntax validation
- ✅ Error messages preserved and enhanced with actual invalid values
- ✅ No behavioral change all code paths that previously raised still raise, just with a more 
  specific exception type

### Does your contribution introduce a new dependency?

No.

### Any other comments?

This is a follow-up to the `assert`-to-`raise` PR. Together, these two PRs eliminate the two most 
common categories of unreliable error handling in the sktime codebase. Note: additional 
`raise Exception` instances exist in `libs/` (vendored code) and `datasets/_readers_writers/tsf.py` 
(~12 instances, better as a separate focused PR).
