### PR TITLE
[ENT] preserve pretrain state during reset

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -178,6 +178,19 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         """
         pass
 
+    def _has_pretrained_state(self):
+        """Return whether this forecaster has pretrained state to preserve."""
+        has_pretrain_capability = self.get_tag(
+            "capability:pretrain", tag_value_default=False, raise_error=False
+        )
+        has_pretrained_state = (
+            hasattr(self, "_pretrained_attrs")
+            and self._pretrained_attrs
+            and hasattr(self, "_state")
+            and self._state in ("pretrained", "fitted")
+        )
+        return bool(has_pretrain_capability and has_pretrained_state)
+
     @classmethod
     def _get_clone_plugins(cls):
         """Get clone plugins for BaseForecaster.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -203,6 +203,15 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         saved["_pretrained_attrs"] = attr_names
         return saved
 
+    def _restore_pretrained_state(self, attrs):
+        """Restore pretrained attributes after an in-place reset."""
+        for attr, value in attrs.items():
+            setattr(self, attr, value)
+        if attrs.get("_pretrained_attrs"):
+            # reset removes fitted/task-specific state, so a fitted pretrained
+            # forecaster must come back as pretrained rather than fitted.
+            self._state = "pretrained"
+
     @classmethod
     def _get_clone_plugins(cls):
         """Get clone plugins for BaseForecaster.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -52,7 +52,6 @@ import pandas as pd
 
 from sktime.base import BaseEstimator
 from sktime.base._proba import _PredictProbaMixin
-from sktime.forecasting.base._pretrained_mixin import _PretrainedStateMixin
 from sktime.datatypes import (
     VectorizedDF,
     check_is_error_msg,
@@ -66,6 +65,7 @@ from sktime.datatypes import (
 from sktime.datatypes._dtypekind import DtypeKind
 from sktime.forecasting.base._clone_plugin import _PretrainedCloner
 from sktime.forecasting.base._fh import ForecastingHorizon
+from sktime.forecasting.base._pretrained_mixin import _PretrainedStateMixin
 from sktime.utils.datetime import _shift
 from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.validation.forecasting import check_alpha, check_cv, check_fh, check_X

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -212,6 +212,27 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
             # forecaster must come back as pretrained rather than fitted.
             self._state = "pretrained"
 
+    def reset(self, keep_pretrained=True):
+        """Reset forecaster while preserving pretrained state by default.
+
+        Parameters
+        ----------
+        keep_pretrained : bool, default=True
+            If True, pretrained attributes tracked in ``_pretrained_attrs`` are
+            restored after reset. If False, pretrained state is discarded and
+            reset behaves like the generic skbase reset.
+
+        Returns
+        -------
+        self : reference to self
+            Reset forecaster.
+        """
+        pretrained_state = self._save_pretrained_state() if keep_pretrained else {}
+        super().reset()
+        if pretrained_state:
+            self._restore_pretrained_state(pretrained_state)
+        return self
+
     @classmethod
     def _get_clone_plugins(cls):
         """Get clone plugins for BaseForecaster.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -233,6 +233,67 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
             self._restore_pretrained_state(pretrained_state)
         return self
 
