### PR TITLE
[BUG] comply with sklearn init specification in GRUFCNNClassifier, MCDCNN torch backends, and RBFForecaster

### DIFF
--- a/sktime/classification/deep_learning/gru.py
+++ b/sktime/classification/deep_learning/gru.py
@@ -303,8 +303,8 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
         dropout: float = 0.0,
         gru_dropout: float = 0.0,
         bidirectional: bool = False,
-        conv_layers: list = [128, 256, 128],
-        kernel_sizes: list = [7, 5, 3],
+        conv_layers: list = None,
+        kernel_sizes: list = None,
         # base classifier specific
         num_epochs: int = 10,
         batch_size: int = 8,
@@ -331,7 +331,7 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
         self.criterion = criterion
         self.criterion_kwargs = criterion_kwargs
         self.optimizer = optimizer
-        self.optimizer_kwargs = {"betas": (0.9, 0.999)} if optimizer == "Adam" else {}
+        self.optimizer_kwargs = optimizer_kwargs
         self.lr = lr
         self.verbose = verbose
         self.random_state = random_state
@@ -360,6 +360,10 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
         # n_instances, n_dims, n_timesteps = X.shape
         self.numclasses = len(np.unique(y))
         _, self.input_size, _ = X.shape
+        # resolve defaults here to avoid mutable default args in __init__
+        # and to comply with sklearn's parameter storage contract
+        conv_layers = self.conv_layers if self.conv_layers is not None else [128, 256, 128]
+        kernel_sizes = self.kernel_sizes if self.kernel_sizes is not None else [7, 5, 3]
         return GRUFCNN(
             input_size=self.input_size,
             hidden_dim=self.hidden_dim,
@@ -371,8 +375,8 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
             dropout=self.dropout,
             gru_dropout=self.gru_dropout,
             bidirectional=self.bidirectional,
-            conv_layers=self.conv_layers,
-            kernel_sizes=self.kernel_sizes,
+            conv_layers=conv_layers,
+            kernel_sizes=kernel_sizes,
         )
 
     @classmethod

--- a/sktime/classification/deep_learning/mcdcnn/_mcdcnn_torch.py
+++ b/sktime/classification/deep_learning/mcdcnn/_mcdcnn_torch.py
@@ -149,14 +149,15 @@ class MCDCNNClassifierTorch(BaseDeepClassifierPytorch):
         self.optim = optim
         self.optim_kwargs = optim_kwargs
 
