### PR TITLE
 [ENH] fix pandas ChainedAssignment warning in DateTimeFeatures manual_selection

### DIFF
--- a/sktime/transformations/series/date.py
+++ b/sktime/transformations/series/date.py
@@ -403,7 +403,7 @@ def _calendar_dummies(x, funcs):
         cd = getattr(date_sequence, funcs)
     cd = pd.DataFrame(cd)
     cd = cd.rename(columns={cd.columns[0]: funcs})
-    cd[funcs] = np.int64(cd[funcs])
+    cd = cd.assign(**{col: np.int64(cd[col]) for col in funcs})
     return cd
 
 


### PR DESCRIPTION
Reference Issues/PRs: Fixes #9640

What does this implement/fix:
Fixes pandas ChainedAssignment FutureWarning in 
DateTimeFeatures manual_selection (line 406, date.py).
Replaces cd[funcs] = np.int64(cd[funcs]) with 
CoW-compatible cd.assign() pattern.

No new dependency added.