+    def set_params(self, **params):
+        """Set forecaster parameters.
+
+        Parameters
+        ----------
+        **params : dict
+            Forecaster parameters. If ``_reset=False`` is passed, parameter
+            values are set without calling ``reset`` on this forecaster or
+            nested forecasters. By default, ``set_params`` calls ``reset``;
+            pretrained state is preserved by the forecaster reset override.
+
+        Returns
+        -------
+        self : reference to self
+            Forecaster with updated parameters.
+        """
+        reset = params.pop("_reset", True)
+
+        if not params:
+            return self
+        valid_params = self.get_params(deep=True)
+
+        unmatched_keys = []
+
+        nested_params = defaultdict(dict)
+        for full_key, value in params.items():
+            key, delim, sub_key = full_key.partition("__")
+            if key not in valid_params:
+                unmatched_keys += [key]
+            elif delim:
+                nested_params[key][sub_key] = value
+            else:
+                setattr(self, key, value)
+                valid_params[key] = value
+
+        if reset:
+            self.reset()
+
+        for key, sub_params in nested_params.items():
+            component = valid_params[key]
+            if isinstance(component, BaseForecaster):
+                component.set_params(**sub_params, _reset=reset)
+            else:
+                component.set_params(**sub_params)
+
+        if len(unmatched_keys) > 0:
+            valid_params = self.get_params(deep=True)
+            unmatched_params = {key: params[key] for key in unmatched_keys}
+            aliased_params = self._alias_params(unmatched_params, valid_params)
+
+            if set(aliased_params) == set(unmatched_params):
+                raise ValueError(
+                    f"Invalid parameter keys provided to set_params of object {self}. "
+                    "Check the list of available parameters "
+                    "with `object.get_params().keys()`. "
+                    f"Invalid keys provided: {unmatched_keys}"
+                )
+
+            self.set_params(**aliased_params, _reset=reset)
+
+        return self
     @classmethod
     def _get_clone_plugins(cls):
         """Get clone plugins for BaseForecaster.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -44,7 +44,6 @@ __author__ = [
 
 __all__ = ["BaseForecaster"]
 
-from collections import defaultdict
 from copy import deepcopy
 from itertools import product
 
@@ -53,6 +52,7 @@ import pandas as pd
 
 from sktime.base import BaseEstimator
 from sktime.base._proba import _PredictProbaMixin
+from sktime.forecasting.base._pretrained_mixin import _PretrainedStateMixin
 from sktime.datatypes import (
     VectorizedDF,
     check_is_error_msg,
@@ -83,7 +83,7 @@ def _coerce_to_list(obj):
         return obj
 
 
-class BaseForecaster(_PredictProbaMixin, BaseEstimator):
+class BaseForecaster(_PretrainedStateMixin, _PredictProbaMixin, BaseEstimator):
     """Base forecaster template class.
 
     The base forecaster specifies the methods and method signatures that all forecasters
@@ -179,122 +179,14 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         """
         pass
 
-    def _has_pretrained_state(self):
-        """Return whether this forecaster has pretrained state to preserve."""
-        has_pretrain_capability = self.get_tag(
-            "capability:pretrain", tag_value_default=False, raise_error=False
-        )
-        has_pretrained_state = (
-            hasattr(self, "_pretrained_attrs")
-            and self._pretrained_attrs
-            and hasattr(self, "_state")
-            and self._state in ("pretrained", "fitted")
-        )
-        return bool(has_pretrain_capability and has_pretrained_state)
+    def _copy_pretrained_attr(self, attr_name, attr_value, memo=None):
+        """Copy a pretrained attribute for ``clone``.
 
-    def _save_pretrained_state(self):
-        """Save pretrained attributes before an in-place reset."""
-        if not self._has_pretrained_state():
-            return {}
-
-        attr_names = list(self._pretrained_attrs)
-        saved = {
-            attr: getattr(self, attr) for attr in attr_names if hasattr(self, attr)
-        }
-        saved["_pretrained_attrs"] = attr_names
-        return saved
-
-    def _restore_pretrained_state(self, attrs):
-        """Restore pretrained attributes after an in-place reset."""
-        for attr, value in attrs.items():
-            setattr(self, attr, value)
-        if attrs.get("_pretrained_attrs"):
-            # reset removes fitted/task-specific state, so a fitted pretrained
-            # forecaster must come back as pretrained rather than fitted.
-            self._state = "pretrained"
-
-    def reset(self, keep_pretrained=True):
-        """Reset forecaster while preserving pretrained state by default.
-
-        Parameters
-        ----------
-        keep_pretrained : bool, default=True
-            If True, pretrained attributes tracked in ``_pretrained_attrs`` are
-            restored after reset. If False, pretrained state is discarded and
-            reset behaves like the generic skbase reset.
-
-        Returns
-        -------
-        self : reference to self
-            Reset forecaster.
+        Subclasses may override this hook for framework-specific copies, for
+        example state-dict based copies of Torch or HuggingFace model objects.
         """
