### PR TITLE
[BUG] fix sklearn init spec non-conformance in GRUFCNNClassifier, MCDCNNClassifierTorch, MCDCNNRegressorTorch, RBFForecaster

### DIFF
--- a/sktime/classification/deep_learning/gru.py
+++ b/sktime/classification/deep_learning/gru.py
@@ -303,8 +303,8 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
         dropout: float = 0.0,
         gru_dropout: float = 0.0,
         bidirectional: bool = False,
-        conv_layers: list = [128, 256, 128],
-        kernel_sizes: list = [7, 5, 3],
+        conv_layers: list = None,
+        kernel_sizes: list = None,
         # base classifier specific
         num_epochs: int = 10,
         batch_size: int = 8,
@@ -331,7 +331,7 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
         self.criterion = criterion
         self.criterion_kwargs = criterion_kwargs
         self.optimizer = optimizer
-        self.optimizer_kwargs = {"betas": (0.9, 0.999)} if optimizer == "Adam" else {}
+        self.optimizer_kwargs = optimizer_kwargs
         self.lr = lr
         self.verbose = verbose
         self.random_state = random_state
@@ -360,6 +360,8 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
         # n_instances, n_dims, n_timesteps = X.shape
         self.numclasses = len(np.unique(y))
         _, self.input_size, _ = X.shape
+        conv_layers = self.conv_layers if self.conv_layers is not None else [128, 256, 128]
+        kernel_sizes = self.kernel_sizes if self.kernel_sizes is not None else [7, 5, 3]
         return GRUFCNN(
             input_size=self.input_size,
             hidden_dim=self.hidden_dim,
@@ -371,9 +373,28 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
             dropout=self.dropout,
             gru_dropout=self.gru_dropout,
             bidirectional=self.bidirectional,
-            conv_layers=self.conv_layers,
-            kernel_sizes=self.kernel_sizes,
+            conv_layers=conv_layers,
+            kernel_sizes=kernel_sizes,
         )
+
+    def _instantiate_optimizer(self):
+        """Instantiate optimizer, applying Adam betas default when needed.
+
+        Overrides parent to preserve the intended Adam default betas=(0.9, 0.999)
+        without storing a computed dict in __init__ (which would violate the sklearn
+        parameter storage contract).
+        """
+        if (
+            self.optimizer_kwargs is None
+            and isinstance(self.optimizer, str)
+            and self.optimizer.lower() == "adam"
+        ):
+            import torch
+
+            return torch.optim.Adam(
+                self.network.parameters(), lr=self.lr, betas=(0.9, 0.999)
+            )
+        return super()._instantiate_optimizer()
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -407,10 +428,9 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
                 "dropout": 0.1,
                 "gru_dropout": 0.1,
                 "bidirectional": False,
-                "conv_layers": [128, 256, 128],
-                "kernel_sizes": [7, 5, 3],
                 "num_epochs": 2,
                 "optimizer": "Adam",
+                "optimizer_kwargs": None,
                 "lr": 0.01,
                 "verbose": False,
                 "random_state": 0,
@@ -428,6 +448,7 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
                 "kernel_sizes": [7, 5, 3],
                 "num_epochs": 2,
                 "optimizer": "Adam",
+                "optimizer_kwargs": {"betas": (0.9, 0.999)},
                 "lr": 0.01,
                 "verbose": False,
                 "random_state": 0,

--- a/sktime/classification/deep_learning/mcdcnn/_mcdcnn_torch.py
+++ b/sktime/classification/deep_learning/mcdcnn/_mcdcnn_torch.py
@@ -144,19 +144,9 @@ class MCDCNNClassifierTorch(BaseDeepClassifierPytorch):
         self.lr = lr
         self.criterion_kwargs = criterion_kwargs
 
-        # used to difrentiate between user passed "SGD"
-        # and the default "SGD" with kwargs
+        # stored as-is: sklearn __init__ contract requires no mutation
         self.optim = optim
         self.optim_kwargs = optim_kwargs
-
-        self.optimizer = optim
-        self.optimizer_kwargs = optim_kwargs
-
-        # default case
-        if self.optim is None:
-            self.optimizer = "SGD"
-            if self.optimizer_kwargs is None:
-                self.optimizer_kwargs = {"momentum": 0.9, "weight_decay": 0.0005}
 
         if len(self.filter_sizes) != len(self.kernel_sizes):
             raise ValueError(
@@ -165,14 +155,22 @@ class MCDCNNClassifierTorch(BaseDeepClassifierPytorch):
                 f"`kernel_sizes` {len(self.kernel_sizes)}."
             )
 