-        self.optimizer = optim
-        self.optimizer_kwargs = optim_kwargs
-
-        # default case
-        if self.optim is None:
-            self.optimizer = "SGD"
-            if self.optimizer_kwargs is None:
-                self.optimizer_kwargs = {"momentum": 0.9, "weight_decay": 0.0005}
+        # compute effective optimizer settings as locals; do not store computed
+        # values on self, to comply with sklearn's __init__ parameter storage
+        # contract. self.optim / self.optim_kwargs above preserve user inputs.
+        optimizer = optim
+        optimizer_kwargs = optim_kwargs
+        if optim is None:
+            optimizer = "SGD"
+            if optimizer_kwargs is None:
+                optimizer_kwargs = {"momentum": 0.9, "weight_decay": 0.0005}
 
         if len(self.filter_sizes) != len(self.kernel_sizes):
             raise ValueError(
@@ -171,8 +172,8 @@ class MCDCNNClassifierTorch(BaseDeepClassifierPytorch):
             activation=self.activation,
             criterion=self.criterion,
             criterion_kwargs=self.criterion_kwargs,
-            optimizer=self.optimizer,
-            optimizer_kwargs=self.optimizer_kwargs,
+            optimizer=optimizer,
+            optimizer_kwargs=optimizer_kwargs,
             callbacks=self.callbacks,
             callback_kwargs=self.callback_kwargs,
             lr=self.lr,

--- a/sktime/forecasting/rbf_forecaster.py
+++ b/sktime/forecasting/rbf_forecaster.py
@@ -117,7 +117,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         centers=None,
         gamma=1.0,
         rbf_type="gaussian",
-        hidden_layers=[64, 32],
+        hidden_layers=None,
         optimizer="adam",
         lr=0.01,
         epochs=100,
@@ -207,6 +207,8 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
             Prediction length (output dimension for direct mode, ignored for AR).
         """
         output_size = fh if self.mode == "direct" else 1
+        # resolve default here to avoid a mutable default argument in __init__
+        hidden_layers = self.hidden_layers if self.hidden_layers is not None else [64, 32]
 
         return RBFNetwork(
             input_size=self.window_length,
@@ -215,7 +217,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
             centers=self.centers,
             gamma=self.gamma,
             rbf_type=self.rbf_type,
-            hidden_layers=self.hidden_layers,
+            hidden_layers=hidden_layers,
             mode=self.mode,
             activation=self.activation,
             dropout_rate=self.dropout_rate,

--- a/sktime/regression/deep_learning/mcdcnn/_mcdcnn_torch.py
+++ b/sktime/regression/deep_learning/mcdcnn/_mcdcnn_torch.py
@@ -140,22 +140,23 @@ class MCDCNNRegressorTorch(BaseDeepRegressorTorch):
         self.verbose = verbose
         self.random_state = random_state
 
-        self.optimizer = self.optim
-        self.optimizer_kwargs = self.optim_kwargs
-
-        # default case
+        # compute effective optimizer settings as locals; do not store computed
+        # values on self, to comply with sklearn's __init__ parameter storage
+        # contract. self.optim / self.optim_kwargs above preserve user inputs.
+        optimizer = self.optim
+        optimizer_kwargs = self.optim_kwargs
         if self.optim is None:
-            self.optimizer = "SGD"
-            if self.optimizer_kwargs is None:
-                self.optimizer_kwargs = {"momentum": 0.9, "weight_decay": 0.0005}
+            optimizer = "SGD"
+            if optimizer_kwargs is None:
+                optimizer_kwargs = {"momentum": 0.9, "weight_decay": 0.0005}
 
         super().__init__(
             num_epochs=self.n_epochs,
             batch_size=self.batch_size,
             criterion=self.criterion,
             criterion_kwargs=self.criterion_kwargs,
-            optimizer=self.optimizer,
-            optimizer_kwargs=self.optimizer_kwargs,
+            optimizer=optimizer,
+            optimizer_kwargs=optimizer_kwargs,
             callbacks=self.callbacks,
             callback_kwargs=self.callback_kwargs,
             lr=self.lr,


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10208. Same class of fix as #2027 (`[BUG] MiniRocket to comply with sklearn init specification`).

#### What does this implement/fix? Explain your changes.

Makes the following estimators comply with sklearn's [`__init__` parameter storage contract](https://scikit-learn.org/stable/developers/develop.html#instantiation) — every parameter is stored verbatim, and there are no mutable default arguments — so that `get_params()`, `clone()` and `set_params()` behave correctly.

- **`GRUFCNNClassifier`**: store `optimizer_kwargs` as-is instead of a computed dict. `betas=(0.9, 0.999)` is already `torch.optim.Adam`'s default, so behaviour is unchanged. The `conv_layers` / `kernel_sizes` mutable list defaults are changed to `None` and resolved in `_build_network`.
- **`MCDCNNClassifierTorch` / `MCDCNNRegressorTorch`**: keep `self.optim` / `self.optim_kwargs` as the verbatim user inputs; compute the effective optimizer settings as local variables passed to `super().__init__()` rather than mutating `self`.
- **`RBFForecaster`**: the `hidden_layers` mutable list default is changed to `None` and resolved in `_build_network`.

Note: the issue's reproduction snippet references `MCDCNNClassifier`, but that name resolves to the TensorFlow backend (`_mcdcnn_tf.py`), which is already compliant (it uses the `self.optimizer_` fitted-attribute convention). The class that carries `optim_kwargs` and the violation is `MCDCNNClassifierTorch` in `_mcdcnn_torch.py` (the file referenced in the issue), which this PR fixes, along with its regression counterpart.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Behaviour preservation of the optimizer defaults (Adam `betas`, SGD `momentum`/`weight_decay`).
- For `GRUFCNNClassifier` I chose not to add an `_instantiate_optimizer` override, since `(0.9, 0.999)` is already the torch Adam default and the previous computed value was never actually used (it was overwritten by `super().__init__`). Happy to add an override if you prefer to make the default explicit.

#### Did you add any tests for the change?

`check_estimator` passes for all four estimators (`GRUFCNNClassifier`, `MCDCNNClassifierTorch`, `MCDCNNRegressorTorch`, `RBFForecaster`), and `get_params()` / `clone()` now round-trip the passed values. I'm happy to add an explicit parametrized round-trip test if maintainers would like one.

#### Any other comments?

This is a behaviour-preserving conformance fix; no public API changes.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors (will request via the all-contributors bot once the PR is open).
- [x] The PR title starts with `[BUG]`.