-        pretrained_state = self._save_pretrained_state() if keep_pretrained else {}
-        super().reset()
-        if pretrained_state:
-            self._restore_pretrained_state(pretrained_state)
-        return self
+        return deepcopy(attr_value, memo)
 
-    def set_params(self, **params):
-        """Set forecaster parameters.
-
-        Parameters
-        ----------
-        **params : dict
-            Forecaster parameters. If ``_reset=False`` is passed, parameter
-            values are set without calling ``reset`` on this forecaster or
-            nested forecasters. By default, ``set_params`` calls ``reset``;
-            pretrained state is preserved by the forecaster reset override.
-
-        Returns
-        -------
-        self : reference to self
-            Forecaster with updated parameters.
-        """
-        reset = params.pop("_reset", True)
-
-        if not params:
-            return self
-        valid_params = self.get_params(deep=True)
-
-        unmatched_keys = []
-
-        nested_params = defaultdict(dict)
-        for full_key, value in params.items():
-            key, delim, sub_key = full_key.partition("__")
-            if key not in valid_params:
-                unmatched_keys += [key]
-            elif delim:
-                nested_params[key][sub_key] = value
-            else:
-                setattr(self, key, value)
-                valid_params[key] = value
-
-        if reset:
-            self.reset()
-
-        for key, sub_params in nested_params.items():
-            component = valid_params[key]
-            if isinstance(component, BaseForecaster):
-                component.set_params(**sub_params, _reset=reset)
-            else:
-                component.set_params(**sub_params)
-
-        if len(unmatched_keys) > 0:
-            valid_params = self.get_params(deep=True)
-            unmatched_params = {key: params[key] for key in unmatched_keys}
-            aliased_params = self._alias_params(unmatched_params, valid_params)
-
-            if set(aliased_params) == set(unmatched_params):
-                raise ValueError(
-                    f"Invalid parameter keys provided to set_params of object {self}. "
-                    "Check the list of available parameters "
-                    "with `object.get_params().keys()`. "
-                    f"Invalid keys provided: {unmatched_keys}"
-                )
-
-            self.set_params(**aliased_params, _reset=reset)
-
-        return self
     @classmethod
     def _get_clone_plugins(cls):
         """Get clone plugins for BaseForecaster.
@@ -1773,7 +1665,7 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         # we want residuals, so fh must be the index of y
         # if data frame: take directly from y
         # to avoid issues with _set_fh, we convert to relative if self.fh is
-        if isinstance(y, (pd.DataFrame, pd.Series)):
+        if isinstance(y, pd.DataFrame | pd.Series):
             fh = ForecastingHorizon(y.index, is_relative=False, freq=self._cutoff)
             if self._fh is not None and self.fh.is_relative:
                 fh = fh.to_relative(self._cutoff)
@@ -2855,7 +2747,7 @@ def _format_moving_cutoff_predictions(y_preds, cutoffs):
         raise ValueError(f"`y_preds` must be a list, but found: {type(y_preds)}")
     if len(y_preds) == 0:
         return pd.DataFrame(columns=cutoffs)
-    if not isinstance(y_preds[0], (pd.DataFrame, pd.Series)):
+    if not isinstance(y_preds[0], pd.DataFrame | pd.Series):
         raise ValueError("y_preds must be a list of pd.Series or pd.DataFrame")
     ylen = len(y_preds[0])
     ytype = type(y_preds[0])

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -191,6 +191,18 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         )
         return bool(has_pretrain_capability and has_pretrained_state)
 
+    def _save_pretrained_state(self):
+        """Save pretrained attributes before an in-place reset."""
+        if not self._has_pretrained_state():
+            return {}
+
+        attr_names = list(self._pretrained_attrs)
+        saved = {
+            attr: getattr(self, attr) for attr in attr_names if hasattr(self, attr)
+        }
+        saved["_pretrained_attrs"] = attr_names
+        return saved
+
     @classmethod
     def _get_clone_plugins(cls):
         """Get clone plugins for BaseForecaster.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -44,6 +44,7 @@ __author__ = [
 
 __all__ = ["BaseForecaster"]
 
+from collections import defaultdict
 from copy import deepcopy
 from itertools import product
 

--- a/sktime/forecasting/base/_clone_plugin.py
+++ b/sktime/forecasting/base/_clone_plugin.py
@@ -1,8 +1,6 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Clone plugin for preserving pretrained state in forecasters."""
 
-from copy import deepcopy
-
 from skbase.base._clone_plugins import BaseCloner, _default_clone
 
 
@@ -50,9 +48,12 @@ class _PretrainedCloner(BaseCloner):
         if obj.get_config()["clone_config"]:
             new_object.set_config(**obj.get_config())
         new_object._pretrained_attrs = list(obj._pretrained_attrs)
+        memo = {}
         for attr in obj._pretrained_attrs:
             if hasattr(obj, attr):
-                setattr(new_object, attr, deepcopy(getattr(obj, attr)))
+                attr_value = getattr(obj, attr)
+                attr_copy = obj._copy_pretrained_attr(attr, attr_value, memo=memo)
+                setattr(new_object, attr, attr_copy)
 
         new_object._state = "pretrained"
 

--- a/sktime/forecasting/base/_pretrained_mixin.py
+++ b/sktime/forecasting/base/_pretrained_mixin.py
@@ -84,7 +84,7 @@ class _PretrainedStateMixin:
         return self
 
     def set_params(self, **params):
-        """Set parameters, optionally skipping reset.
+        """Set parameters, optionally controlling pretrained state reset.
 
         Reimplements skbase's ``BaseObject.set_params`` to support the
         ``_reset`` control flag. When ``_reset=False``, parameter values
@@ -96,12 +96,16 @@ class _PretrainedStateMixin:
         inherited ``set_params`` except that ``self.reset()`` calls this
         mixin's override which preserves pretrained state.
 
+        Passing ``_keep_pretrained=False`` discards pretrained state when
+        ``_reset=True``.
+
         Parameters
         ----------
         **params : dict
             Object parameters. If ``_reset=False`` is passed, parameter
             values are set without calling ``reset`` on this object or
-            nested components.
+            nested components. If ``_keep_pretrained=False`` is passed,
+            pretrained attributes are discarded during reset.
 
         Returns
         -------
@@ -109,6 +113,7 @@ class _PretrainedStateMixin:
             Instance with updated parameters.
         """
         reset = params.pop("_reset", True)
+        keep_pretrained = params.pop("_keep_pretrained", True)
 
         if not params:
             return self
@@ -128,14 +133,18 @@ class _PretrainedStateMixin:
                 valid_params[key] = value
 
         if reset:
-            self.reset()
+            self.reset(keep_pretrained=keep_pretrained)
 
         for key, sub_params in nested_params.items():
             component = valid_params[key]
             if hasattr(component, "set_params"):
                 # propagate _reset only to objects likely to understand it
                 if isinstance(component, _PretrainedStateMixin):
-                    component.set_params(**sub_params, _reset=reset)
+                    component.set_params(
+                        **sub_params,
+                        _reset=reset,
+                        _keep_pretrained=keep_pretrained,
+                    )
                 else:
                     component.set_params(**sub_params)
 
@@ -152,6 +161,10 @@ class _PretrainedStateMixin:
                     f"Invalid keys provided: {unmatched_keys}"
                 )
 
-            self.set_params(**aliased_params, _reset=reset)
+            self.set_params(
+                **aliased_params,
+                _reset=reset,
+                _keep_pretrained=keep_pretrained,
+            )
 
         return self

--- a/sktime/forecasting/base/_pretrained_mixin.py
+++ b/sktime/forecasting/base/_pretrained_mixin.py
@@ -1,0 +1,157 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Mixin for preserving pretrained state across reset and set_params.
+
+This module exists as a staging bridge (sktime-only). It overrides
+``reset`` and ``set_params`` from skbase's ``BaseObject`` because skbase does
+not yet provide hooks for non-resettable attributes. When skbase gains native
+support, this mixin can be removed from BaseForecaster's inheritance
+list and the file deleted.
+
+See https://github.com/sktime/skbase/issues/554 for the upstream issue.
+"""
+
+__author__ = ["simonblanke"]
+
+from collections import defaultdict
+
+
+class _PretrainedStateMixin:
+    """Preserve pretrained state across ``reset`` and ``set_params``.
+
+    Temporary mixin for ``BaseForecaster``. Overrides ``reset`` and
+    ``set_params`` inherited from skbase to save and restore attributes
+    tracked in ``_pretrained_attrs``. Intended to be removed once skbase
+    provides equivalent hooks natively.
+    """
+
+    def _has_pretrained_state(self):
+        """Return whether this instance has pretrained state to preserve."""
+        has_pretrain_capability = self.get_tag(
+            "capability:pretrain", tag_value_default=False, raise_error=False
+        )
+        has_pretrained_state = (
+            hasattr(self, "_pretrained_attrs")
+            and self._pretrained_attrs
+            and hasattr(self, "_state")
+            and self._state in ("pretrained", "fitted")
+        )
+        return bool(has_pretrain_capability and has_pretrained_state)
+
+    def _save_pretrained_state(self):
+        """Save pretrained attributes before an in-place reset."""
+        if not self._has_pretrained_state():
+            return {}
+
+        attr_names = list(self._pretrained_attrs)
+        saved = {
+            attr: getattr(self, attr) for attr in attr_names if hasattr(self, attr)
+        }
+        saved["_pretrained_attrs"] = attr_names
+        return saved
+
+    def _restore_pretrained_state(self, attrs):
+        """Restore pretrained attributes after an in-place reset."""
+        for attr, value in attrs.items():
+            setattr(self, attr, value)
+        if attrs.get("_pretrained_attrs"):
+            # reset removes fitted/task-specific state, so a fitted pretrained
+            # forecaster must come back as pretrained rather than fitted.
+            self._state = "pretrained"
+
+    def reset(self, keep_pretrained=True):
+        """Reset object while preserving pretrained state by default.
+
+        Wraps skbase's ``BaseObject.reset`` to save pretrained attributes
+        before the reset wipes all instance state, and restores them
+        afterwards.
+
+        Parameters
+        ----------
+        keep_pretrained : bool, default=True
+            If True, pretrained attributes tracked in ``_pretrained_attrs``
+            are restored after reset. If False, pretrained state is
+            discarded and reset behaves like the generic skbase reset.
+
+        Returns
+        -------
+        self : reference to self
+            Reset instance.
+        """
+        pretrained_state = self._save_pretrained_state() if keep_pretrained else {}
+        super().reset()
+        if pretrained_state:
+            self._restore_pretrained_state(pretrained_state)
+        return self
+
+    def set_params(self, **params):
+        """Set parameters, optionally skipping reset.
+
+        Reimplements skbase's ``BaseObject.set_params`` to support the
+        ``_reset`` control flag. When ``_reset=False``, parameter values
+        are written via ``setattr`` without calling ``reset``, preserving
+        all current state including fitted attributes. The flag propagates
+        to nested forecasters.
+
+        When ``_reset=True`` (the default), behaviour is identical to the
+        inherited ``set_params`` except that ``self.reset()`` calls this
+        mixin's override which preserves pretrained state.
+
+        Parameters
+        ----------
+        **params : dict
+            Object parameters. If ``_reset=False`` is passed, parameter
+            values are set without calling ``reset`` on this object or
+            nested components.
+
+        Returns
+        -------
+        self : reference to self
+            Instance with updated parameters.
+        """
+        reset = params.pop("_reset", True)
+
+        if not params:
+            return self
+        valid_params = self.get_params(deep=True)
+
+        unmatched_keys = []
+
+        nested_params = defaultdict(dict)
+        for full_key, value in params.items():
+            key, delim, sub_key = full_key.partition("__")
+            if key not in valid_params:
+                unmatched_keys += [key]
+            elif delim:
+                nested_params[key][sub_key] = value
+            else:
+                setattr(self, key, value)
+                valid_params[key] = value
+
+        if reset:
+            self.reset()
+
+        for key, sub_params in nested_params.items():
+            component = valid_params[key]
+            if hasattr(component, "set_params"):
+                # propagate _reset only to objects likely to understand it
+                if isinstance(component, _PretrainedStateMixin):
+                    component.set_params(**sub_params, _reset=reset)
+                else:
+                    component.set_params(**sub_params)
+
+        if len(unmatched_keys) > 0:
+            valid_params = self.get_params(deep=True)
+            unmatched_params = {key: params[key] for key in unmatched_keys}
+            aliased_params = self._alias_params(unmatched_params, valid_params)
+
+            if set(aliased_params) == set(unmatched_params):
+                raise ValueError(
+                    "Invalid parameter keys provided to set_params of "
+                    f"object {self}. Check the list of available parameters "
+                    "with `object.get_params().keys()`. "
+                    f"Invalid keys provided: {unmatched_keys}"
+                )
+
+            self.set_params(**aliased_params, _reset=reset)
+
+        return self

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -1151,8 +1151,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         estimator_instance.reset()
 
         assert estimator_instance.state == "pretrained", (
-            f"State after reset should be 'pretrained', "
-            f"got {estimator_instance.state}"
+            f"State after reset should be 'pretrained', got {estimator_instance.state}"
         )
 
         pretrained_params_after = estimator_instance.get_pretrained_params()

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -1123,6 +1123,46 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
                 f"after fit: {pretrained_attrs_after}"
             )
 
+    def test_pretrain_reset_preserves_state(self, estimator_instance, n_columns):
+        """Test reset() preserves pretrained state by default."""
+        if not estimator_instance.get_tag(
+            "capability:pretrain", tag_value_default=False, raise_error=False
+        ):
+            return None
+
+        from sktime.utils._testing.hierarchical import _make_hierarchical
+
+        fh = self._pretrain_fh(estimator_instance)
+
+        y_panel = _make_hierarchical(
+            hierarchy_levels=(3,),
+            min_timepoints=10,
+            max_timepoints=10,
+            n_columns=n_columns,
+        )
+        estimator_instance.pretrain(y_panel, fh=fh)
+
+        pretrained_params_before = estimator_instance.get_pretrained_params()
+        pretrained_attrs_before = list(pretrained_params_before.keys())
+        assert len(pretrained_attrs_before) > 0, (
+            "Expected pretrained attributes after pretrain()"
+        )
+
+        estimator_instance.reset()
+
+        assert estimator_instance.state == "pretrained", (
+            f"State after reset should be 'pretrained', "
+            f"got {estimator_instance.state}"
+        )
+
+        pretrained_params_after = estimator_instance.get_pretrained_params()
+        for attr in pretrained_attrs_before:
+            assert attr in pretrained_params_after, (
+                f"Pretrained attribute {attr} was removed by reset(). "
+                f"Attributes before reset: {pretrained_attrs_before}, "
+                f"after reset: {list(pretrained_params_after.keys())}"
+            )
+
     def test_pretrain_rejects_single_series(self, estimator_instance, n_columns):
         """Test that pretrain() raises TypeError for single series input.
 

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -1163,6 +1163,51 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
                 f"after reset: {list(pretrained_params_after.keys())}"
             )
 