+        # resolve defaults as local vars so the parent stores conformant values
+        _optimizer = optim if optim is not None else "SGD"
+        _optimizer_kwargs = (
+            optim_kwargs
+            if not (optim is None and optim_kwargs is None)
+            else {"momentum": 0.9, "weight_decay": 0.0005}
+        )
+
         super().__init__(
             num_epochs=self.n_epochs,
             batch_size=self.batch_size,
             activation=self.activation,
             criterion=self.criterion,
             criterion_kwargs=self.criterion_kwargs,
-            optimizer=self.optimizer,
-            optimizer_kwargs=self.optimizer_kwargs,
+            optimizer=_optimizer,
+            optimizer_kwargs=_optimizer_kwargs,
             callbacks=self.callbacks,
             callback_kwargs=self.callback_kwargs,
             lr=self.lr,
@@ -225,6 +223,34 @@ class MCDCNNClassifierTorch(BaseDeepClassifierPytorch):
             random_state=self.random_state,
         )
 
+    def _instantiate_optimizer(self):
+        """Instantiate optimizer from the sklearn-conformant optim/optim_kwargs params.
+
+        Uses self.optim and self.optim_kwargs (the params declared in __init__) rather
+        than self.optimizer/self.optimizer_kwargs (set by the parent) so that
+        set_params(optim=...) propagates correctly to the optimizer used in training.
+        """
+        import torch
+
+        params = self.network.parameters()
+        if self.optim is None:
+            kwargs = (
+                self.optim_kwargs
+                if self.optim_kwargs is not None
+                else {"momentum": 0.9, "weight_decay": 0.0005}
+            )
+            return torch.optim.SGD(params, lr=self.lr, **kwargs)
+        if isinstance(self.optim, str):
+            if self.optim not in self.optimizers:
+                raise TypeError(
+                    f"Unrecognized optimizer '{self.optim}'. "
+                    f"Must be one of {list(self.optimizers)}."
+                )
+            kwargs = self.optim_kwargs if self.optim_kwargs is not None else {}
+            return self.optimizers[self.optim](params, lr=self.lr, **kwargs)
+        # assume it's already a torch.optim.Optimizer instance
+        return self.optim
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
@@ -244,6 +270,7 @@ class MCDCNNClassifierTorch(BaseDeepClassifierPytorch):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
+        # default: optim=None exercises the default-SGD path
         params1 = {"random_state": 0}
         params2 = {
             "n_epochs": 1,
@@ -259,6 +286,7 @@ class MCDCNNClassifierTorch(BaseDeepClassifierPytorch):
             "lr": 0.005,
             "random_state": 0,
         }
+        # explicit Adam + kwargs: exercises set_params propagation
         params3 = {
             "n_epochs": 2,
             "batch_size": 2,
@@ -275,4 +303,14 @@ class MCDCNNClassifierTorch(BaseDeepClassifierPytorch):
             "lr": 0.01,
             "random_state": 0,
         }
-        return [params1, params2, params3]
+        # optim=None, explicit optim_kwargs: custom SGD kwargs stored as-is
+        params4 = {
+            "n_epochs": 1,
+            "batch_size": 4,
+            "kernel_sizes": (3,),
+            "filter_sizes": (6,),
+            "optim": None,
+            "optim_kwargs": {"momentum": 0.5, "weight_decay": 0.001},
+            "random_state": 0,
+        }
+        return [params1, params2, params3, params4]

--- a/sktime/forecasting/rbf_forecaster.py
+++ b/sktime/forecasting/rbf_forecaster.py
@@ -117,7 +117,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         centers=None,
         gamma=1.0,
         rbf_type="gaussian",
-        hidden_layers=[64, 32],
+        hidden_layers=None,
         optimizer="adam",
         lr=0.01,
         epochs=100,
