### PR TITLE
fix: replace deprecated setup.py with pip install in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ release: ## Make a release
 	python3 $(BUILD_TOOLS)/make_release.py
 
 install: ## Install for the current user using the default python command
-	python3 setup.py build_ext --inplace && python setup.py install --user
+	python3 -m pip install --user .
 
 test: ## Run unit tests
 	-rm -rf ${TEST_DIR}


### PR DESCRIPTION
The make install command was calling setup.py which no longer exists since sktime migrated to pyproject.toml. Switching to 'python3 -m pip install --user .' fixes the install target.

Fixes #10241