+    def test_pretrain_set_params_preserves_state(self, estimator_instance, n_columns):
+        """Test set_params() preserves pretrained state by default."""
+        if not estimator_instance.get_tag(
+            "capability:pretrain", tag_value_default=False, raise_error=False
+        ):
+            return None
+
+        params = estimator_instance.get_params(deep=False)
+        if not params:
+            return None
+
+        from sktime.utils._testing.hierarchical import _make_hierarchical
+
+        fh = self._pretrain_fh(estimator_instance)
+
+        y_panel = _make_hierarchical(
+            hierarchy_levels=(3,),
+            min_timepoints=10,
+            max_timepoints=10,
+            n_columns=n_columns,
+        )
+        estimator_instance.pretrain(y_panel, fh=fh)
+
+        pretrained_params_before = estimator_instance.get_pretrained_params()
+        pretrained_attrs_before = list(pretrained_params_before.keys())
+        assert len(pretrained_attrs_before) > 0, (
+            "Expected pretrained attributes after pretrain()"
+        )
+
+        param_name, param_value = next(iter(params.items()))
+        estimator_instance.set_params(**{param_name: param_value})
+
+        assert estimator_instance.state == "pretrained", (
+            f"State after set_params should be 'pretrained', "
+            f"got {estimator_instance.state}"
+        )
+
+        pretrained_params_after = estimator_instance.get_pretrained_params()
+        for attr in pretrained_attrs_before:
+            assert attr in pretrained_params_after, (
+                f"Pretrained attribute {attr} was removed by set_params(). "
+                f"Attributes before set_params: {pretrained_attrs_before}, "
+                f"after set_params: {list(pretrained_params_after.keys())}"
+            )
+
     def test_pretrain_rejects_single_series(self, estimator_instance, n_columns):
         """Test that pretrain() raises TypeError for single series input.
 

--- a/sktime/forecasting/tests/test_dummy_global.py
+++ b/sktime/forecasting/tests/test_dummy_global.py
@@ -328,3 +328,97 @@ class TestDummyGlobalForecaster:
         assert not hasattr(forecaster, "global_mean_")
         assert not hasattr(forecaster, "_pretrained_attrs")
 
+    def test_set_params_preserves_pretrained_attrs_by_default(self):
+        """Test set_params preserves pretrained attributes by default."""
+        forecaster = DummyGlobalForecaster(strategy="mean")
+        y_panel = _make_hierarchical(
+            hierarchy_levels=(3,), min_timepoints=10, max_timepoints=10, n_columns=1
+        )
+        forecaster.pretrain(y_panel)
+        pretrain_mean = forecaster.global_mean_
+
+        forecaster.set_params(strategy="last")
+
+        assert forecaster.strategy == "last"
+        assert forecaster._state == "pretrained"
+        assert hasattr(forecaster, "global_mean_")
+        np.testing.assert_almost_equal(forecaster.global_mean_, pretrain_mean)
+
+    def test_set_params_can_discard_pretrained_attrs(self):
+        """Test set_params can explicitly discard pretrained attributes."""
+        forecaster = DummyGlobalForecaster(strategy="mean")
+        y_panel = _make_hierarchical(
+            hierarchy_levels=(3,), min_timepoints=10, max_timepoints=10, n_columns=1
+        )
+        forecaster.pretrain(y_panel)
+
+        forecaster.set_params(strategy="last", _keep_pretrained=False)
+
+        assert forecaster.strategy == "last"
+        assert forecaster._state == "new"
+        assert not hasattr(forecaster, "global_mean_")
+        assert not hasattr(forecaster, "_pretrained_attrs")
+
+    def test_reset_after_fit_preserves_only_pretrained_attrs(self):
+        """Test reset after fit removes fitted attrs but keeps pretrained attrs."""
+        forecaster = DummyGlobalForecaster(strategy="last")
+        y_panel = _make_hierarchical(
+            hierarchy_levels=(3,), min_timepoints=10, max_timepoints=10, n_columns=1
+        )
+        forecaster.pretrain(y_panel)
+        pretrain_mean = forecaster.global_mean_
+
+        y_train = _make_series(n_columns=1, n_timepoints=20)
+        forecaster.fit(y_train, fh=[1, 2, 3])
+        assert hasattr(forecaster, "last_value_")
+
+        forecaster.reset()
+
+        assert forecaster._state == "pretrained"
+        assert hasattr(forecaster, "global_mean_")
+        assert not hasattr(forecaster, "last_value_")
+        np.testing.assert_almost_equal(forecaster.global_mean_, pretrain_mean)
+
+    def test_set_params_after_fit_preserves_only_pretrained_attrs(self):
+        """Test set_params after fit removes fitted attrs but keeps pretrained attrs."""
+        forecaster = DummyGlobalForecaster(strategy="last")
+        y_panel = _make_hierarchical(
+            hierarchy_levels=(3,), min_timepoints=10, max_timepoints=10, n_columns=1
+        )
+        forecaster.pretrain(y_panel)
+        pretrain_mean = forecaster.global_mean_
+
+        y_train = _make_series(n_columns=1, n_timepoints=20)
+        forecaster.fit(y_train, fh=[1, 2, 3])
+        assert hasattr(forecaster, "last_value_")
+
+        forecaster.set_params(strategy="mean")
+
+        assert forecaster.strategy == "mean"
+        assert forecaster._state == "pretrained"
+        assert hasattr(forecaster, "global_mean_")
+        assert not hasattr(forecaster, "last_value_")
+        np.testing.assert_almost_equal(forecaster.global_mean_, pretrain_mean)
+
+    def test_clone_uses_pretrained_attr_copy_hook(self):
+        """Test clone delegates pretrained attr copying to the forecaster hook."""
+
+        class HookedDummyGlobalForecaster(DummyGlobalForecaster):
+            def _copy_pretrained_attr(self, attr_name, attr_value, memo=None):
+                if attr_name == "global_mean_":
+                    self.copied_attr_name_ = attr_name
+                    return attr_value + 1
+                return super()._copy_pretrained_attr(attr_name, attr_value, memo=memo)
+
+        forecaster = HookedDummyGlobalForecaster(strategy="mean")
+        y_panel = _make_hierarchical(
+            hierarchy_levels=(3,), min_timepoints=10, max_timepoints=10, n_columns=1
+        )
+        forecaster.pretrain(y_panel)
+        pretrain_mean = forecaster.global_mean_
+
+        cloned = forecaster.clone()
+
+        assert forecaster.copied_attr_name_ == "global_mean_"
+        assert cloned._state == "pretrained"
+        np.testing.assert_almost_equal(cloned.global_mean_, pretrain_mean + 1)

--- a/sktime/forecasting/tests/test_dummy_global.py
+++ b/sktime/forecasting/tests/test_dummy_global.py
@@ -298,3 +298,33 @@ class TestDummyGlobalForecaster:
         assert cloned_inner._state == "pretrained"
         assert hasattr(cloned_inner, "global_mean_")
         np.testing.assert_almost_equal(cloned_inner.global_mean_, pretrain_mean)
+
+    def test_reset_preserves_pretrained_attrs(self):
+        """Test reset preserves pretrained attributes by default."""
+        forecaster = DummyGlobalForecaster(strategy="mean")
+        y_panel = _make_hierarchical(
+            hierarchy_levels=(3,), min_timepoints=10, max_timepoints=10, n_columns=1
+        )
+        forecaster.pretrain(y_panel)
+        pretrain_mean = forecaster.global_mean_
+
+        forecaster.reset()
+
+        assert forecaster._state == "pretrained"
+        assert hasattr(forecaster, "global_mean_")
+        np.testing.assert_almost_equal(forecaster.global_mean_, pretrain_mean)
+
+    def test_reset_can_discard_pretrained_attrs(self):
+        """Test reset can explicitly discard pretrained attributes."""
+        forecaster = DummyGlobalForecaster(strategy="mean")
+        y_panel = _make_hierarchical(
+            hierarchy_levels=(3,), min_timepoints=10, max_timepoints=10, n_columns=1
+        )
+        forecaster.pretrain(y_panel)
+
+        forecaster.reset(keep_pretrained=False)
+
+        assert forecaster._state == "new"
+        assert not hasattr(forecaster, "global_mean_")
+        assert not hasattr(forecaster, "_pretrained_attrs")
+


### PR DESCRIPTION
Relates to https://github.com/sktime/enhancement-proposals/pull/50

This PR is the first infrastructure step for making sktime's `BaseForecaster` pretraining API usable in normal estimator workflows such as `reset`, `set_params`, cloning, model selection, and composites.

The central problem is that sktime already has a `pretrain -> fit -> predict` state machine, but generic estimator operations can destroy pretrained state. In particular, `set_params` in skbase resets an estimator after changing hyperparameters. A normal reset deletes fitted attributes, and pretrained model weights are stored as fitted-like runtime attributes. Without special handling, calling `set_params` after `pretrain` removes the pretrained state.

This PR makes the default behavior preserve pretrained state, while still providing an explicit path to discard it.


## What This PR Does Not Do

This PR should remain a narrow infrastructure PR. It should not become the full foundation model API unification. So it does not:

- introduce explicit pretrained attribute tags
- formalize `_pretrain_update`
- migrate foundation models
- solve composite behavior comprehensively
- change skbase