@@ -208,6 +208,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         """
         output_size = fh if self.mode == "direct" else 1
 
+        hidden_layers = self.hidden_layers if self.hidden_layers is not None else [64, 32]
         return RBFNetwork(
             input_size=self.window_length,
             hidden_size=self.hidden_size,
@@ -215,7 +216,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
             centers=self.centers,
             gamma=self.gamma,
             rbf_type=self.rbf_type,
-            hidden_layers=self.hidden_layers,
+            hidden_layers=hidden_layers,
             mode=self.mode,
             activation=self.activation,
             dropout_rate=self.dropout_rate,
@@ -599,6 +600,17 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
                 "pred_len": 3,
                 "activation": "gelu",
                 "dropout_rate": 0.2,
+            },
+            # hidden_layers=None exercises the default-list path without mutable sharing
+            {
+                "window_length": 5,
+                "hidden_size": 8,
+                "batch_size": 16,
+                "hidden_layers": None,
+                "epochs": 3,
+                "lr": 0.01,
+                "device": "cpu",
+                "mode": "ar",
             },
         ]
 

--- a/sktime/regression/deep_learning/mcdcnn/_mcdcnn_torch.py
+++ b/sktime/regression/deep_learning/mcdcnn/_mcdcnn_torch.py
@@ -131,6 +131,7 @@ class MCDCNNRegressorTorch(BaseDeepRegressorTorch):
         self.activation_hidden = activation_hidden
         self.use_bias = use_bias
 
+        # stored as-is: sklearn __init__ contract requires no mutation
         self.optim = optim
         self.optim_kwargs = optim_kwargs
 
@@ -140,22 +141,21 @@ class MCDCNNRegressorTorch(BaseDeepRegressorTorch):
         self.verbose = verbose
         self.random_state = random_state
 
-        self.optimizer = self.optim
-        self.optimizer_kwargs = self.optim_kwargs
-
-        # default case
-        if self.optim is None:
-            self.optimizer = "SGD"
-            if self.optimizer_kwargs is None:
-                self.optimizer_kwargs = {"momentum": 0.9, "weight_decay": 0.0005}
+        # resolve defaults as local vars so the parent stores conformant values
+        _optimizer = optim if optim is not None else "SGD"
+        _optimizer_kwargs = (
+            optim_kwargs
+            if not (optim is None and optim_kwargs is None)
+            else {"momentum": 0.9, "weight_decay": 0.0005}
+        )
 
         super().__init__(
             num_epochs=self.n_epochs,
             batch_size=self.batch_size,
             criterion=self.criterion,
             criterion_kwargs=self.criterion_kwargs,
-            optimizer=self.optimizer,
-            optimizer_kwargs=self.optimizer_kwargs,
+            optimizer=_optimizer,
+            optimizer_kwargs=_optimizer_kwargs,
             callbacks=self.callbacks,
             callback_kwargs=self.callback_kwargs,
             lr=self.lr,
@@ -215,6 +215,60 @@ class MCDCNNRegressorTorch(BaseDeepRegressorTorch):
             use_bias=self.use_bias,
         )
 
+    def _instantiate_optimizer(self):
+        """Instantiate optimizer from the sklearn-conformant optim/optim_kwargs params.
+
+        Uses self.optim and self.optim_kwargs (the params declared in __init__) rather
+        than self.optimizer/self.optimizer_kwargs (set by the parent) so that
+        set_params(optim=...) propagates correctly to the optimizer used in training.
+        """
+        from sktime.utils.dependencies import _safe_import
+
+        params = self.network.parameters()
+        if self.optim is None:
+            kwargs = (
+                self.optim_kwargs
+                if self.optim_kwargs is not None
+                else {"momentum": 0.9, "weight_decay": 0.0005}
+            )
+            SGD = _safe_import("torch.optim.SGD")
+            return SGD(params, lr=self.lr, **kwargs)
+        if self._all_optimizers is None:
+            self._all_optimizers = {
+                "adadelta": "Adadelta",
+                "adagrad": "Adagrad",
+                "adam": "Adam",
+                "adamw": "AdamW",
+                "sparseadam": "SparseAdam",
+                "adamax": "Adamax",
+                "asgd": "ASGD",
+                "lbfgs": "LBFGS",
+                "nadam": "NAdam",
+                "radam": "RAdam",
+                "rmsprop": "RMSprop",
+                "rprop": "Rprop",
+                "sgd": "SGD",
+            }
+        torchOptimizer = _safe_import("torch.optim.Optimizer")
+        if isinstance(self.optim, str):
+            key = self.optim.lower()
+            if key not in self._all_optimizers:
+                raise ValueError(
+                    f"Unknown optimizer: '{self.optim}'. Please pass one of "
+                    f"{', '.join(self._all_optimizers)} for `optim`."
+                )
+            optimizer_class = _safe_import(
+                f"torch.optim.{self._all_optimizers[key]}"
+            )
+            kwargs = self.optim_kwargs if self.optim_kwargs is not None else {}
+            return optimizer_class(params, lr=self.lr, **kwargs)
+        if isinstance(self.optim, torchOptimizer):
+            return self.optim
+        raise TypeError(
+            "`optim` must be None, a str, or a torch.optim.Optimizer instance. "
+            f"Got {type(self.optim)} instead."
+        )
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
@@ -234,10 +288,11 @@ class MCDCNNRegressorTorch(BaseDeepRegressorTorch):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
+        # default: optim=None exercises the default-SGD path
         params1 = {
             "n_epochs": 1,
             "random_state": 0,
-        }  # default params with 1 epoch
+        }
         params2 = {
             "n_epochs": 1,
             "batch_size": 16,
@@ -249,6 +304,7 @@ class MCDCNNRegressorTorch(BaseDeepRegressorTorch):
             "activation": None,
             "random_state": 0,
         }
+        # explicit Adam + kwargs: exercises set_params propagation
         params3 = {
             "n_epochs": 2,
             "batch_size": 2,
@@ -264,6 +320,15 @@ class MCDCNNRegressorTorch(BaseDeepRegressorTorch):
             "optim_kwargs": {"weight_decay": 0.001},
             "lr": 0.01,
             "random_state": 0,
-        }  # override optimizer
+        }
+        # optim=None, explicit optim_kwargs: custom SGD kwargs stored as-is
+        params4 = {
+            "n_epochs": 1,
+            "kernel_sizes": (5,),
+            "filter_sizes": (8,),
+            "optim": None,
+            "optim_kwargs": {"momentum": 0.5, "weight_decay": 0.001},
+            "random_state": 0,
+        }
 
-        return [params1, params2, params3]
+        return [params1, params2, params3, params4]


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10208.

#### What does this implement/fix? Explain your changes.

Restores two sklearn `__init__` invariants across four estimators:

**1. No mutable default arguments**
- `GRUFCNNClassifier`: `conv_layers` and `kernel_sizes` default to `None`; real defaults resolved in `_build_network` at use-time.
- `RBFForecaster`: `hidden_layers` defaults to `None`; real default resolved in `_build_network`.

**2. Parameters stored exactly as passed (no `self.<param>` mutation in `__init__`)**
- `GRUFCNNClassifier`: `self.optimizer_kwargs` was computed from the optimizer name (`{"betas": (0.9, 0.999)}` when `optimizer="Adam"`). Now stored verbatim. The Adam betas default is applied in a `_instantiate_optimizer` override at fit-time only — so `get_params()`, `clone()`, and `set_params()` all round-trip correctly.
- `MCDCNNClassifierTorch` / `MCDCNNRegressorTorch`: `self.optimizer` and `self.optimizer_kwargs` were mutated inside `__init__`. Now resolved as local variables and forwarded to `super().__init__()` only; `self.optim` / `self.optim_kwargs` are stored as-is. A `_instantiate_optimizer` override reads the sklearn-conformant `optim`/`optim_kwargs` params directly, so `set_params(optim=...)` propagates correctly to the optimizer used in training.

**Why prior PRs #10209 and #10216 were rejected:** both overrode `_instantiate_optimizer` but fell through to `super()._instantiate_optimizer()` for the non-`None` case. The parent's method reads `self.optimizer` (set once by `super().__init__()`), which goes stale after `set_params(optim=...)` updates only `self.optim`. This fix avoids that fall-through by implementing the full optimizer dispatch in the child override using the conformant params.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- The `_instantiate_optimizer` override in `MCDCNNClassifierTorch` uses `self.optimizers` (set by `BaseDeepClassifierPytorch.__post_init__`) for string lookup — confirm this is safe to call before `_build_network`.
- The `_instantiate_optimizer` override in `MCDCNNRegressorTorch` replicates the `_all_optimizers` dict from the parent rather than calling `super()` — open to refactoring if you prefer a shared helper.
- The `_optimizer_kwargs` local variable logic: `optim=None, optim_kwargs=None` → apply SGD momentum default; `optim=None, optim_kwargs=<dict>` → use the user's dict (custom SGD kwargs).

#### Did you add any tests for the change?

`get_test_params` updated in all four estimators with entries that exercise `optimizer_kwargs=None` / `optim=None` / `hidden_layers=None`, so `check_estimator`'s `test_set_params_sklearn` covers the conformance invariants automatically.

#### PR checklist

##### For all contributions

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix