### PR TITLE
 [ENH] add regression test for manual_selection CoW warning fix

### DIFF
--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -423,3 +423,19 @@ def test_fit_transform_no_warnings():
         warnings.simplefilter("always")
         transformer.fit_transform(y)
         assert len(w) == 0
+@pytest.mark.skipif(
+    not run_test_for_class(DateTimeFeatures),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_manual_selection_no_warnings():
+    """Test manual_selection does not raise chained assignment warnings."""
+    y = load_airline()
+
+    transformer = DateTimeFeatures(
+        ts_freq="M",
+        manual_selection=["day_of_week", "month_of_year"],
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        transformer.fit_transform(y)


### PR DESCRIPTION
The existing `test_fit_transform_no_warnings` test covers the general `fit_transform` path.
This test specifically covers the `manual_selection` branch in `_calendar_dummies` (line 406),
 which previously triggered a pandas `ChainedAssignment` warning that was not covered by the existing test.
