### PR TITLE
[DOC] clarify window_length parameter applies to mean and drift strat…

### DIFF
--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -90,9 +90,10 @@ class NaiveForecaster(_BaseWindowForecaster):
         Seasonal periodicity to use in the seasonal forecasting. None=1.
 
     window_length : int or None, default=None
-        Window length to use in the ``mean`` strategy. If None, entire training
-            series will be used.
-
+    Window length to use in the ``mean`` and ``drift`` strategies.
+    If None, the entire training series will be used.
+    Ignored for the ``last`` strategy.
+    
     References
     ----------
     .. [1] Hyndman, R.J., & Athanasopoulos, G. (2021) Forecasting:


### PR DESCRIPTION
Clarifies that `window_length` parameter applies to both `mean` 
and `drift` strategies, not just `mean`. Also clarifies that it 
is ignored for the `last` strategy.

The previous docstring only mentioned `mean` strategy which was 
incomplete and potentially confusing for users.
