### PR TITLE
[ENH] add `tests:vm` tag to `HCrystalBallAdapter`

### DIFF
--- a/sktime/forecasting/adapters/_hcrystalball.py
+++ b/sktime/forecasting/adapters/_hcrystalball.py
@@ -116,6 +116,9 @@ class HCrystalBallAdapter(BaseForecaster):
         "capability:exogenous": False,
         "requires-fh-in-fit": False,
         "capability:missing_values": False,
+        # test and CI flags
+        # -----------------
+        "tests:vm": True,
     }
 
     def __init__(self, model):

--- a/sktime/forecasting/adapters/_hcrystalball.py
+++ b/sktime/forecasting/adapters/_hcrystalball.py
@@ -109,7 +109,7 @@ class HCrystalBallAdapter(BaseForecaster):
         # --------------
         "authors": "MichalChromcak",
         "maintainers": "MichalChromcak",
-        "python_dependencies": "hcrystalball",
+        "python_dependencies": ["hcrystalball", "setuptools"],
         "tests:python_dependencies": ["statsmodels"],
         # estimator type
         # --------------

--- a/sktime/forecasting/adapters/_hcrystalball.py
+++ b/sktime/forecasting/adapters/_hcrystalball.py
@@ -119,6 +119,8 @@ class HCrystalBallAdapter(BaseForecaster):
         # test and CI flags
         # -----------------
         "tests:vm": True,
+        "tests:skip_by_name": ["test_get_test_params_coverage"]
+        # old package with secondary dependencies
     }
 
     def __init__(self, model):

--- a/sktime/forecasting/adapters/_hcrystalball.py
+++ b/sktime/forecasting/adapters/_hcrystalball.py
@@ -109,7 +109,7 @@ class HCrystalBallAdapter(BaseForecaster):
         # --------------
         "authors": "MichalChromcak",
         "maintainers": "MichalChromcak",
-        "python_dependencies": ["hcrystalball", "setuptools"],
+        "python_dependencies": ["hcrystalball", "setuptools<82"],
         "tests:python_dependencies": ["statsmodels"],
         # estimator type
         # --------------

--- a/sktime/forecasting/adapters/_hcrystalball.py
+++ b/sktime/forecasting/adapters/_hcrystalball.py
@@ -119,7 +119,7 @@ class HCrystalBallAdapter(BaseForecaster):
         # test and CI flags
         # -----------------
         "tests:vm": True,
-        "tests:skip_by_name": ["test_get_test_params_coverage"]
+        "tests:skip_by_name": ["test_get_test_params_coverage"],
         # old package with secondary dependencies
     }
 


### PR DESCRIPTION
adds `tests:vm` tag to `HCrystalBallAdapter` to ensure testing on a VM with `hcrystalball` installed.