### PR TITLE
[BUG] add missing `tests:libs` and `tests:vm` tags for forecasters with internal dependencies

### DIFF
--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -25,7 +25,11 @@ class _ProphetAdapter(BaseForecaster):
         "capability:missing_values": True,
         "y_inner_mtype": "pd.DataFrame",
         "python_dependencies": "prophet",
-        "tests:vm": True,  # all estimators depending on prophet are tested in VM
+        # CI and testing tags
+        # -------------------
+        "tests:vm": True,
+        # libs tag is set so child classes get tested if this file changes
+        "tests:libs": ["sktime.forecasting.base.adapters._fbprophet"],
     }
 
     def _convert_int_to_date(self, y):

--- a/sktime/forecasting/base/adapters/_neuralforecast.py
+++ b/sktime/forecasting/base/adapters/_neuralforecast.py
@@ -92,6 +92,11 @@ class _NeuralForecastAdapter(_GlobalForecastingDeprecationMixin, BaseForecaster)
         "capability:missing_values": False,
         "capability:insample": False,
         "capability:global_forecasting": True,
+        # CI and testing tags
+        # -------------------
+        "tests:vm": True,
+        # libs tag is set so child classes get tested if this file changes
+        "tests:libs": ["sktime.forecasting.base.adapters._neuralforecast"],
     }
 
     def __init__(

--- a/sktime/forecasting/base/adapters/_pytorch.py
+++ b/sktime/forecasting/base/adapters/_pytorch.py
@@ -48,6 +48,11 @@ class BaseDeepNetworkPyTorch(BaseForecaster):
         "capability:pred_int:insample": False,
         "capability:multivariate": True,
         "capability:exogenous": False,
+        # CI and testing tags
+        # -------------------
+        "tests:vm": True,
+        # libs tag is set so child classes get tested if this file changes
+        "tests:libs": ["sktime.forecasting.base.adapters._pytorch"],
     }
 
     def __init__(

--- a/sktime/forecasting/base/adapters/_pytorchforecasting.py
+++ b/sktime/forecasting/base/adapters/_pytorchforecasting.py
@@ -84,6 +84,11 @@ class _PytorchForecastingAdapter(_GlobalForecastingDeprecationMixin, BaseForecas
         "capability:insample": False,
         "capability:pred_int": False,
         "capability:pred_int:insample": False,
+        # CI and testing tags
+        # -------------------
+        "tests:vm": True,
+        # libs tag is set so child classes get tested if this file changes
+        "tests:libs": ["sktime.forecasting.base.adapters._pytorchforecasting"],
     }
 
     def __init__(

--- a/sktime/forecasting/base/adapters/_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_statsforecast.py
@@ -31,6 +31,8 @@ class _StatsForecastAdapter(BaseForecaster):
         # CI and test dependencies
         # ------------------------
         "tests:vm": True,
+        # libs tag is set so child classes get tested if this file changes
+        "tests:libs": ["sktime.forecasting.base.adapters._statsforecast"],
     }
 
     def __init__(self):

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -29,6 +29,11 @@ class _StatsModelsAdapter(BaseForecaster):
         "capability:exogenous": False,
         "requires-fh-in-fit": False,
         "capability:missing_values": False,
+        # CI and testing tags
+        # -------------------
+        "tests:vm": True,
+        # libs tag is set so child classes get tested if this file changes
+        "tests:libs": ["sktime.forecasting.base.adapters._statsmodels"],
     }
 
     def __init__(self, random_state=None):

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -26,8 +26,11 @@ class _TbatsAdapter(BaseForecaster):
         "capability:missing_values": False,
         # todo 0.41.0: check whether numpy and scipy bounds are still needed
         "python_dependencies": ["tbats", "numpy<2", "scipy<1.16"],
-        # VM and test flags
-        "tests:vm": True,  # tested on separate VM due to tbats dependency
+        # CI and testing tags
+        # -------------------
+        "tests:vm": True,
+        # libs tag is set so child classes get tested if this file changes
+        "tests:libs": ["sktime.forecasting.base.adapters._tbats"],
     }
 
     def __init__(


### PR DESCRIPTION
This PR adds missing `tests:libs` tags for forecasters with internal dependencies on adapter superclasses, to ensure the respective forecasters are tested whenever the adapter class is changed.

Also adds a `tests:vm` tag to the superclasses, all of which have specific soft dependencies, to ensure the tests run on a VM with said soft dependencies, instead of being skipped.

Closes a hole in test coverage for the specific edge case where only the adapter class is changed - on current `main`, this would not have triggered tests.