### PR TITLE
docs: fix fracdiff README typo

### DIFF
--- a/sktime/libs/fracdiff/README.md
+++ b/sktime/libs/fracdiff/README.md
@@ -118,7 +118,7 @@ For example, 0.5th differentiation of S&P 500 historical price looks like this:
 ![spx](./examples/fig/spx.png)
 
 [`Fracdiff`](https://fracdiff.github.io/fracdiff/#id1) is compatible with scikit-learn API.
-One can imcorporate it into a pipeline.
+One can incorporate it into a pipeline.
 
 ```python
 from sklearn.linear_model import LinearRegression


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Correct `imcorporate` to `incorporate` in the fracdiff README.

Fixes #9414

## Test plan
- static validation: `imcorporate` appeared 1 time(s) in `sktime/libs/fracdiff/README.md` before replacement.
- static validation: `imcorporate` absent and `incorporate` present in `sktime/libs/fracdiff/README.md` after patch.
- Not run: runtime test suite, because this is a documentation-only fix.
