### PR TITLE
[MNT] Update Makefile install target for pyproject builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ help:
 release: ## Make a release
 	python3 $(BUILD_TOOLS)/make_release.py
 
-install: ## Install for the current user using the default python command
-	python3 setup.py build_ext --inplace && python setup.py install --user
+install: ## Install editable into the active Python environment
+	python3 -m pip install -e .
 
 test: ## Run unit tests
 	-rm -rf ${TEST_DIR}


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10241

#### What does this implement/fix? Explain your changes.

Updates the Makefile `install` target to use the project metadata in `pyproject.toml` instead of the removed root `setup.py`.

The target now runs:

```bash
python3 -m pip install .
```

This matches the current installation documentation and avoids the `python3: can't open file ... setup.py` failure reported in the issue.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Whether the Makefile target should remain a normal environment install or use a different contributor-oriented mode.

#### Did you add any tests for the change?

No automated test added; this is a Makefile command update.

Verification performed:

- `make -n install`
- `git diff --check`

I also attempted a pip dry-run in the system Python and a temporary venv. The system Python is externally managed by Homebrew, and the temporary venv lacks the project build backend (`setuptools.build_meta`) unless build dependencies are installed, so those environment checks were not used as pass/fail evidence.
