### PR TITLE
[ENH] remove deprecated `scipy` Kulsinski distance from tests

### DIFF
--- a/sktime/dists_kernels/scipy_dist.py
+++ b/sktime/dists_kernels/scipy_dist.py
@@ -26,7 +26,7 @@ class ScipyDist(BasePairwiseTransformer):
         if string, one of: ``braycurtis``, ``canberra``, ``chebyshev``, ``cityblock``,
             ``correlation``, ``cosine``, ``dice``, ``euclidean``, ``hamming``,
             ``jaccard``, ``jensenshannon``,
-            ``kulsinski`` (< scipy 1.11) or ``kulczynski1`` (from scipy 1.11),
+            ``kulsinski`` (< scipy 1.11) or ``kulczynski1`` (scipy >=1.11, <1.17),
             ``mahalanobis``, ``matching``, ``minkowski``,
             ``rogerstanimoto``, ``russellrao``, ``seuclidean``, ``sokalmichener``,
             ``sokalsneath``, ``sqeuclidean``, ``yule``

--- a/sktime/dists_kernels/tests/test_scipy_dist.py
+++ b/sktime/dists_kernels/tests/test_scipy_dist.py
@@ -3,6 +3,8 @@
 import numpy as np
 import pytest
 
+from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.dists_kernels.scipy_dist import ScipyDist
 from sktime.tests.test_switch import run_test_for_class
 from sktime.utils._testing.panel import make_transformer_problem
@@ -56,27 +58,6 @@ def X2_df():
     )
 
 
-def _get_kul_name():
-    """Get name of kul... distance.
-
-    Utility to bridge deprecation of kulsinski distance in scipy.
-    Name pre-1.11.0 is kulsinski, and from 1.11.0 it is kulczynski1.
-
-    Returns
-    -------
-    name : str
-        one of "kulsinski" (if scipy < 1.11.0) and "kulczynski1" (if scipy >= 1.11.0)
-    """
-    try:
-        from scipy.spatial.distance import kulczynski1  # noqa: F401
-
-        name = "kulczynski1"
-    except Exception:
-        name = "kulsinski"
-
-    return name
-
-
 # potential parameters
 METRIC_VALUES = [
     "braycurtis",
@@ -90,7 +71,6 @@ METRIC_VALUES = [
     "hamming",
     "jaccard",
     "jensenshannon",
-    _get_kul_name(),
     "mahalanobis",
     "matching",
     "minkowski",
@@ -104,6 +84,13 @@ METRIC_VALUES = [
 ]
 P_VALUES = [1, 2, 5, 10]
 COLALIGN_VALUES = ["intersect", "force-align", "none"]
+
+
+if _check_soft_dependencies("scipy<1.11.0", severity="none"):
+    METRIC_VALUES.append("kulsinski")
+elif _check_soft_dependencies("scipy<1.17.0", severity="none"):
+    METRIC_VALUES.append("kulczynski1")
+# kulsinski distance is no longer prsent after scipy 1.17
 
 
 @pytest.mark.skipif(

--- a/sktime/dists_kernels/tests/test_scipy_dist.py
+++ b/sktime/dists_kernels/tests/test_scipy_dist.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 import pytest
-
 from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.dists_kernels.scipy_dist import ScipyDist

--- a/sktime/dists_kernels/tests/test_scipy_dist.py
+++ b/sktime/dists_kernels/tests/test_scipy_dist.py
@@ -89,7 +89,7 @@ if _check_soft_dependencies("scipy<1.11.0", severity="none"):
     METRIC_VALUES.append("kulsinski")
 elif _check_soft_dependencies("scipy<1.17.0", severity="none"):
     METRIC_VALUES.append("kulczynski1")
-# kulsinski distance is no longer prsent after scipy 1.17
+# kulsinski distance is no longer present after scipy 1.17
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/10190 by removing the Kulsinski distance from the tests in case `scipy>=1.17`.