### PR TITLE
[ENH] TimesFM 2.x forecasting foundation models

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -679,6 +679,14 @@ Pre-trained and foundation models
 
     TimesFMForecaster
 
+.. currentmodule:: sktime.forecasting.timesfm2_forecaster
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    TimesFM2Forecaster
+
 .. currentmodule:: sktime.forecasting.ttm
 
 .. autosummary::

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -32,6 +32,13 @@ class TimesFM2Forecaster(BaseForecaster):
         is not ``None``, this overrides or supplies the model configuration in
         ``from_pretrained``. If ``model_path`` is ``None``, it is used to
         initialize the model from configuration.
+    forward_kwargs : dict, optional (default=None)
+        Keyword arguments passed directly to the Hugging Face model forward
+        method during inference. See the Hugging Face TimesFM forward
+        documentation for supported model-specific options such as
+        ``forecast_context_len``, ``truncate_negative``, or
+        ``force_flip_invariance``.
+        See [5]_ for TimesFM-2.0 and [6]_ for TimesFM-2.5.
     validation_split : float, default=0.2
         Fraction of data reserved for validation. This parameter is retained for
         compatibility with Hugging Face training-style interfaces; the current
@@ -60,6 +67,8 @@ class TimesFM2Forecaster(BaseForecaster):
     .. [2] https://github.com/google-research/timesfm
     .. [3] https://huggingface.co/google/timesfm-2.5-200m-transformers
     .. [4] https://huggingface.co/google/timesfm-2.0-500m-pytorch
+    .. [5] https://huggingface.co/docs/transformers/en/model_doc/timesfm#transformers.TimesFmModelForPrediction.forward
+    .. [6] https://huggingface.co/docs/transformers/en/model_doc/timesfm2_5#transformers.TimesFm2_5ModelForPrediction.forward
 
     Examples
     --------
@@ -90,6 +99,7 @@ class TimesFM2Forecaster(BaseForecaster):
         self,
         model_path="google/timesfm-2.5-200m-transformers",
         config=None,
+        forward_kwargs=None,
         validation_split=0.2,
         training_args=None,
         compute_loss_func=None,
@@ -99,6 +109,7 @@ class TimesFM2Forecaster(BaseForecaster):
     ):
         self.model_path = model_path
         self.config = config
+        self.forward_kwargs = forward_kwargs
         self.validation_split = validation_split
         self.training_args = training_args
         self.compute_loss_func = compute_loss_func
@@ -184,7 +195,8 @@ class TimesFM2Forecaster(BaseForecaster):
         fh = fh.to_relative(self.cutoff)
         preds_idx = fh._values.values - 1
 
-        output = self.model_(past_values=past_values)
+        forward_kwargs = {} if self.forward_kwargs is None else self.forward_kwargs
+        output = self.model_(past_values=past_values, **forward_kwargs)
 
         preds = output.mean_predictions
         preds = preds.ravel()

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -36,7 +36,7 @@ class TimesFM2Forecaster(BaseForecaster):
         Fraction of data reserved for validation. This parameter is retained for
         compatibility with Hugging Face training-style interfaces; the current
         zero-shot implementation does not fine-tune the model.
-    args : transformers.TrainingArguments or dict, optional (default=None)
+    training_args : transformers.TrainingArguments or dict, optional (default=None)
         Training arguments placeholder for future fine-tuning support. Not used
         by the current zero-shot implementation.
     compute_loss_func : callable, optional (default=None)
@@ -91,7 +91,7 @@ class TimesFM2Forecaster(BaseForecaster):
         model_path="google/timesfm-2.5-200m-transformers",
         config=None,
         validation_split=0.2,
-        args=None,
+        training_args=None,
         compute_loss_func=None,
         compute_metrics=None,
         callbacks=None,
@@ -100,7 +100,7 @@ class TimesFM2Forecaster(BaseForecaster):
         self.model_path = model_path
         self.config = config
         self.validation_split = validation_split
-        self.args = args
+        self.training_args = training_args
         self.compute_loss_func = compute_loss_func
         self.compute_metrics = compute_metrics
         self.callbacks = callbacks

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -467,9 +467,18 @@ class _TimesFM2WindowDataset:
         min_length = context_length + horizon_length
         self.samples = []
         for series in series_list:
+            if len(series) <= horizon_length:
+                continue
             series = _pad_series(series, min_length)
             for start in range(len(series) - min_length + 1):
                 self.samples.append(series[start : start + min_length])
+
+        if not self.samples:
+            raise ValueError(
+                "No training samples could be generated. "
+                f"Each series must have length greater than horizon_length "
+                f"({horizon_length})."
+            )
 
     def __len__(self):
         """Return length of dataset."""

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -293,7 +293,7 @@ class TimesFM2Forecaster(BaseForecaster):
         past_values = past_values.to(self.model_.dtype)
         past_values = past_values.to(self.model_.device)
 
-        forward_kwargs = {} if self.forward_kwargs is None else self.forward_kwargs
+        forward_kwargs = {} if not self.forward_kwargs else self.forward_kwargs
         output = self.model_(past_values=past_values, **forward_kwargs)
 
         preds = output.mean_predictions
@@ -377,7 +377,7 @@ class TimesFM2Forecaster(BaseForecaster):
         past_values = past_values.to(self.model_.dtype)
         past_values = past_values.to(self.model_.device)
 
-        forward_kwargs = {} if self.forward_kwargs is None else self.forward_kwargs
+        forward_kwargs = {} if not self.forward_kwargs else self.forward_kwargs
         output = self.model_(past_values=past_values, **forward_kwargs)
 
         preds = output.full_predictions
@@ -519,7 +519,7 @@ class _CachedTimesFM2:
 
         if self.model_path is not None:
             config = self.config
-            if config is None:
+            if not config:
                 config = AutoConfig.from_pretrained(self.model_path)
             if isinstance(config, dict):
                 config_class = _get_timesfm_config_class(config)
@@ -532,7 +532,7 @@ class _CachedTimesFM2:
             )
         else:
             config = self.config
-            if config is None:
+            if not config:
                 config = TimesFmConfig()
             if isinstance(config, dict):
                 config_class = _get_timesfm_config_class(config)

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -88,7 +88,7 @@ class TimesFM2Forecaster(BaseForecaster):
         "capability:exogenous": False,
         "requires-fh-in-fit": False,
         "capability:insample": False,
-        "capability:pred_int": False,
+        "capability:pred_int": True,
         "capability:pretrain": True,
         "authors": ["rajatsen91", "siriuz42", "geetu040"],
         # rajatsen91, siriuz42 for google-research/timesfm
@@ -301,6 +301,95 @@ class TimesFM2Forecaster(BaseForecaster):
 
         return preds
 
+    def _predict_quantiles(self, fh, X, alpha):
+        """Compute/return prediction quantiles for a forecast.
+
+        private _predict_quantiles containing the core logic,
+            called from predict_quantiles and possibly predict_interval
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon
+            The forecasting horizon with the steps ahead to to predict.
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series for the forecast
+        alpha : list of float (guaranteed not None and floats in [0,1] interval)
+            A list of probabilities at which quantile forecasts are computed.
+
+        Returns
+        -------
+        quantiles : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+                second level being the values of alpha passed to the function.
+            Row index is fh, with additional (upper) levels equal to instance levels,
+                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+            Entries are quantile forecasts, for var in col index,
+                at quantile probability in second col index, for the row index.
+        """
+        import torch
+
+        self.model_ = self._load_model()
+
+        horizon_length = self.model_.config.horizon_length
+        quantiles = self.model_.config.quantiles
+        past_values = self.context_
+
+        if fh is None:
+            fh = self.fh
+        fh = fh.to_relative(self.cutoff)
+        preds_idx = fh._values.values - 1
+        if np.max(preds_idx) >= horizon_length:
+            raise ValueError(
+                "The requested forecasting horizon extends beyond the TimesFM "
+                f"model horizon_length. The maximum requested relative horizon "
+                f"is {np.max(preds_idx) + 1}, but model.config.horizon_length is "
+                f"{horizon_length}."
+            )
+
+        if alpha is None:
+            alpha = quantiles
+        alpha = [round(i, 3) for i in alpha]
+        quantiles = [round(i, 3) for i in quantiles]
+        if not set(alpha).issubset(set(quantiles)):
+            raise ValueError(
+                "The requested quantiles are different than the ones in config "
+                f"alpha: {alpha} and valid quantiles in config: {quantiles}"
+            )
+        quantiles_idx = np.array([quantiles.index(i) for i in alpha])
+
+        past_values = np.expand_dims(past_values, axis=0)
+        past_values = torch.from_numpy(past_values)
+        past_values = past_values.to(self.model_.dtype)
+        past_values = past_values.to(self.model_.device)
+
+        forward_kwargs = {} if self.forward_kwargs is None else self.forward_kwargs
+        output = self.model_(past_values=past_values, **forward_kwargs)
+
+        preds = output.full_predictions
+        preds = preds.squeeze(0)
+        preds = preds[preds_idx]
+        preds = preds[:, quantiles_idx]
+        preds = preds.detach().cpu().numpy()
+
+        index = fh.to_absolute(self._cutoff)._values
+        name = self.context_.name if self.context_.name is not None else 0
+        columns = pd.MultiIndex.from_product([[name], alpha])
+        pred_quantiles = pd.DataFrame(
+            data=preds,
+            index=index,
+            columns=columns,
+        )
+
+        return pred_quantiles
+
     def __getstate__(self):
         """Return state for pickling, excluding the model object."""
         state = self.__dict__.copy()
@@ -355,6 +444,8 @@ class TimesFM2Forecaster(BaseForecaster):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+        intervals = [0.9, 0.75, 0.5, 0.25, 0.1, 0.05]
+        quantiles = sorted(q for p in intervals for q in ((1 - p) / 2, (1 + p) / 2))
         return [
             {
                 "model_path": None,
@@ -368,6 +459,7 @@ class TimesFM2Forecaster(BaseForecaster):
                     "context_length": 8,
                     "horizon_length": 6,
                     "patch_length": 2,
+                    "quantiles": quantiles,
                 },
                 "validation_split": 0.1,
                 "training_args": {
@@ -388,6 +480,7 @@ class TimesFM2Forecaster(BaseForecaster):
                     "context_length": 8,
                     "horizon_length": 6,
                     "patch_length": 2,
+                    "quantiles": quantiles,
                 },
                 "validation_split": 0.1,
                 "training_args": {

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -1,264 +1,114 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Extension template for forecasters.
+"""Interface for the HuggingFace TimesFM-2.x forecasting model series."""
 
-Purpose of this implementation template:
-    quick implementation of new estimators following the template
-    NOT a concrete class to import! This is NOT a base class or concrete class!
-    This is to be used as a "fill-in" coding template.
+__author__ = ["rajatsen91", "siriuz42", "geetu040"]
+# rajatsen91 for google-research/timesfm
 
-How to use this implementation template to implement a new estimator:
-- make a copy of the template in a suitable location, give it a descriptive name.
-- work through all the "todo" comments below
-- fill in code for mandatory methods, and optionally for optional methods
-- do not write to reserved variables: is_fitted, _is_fitted, _state,
-    _pretrained_attrs, _X, _y, cutoff, _fh, _cutoff, _converter_store_y,
-    forecasters_, _tags, _tags_dynamic, _is_vectorized
-- you can add more private methods, but do not override BaseEstimator's private methods
-    an easy way to be safe is to prefix your methods with "_custom"
-- change docstrings for functions and the file
-- ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
-- once complete: use as a local library, or contribute to sktime via PR
-- more details:
-  https://www.sktime.net/en/stable/developer_guide/add_estimators.html
+__all__ = ["TimesFM2Forecaster"]
 
-Mandatory methods to implement:
-    fitting         - _fit(self, y, X=None, fh=None)
-    forecasting     - _predict(self, fh=None, X=None)
-
-Optional methods to implement:
-    updating                    - _update(self, y, X=None, update_params=True):
-    predicting quantiles        - _predict_quantiles(self, fh, X=None, alpha=None)
-    OR predicting intervals     - _predict_interval(self, fh, X=None, coverage=None)
-    predicting variance         - _predict_var(self, fh, X=None, cov=False)
-    distribution forecast       - _predict_proba(self, fh, X=None)
-    fitted parameter inspection - _get_fitted_params()
-    pretraining (1st batch)     - _pretrain(self, y, X=None, fh=None)
-    pretraining (update)        - _pretrain_update(self, y, X=None, fh=None)
-
-Testing - required for sktime test framework and check_estimator usage:
-    get default parameters for test instance(s) - get_test_params()
-"""
-# todo: write an informative docstring for the file or module, remove the above
-# todo: add an appropriate copyright notice for your estimator
-#       estimators contributed to sktime should have the copyright notice at the top
-#       estimators of your own do not need to have permissive or BSD-3 copyright
-
-# todo: uncomment the following line, enter authors' GitHub IDs
-# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+import numpy as np
+import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster
-
-# todo: add any necessary imports here
-
-# todo: for imports of sktime soft dependencies:
-# make sure to fill in the "python_dependencies" tag with the package import name
-# import soft dependencies only inside methods of the class, not at the top of the file
+from sktime.utils.singleton import _multiton
 
 
-# todo: change class name and write docstring
-class MyForecaster(BaseForecaster):
-    """Custom forecaster. todo: write docstring.
+class TimesFM2Forecaster(BaseForecaster):
+    """TimesFM-2.x forecaster via Hugging Face transformers.
 
-    todo: describe your custom forecaster here
+    TimesFM is a pretrained time-series foundation model developed by
+    Google Research for zero-shot forecasting. This forecaster wraps the
+    Hugging Face ``transformers`` implementation of TimesFM-2.x and exposes
+    it through the sktime forecasting interface.
 
     Parameters
     ----------
-    parama : int
-        descriptive explanation of parama
-    paramb : string, optional (default='default')
-        descriptive explanation of paramb
-    paramc : boolean, optional (default=MyOtherEstimator(foo=42))
-        descriptive explanation of paramc
-    and so on
+    model_path : str, default="google/timesfm-2.5-200m-transformers"
+        Hugging Face model identifier or local path to a TimesFM-2.x checkpoint.
+        If ``None``, a model is initialized from ``config`` or from the default
+        ``transformers.TimesFmConfig``.
+    config : transformers.TimesFmConfig or dict, optional (default=None)
+        Configuration passed to the Hugging Face model loader. If ``model_path``
+        is not ``None``, this overrides or supplies the model configuration in
+        ``from_pretrained``. If ``model_path`` is ``None``, it is used to
+        initialize the model from configuration.
+    validation_split : float, default=0.2
+        Fraction of data reserved for validation. This parameter is retained for
+        compatibility with Hugging Face training-style interfaces; the current
+        zero-shot implementation does not fine-tune the model.
+    args : transformers.TrainingArguments or dict, optional (default=None)
+        Training arguments placeholder for future fine-tuning support. Not used
+        by the current zero-shot implementation.
+    compute_loss_func : callable, optional (default=None)
+        Custom loss function placeholder for future fine-tuning support. Not
+        used by the current zero-shot implementation.
+    compute_metrics : callable or list of callable, optional (default=None)
+        Metric function or functions placeholder for future fine-tuning support.
+        Not used by the current zero-shot implementation.
+    callbacks : list, optional (default=None)
+        Hugging Face Trainer callbacks placeholder for future fine-tuning
+        support. Not used by the current zero-shot implementation.
+    device : str, default="cpu"
+        Device on which to run the model, for example ``"cpu"``, ``"cuda"``,
+        or ``"cuda:0"``.
+
+    References
+    ----------
+    .. [1] Das, A., Kong, W., Sen, R., and Zhou, Y. (2024).
+       A decoder-only foundation model for time-series forecasting. CoRR.
+       https://arxiv.org/abs/2310.10688
+    .. [2] https://github.com/google-research/timesfm
+    .. [3] https://huggingface.co/google/timesfm-2.5-200m-transformers
+    .. [4] https://huggingface.co/google/timesfm-2.0-500m-pytorch
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
+    >>> y = load_airline()
+    >>> forecaster = TimesFM2Forecaster(
+    ...     model_path="google/timesfm-2.5-200m-transformers",
+    ...     device="cpu",
+    ... )  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
     """
 
-    # todo: fill out estimator tags here
-    #  tags are inherited from parent class if they are not set
-    # todo: define the forecaster scitype by setting the tags
-    #  the "forecaster scitype" is determined by the tags
-    #   scitype:y - the expected input scitype of y - univariate or multivariate or both
-    #  when changing scitype:y to multivariate or both:
-    #   y_inner_mtype should be changed to pd.DataFrame
-    # other tags are "safe defaults" which can usually be left as-is
     _tags = {
-        # tags and full specifications are available in the tag API reference
-        # https://www.sktime.net/en/stable/api_reference/tags.html
-        # to list all valid tags with description, use sktime.registry.all_tags
-        #   all_tags(estimator_types="forecaster", as_dataframe=True)
-        #
-        # behavioural tags: internal type
-        # -------------------------------
-        #
-        # y_inner_mtype, X_inner_mtype control which format X/y appears in
-        # in the inner functions _fit, _predict, etc
-        "y_inner_mtype": "pd.Series",
-        "X_inner_mtype": "pd.DataFrame",
-        # valid values: str and list of str
-        # if str, must be a valid mtype str, in sktime.datatypes.MTYPE_REGISTER
-        #   of scitype Series, Panel (panel data) or Hierarchical (hierarchical series)
-        #   in that case, all inputs are converted to that one type
-        # if list of str, must be a list of valid str specifiers
-        #   in that case, X/y are passed through without conversion if on the list
-        #   if not on the list, converted to the first entry of the same scitype
-        #
-        # capability:multivariate controls whether inner y can be multivariate
-        # if multivariate is not valid, applies vectorization over variables
-        "capability:multivariate": False,
-        # valid values: True, False
-        #   False: inner _fit, _predict, etc, receive only univariate series
-        #   True: inner methods work with series with any number of variables
-        #
-        # capability tags: properties of the estimator
-        # --------------------------------------------
-        #
-        # capability:exogenous = does estimator use exogeneous X nontrivially?
-        "capability:exogenous": True,
-        # valid values: boolean False (ignores X), True (uses X in non-trivial manner)
-        # CAVEAT: if tag is set to False, inner methods always see X=None
-        #
-        # requires-fh-in-fit = is forecasting horizon always required in fit?
-        "requires-fh-in-fit": True,
-        # valid values: boolean True (yes), False (no)
-        # if True, raises exception in fit if fh has not been passed
-        #
-        # X-y-must-have-same-index = can estimator handle different X/y index?
-        "X-y-must-have-same-index": True,
-        # valid values: boolean True (yes), False (no)
-        # if True, raises exception if X.index is not contained in y.index
-        #
-        # enforce_index_type = index type that needs to be enforced in X/y
-        "enforce_index_type": None,
-        # valid values: pd.Index subtype, or list of pd.Index subtype
-        # if not None, raises exception if X.index, y.index level -1 is not of that type
-        #
-        # handles-missing-data = can estimator handle missing data?
-        "capability:missing_values": False,
-        # valid values: boolean True (yes), False (no)
-        # if False, raises exception if y or X passed contain missing data (nans)
-        #
-        # capability:insample = can forecaster make in-sample forecasts?
-        "capability:insample": True,
-        # valid values: boolean True (yes), False (no)
-        # if False, exception raised if any forecast method called with in-sample fh
-        #
-        # capability:pred_int = does forecaster implement probabilistic forecasts?
+        "capability:exogenous": False,
+        "requires-fh-in-fit": False,
+        "capability:insample": False,
         "capability:pred_int": False,
-        # valid values: boolean True (yes), False (no)
-        # if False, exception raised if proba methods are called (predict_interval etc)
-        #
-        # capability:pred_int:insample = can forecaster make in-sample proba forecasts?
-        "capability:pred_int:insample": True,
-        # valid values: boolean True (yes), False (no)
-        # only needs to be set if capability:pred_int is True
-        # if False, exception raised if proba methods are called with in-sample fh
-        #
-        # capability:pretrain = does forecaster support pretraining on panel data?
         "capability:pretrain": False,
-        # valid values: boolean True (yes), False (no)
-        # if True, implement _pretrain and optionally _pretrain_update below
-        # enables the pretrain -> fit -> predict workflow for global learning
-        #
-        # ----------------------------------------------------------------------------
-        # packaging info - only required for sktime contribution or 3rd party packages
-        # ----------------------------------------------------------------------------
-        #
-        # ownership and contribution tags
-        # -------------------------------
-        #
-        # author = author(s) of th estimator
-        # an author is anyone with significant contribution to the code at some point
-        "authors": ["author1", "author2"],
-        # valid values: str or list of str, should be GitHub handles
-        # this should follow best scientific contribution practices
-        # scope is the code, not the methodology (method is per paper citation)
-        # if interfacing a 3rd party estimator, ensure to give credit to the
-        # authors of the interfaced estimator
-        #
-        # maintainer = current maintainer(s) of the estimator
-        # per algorithm maintainer role, see governance document
-        # this is an "owner" type role, with rights and maintenance duties
-        # for 3rd party interfaces, the scope is the sktime class only
-        "maintainers": ["maintainer1", "maintainer2"],
-        # valid values: str or list of str, should be GitHub handles
-        # remove tag if maintained by sktime core team
-        #
-        # dependency tags: python version and soft dependencies
-        # -----------------------------------------------------
-        #
-        # python version requirement
-        "python_version": None,
-        # valid values: str, PEP 440 valid python version specifiers
-        # raises exception at construction if local python version is incompatible
-        #
-        # soft dependency requirement
-        "python_dependencies": None,
-        # valid values: str or list of str, PEP 440 valid package version specifiers
-        # raises exception at construction if modules at strings cannot be imported
+        "authors": ["rajatsen91", "siriuz42", "geetu040"],
+        # rajatsen91, siriuz42 for google-research/timesfm
+        "maintainers": ["geetu040"],
+        "python_dependencies": ["torch", "transformers"],
     }
-    #  in case of inheritance, concrete class should typically set tags
-    #  alternatively, descendants can set tags in __init__ (avoid this if possible)
 
-    # todo: add any hyper-parameters and components to constructor
-    def __init__(self, parama, paramb="default", paramc=None):
-        # estimators should precede parameters
-        #  if estimators have default values, set None and initialize below
+    def __init__(
+        self,
+        model_path="google/timesfm-2.5-200m-transformers",
+        config=None,
+        validation_split=0.2,
+        args=None,
+        compute_loss_func=None,
+        compute_metrics=None,
+        callbacks=None,
+        device="cpu",
+    ):
+        self.model_path = model_path
+        self.config = config
+        self.validation_split = validation_split
+        self.args = args
+        self.compute_loss_func = compute_loss_func
+        self.compute_metrics = compute_metrics
+        self.callbacks = callbacks
+        self.device = device
 
-        # todo: write any hyper-parameters and components to self
-        self.parama = parama
-        self.paramb = paramb
-        # IMPORTANT: the self.params should never be overwritten or mutated from now on
-        # for handling defaults etc, write to other attributes, e.g., self._paramc
-        self.paramc = paramc
-
-        # leave this as is
         super().__init__()
 
-        # do not put anything else in __init__,
-        # use __post_init__ for any further initialization logic
-
-    # todo: add if there is dynamic tag setting logic, otherwise delete this method
-    def __dynamic_tags__(self):
-        """Dynamic tag setter logic for setting tag values conditional on parameters.
-
-        This method should be used for setting dynamic tags only.
-        """
-        # todo: if tags of estimator depend on component tags, set these here
-        #  typically only needed if estimator is a composite
-        #  tags set here apply to the instance, and override the class tags
-        #
-        # example 1: conditional setting of a tag based on parameter foo
-        # if self.foo == 42:
-        #   self.set_tags(**{"capability:missing_values": True})
-        # example 2: cloning tags from component estimator component_estimator
-        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
-
-    # todo: add any post-init logic here, otherwise delete this method
-    def __post_init__(self):
-        """Post-init constructor logic, can be used by inheriting classes.
-
-        This method should be used for:
-
-        * parameter validation
-        * initialization logic beyond self.param = param
-        * any soft dependency imports in the constructor
-
-        IMPORTANT: no significant compute or memory use should happen in __post_init__,
-        memory and compute intensive operations should be in _fit, not __post_init__.
-        """
-        # todo: optional, parameter checking or coercion should happen here
-        # if writes derived values to self, should *not* overwrite self.paramc etc
-        # instead, write to self._paramc, self._newparam (starting with _)
-        # example of handling conditional parameters or mutable defaults:
-        if self.paramc is None:
-            from sktime.somewhere import MyOtherEstimator
-
-            self._paramc = MyOtherEstimator(foo=42)
-        else:
-            # estimators should be cloned to avoid side effects
-            self._paramc = self.paramc.clone()
-
-    # todo: implement this, mandatory
-    def _fit(self, y, X, fh):
+    def _fit(self, y, X=None, fh=None):
         """Fit forecaster to training data.
 
         private _fit containing the core logic, called from fit
@@ -289,22 +139,9 @@ class MyForecaster(BaseForecaster):
         -------
         self : reference to self
         """
+        self.model_ = self._load_model()
+        self.context_ = y
 
-        # implement here
-        # IMPORTANT: avoid side effects to y, X, fh
-        #
-        # any model parameters should be written to attributes ending in "_"
-        #  attributes set by the constructor must not be overwritten
-        #  if used, estimators should be cloned to attributes ending in "_"
-        #  the clones, not the originals should be used or fitted if needed
-        #
-        # Note: when interfacing a model that has fit, with parameters
-        #   that are not data (y, X) or forecasting-horizon-like,
-        #   but model parameters, *don't* add as arguments to fit, but treat as follows:
-        #   1. pass to constructor,  2. write to self in constructor,
-        #   3. read from self in _fit,  4. pass to interfaced_model.fit in _fit
-
-    # todo: implement this, mandatory
     def _predict(self, fh, X):
         """Forecast time series at future horizon.
 
@@ -332,362 +169,70 @@ class MyForecaster(BaseForecaster):
             should be of the same type as seen in _fit, as in "y_inner_mtype" tag
             Point predictions
         """
+        import torch
 
-        # implement here
-        # IMPORTANT: avoid side effects to X, fh
+        self.model_ = self._load_model()
 
-    # todo: consider implementing this, optional
-    # if not implementing, delete the _update method
-    def _update(self, y, X=None, update_params=True):
-        """Update time series to incremental training data.
+        past_values = self.context_
+        past_values = np.expand_dims(past_values, axis=0)
+        past_values = torch.from_numpy(past_values)
+        past_values = past_values.to(self.model_.dtype)
+        past_values = past_values.to(self.model_.device)
 
-        private _update containing the core logic, called from update
+        if fh is None:
+            fh = self.fh
+        fh = fh.to_relative(self.cutoff)
+        preds_idx = fh._values.values - 1
 
-        State required:
-            Requires state to be "fitted".
+        output = self.model_(past_values=past_values)
 
-        Accesses in self:
-            Fitted model attributes ending in "_"
-            self.cutoff
+        preds = output.mean_predictions
+        preds = preds.ravel()
+        preds = preds[preds_idx]
+        preds = preds.detach().cpu().numpy()
+        preds = pd.Series(
+            preds,
+            index=fh.to_absolute(self._cutoff)._values,
+            name=self.context_.name,
+        )
 
-        Writes to self:
-            Sets fitted model attributes ending in "_", if update_params=True.
-            Does not write to self if update_params=False.
+        return preds
 
-        Parameters
-        ----------
-        y : sktime time series object
-            guaranteed to be of a type in self.get_tag("y_inner_mtype")
-            Time series with which to update the forecaster.
+    def __getstate__(self):
+        """Return state for pickling, excluding the model object."""
+        state = self.__dict__.copy()
+        if "model_" in state:
+            state["model_"] = None
+        return state
 
-            * if self.get_tag("capability:multivariate")==False:
-              guaranteed to be univariate (e.g., single-column for DataFrame)
-            * if self.get_tag("capability:multivariate")==True: no restrictions apply,
-              the method should handle uni- and multivariate y appropriately
+    def __setstate__(self, state):
+        """Restore state; the model will be reloaded on next prediction."""
+        self.__dict__.update(state)
 
-        X :  sktime time series object, optional (default=None)
-            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
-            Exogeneous time series for the forecast
-        update_params : bool, optional (default=True)
-            whether model parameters should be updated
+    def _load_model(self):
+        if hasattr(self, "model_") and self.model_ is not None:
+            return self.model_
 
-        Returns
-        -------
-        self : reference to self
-        """
+        self.model_ = _CachedTimesFM2(
+            key=self._get_unique_key(),
+            model_path=self.model_path,
+            config=self.config,
+            device=self.device,
+        ).load()
 
-        # implement here
-        # IMPORTANT: avoid side effects to X, fh
+        return self.model_
 
-    # todo: consider implementing this, optional
-    # if not implementing, delete the _pretrain and _pretrain_update methods
-    # requires setting the tag "capability:pretrain" to True
-    # pretrain receives panel or hierarchical data (MultiIndex DataFrame)
-    # and should learn global patterns shared across instances
-    def _pretrain(self, y, X=None, fh=None):
-        """Pretrain forecaster on panel/global data (first batch).
+    def _get_unique_key(self):
+        return str(
+            sorted(
+                {
+                    "model_path": self.model_path,
+                    "config": self.config,
+                    "device": self.device,
+                }.items()
+            )
+        )
 
-        private _pretrain containing the core logic, called from pretrain
-
-        Writes to self:
-            Sets pretrained model attributes ending in "_".
-
-        Parameters
-        ----------
-        y : pd.DataFrame with MultiIndex (guaranteed Panel or Hierarchical)
-            Panel or hierarchical time series data to pretrain on.
-            The last index level is time, all other levels identify instances.
-        X : pd.DataFrame, optional (default=None)
-            Exogenous time series.
-        fh : ForecastingHorizon or None, optional (default=None)
-            Forecasting horizon.
-
-        Returns
-        -------
-        self : reference to self
-        """
-
-        # implement here
-        # IMPORTANT: avoid side effects to y, X, fh
-        #
-        # any pretrained model parameters should be written to attributes ending in "_"
-        #   these will be automatically tracked by the base class
-        #   and accessible via get_pretrained_params()
-        #
-        # example:
-        #   self.global_mean_ = y.values.mean()
-        #   self.n_pretrain_instances_ = len(y.index.droplevel(-1).unique())
-
-    # todo: consider implementing this, optional
-    # if not implementing, delete this method (default calls _pretrain)
-    def _pretrain_update(self, y, X=None, fh=None):
-        """Update pretrained forecaster with additional panel data.
-
-        private _pretrain_update, called from pretrain when already pretrained.
-        Default implementation calls _pretrain. Override for incremental logic.
-
-        Parameters
-        ----------
-        y : pd.DataFrame with MultiIndex (guaranteed Panel or Hierarchical)
-            Additional panel data to learn from.
-        X : pd.DataFrame, optional (default=None)
-            Exogenous time series.
-        fh : ForecastingHorizon or None, optional (default=None)
-            Forecasting horizon.
-
-        Returns
-        -------
-        self : reference to self
-        """
-        # default: just call _pretrain again
-        # override for incremental/online pretraining
-        return self._pretrain(y=y, X=X, fh=fh)
-
-    # todo: consider implementing this, optional
-    # if not implementing, delete the _update_predict_single method
-    def _update_predict_single(self, y, fh, X=None, update_params=True):
-        """Update forecaster and then make forecasts.
-
-        Implements default behaviour of calling update and predict sequentially, but can
-        be overwritten by subclasses to implement more efficient updating algorithms
-        when available.
-        """
-        self.update(y, X, update_params=update_params)
-        return self.predict(fh, X)
-        # implement here
-        # IMPORTANT: avoid side effects to y, X, fh
-
-    # todo: consider implementing one of _predict_quantiles and _predict_interval
-    #   if one is implemented, the other one works automatically
-    #   when interfacing or implementing, consider which of the two is easier
-    #   both can be implemented if desired, but usually that is not necessary
-    #
-    # if _predict_var or _predict_proba is implemented, this will have a default
-    #   implementation which uses _predict_proba or _predict_var under normal assumption
-    #
-    # if implementing _predict_interval, delete _predict_quantiles
-    # if not implementing either, delete both methods
-    def _predict_quantiles(self, fh, X, alpha):
-        """Compute/return prediction quantiles for a forecast.
-
-        private _predict_quantiles containing the core logic,
-            called from predict_quantiles and possibly predict_interval
-
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-            Fitted model attributes ending in "_"
-            self.cutoff
-
-        Parameters
-        ----------
-        fh : guaranteed to be ForecastingHorizon
-            The forecasting horizon with the steps ahead to to predict.
-        X :  sktime time series object, optional (default=None)
-            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
-            Exogeneous time series for the forecast
-        alpha : list of float (guaranteed not None and floats in [0,1] interval)
-            A list of probabilities at which quantile forecasts are computed.
-
-        Returns
-        -------
-        quantiles : pd.DataFrame
-            Column has multi-index: first level is variable name from y in fit,
-                second level being the values of alpha passed to the function.
-            Row index is fh, with additional (upper) levels equal to instance levels,
-                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
-            Entries are quantile forecasts, for var in col index,
-                at quantile probability in second col index, for the row index.
-        """
-        # implement here
-        # IMPORTANT: avoid side effects to y, X, fh, alpha
-        #
-        # Note: unlike in predict_quantiles where alpha can be float or list of float
-        #   alpha in _predict_quantiles is guaranteed to be a list of float
-
-    # implement one of _predict_interval or _predict_quantiles (above), or delete both
-    #
-    # if implementing _predict_quantiles, delete _predict_interval
-    # if not implementing either, delete both methods
-    def _predict_interval(self, fh, X, coverage):
-        """Compute/return prediction quantiles for a forecast.
-
-        private _predict_interval containing the core logic,
-            called from predict_interval and possibly predict_quantiles
-
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-            Fitted model attributes ending in "_"
-            self.cutoff
-
-        Parameters
-        ----------
-        fh : guaranteed to be ForecastingHorizon
-            The forecasting horizon with the steps ahead to to predict.
-        X :  sktime time series object, optional (default=None)
-            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
-            Exogeneous time series for the forecast
-        coverage : list of float (guaranteed not None and floats in [0,1] interval)
-           nominal coverage(s) of predictive interval(s)
-
-        Returns
-        -------
-        pred_int : pd.DataFrame
-            Column has multi-index: first level is variable name from y in fit,
-                second level coverage fractions for which intervals were computed.
-                    in the same order as in input `coverage`.
-                Third level is string "lower" or "upper", for lower/upper interval end.
-            Row index is fh, with additional (upper) levels equal to instance levels,
-                from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
-            Entries are forecasts of lower/upper interval end,
-                for var in col index, at nominal coverage in second col index,
-                lower/upper depending on third col index, for the row index.
-                Upper/lower interval end forecasts are equivalent to
-                quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
-        """
-        # implement here
-        # IMPORTANT: avoid side effects to y, X, fh, coverage
-        #
-        # Note: unlike in predict_interval where coverage can be float or list of float
-        #   coverage in _predict_interval is guaranteed to be a list of float
-
-    # todo: consider implementing _predict_var
-    #
-    # if _predict_proba or interval/quantiles are implemented, this will have a default
-    #   implementation which uses _predict_proba or quantiles under normal assumption
-    #
-    # if not implementing, delete _predict_var
-    def _predict_var(self, fh, X=None, cov=False):
-        """Forecast variance at future horizon.
-
-        private _predict_var containing the core logic, called from predict_var
-
-        Parameters
-        ----------
-        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
-            The forecasting horizon with the steps ahead to to predict.
-            If not passed in _fit, guaranteed to be passed here
-        X :  sktime time series object, optional (default=None)
-            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
-            Exogeneous time series for the forecast
-        cov : bool, optional (default=False)
-            if True, computes covariance matrix forecast.
-            if False, computes marginal variance forecasts.
-
-        Returns
-        -------
-        pred_var : pd.DataFrame, format dependent on `cov` variable
-            If cov=False:
-                Column names are exactly those of `y` passed in `fit`/`update`.
-                    For nameless formats, column index will be a RangeIndex.
-                Row index is fh, with additional levels equal to instance levels,
-                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
-                Entries are variance forecasts, for var in col index.
-                A variance forecast for given variable and fh index is a predicted
-                    variance for that variable and index, given observed data.
-            If cov=True:
-                Column index is a multiindex: 1st level is variable names (as above)
-                    2nd level is fh.
-                Row index is fh, with additional levels equal to instance levels,
-                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
-                Entries are (co-)variance forecasts, for var in col index, and
-                    covariance between time index in row and col.
-                Note: no covariance forecasts are returned between different variables.
-        """
-        # implement here
-        # implementing the cov=True case is optional and can be omitted
-
-    # todo: consider implementing _predict_proba
-    #
-    # if interval/quantiles or _predict_var are implemented, this will have a default
-    #   implementation which uses variance or quantiles under normal assumption
-    #
-    # if not implementing, delete _predict_proba
-    def _predict_proba(self, fh, X, marginal=True):
-        """Compute/return fully probabilistic forecasts.
-
-        private _predict_proba containing the core logic, called from predict_proba
-
-        Parameters
-        ----------
-        fh : int, list, np.array or ForecastingHorizon (not optional)
-            The forecasting horizon encoding the time stamps to forecast at.
-            if has not been passed in fit, must be passed, not optional
-        X : sktime time series object, optional (default=None)
-                Exogeneous time series for the forecast
-            Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
-            if self.get_tag("X-y-must-have-same-index"),
-                X.index must contain fh.index and y.index both
-        marginal : bool, optional (default=True)
-            whether returned distribution is marginal by time index
-
-        Returns
-        -------
-        pred_dist : sktime BaseDistribution
-            predictive distribution
-            if marginal=True, will be marginal distribution by time point
-            if marginal=False and implemented by method, will be joint
-        """
-        # implement here
-        # returned BaseDistribution should have same index and columns
-        # as the predict return
-        #
-        # implementing the marginal=False case is optional and can be omitted
-
-    # todo: consider implementing this, optional
-    # if not implementing, delete the method
-    def _predict_moving_cutoff(self, y, cv, X=None, update_params=True):
-        """Make single-step or multi-step moving cutoff predictions.
-
-        Parameters
-        ----------
-        y : pd.Series
-        cv : temporal cross-validation generator
-        X : pd.DataFrame
-        update_params : bool
-
-        Returns
-        -------
-        y_pred = pd.Series
-        """
-
-        # implement here
-        # IMPORTANT: avoid side effects to y, X, cv
-
-    # todo: consider implementing this, optional
-    # implement only if different from default:
-    #   default retrieves all self attributes ending in "_"
-    #   and returns them with keys that have the "_" removed
-    # if not implementing, delete the method
-    #   avoid overriding get_fitted_params
-    def _get_fitted_params(self):
-        """Get fitted parameters.
-
-        private _get_fitted_params, called from get_fitted_params
-
-        State required:
-            Requires state to be "fitted".
-
-        Returns
-        -------
-        fitted_params : dict with str keys
-            fitted parameters, keyed by names of fitted parameter
-        """
-        # implement here
-        #
-        # when this function is reached, it is already guaranteed that self is fitted
-        #   this does not need to be checked separately
-        #
-        # parameters of components should follow the sklearn convention:
-        #   separate component name from parameter name by double-underscore
-        #   e.g., componentname__paramname
-
-    # todo: implement this if this is an estimator contributed to sktime
-    #   or to run local automated unit and integration testing of estimator
-    #   method should return default parameters, so that a test instance can be created
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
@@ -707,47 +252,64 @@ class MyForecaster(BaseForecaster):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+        return [
+            {
+                "model_path": None,
+                "config": {
+                    "architectures": ["TimesFm2ModelForPrediction"],
+                    "num_hidden_layers": 1,
+                    "hidden_size": 16,
+                    "intermediate_size": 16,
+                    "head_dim": 8,
+                    "num_attention_heads": 4,
+                },
+                "device": "cpu",
+            },
+            {
+                "model_path": None,
+                "config": {
+                    "architectures": ["TimesFm2_5ModelForPrediction"],
+                    "num_hidden_layers": 1,
+                    "hidden_size": 8,
+                    "intermediate_size": 4,
+                    "head_dim": 2,
+                    "num_attention_heads": 1,
+                },
+            },
+        ]
 
-        # todo: set the testing parameters for the estimators
-        # Testing parameters can be dictionary or list of dictionaries
-        # Testing parameter choice should cover internal cases well.
-        #
-        # this method can, if required, use:
-        #   class properties (e.g., inherited); parent class test case
-        #   imported objects such as estimators from sktime or sklearn
-        # important: all such imports should be *inside get_test_params*, not at the top
-        #            since imports are used only at testing time
-        #
-        # The parameter_set argument is not used for automated, module level tests.
-        #   It can be used in custom, estimator specific tests, for "special" settings.
-        # A parameter dictionary must be returned *for all values* of parameter_set,
-        #   i.e., "parameter_set not available" errors should never be raised.
-        #
-        # A good parameter set should primarily satisfy two criteria,
-        #   1. Chosen set of parameters should have a low testing time,
-        #      ideally in the magnitude of few seconds for the entire test suite.
-        #       This is vital for the cases where default values result in
-        #       "big" models which not only increases test time but also
-        #       run into the risk of test workers crashing.
-        #   2. There should be a minimum two such parameter sets with different
-        #      sets of values to ensure a wide range of code coverage is provided.
-        #
-        # example 1: specify params as dictionary
-        # any number of params can be specified
-        # params = {"est": value0, "parama": value1, "paramb": value2}
-        #
-        # example 2: specify params as list of dictionary
-        # note: Only first dictionary will be used by create_test_instance
-        # params = [{"est": value1, "parama": value2},
-        #           {"est": value3, "parama": value4}]
-        # return params
-        #
-        # example 3: parameter set depending on param_set value
-        #   note: only needed if a separate parameter set is needed in tests
-        # if parameter_set == "special_param_set":
-        #     params = {"est": value1, "parama": value2}
-        #     return params
-        #
-        # # "default" params - always returned except for "special_param_set" value
-        # params = {"est": value3, "parama": value4}
-        # return params
+
+@_multiton
+class _CachedTimesFM2:
+    """Cached TimesFM 2.5 model instance."""
+
+    def __init__(self, key, model_path, config, device):
+        self.key = key
+        self.model_path = model_path
+        self.config = config
+        self.device = device
+        self.model_ = None
+
+    def load(self):
+        if self.model_ is not None:
+            return self.model_
+
+        from transformers import AutoModelForTimeSeriesPrediction, TimesFmConfig
+
+        if self.model_path is not None:
+            self.model_ = AutoModelForTimeSeriesPrediction.from_pretrained(
+                self.model_path,
+                config=self.config,
+            )
+            self.model_ = self.model_.to(self.device)
+            return self.model_
+
+        config = self.config
+        if config is None:
+            config = TimesFmConfig()
+        if isinstance(config, dict):
+            config = TimesFmConfig.from_dict(config)
+
+        self.model_ = AutoModelForTimeSeriesPrediction.from_config(config)
+        self.model_ = self.model_.to(self.device)
+        return self.model_

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -94,7 +94,7 @@ class TimesFM2Forecaster(BaseForecaster):
         "authors": ["rajatsen91", "siriuz42", "geetu040"],
         # rajatsen91, siriuz42 for google-research/timesfm
         "maintainers": ["geetu040"],
-        "python_dependencies": ["torch", "transformers>=4.52.0"],
+        "python_dependencies": ["transformers[torch]>=4.52.0"],
         "tests:vm": True,
     }
 

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -93,7 +93,8 @@ class TimesFM2Forecaster(BaseForecaster):
         "authors": ["rajatsen91", "siriuz42", "geetu040"],
         # rajatsen91, siriuz42 for google-research/timesfm
         "maintainers": ["geetu040"],
-        "python_dependencies": ["torch", "transformers"],
+        "python_dependencies": ["torch", "transformers>=4.52.0"],
+        "tests:vm": True,
     }
 
     def __init__(
@@ -446,11 +447,12 @@ class TimesFM2Forecaster(BaseForecaster):
         """
         intervals = [0.9, 0.75, 0.5, 0.25, 0.1, 0.05]
         quantiles = sorted(q for p in intervals for q in ((1 - p) / 2, (1 + p) / 2))
+        quantiles = [0.1] + quantiles
         return [
             {
                 "model_path": None,
                 "config": {
-                    "architectures": ["TimesFm2ModelForPrediction"],
+                    "architectures": ["TimesFmModelForPrediction"],
                     "num_hidden_layers": 1,
                     "hidden_size": 16,
                     "intermediate_size": 16,
@@ -477,6 +479,7 @@ class TimesFM2Forecaster(BaseForecaster):
                     "intermediate_size": 4,
                     "head_dim": 2,
                     "num_attention_heads": 1,
+                    "num_key_value_heads": 1,
                     "context_length": 8,
                     "horizon_length": 6,
                     "patch_length": 2,
@@ -506,12 +509,20 @@ class _CachedTimesFM2:
         if self.model_ is not None:
             return self.model_
 
-        from transformers import AutoModelForTimeSeriesPrediction, TimesFmConfig
+        from transformers import AutoConfig, TimesFmConfig
 
         if self.model_path is not None:
-            self.model_ = AutoModelForTimeSeriesPrediction.from_pretrained(
+            config = self.config
+            if config is None:
+                config = AutoConfig.from_pretrained(self.model_path)
+            elif isinstance(config, dict):
+                config_class = _get_timesfm_config_class(config)
+                config = config_class.from_dict(config)
+
+            model_class = _get_timesfm_model_class(config)
+            self.model_ = model_class.from_pretrained(
                 self.model_path,
-                config=self.config,
+                config=config,
             )
             self.model_ = self.model_.to(self.device)
             return self.model_
@@ -520,11 +531,32 @@ class _CachedTimesFM2:
         if config is None:
             config = TimesFmConfig()
         if isinstance(config, dict):
-            config = TimesFmConfig.from_dict(config)
+            config_class = _get_timesfm_config_class(config)
+            config = config_class.from_dict(config)
 
-        self.model_ = AutoModelForTimeSeriesPrediction.from_config(config)
+        model_class = _get_timesfm_model_class(config)
+        self.model_ = model_class(config)
         self.model_ = self.model_.to(self.device)
         return self.model_
+
+
+def _get_timesfm_model_class(config):
+    """Return the TimesFM prediction class named by the config architecture."""
+    import transformers
+
+    architectures = getattr(config, "architectures", None) or [
+        "TimesFmModelForPrediction"
+    ]
+    return getattr(transformers, architectures[0])
+
+
+def _get_timesfm_config_class(config):
+    """Return the TimesFM config class named by a config dict architecture."""
+    import transformers
+
+    architectures = config.get("architectures") or ["TimesFmModelForPrediction"]
+    config_class_name = architectures[0].replace("ModelForPrediction", "Config")
+    return getattr(transformers, config_class_name)
 
 
 def _prepare_series_list(data):

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -89,9 +89,10 @@ class TimesFM2Forecaster(BaseForecaster):
     peft_config : peft.PeftConfig, optional (default=None)
         If provided, wraps the loaded base model with PEFT using
         ``peft.get_peft_model``.
-    device : str, default="cpu"
-        Device string used to move the loaded model, for example ``"cpu"``,
-        ``"cuda"``, or ``"cuda:0"``.
+    device_map : str, dict, int, or torch.device, default="cpu"
+        Device placement following the ``transformers`` ``device_map`` naming
+        convention, for example ``"cpu"``, ``"cuda"``, ``"cuda:0"``, or
+        ``"auto"``.
 
     References
     ----------
@@ -120,14 +121,14 @@ class TimesFM2Forecaster(BaseForecaster):
     >>> y = load_airline()
     >>> forecaster = TimesFM2Forecaster(
     ...     model_path="google/timesfm-2.5-200m-transformers",
-    ...     device="cpu",
+    ...     device_map="cpu",
     ... )  # doctest: +SKIP
     >>> forecaster.fit(y)  # doctest: +SKIP
     >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
 
     Quantile prediction using model-supported alphas:
 
-    >>> forecaster = TimesFM2Forecaster(device="cpu")  # doctest: +SKIP
+    >>> forecaster = TimesFM2Forecaster(device_map="cpu")  # doctest: +SKIP
     >>> forecaster.fit(y)  # doctest: +SKIP
     >>> q_pred = forecaster.predict_quantiles(  # doctest: +SKIP
     ...     fh=[1, 2, 3],
@@ -151,7 +152,7 @@ class TimesFM2Forecaster(BaseForecaster):
     >>> forecaster = TimesFM2Forecaster(  # doctest: +SKIP
     ...     model_path=None,
     ...     config=cfg,
-    ...     device="cpu",
+    ...     device_map="cpu",
     ... )
 
     Global pretraining on panel data:
@@ -201,7 +202,7 @@ class TimesFM2Forecaster(BaseForecaster):
         compute_metrics=None,
         callbacks=None,
         peft_config=None,
-        device="cpu",
+        device_map="cpu",
     ):
         self.model_path = model_path
         self.config = config
@@ -212,7 +213,7 @@ class TimesFM2Forecaster(BaseForecaster):
         self.compute_metrics = compute_metrics
         self.callbacks = callbacks
         self.peft_config = peft_config
-        self.device = device
+        self.device_map = device_map
 
         super().__init__()
 
@@ -495,8 +496,8 @@ class TimesFM2Forecaster(BaseForecaster):
         Returns
         -------
         model : transformers.PreTrainedModel
-            Loaded model on ``self.device``. If ``self.model_`` already exists,
-            it is returned directly.
+            Loaded model according to ``self.device_map``. If ``self.model_``
+            already exists, it is returned directly.
         """
         if hasattr(self, "model_") and self.model_ is not None:
             return self.model_
@@ -505,7 +506,7 @@ class TimesFM2Forecaster(BaseForecaster):
             key=self._get_unique_key(),
             model_path=self.model_path,
             config=self.config,
-            device=self.device,
+            device_map=self.device_map,
             peft_config=self.peft_config,
         ).load()
 
@@ -523,7 +524,7 @@ class TimesFM2Forecaster(BaseForecaster):
         key = {
             "model_path": self.model_path,
             "config": self.config,
-            "device": self.device,
+            "device_map": self.device_map,
             "peft_config": self.peft_config,
         }
         return str(sorted(key.items()))
@@ -570,7 +571,7 @@ class TimesFM2Forecaster(BaseForecaster):
                     "max_steps": 1,
                     "eval_steps": 1,
                 },
-                "device": "cpu",
+                "device_map": "cpu",
             },
             {
                 "model_path": None,
@@ -615,16 +616,16 @@ class _CachedTimesFM2:
         Configuration used for model loading/creation.
     peft_config : peft.PeftConfig or None
         Optional PEFT wrapping configuration.
-    device : str
-        Device to move the created model to.
+    device_map : str, dict, int, or torch.device
+        Device placement for loading models.
     """
 
-    def __init__(self, key, model_path, config, peft_config, device):
+    def __init__(self, key, model_path, config, peft_config, device_map):
         self.key = key
         self.model_path = model_path
         self.config = config
         self.peft_config = peft_config
-        self.device = device
+        self.device_map = device_map
         self.model_ = None
 
     def load(self):
@@ -633,7 +634,7 @@ class _CachedTimesFM2:
         Returns
         -------
         model : transformers.PreTrainedModel
-            Loaded TimesFM prediction model on ``self.device``.
+            Loaded TimesFM prediction model according to ``self.device_map``.
 
         Notes
         -----
@@ -659,6 +660,7 @@ class _CachedTimesFM2:
             self.model_ = model_class.from_pretrained(
                 self.model_path,
                 config=config,
+                device_map=self.device_map,
             )
         else:
             config = self.config
@@ -670,8 +672,7 @@ class _CachedTimesFM2:
 
             model_class = _get_timesfm_model_class(config)
             self.model_ = model_class(config)
-
-        self.model_ = self.model_.to(self.device)
+            self.model_ = self.model_.to(self.device_map)
 
         if self.peft_config is not None:
             self.model_ = self._wrap_with_peft()

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -153,8 +153,6 @@ class TimesFM2Forecaster(BaseForecaster):
     ...     config=cfg,
     ...     device="cpu",
     ... )
-    >>> forecaster.fit(y)  # doctest: +SKIP
-    >>> y_pred = forecaster.predict(fh=[1, 2])  # doctest: +SKIP
 
     Global pretraining on panel data:
 
@@ -165,6 +163,7 @@ class TimesFM2Forecaster(BaseForecaster):
     ...     model_path="google/timesfm-2.5-200m-transformers",
     ...     training_args={"max_steps": 1, "eval_steps": 1},
     ...     validation_split=0.1,
+    ...     config={"context_length": 32, "horizon_length": 8},
     ... )
     >>> forecaster.pretrain(y_panel)  # doctest: +SKIP
 

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -399,6 +399,25 @@ class TimesFM2Forecaster(BaseForecaster):
         self.model_ = self._load_model()
         self.context_ = y
 
+    def _validate_predict_fh(self, fh):
+        """Return relative forecasting horizon indices after capacity validation."""
+        if fh is None:
+            fh = self.fh
+        fh = fh.to_relative(self.cutoff)
+        preds_idx = fh._values.values - 1
+
+        horizon_length = self.model_.config.horizon_length
+        if np.max(preds_idx) >= horizon_length:
+            raise ValueError(
+                "Requested forecasting horizon exceeds TimesFM model capacity: "
+                f"max requested step={np.max(preds_idx) + 1}, "
+                f"configured horizon_length={horizon_length}. "
+                "Use a shorter horizon or a model/config with a larger "
+                "horizon_length."
+            )
+
+        return fh, preds_idx
+
     def _predict(self, fh, X):
         """Forecast time series at future horizon.
 
@@ -430,20 +449,7 @@ class TimesFM2Forecaster(BaseForecaster):
 
         self.model_ = self._load_model()
 
-        if fh is None:
-            fh = self.fh
-        fh = fh.to_relative(self.cutoff)
-        preds_idx = fh._values.values - 1
-
-        horizon_length = self.model_.config.horizon_length
-        if np.max(preds_idx) >= horizon_length:
-            raise ValueError(
-                "Requested forecasting horizon exceeds TimesFM model capacity: "
-                f"max requested step={np.max(preds_idx) + 1}, "
-                f"configured horizon_length={horizon_length}. "
-                "Use a shorter horizon or a model/config with a larger "
-                "horizon_length."
-            )
+        fh, preds_idx = self._validate_predict_fh(fh)
 
         past_values = self.context_
         past_values = np.expand_dims(past_values, axis=0)
@@ -503,22 +509,10 @@ class TimesFM2Forecaster(BaseForecaster):
 
         self.model_ = self._load_model()
 
-        horizon_length = self.model_.config.horizon_length
         quantiles = self.model_.config.quantiles
         past_values = self.context_
 
-        if fh is None:
-            fh = self.fh
-        fh = fh.to_relative(self.cutoff)
-        preds_idx = fh._values.values - 1
-        if np.max(preds_idx) >= horizon_length:
-            raise ValueError(
-                "Requested forecasting horizon exceeds TimesFM model capacity: "
-                f"max requested step={np.max(preds_idx) + 1}, "
-                f"configured horizon_length={horizon_length}. "
-                "Use a shorter horizon or a model/config with a larger "
-                "horizon_length."
-            )
+        fh, preds_idx = self._validate_predict_fh(fh)
 
         if alpha is None:
             alpha = quantiles

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -97,6 +97,9 @@ class TimesFM2Forecaster(BaseForecaster):
         Data type used for model loading, following the ``transformers``
         ``dtype`` convention, for example ``torch.float16``,
         ``torch.bfloat16``, or ``"auto"``.
+    quantization_config : transformers.quantizers.HfQuantizer, optional
+        Valid quantization configuration object compatible with
+        ``transformers.PreTrainedModel.from_pretrained``.
 
     References
     ----------
@@ -115,6 +118,8 @@ class TimesFM2Forecaster(BaseForecaster):
        https://huggingface.co/docs/transformers/en/model_doc/timesfm2_5#transformers.TimesFm2_5ModelForPrediction.forward
     .. [7] Trainer/TrainingArguments docs:
        https://huggingface.co/docs/transformers/en/main_classes/trainer
+    .. [8] Quantization docs:
+       https://huggingface.co/docs/transformers/en/main_classes/quantization
 
     Examples
     --------
@@ -208,6 +213,7 @@ class TimesFM2Forecaster(BaseForecaster):
         peft_config=None,
         device_map="cpu",
         dtype=None,
+        quantization_config=None,
     ):
         self.model_path = model_path
         self.config = config
@@ -220,6 +226,7 @@ class TimesFM2Forecaster(BaseForecaster):
         self.peft_config = peft_config
         self.device_map = device_map
         self.dtype = dtype
+        self.quantization_config = quantization_config
 
         super().__init__()
 
@@ -515,6 +522,7 @@ class TimesFM2Forecaster(BaseForecaster):
             config=self.config,
             device_map=self.device_map,
             dtype=self.dtype,
+            quantization_config=self.quantization_config,
             peft_config=self.peft_config,
         ).load()
 
@@ -534,6 +542,7 @@ class TimesFM2Forecaster(BaseForecaster):
             "config": self.config,
             "device_map": self.device_map,
             "dtype": self.dtype,
+            "quantization_config": self.quantization_config,
             "peft_config": self.peft_config,
         }
         return str(sorted(key.items()))
@@ -629,6 +638,8 @@ class _CachedTimesFM2:
         Device placement for loading models.
     dtype : torch.dtype or str or None
         Data type used for model loading.
+    quantization_config : transformers.quantizers.HfQuantizer or None
+        Quantization configuration used for model loading.
     """
 
     def __init__(
@@ -639,6 +650,7 @@ class _CachedTimesFM2:
         peft_config,
         device_map,
         dtype,
+        quantization_config,
     ):
         self.key = key
         self.model_path = model_path
@@ -646,6 +658,7 @@ class _CachedTimesFM2:
         self.peft_config = peft_config
         self.device_map = device_map
         self.dtype = dtype
+        self.quantization_config = quantization_config
         self.model_ = None
 
     def load(self):
@@ -654,8 +667,8 @@ class _CachedTimesFM2:
         Returns
         -------
         model : transformers.PreTrainedModel
-            Loaded TimesFM prediction model according to ``self.device_map``
-            and ``self.dtype``.
+            Loaded TimesFM prediction model according to ``self.device_map``,
+            ``self.dtype``, and ``self.quantization_config``.
 
         Notes
         -----
@@ -683,6 +696,7 @@ class _CachedTimesFM2:
                 config=config,
                 device_map=self.device_map,
                 dtype=self.dtype,
+                quantization_config=self.quantization_config,
             )
         else:
             config = self.config

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -733,61 +733,61 @@ class _CachedTimesFM2:
         if self.model_ is not None:
             return self.model_
 
-        from transformers import AutoConfig, TimesFmConfig
-
         if self.model_path is not None:
-            config = self.config
-            if not config:
-                config = AutoConfig.from_pretrained(self.model_path)
-            if isinstance(config, dict):
-                config_class = _get_timesfm_config_class(config)
-                config = config_class.from_dict(config)
-
-            model_class = _get_timesfm_model_class(config)
-            self.model_ = model_class.from_pretrained(
-                self.model_path,
-                config=config,
-                device_map=self.device_map,
-                dtype=self.dtype,
-                quantization_config=self.quantization_config,
-            )
+            self.model_ = self._load_from_path()
         else:
-            config = self.config
-            if not config:
-                config = TimesFmConfig()
-            if isinstance(config, dict):
-                config_class = _get_timesfm_config_class(config)
-                config = config_class.from_dict(config)
-
-            model_class = _get_timesfm_model_class(config)
-            self.model_ = model_class(config)
-            self.model_ = self.model_.to(self.device_map)
-            if self.dtype is not None:
-                self.model_ = self.model_.to(dtype=self.dtype)
-
-        if self.peft_config is not None:
-            self.model_ = self._wrap_with_peft()
+            self.model_ = self._load_randomly()
 
         return self.model_
 
-    def _wrap_with_peft(self):
-        """Wrap loaded model with PEFT.
+    def _load_from_path(self):
+        """Load TimesFM model weights from ``self.model_path``."""
+        from transformers import AutoConfig
 
-        Returns
-        -------
-        model : torch.nn.Module
-            PEFT-wrapped model.
+        config = self.config
+        if not config:
+            config = AutoConfig.from_pretrained(self.model_path)
+        if isinstance(config, dict):
+            config_class = _get_timesfm_config_class(config)
+            config = config_class.from_dict(config)
 
-        Raises
-        ------
-        ModuleNotFoundError
-            If ``peft`` is not installed.
-        """
-        _check_soft_dependencies("peft", severity="error")
+        model_class = _get_timesfm_model_class(config)
 
-        from peft import get_peft_model
+        model = model_class.from_pretrained(
+            self.model_path,
+            config=config,
+            device_map=self.device_map,
+            dtype=self.dtype,
+            quantization_config=self.quantization_config,
+        )
 
-        return get_peft_model(self.model_, deepcopy(self.peft_config))
+        if self.peft_config is not None and _check_soft_dependencies(
+            "peft", severity="error"
+        ):
+            from peft import get_peft_model
+
+            model = get_peft_model(self.model, deepcopy(self.peft_config))
+
+        return model
+
+    def _load_randomly(self):
+        """Initialize a TimesFM model randomly from config."""
+        from transformers import TimesFmConfig
+
+        config = self.config
+        if not config:
+            config = TimesFmConfig()
+        if isinstance(config, dict):
+            config_class = _get_timesfm_config_class(config)
+            config = config_class.from_dict(config)
+
+        model_class = _get_timesfm_model_class(config)
+        model = model_class(config)
+        model = model.to(self.device_map)
+        if self.dtype is not None:
+            model = model.to(dtype=self.dtype)
+
+        return model
 
 
 def _get_timesfm_model_class(config):

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -125,68 +125,119 @@ class TimesFM2Forecaster(BaseForecaster):
 
     Examples
     --------
-    Basic zero-shot forecasting from a pretrained checkpoint:
+    Simple zero-shot forecasting with TimesFM-2.5:
 
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
     >>> y = load_airline()
-    >>> forecaster = TimesFM2Forecaster(
-    ...     model_path="google/timesfm-2.5-200m-transformers",
-    ...     device_map="cpu",
-    ... )  # doctest: +SKIP
+    >>> # By default, loads google/timesfm-2.5-200m-transformers.
+    >>> forecaster = TimesFM2Forecaster()  # doctest: +SKIP
+    >>> # fit loads the model weights and stores the forecasting context.
     >>> forecaster.fit(y)  # doctest: +SKIP
     >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
 
-    Quantile prediction using model-supported alphas:
+    Simple zero-shot forecasting with TimesFM-2.0:
 
-    >>> forecaster = TimesFM2Forecaster(device_map="cpu")  # doctest: +SKIP
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
+    >>> y = load_airline()
+    >>> # Loads google/timesfm-2.0-500m-pytorch.
+    >>> forecaster = TimesFM2Forecaster(  # doctest: +SKIP
+    ...     model_path="google/timesfm-2.0-500m-pytorch",
+    ...     forward_kwargs={"forecast_context_len": 1024},
+    ... )
     >>> forecaster.fit(y)  # doctest: +SKIP
-    >>> q_pred = forecaster.predict_quantiles(  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
+
+    Quantile prediction:
+
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
+    >>> y = load_airline()
+    >>> forecaster = TimesFM2Forecaster()  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> # Select only quantiles available in the model config.
+    >>> y_pred = forecaster.predict_quantiles(  # doctest: +SKIP
     ...     fh=[1, 2, 3],
     ...     alpha=[0.1, 0.5, 0.9],
     ... )
 
-    Initialize from config only (no pretrained checkpoint):
+    Reduced-memory inference with dtype and quantization settings:
 
-    >>> cfg = {
-    ...     "architectures": ["TimesFmModelForPrediction"],
-    ...     "num_hidden_layers": 1,
-    ...     "hidden_size": 16,
-    ...     "intermediate_size": 16,
-    ...     "head_dim": 8,
-    ...     "num_attention_heads": 4,
-    ...     "context_length": 8,
-    ...     "horizon_length": 6,
-    ...     "patch_length": 2,
-    ...     "quantiles": [0.1, 0.5, 0.9],
-    ... }
-    >>> forecaster = TimesFM2Forecaster(  # doctest: +SKIP
-    ...     model_path=None,
-    ...     config=cfg,
-    ...     device_map="cpu",
-    ... )
-
-    Global pretraining on panel data:
-
-    >>> from sktime.datasets import load_tecator
-    >>> y_panel = load_tecator(return_type="pd-multiindex")  # doctest: +SKIP
-    >>> y_panel = y_panel.drop(columns=["class_val"])  # doctest: +SKIP
+    >>> import torch  # doctest: +SKIP
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
+    >>> from transformers import QuantoConfig  # doctest: +SKIP
+    >>> y = load_airline()
     >>> forecaster = TimesFM2Forecaster(  # doctest: +SKIP
     ...     model_path="google/timesfm-2.5-200m-transformers",
-    ...     training_args={"max_steps": 1, "eval_steps": 1},
-    ...     validation_split=0.1,
-    ...     config={"context_length": 32, "horizon_length": 8},
+    ...     device_map="auto",
+    ...     dtype=torch.bfloat16,
+    ...     quantization_config=QuantoConfig(weights="int8"),
     ... )
-    >>> forecaster.pretrain(y_panel)  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
 
-    Optional PEFT wrapping (requires ``peft``):
+    Global training with a PEFT configuration:
 
     >>> from peft import LoraConfig  # doctest: +SKIP
-    >>> peft_cfg = LoraConfig(r=8, lora_alpha=16)  # doctest: +SKIP
-    >>> forecaster = TimesFM2Forecaster(  # doctest: +SKIP
-    ...     peft_config=peft_cfg,
-    ...     training_args={"max_steps": 1, "eval_steps": 1},
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
+    >>> from sktime.utils._testing.hierarchical import _make_hierarchical
+    >>> y_panel = _make_hierarchical(  # doctest: +SKIP
+    ...     hierarchy_levels=(3,),
+    ...     min_timepoints=128,
+    ...     max_timepoints=400,
     ... )
+    >>> y = load_airline()
+    >>> forecaster = TimesFM2Forecaster(  # doctest: +SKIP
+    ...     model_path="google/timesfm-2.5-200m-transformers",
+    ...     peft_config=LoraConfig(
+    ...         r=8,
+    ...         lora_alpha=32,
+    ...         target_modules=["q_proj", "v_proj"],
+    ...         lora_dropout=0.01,
+    ...     ),
+    ... )
+    >>> # Training happens on hierarchical data.
+    >>> forecaster.pretrain(y_panel)  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
+
+    Global training on a randomly initialized model with custom config:
+
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
+    >>> from sktime.utils._testing.hierarchical import _make_hierarchical
+    >>> y_panel = _make_hierarchical(  # doctest: +SKIP
+    ...     hierarchy_levels=(3,),
+    ...     min_timepoints=128,
+    ...     max_timepoints=400,
+    ... )
+    >>> y = load_airline()
+    >>> forecaster = TimesFM2Forecaster(  # doctest: +SKIP
+    ...     model_path=None,
+    ...     config={
+    ...         "architectures": ["TimesFmModelForPrediction"],
+    ...         "num_hidden_layers": 1,
+    ...         "hidden_size": 16,
+    ...         "intermediate_size": 16,
+    ...         "head_dim": 8,
+    ...         "num_attention_heads": 4,
+    ...         "context_length": 8,
+    ...         "horizon_length": 6,
+    ...         "patch_length": 2,
+    ...         "quantiles": [0.25, 0.5, 0.75],
+    ...     },
+    ...     validation_split=0.1,
+    ...     training_args={
+    ...         "max_steps": 1,
+    ...         "eval_steps": 1,
+    ...     },
+    ... )
+    >>> forecaster.pretrain(y_panel)  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -164,7 +164,7 @@ class TimesFM2Forecaster(BaseForecaster):
             y_train = y
             y_eval = None
 
-        train = _TimesFM2WindowDataset(
+        train = PyTorchDataset(
             series_list=_prepare_series_list(y_train),
             context_length=context_length,
             horizon_length=horizon_length,
@@ -175,7 +175,7 @@ class TimesFM2Forecaster(BaseForecaster):
             self.validation_split is not None
             and len(y_eval) >= context_length + horizon_length
         ):
-            eval = _TimesFM2WindowDataset(
+            eval = PyTorchDataset(
                 series_list=_prepare_series_list(y_eval),
                 context_length=context_length,
                 horizon_length=horizon_length,
@@ -603,7 +603,7 @@ def _pad_series(series, seq_len):
     return series
 
 
-class _TimesFM2WindowDataset:
+class PyTorchDataset:
     def __init__(self, series_list, context_length, horizon_length):
         self.series_list = series_list
         self.context_length = context_length

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -1,0 +1,753 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Extension template for forecasters.
+
+Purpose of this implementation template:
+    quick implementation of new estimators following the template
+    NOT a concrete class to import! This is NOT a base class or concrete class!
+    This is to be used as a "fill-in" coding template.
+
+How to use this implementation template to implement a new estimator:
+- make a copy of the template in a suitable location, give it a descriptive name.
+- work through all the "todo" comments below
+- fill in code for mandatory methods, and optionally for optional methods
+- do not write to reserved variables: is_fitted, _is_fitted, _state,
+    _pretrained_attrs, _X, _y, cutoff, _fh, _cutoff, _converter_store_y,
+    forecasters_, _tags, _tags_dynamic, _is_vectorized
+- you can add more private methods, but do not override BaseEstimator's private methods
+    an easy way to be safe is to prefix your methods with "_custom"
+- change docstrings for functions and the file
+- ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
+- once complete: use as a local library, or contribute to sktime via PR
+- more details:
+  https://www.sktime.net/en/stable/developer_guide/add_estimators.html
+
+Mandatory methods to implement:
+    fitting         - _fit(self, y, X=None, fh=None)
+    forecasting     - _predict(self, fh=None, X=None)
+
+Optional methods to implement:
+    updating                    - _update(self, y, X=None, update_params=True):
+    predicting quantiles        - _predict_quantiles(self, fh, X=None, alpha=None)
+    OR predicting intervals     - _predict_interval(self, fh, X=None, coverage=None)
+    predicting variance         - _predict_var(self, fh, X=None, cov=False)
+    distribution forecast       - _predict_proba(self, fh, X=None)
+    fitted parameter inspection - _get_fitted_params()
+    pretraining (1st batch)     - _pretrain(self, y, X=None, fh=None)
+    pretraining (update)        - _pretrain_update(self, y, X=None, fh=None)
+
+Testing - required for sktime test framework and check_estimator usage:
+    get default parameters for test instance(s) - get_test_params()
+"""
+# todo: write an informative docstring for the file or module, remove the above
+# todo: add an appropriate copyright notice for your estimator
+#       estimators contributed to sktime should have the copyright notice at the top
+#       estimators of your own do not need to have permissive or BSD-3 copyright
+
+# todo: uncomment the following line, enter authors' GitHub IDs
+# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+
+from sktime.forecasting.base import BaseForecaster
+
+# todo: add any necessary imports here
+
+# todo: for imports of sktime soft dependencies:
+# make sure to fill in the "python_dependencies" tag with the package import name
+# import soft dependencies only inside methods of the class, not at the top of the file
+
+
+# todo: change class name and write docstring
+class MyForecaster(BaseForecaster):
+    """Custom forecaster. todo: write docstring.
+
+    todo: describe your custom forecaster here
+
+    Parameters
+    ----------
+    parama : int
+        descriptive explanation of parama
+    paramb : string, optional (default='default')
+        descriptive explanation of paramb
+    paramc : boolean, optional (default=MyOtherEstimator(foo=42))
+        descriptive explanation of paramc
+    and so on
+    """
+
+    # todo: fill out estimator tags here
+    #  tags are inherited from parent class if they are not set
+    # todo: define the forecaster scitype by setting the tags
+    #  the "forecaster scitype" is determined by the tags
+    #   scitype:y - the expected input scitype of y - univariate or multivariate or both
+    #  when changing scitype:y to multivariate or both:
+    #   y_inner_mtype should be changed to pd.DataFrame
+    # other tags are "safe defaults" which can usually be left as-is
+    _tags = {
+        # tags and full specifications are available in the tag API reference
+        # https://www.sktime.net/en/stable/api_reference/tags.html
+        # to list all valid tags with description, use sktime.registry.all_tags
+        #   all_tags(estimator_types="forecaster", as_dataframe=True)
+        #
+        # behavioural tags: internal type
+        # -------------------------------
+        #
+        # y_inner_mtype, X_inner_mtype control which format X/y appears in
+        # in the inner functions _fit, _predict, etc
+        "y_inner_mtype": "pd.Series",
+        "X_inner_mtype": "pd.DataFrame",
+        # valid values: str and list of str
+        # if str, must be a valid mtype str, in sktime.datatypes.MTYPE_REGISTER
+        #   of scitype Series, Panel (panel data) or Hierarchical (hierarchical series)
+        #   in that case, all inputs are converted to that one type
+        # if list of str, must be a list of valid str specifiers
+        #   in that case, X/y are passed through without conversion if on the list
+        #   if not on the list, converted to the first entry of the same scitype
+        #
+        # capability:multivariate controls whether inner y can be multivariate
+        # if multivariate is not valid, applies vectorization over variables
+        "capability:multivariate": False,
+        # valid values: True, False
+        #   False: inner _fit, _predict, etc, receive only univariate series
+        #   True: inner methods work with series with any number of variables
+        #
+        # capability tags: properties of the estimator
+        # --------------------------------------------
+        #
+        # capability:exogenous = does estimator use exogeneous X nontrivially?
+        "capability:exogenous": True,
+        # valid values: boolean False (ignores X), True (uses X in non-trivial manner)
+        # CAVEAT: if tag is set to False, inner methods always see X=None
+        #
+        # requires-fh-in-fit = is forecasting horizon always required in fit?
+        "requires-fh-in-fit": True,
+        # valid values: boolean True (yes), False (no)
+        # if True, raises exception in fit if fh has not been passed
+        #
+        # X-y-must-have-same-index = can estimator handle different X/y index?
+        "X-y-must-have-same-index": True,
+        # valid values: boolean True (yes), False (no)
+        # if True, raises exception if X.index is not contained in y.index
+        #
+        # enforce_index_type = index type that needs to be enforced in X/y
+        "enforce_index_type": None,
+        # valid values: pd.Index subtype, or list of pd.Index subtype
+        # if not None, raises exception if X.index, y.index level -1 is not of that type
+        #
+        # handles-missing-data = can estimator handle missing data?
+        "capability:missing_values": False,
+        # valid values: boolean True (yes), False (no)
+        # if False, raises exception if y or X passed contain missing data (nans)
+        #
+        # capability:insample = can forecaster make in-sample forecasts?
+        "capability:insample": True,
+        # valid values: boolean True (yes), False (no)
+        # if False, exception raised if any forecast method called with in-sample fh
+        #
+        # capability:pred_int = does forecaster implement probabilistic forecasts?
+        "capability:pred_int": False,
+        # valid values: boolean True (yes), False (no)
+        # if False, exception raised if proba methods are called (predict_interval etc)
+        #
+        # capability:pred_int:insample = can forecaster make in-sample proba forecasts?
+        "capability:pred_int:insample": True,
+        # valid values: boolean True (yes), False (no)
+        # only needs to be set if capability:pred_int is True
+        # if False, exception raised if proba methods are called with in-sample fh
+        #
+        # capability:pretrain = does forecaster support pretraining on panel data?
+        "capability:pretrain": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, implement _pretrain and optionally _pretrain_update below
+        # enables the pretrain -> fit -> predict workflow for global learning
+        #
+        # ----------------------------------------------------------------------------
+        # packaging info - only required for sktime contribution or 3rd party packages
+        # ----------------------------------------------------------------------------
+        #
+        # ownership and contribution tags
+        # -------------------------------
+        #
+        # author = author(s) of th estimator
+        # an author is anyone with significant contribution to the code at some point
+        "authors": ["author1", "author2"],
+        # valid values: str or list of str, should be GitHub handles
+        # this should follow best scientific contribution practices
+        # scope is the code, not the methodology (method is per paper citation)
+        # if interfacing a 3rd party estimator, ensure to give credit to the
+        # authors of the interfaced estimator
+        #
+        # maintainer = current maintainer(s) of the estimator
+        # per algorithm maintainer role, see governance document
+        # this is an "owner" type role, with rights and maintenance duties
+        # for 3rd party interfaces, the scope is the sktime class only
+        "maintainers": ["maintainer1", "maintainer2"],
+        # valid values: str or list of str, should be GitHub handles
+        # remove tag if maintained by sktime core team
+        #
+        # dependency tags: python version and soft dependencies
+        # -----------------------------------------------------
+        #
+        # python version requirement
+        "python_version": None,
+        # valid values: str, PEP 440 valid python version specifiers
+        # raises exception at construction if local python version is incompatible
+        #
+        # soft dependency requirement
+        "python_dependencies": None,
+        # valid values: str or list of str, PEP 440 valid package version specifiers
+        # raises exception at construction if modules at strings cannot be imported
+    }
+    #  in case of inheritance, concrete class should typically set tags
+    #  alternatively, descendants can set tags in __init__ (avoid this if possible)
+
+    # todo: add any hyper-parameters and components to constructor
+    def __init__(self, parama, paramb="default", paramc=None):
+        # estimators should precede parameters
+        #  if estimators have default values, set None and initialize below
+
+        # todo: write any hyper-parameters and components to self
+        self.parama = parama
+        self.paramb = paramb
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._paramc
+        self.paramc = paramc
+
+        # leave this as is
+        super().__init__()
+
+        # do not put anything else in __init__,
+        # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
+
+    # todo: add any post-init logic here, otherwise delete this method
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        # todo: optional, parameter checking or coercion should happen here
+        # if writes derived values to self, should *not* overwrite self.paramc etc
+        # instead, write to self._paramc, self._newparam (starting with _)
+        # example of handling conditional parameters or mutable defaults:
+        if self.paramc is None:
+            from sktime.somewhere import MyOtherEstimator
+
+            self._paramc = MyOtherEstimator(foo=42)
+        else:
+            # estimators should be cloned to avoid side effects
+            self._paramc = self.paramc.clone()
+
+    # todo: implement this, mandatory
+    def _fit(self, y, X, fh):
+        """Fit forecaster to training data.
+
+        private _fit containing the core logic, called from fit
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        y : sktime time series object
+            guaranteed to be of an mtype in self.get_tag("y_inner_mtype")
+            Time series to which to fit the forecaster.
+
+            * if self.get_tag("capability:multivariate")==False:
+              guaranteed to be univariate (e.g., single-column for DataFrame)
+            * if self.get_tag("capability:multivariate")==True: no restrictions apply,
+              the method should handle uni- and multivariate y appropriately
+
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            Required (non-optional) here if self.get_tag("requires-fh-in-fit")==True
+            Otherwise, if not passed in _fit, guaranteed to be passed in _predict
+        X : sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series to fit to.
+
+        Returns
+        -------
+        self : reference to self
+        """
+
+        # implement here
+        # IMPORTANT: avoid side effects to y, X, fh
+        #
+        # any model parameters should be written to attributes ending in "_"
+        #  attributes set by the constructor must not be overwritten
+        #  if used, estimators should be cloned to attributes ending in "_"
+        #  the clones, not the originals should be used or fitted if needed
+        #
+        # Note: when interfacing a model that has fit, with parameters
+        #   that are not data (y, X) or forecasting-horizon-like,
+        #   but model parameters, *don't* add as arguments to fit, but treat as follows:
+        #   1. pass to constructor,  2. write to self in constructor,
+        #   3. read from self in _fit,  4. pass to interfaced_model.fit in _fit
+
+    # todo: implement this, mandatory
+    def _predict(self, fh, X):
+        """Forecast time series at future horizon.
+
+        private _predict containing the core logic, called from predict
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            If not passed in _fit, guaranteed to be passed here
+        X : sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series for the forecast
+
+        Returns
+        -------
+        y_pred : sktime time series object
+            should be of the same type as seen in _fit, as in "y_inner_mtype" tag
+            Point predictions
+        """
+
+        # implement here
+        # IMPORTANT: avoid side effects to X, fh
+
+    # todo: consider implementing this, optional
+    # if not implementing, delete the _update method
+    def _update(self, y, X=None, update_params=True):
+        """Update time series to incremental training data.
+
+        private _update containing the core logic, called from update
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Writes to self:
+            Sets fitted model attributes ending in "_", if update_params=True.
+            Does not write to self if update_params=False.
+
+        Parameters
+        ----------
+        y : sktime time series object
+            guaranteed to be of a type in self.get_tag("y_inner_mtype")
+            Time series with which to update the forecaster.
+
+            * if self.get_tag("capability:multivariate")==False:
+              guaranteed to be univariate (e.g., single-column for DataFrame)
+            * if self.get_tag("capability:multivariate")==True: no restrictions apply,
+              the method should handle uni- and multivariate y appropriately
+
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series for the forecast
+        update_params : bool, optional (default=True)
+            whether model parameters should be updated
+
+        Returns
+        -------
+        self : reference to self
+        """
+
+        # implement here
+        # IMPORTANT: avoid side effects to X, fh
+
+    # todo: consider implementing this, optional
+    # if not implementing, delete the _pretrain and _pretrain_update methods
+    # requires setting the tag "capability:pretrain" to True
+    # pretrain receives panel or hierarchical data (MultiIndex DataFrame)
+    # and should learn global patterns shared across instances
+    def _pretrain(self, y, X=None, fh=None):
+        """Pretrain forecaster on panel/global data (first batch).
+
+        private _pretrain containing the core logic, called from pretrain
+
+        Writes to self:
+            Sets pretrained model attributes ending in "_".
+
+        Parameters
+        ----------
+        y : pd.DataFrame with MultiIndex (guaranteed Panel or Hierarchical)
+            Panel or hierarchical time series data to pretrain on.
+            The last index level is time, all other levels identify instances.
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series.
+        fh : ForecastingHorizon or None, optional (default=None)
+            Forecasting horizon.
+
+        Returns
+        -------
+        self : reference to self
+        """
+
+        # implement here
+        # IMPORTANT: avoid side effects to y, X, fh
+        #
+        # any pretrained model parameters should be written to attributes ending in "_"
+        #   these will be automatically tracked by the base class
+        #   and accessible via get_pretrained_params()
+        #
+        # example:
+        #   self.global_mean_ = y.values.mean()
+        #   self.n_pretrain_instances_ = len(y.index.droplevel(-1).unique())
+
+    # todo: consider implementing this, optional
+    # if not implementing, delete this method (default calls _pretrain)
+    def _pretrain_update(self, y, X=None, fh=None):
+        """Update pretrained forecaster with additional panel data.
+
+        private _pretrain_update, called from pretrain when already pretrained.
+        Default implementation calls _pretrain. Override for incremental logic.
+
+        Parameters
+        ----------
+        y : pd.DataFrame with MultiIndex (guaranteed Panel or Hierarchical)
+            Additional panel data to learn from.
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series.
+        fh : ForecastingHorizon or None, optional (default=None)
+            Forecasting horizon.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        # default: just call _pretrain again
+        # override for incremental/online pretraining
+        return self._pretrain(y=y, X=X, fh=fh)
+
+    # todo: consider implementing this, optional
+    # if not implementing, delete the _update_predict_single method
+    def _update_predict_single(self, y, fh, X=None, update_params=True):
+        """Update forecaster and then make forecasts.
+
+        Implements default behaviour of calling update and predict sequentially, but can
+        be overwritten by subclasses to implement more efficient updating algorithms
+        when available.
+        """
+        self.update(y, X, update_params=update_params)
+        return self.predict(fh, X)
+        # implement here
+        # IMPORTANT: avoid side effects to y, X, fh
+
+    # todo: consider implementing one of _predict_quantiles and _predict_interval
+    #   if one is implemented, the other one works automatically
+    #   when interfacing or implementing, consider which of the two is easier
+    #   both can be implemented if desired, but usually that is not necessary
+    #
+    # if _predict_var or _predict_proba is implemented, this will have a default
+    #   implementation which uses _predict_proba or _predict_var under normal assumption
+    #
+    # if implementing _predict_interval, delete _predict_quantiles
+    # if not implementing either, delete both methods
+    def _predict_quantiles(self, fh, X, alpha):
+        """Compute/return prediction quantiles for a forecast.
+
+        private _predict_quantiles containing the core logic,
+            called from predict_quantiles and possibly predict_interval
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon
+            The forecasting horizon with the steps ahead to to predict.
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series for the forecast
+        alpha : list of float (guaranteed not None and floats in [0,1] interval)
+            A list of probabilities at which quantile forecasts are computed.
+
+        Returns
+        -------
+        quantiles : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+                second level being the values of alpha passed to the function.
+            Row index is fh, with additional (upper) levels equal to instance levels,
+                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+            Entries are quantile forecasts, for var in col index,
+                at quantile probability in second col index, for the row index.
+        """
+        # implement here
+        # IMPORTANT: avoid side effects to y, X, fh, alpha
+        #
+        # Note: unlike in predict_quantiles where alpha can be float or list of float
+        #   alpha in _predict_quantiles is guaranteed to be a list of float
+
+    # implement one of _predict_interval or _predict_quantiles (above), or delete both
+    #
+    # if implementing _predict_quantiles, delete _predict_interval
+    # if not implementing either, delete both methods
+    def _predict_interval(self, fh, X, coverage):
+        """Compute/return prediction quantiles for a forecast.
+
+        private _predict_interval containing the core logic,
+            called from predict_interval and possibly predict_quantiles
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon
+            The forecasting horizon with the steps ahead to to predict.
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series for the forecast
+        coverage : list of float (guaranteed not None and floats in [0,1] interval)
+           nominal coverage(s) of predictive interval(s)
+
+        Returns
+        -------
+        pred_int : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+                second level coverage fractions for which intervals were computed.
+                    in the same order as in input `coverage`.
+                Third level is string "lower" or "upper", for lower/upper interval end.
+            Row index is fh, with additional (upper) levels equal to instance levels,
+                from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+            Entries are forecasts of lower/upper interval end,
+                for var in col index, at nominal coverage in second col index,
+                lower/upper depending on third col index, for the row index.
+                Upper/lower interval end forecasts are equivalent to
+                quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
+        """
+        # implement here
+        # IMPORTANT: avoid side effects to y, X, fh, coverage
+        #
+        # Note: unlike in predict_interval where coverage can be float or list of float
+        #   coverage in _predict_interval is guaranteed to be a list of float
+
+    # todo: consider implementing _predict_var
+    #
+    # if _predict_proba or interval/quantiles are implemented, this will have a default
+    #   implementation which uses _predict_proba or quantiles under normal assumption
+    #
+    # if not implementing, delete _predict_var
+    def _predict_var(self, fh, X=None, cov=False):
+        """Forecast variance at future horizon.
+
+        private _predict_var containing the core logic, called from predict_var
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            If not passed in _fit, guaranteed to be passed here
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series for the forecast
+        cov : bool, optional (default=False)
+            if True, computes covariance matrix forecast.
+            if False, computes marginal variance forecasts.
+
+        Returns
+        -------
+        pred_var : pd.DataFrame, format dependent on `cov` variable
+            If cov=False:
+                Column names are exactly those of `y` passed in `fit`/`update`.
+                    For nameless formats, column index will be a RangeIndex.
+                Row index is fh, with additional levels equal to instance levels,
+                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+                Entries are variance forecasts, for var in col index.
+                A variance forecast for given variable and fh index is a predicted
+                    variance for that variable and index, given observed data.
+            If cov=True:
+                Column index is a multiindex: 1st level is variable names (as above)
+                    2nd level is fh.
+                Row index is fh, with additional levels equal to instance levels,
+                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+                Entries are (co-)variance forecasts, for var in col index, and
+                    covariance between time index in row and col.
+                Note: no covariance forecasts are returned between different variables.
+        """
+        # implement here
+        # implementing the cov=True case is optional and can be omitted
+
+    # todo: consider implementing _predict_proba
+    #
+    # if interval/quantiles or _predict_var are implemented, this will have a default
+    #   implementation which uses variance or quantiles under normal assumption
+    #
+    # if not implementing, delete _predict_proba
+    def _predict_proba(self, fh, X, marginal=True):
+        """Compute/return fully probabilistic forecasts.
+
+        private _predict_proba containing the core logic, called from predict_proba
+
+        Parameters
+        ----------
+        fh : int, list, np.array or ForecastingHorizon (not optional)
+            The forecasting horizon encoding the time stamps to forecast at.
+            if has not been passed in fit, must be passed, not optional
+        X : sktime time series object, optional (default=None)
+                Exogeneous time series for the forecast
+            Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
+            if self.get_tag("X-y-must-have-same-index"),
+                X.index must contain fh.index and y.index both
+        marginal : bool, optional (default=True)
+            whether returned distribution is marginal by time index
+
+        Returns
+        -------
+        pred_dist : sktime BaseDistribution
+            predictive distribution
+            if marginal=True, will be marginal distribution by time point
+            if marginal=False and implemented by method, will be joint
+        """
+        # implement here
+        # returned BaseDistribution should have same index and columns
+        # as the predict return
+        #
+        # implementing the marginal=False case is optional and can be omitted
+
+    # todo: consider implementing this, optional
+    # if not implementing, delete the method
+    def _predict_moving_cutoff(self, y, cv, X=None, update_params=True):
+        """Make single-step or multi-step moving cutoff predictions.
+
+        Parameters
+        ----------
+        y : pd.Series
+        cv : temporal cross-validation generator
+        X : pd.DataFrame
+        update_params : bool
+
+        Returns
+        -------
+        y_pred = pd.Series
+        """
+
+        # implement here
+        # IMPORTANT: avoid side effects to y, X, cv
+
+    # todo: consider implementing this, optional
+    # implement only if different from default:
+    #   default retrieves all self attributes ending in "_"
+    #   and returns them with keys that have the "_" removed
+    # if not implementing, delete the method
+    #   avoid overriding get_fitted_params
+    def _get_fitted_params(self):
+        """Get fitted parameters.
+
+        private _get_fitted_params, called from get_fitted_params
+
+        State required:
+            Requires state to be "fitted".
+
+        Returns
+        -------
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
+        """
+        # implement here
+        #
+        # when this function is reached, it is already guaranteed that self is fitted
+        #   this does not need to be checked separately
+        #
+        # parameters of components should follow the sklearn convention:
+        #   separate component name from parameter name by double-underscore
+        #   e.g., componentname__paramname
+
+    # todo: implement this if this is an estimator contributed to sktime
+    #   or to run local automated unit and integration testing of estimator
+    #   method should return default parameters, so that a test instance can be created
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for forecasters.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+
+        # todo: set the testing parameters for the estimators
+        # Testing parameters can be dictionary or list of dictionaries
+        # Testing parameter choice should cover internal cases well.
+        #
+        # this method can, if required, use:
+        #   class properties (e.g., inherited); parent class test case
+        #   imported objects such as estimators from sktime or sklearn
+        # important: all such imports should be *inside get_test_params*, not at the top
+        #            since imports are used only at testing time
+        #
+        # The parameter_set argument is not used for automated, module level tests.
+        #   It can be used in custom, estimator specific tests, for "special" settings.
+        # A parameter dictionary must be returned *for all values* of parameter_set,
+        #   i.e., "parameter_set not available" errors should never be raised.
+        #
+        # A good parameter set should primarily satisfy two criteria,
+        #   1. Chosen set of parameters should have a low testing time,
+        #      ideally in the magnitude of few seconds for the entire test suite.
+        #       This is vital for the cases where default values result in
+        #       "big" models which not only increases test time but also
+        #       run into the risk of test workers crashing.
+        #   2. There should be a minimum two such parameter sets with different
+        #      sets of values to ensure a wide range of code coverage is provided.
+        #
+        # example 1: specify params as dictionary
+        # any number of params can be specified
+        # params = {"est": value0, "parama": value1, "paramb": value2}
+        #
+        # example 2: specify params as list of dictionary
+        # note: Only first dictionary will be used by create_test_instance
+        # params = [{"est": value1, "parama": value2},
+        #           {"est": value3, "parama": value4}]
+        # return params
+        #
+        # example 3: parameter set depending on param_set value
+        #   note: only needed if a separate parameter set is needed in tests
+        # if parameter_set == "special_param_set":
+        #     params = {"est": value1, "parama": value2}
+        #     return params
+        #
+        # # "default" params - always returned except for "special_param_set" value
+        # params = {"est": value3, "parama": value4}
+        # return params

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -69,6 +69,7 @@ class TimesFM2Forecaster(BaseForecaster):
     .. [4] https://huggingface.co/google/timesfm-2.0-500m-pytorch
     .. [5] https://huggingface.co/docs/transformers/en/model_doc/timesfm#transformers.TimesFmModelForPrediction.forward
     .. [6] https://huggingface.co/docs/transformers/en/model_doc/timesfm2_5#transformers.TimesFm2_5ModelForPrediction.forward
+    .. [7] https://huggingface.co/docs/transformers/v5.9.0/en/main_classes/trainer#transformers.TrainingArguments
 
     Examples
     --------
@@ -341,10 +342,14 @@ class TimesFM2Forecaster(BaseForecaster):
                     "head_dim": 8,
                     "num_attention_heads": 4,
                     "context_length": 8,
-                    "horizon_length": 4,
+                    "horizon_length": 6,
                     "patch_length": 2,
                 },
                 "validation_split": 0.1,
+                "training_args": {
+                    "max_steps": 1,
+                    "eval_steps": 1,
+                },
                 "device": "cpu",
             },
             {
@@ -361,6 +366,10 @@ class TimesFM2Forecaster(BaseForecaster):
                     "patch_length": 2,
                 },
                 "validation_split": 0.1,
+                "training_args": {
+                    "max_steps": 1,
+                    "eval_steps": 1,
+                },
             },
         ]
 
@@ -401,31 +410,30 @@ class _CachedTimesFM2:
         return self.model_
 
 
+def _pad_series(series, seq_len):
+    pad_length = seq_len - len(series)
+    if pad_length >= 0:
+        series = np.pad(
+            series,
+            (pad_length, 0),
+            mode="constant",
+            constant_values=0,
+        )
+    return series
+
+
 class _TimesFM2WindowDataset:
-    """Full-window dataset for TimesFM fine-tuning.
-
-    Each item contains a fixed-length context and fixed-length target horizon.
-    Contexts are not padded, matching TimesFM's internal RevIN assumptions.
-    """
-
     def __init__(self, series_list, context_length, horizon_length):
+        self.series_list = series_list
         self.context_length = context_length
         self.horizon_length = horizon_length
-        self.series_list = series_list
-        self.samples = []
 
         min_length = context_length + horizon_length
-        for series_idx, series in enumerate(series_list):
+        self.samples = []
+        for series in series_list:
+            series = _pad_series(series, min_length)
             for start in range(len(series) - min_length + 1):
-                self.samples.append((series_idx, start))
-
-        if not self.samples:
-            shortest = min(len(series) for series in series_list)
-            raise ValueError(
-                "Training data is too short for TimesFM fine-tuning. "
-                f"Need at least context_length + horizon_length = {min_length} "
-                f"observations, but the shortest series has {shortest}."
-            )
+                self.samples.append(series[start : start + min_length])
 
     def __len__(self):
         """Return length of dataset."""
@@ -435,16 +443,15 @@ class _TimesFM2WindowDataset:
         """Return data point."""
         import torch
 
-        series_idx, start = self.samples[i]
-        series = self.series_list[series_idx]
-        target_start = start + self.context_length
-        target_end = target_start + self.horizon_length
+        sample = self.samples[i]
+
+        past_values = sample[: self.context_length]
+        future_values = sample[self.context_length :]
+
+        past_values = torch.tensor(past_values, dtype=torch.float32)
+        future_values = torch.tensor(future_values, dtype=torch.float32)
 
         return {
-            "past_values": torch.tensor(
-                series[start:target_start], dtype=torch.float32
-            ),
-            "future_values": torch.tensor(
-                series[target_start:target_end], dtype=torch.float32
-            ),
+            "past_values": past_values,
+            "future_values": future_values,
         }

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -71,6 +71,20 @@ class TimesFM2Forecaster(BaseForecaster):
         If provided as ``dict``, the architecture entry (for example
         ``"TimesFmModelForPrediction"`` or ``"TimesFm2_5ModelForPrediction"``)
         is used to infer the config class.
+    device_map : str, dict, int, or torch.device, default="cpu"
+        Device placement following the ``transformers`` ``device_map`` naming
+        convention, for example ``"cpu"``, ``"cuda"``, ``"cuda:0"``, or
+        ``"auto"``.
+    dtype : torch.dtype or str, optional (default=None)
+        Data type used for model loading, following the ``transformers``
+        ``dtype`` convention, for example ``torch.float16``,
+        ``torch.bfloat16``, or ``"auto"``.
+    quantization_config : transformers.quantizers.HfQuantizer, optional
+        Valid quantization configuration object compatible with
+        ``transformers.PreTrainedModel.from_pretrained``.
+    peft_config : peft.PeftConfig, optional (default=None)
+        If provided, wraps the loaded base model with PEFT using
+        ``peft.get_peft_model``.
     forward_kwargs : dict, optional (default=None)
         Additional keyword arguments forwarded to ``model(...)`` during
         :meth:`predict` and :meth:`predict_quantiles`.
@@ -86,20 +100,6 @@ class TimesFM2Forecaster(BaseForecaster):
         Metrics callback(s) passed to ``transformers.Trainer``.
     callbacks : list, optional (default=None)
         Trainer callbacks passed to ``transformers.Trainer``.
-    peft_config : peft.PeftConfig, optional (default=None)
-        If provided, wraps the loaded base model with PEFT using
-        ``peft.get_peft_model``.
-    device_map : str, dict, int, or torch.device, default="cpu"
-        Device placement following the ``transformers`` ``device_map`` naming
-        convention, for example ``"cpu"``, ``"cuda"``, ``"cuda:0"``, or
-        ``"auto"``.
-    dtype : torch.dtype or str, optional (default=None)
-        Data type used for model loading, following the ``transformers``
-        ``dtype`` convention, for example ``torch.float16``,
-        ``torch.bfloat16``, or ``"auto"``.
-    quantization_config : transformers.quantizers.HfQuantizer, optional
-        Valid quantization configuration object compatible with
-        ``transformers.PreTrainedModel.from_pretrained``.
 
     References
     ----------
@@ -204,29 +204,29 @@ class TimesFM2Forecaster(BaseForecaster):
         self,
         model_path="google/timesfm-2.5-200m-transformers",
         config=None,
+        device_map="cpu",
+        dtype=None,
+        quantization_config=None,
+        peft_config=None,
         forward_kwargs=None,
         validation_split=0.2,
         training_args=None,
         compute_loss_func=None,
         compute_metrics=None,
         callbacks=None,
-        peft_config=None,
-        device_map="cpu",
-        dtype=None,
-        quantization_config=None,
     ):
         self.model_path = model_path
         self.config = config
+        self.device_map = device_map
+        self.dtype = dtype
+        self.quantization_config = quantization_config
+        self.peft_config = peft_config
         self.forward_kwargs = forward_kwargs
         self.validation_split = validation_split
         self.training_args = training_args
         self.compute_loss_func = compute_loss_func
         self.compute_metrics = compute_metrics
         self.callbacks = callbacks
-        self.peft_config = peft_config
-        self.device_map = device_map
-        self.dtype = dtype
-        self.quantization_config = quantization_config
 
         super().__init__()
 

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -1,5 +1,5 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""TimesFM-2 forecaster adapter for ``sktime``.
+"""TimesFM-2 forecaster for ``sktime``.
 
 This module provides an ``sktime`` forecaster wrapping the Hugging Face
 ``transformers`` implementation of Google Research TimesFM-2 models
@@ -8,11 +8,9 @@ This module provides an ``sktime`` forecaster wrapping the Hugging Face
 - zero-shot prediction through :meth:`fit` + :meth:`predict`
 - global pretraining on panel/hierarchical data through :meth:`pretrain`
 - quantile prediction through :meth:`predict_quantiles`
-- optional PEFT wrapping during model loading
-
-The adapter intentionally keeps the estimator API aligned with ``sktime`` while
-delegating model loading, forward passes, and optional training to
-``transformers`` classes.
+- Hugging Face ``device_map`` and ``dtype`` model-loading options
+- optional quantized pretrained model loading
+- optional PEFT wrapping for pretrained models
 """
 
 __author__ = ["rajatsen91", "siriuz42", "geetu040"]
@@ -49,10 +47,15 @@ class TimesFM2Forecaster(BaseForecaster):
       forecast steps beyond this limit raise ``ValueError``.
     - Quantile prediction is only available for quantiles present in
       ``model.config.quantiles``.
+    - ``device_map`` and ``dtype`` are supported for both pretrained loading
+      and config-only initialization. For pretrained loading, they are passed
+      to ``from_pretrained``; for config-only initialization, they are applied
+      after model construction.
+    - ``quantization_config`` and ``peft_config`` are applied only when loading
+      a pretrained model from ``model_path``. They are not used for config-only
+      initialization with ``model_path=None``.
     - Loaded models are cached via a multiton helper keyed by model-loading
       inputs to avoid repeated model instantiation.
-    - For pickling, ``model_`` is excluded from serialized state and reloaded
-      lazily after unpickling.
 
     Parameters
     ----------
@@ -81,15 +84,19 @@ class TimesFM2Forecaster(BaseForecaster):
         ``dtype`` convention, for example ``torch.float16``,
         ``torch.bfloat16``, or ``"auto"``.
     quantization_config : transformers.quantizers.HfQuantizer, optional
-        Valid quantization configuration object compatible with
-        ``transformers.PreTrainedModel.from_pretrained`` [8]_.
+        Valid quantization configuration object compatible with pretrained
+        loading through ``transformers.PreTrainedModel.from_pretrained`` [8]_.
+        Applied only when ``model_path`` is not ``None``; ignored for
+        config-only initialization with ``model_path=None``.
     forward_kwargs : dict, optional (default=None)
         Additional keyword arguments forwarded to ``model(...)`` during
         :meth:`predict` and :meth:`predict_quantiles`; see the TimesFM-2.0 [5]_
         and TimesFM-2.5 [6]_ forward APIs.
     peft_config : peft.PeftConfig, optional (default=None)
-        If provided, wraps the loaded base model with PEFT using
-        ``peft.get_peft_model``.
+        If provided, wraps the loaded pretrained base model with PEFT using
+        ``peft.get_peft_model``. Applied only when ``model_path`` is not
+        ``None``; ignored for config-only initialization with
+        ``model_path=None``.
     validation_split : float or None, default=0.2
         Fraction of data reserved for evaluation when :meth:`pretrain` is used.
         If ``None``, no evaluation dataset is created.
@@ -106,7 +113,7 @@ class TimesFM2Forecaster(BaseForecaster):
     References
     ----------
     .. [1] Das, A., Kong, W., Sen, R., and Zhou, Y. (2024).
-       *A Decoder-only Foundation Model for Time-series Forecasting*.
+       A Decoder-only Foundation Model for Time-series Forecasting.
        CoRR. https://arxiv.org/abs/2310.10688
     .. [2] Google Research TimesFM repository:
        https://github.com/google-research/timesfm
@@ -162,7 +169,7 @@ class TimesFM2Forecaster(BaseForecaster):
     ...     alpha=[0.1, 0.5, 0.9],
     ... )
 
-    Reduced-memory inference with dtype and quantization settings:
+    Reduced-memory inference with device placement, dtype, and quantization:
 
     >>> import torch  # doctest: +SKIP
     >>> from sktime.datasets import load_airline
@@ -178,7 +185,7 @@ class TimesFM2Forecaster(BaseForecaster):
     >>> forecaster.fit(y)  # doctest: +SKIP
     >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
 
-    Global training with a PEFT configuration:
+    Global training with a PEFT-wrapped pretrained model:
 
     >>> from peft import LoraConfig  # doctest: +SKIP
     >>> from sktime.datasets import load_airline
@@ -205,6 +212,9 @@ class TimesFM2Forecaster(BaseForecaster):
     >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
 
     Global training on a randomly initialized model with custom config:
+    ``device_map`` and ``dtype`` can still be applied in this path, but
+    ``quantization_config`` and ``peft_config`` require a pretrained
+    ``model_path`` and are ignored when ``model_path=None``.
 
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
@@ -686,7 +696,7 @@ class _CachedTimesFM2:
     dtype : torch.dtype or str or None
         Data type used for model loading.
     quantization_config : transformers.quantizers.HfQuantizer or None
-        Quantization configuration used for model loading.
+        Quantization configuration used for pretrained model loading.
     """
 
     def __init__(
@@ -719,10 +729,13 @@ class _CachedTimesFM2:
 
         Notes
         -----
-        - If ``model_path`` is set, loads weights via ``from_pretrained``.
+        - If ``model_path`` is set, loads weights via ``from_pretrained`` with
+          ``device_map``, ``dtype``, and optional ``quantization_config``.
         - If ``model_path`` is ``None``, initializes from config.
-        - If ``peft_config`` is provided, wraps the model with PEFT after base
-          loading and device placement.
+        - If ``peft_config`` is provided with a pretrained ``model_path``,
+          wraps the model with PEFT after base loading and device placement.
+        - ``quantization_config`` and ``peft_config`` are not applied in the
+          config-only initialization path.
         """
         if self.model_ is not None:
             return self.model_
@@ -735,7 +748,11 @@ class _CachedTimesFM2:
         return self.model_
 
     def _load_from_path(self):
-        """Load TimesFM model weights from ``self.model_path``."""
+        """Load pretrained TimesFM weights from ``self.model_path``.
+
+        This path applies ``device_map``, ``dtype``, ``quantization_config``,
+        and optional PEFT wrapping.
+        """
         from transformers import AutoConfig
 
         config = self.config
@@ -760,12 +777,16 @@ class _CachedTimesFM2:
         ):
             from peft import get_peft_model
 
-            model = get_peft_model(self.model, deepcopy(self.peft_config))
+            model = get_peft_model(model, deepcopy(self.peft_config))
 
         return model
 
     def _load_randomly(self):
-        """Initialize a TimesFM model randomly from config."""
+        """Initialize a TimesFM model from config without pretrained weights.
+
+        This path applies ``device_map`` and ``dtype`` after model construction.
+        It does not apply ``quantization_config`` or ``peft_config``.
+        """
         from transformers import TimesFmConfig
 
         config = self.config

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -6,10 +6,14 @@ __author__ = ["rajatsen91", "siriuz42", "geetu040"]
 
 __all__ = ["TimesFM2Forecaster"]
 
+from copy import deepcopy
+from warnings import warn
+
 import numpy as np
 import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster
+from sktime.split import temporal_train_test_split
 from sktime.utils.singleton import _multiton
 
 
@@ -40,21 +44,17 @@ class TimesFM2Forecaster(BaseForecaster):
         ``force_flip_invariance``.
         See [5]_ for TimesFM-2.0 and [6]_ for TimesFM-2.5.
     validation_split : float, default=0.2
-        Fraction of data reserved for validation. This parameter is retained for
-        compatibility with Hugging Face training-style interfaces; the current
-        zero-shot implementation does not fine-tune the model.
+        Fraction of data reserved for validation when ``training_args`` is
+        supplied. If ``None``, no validation dataset is passed to the Hugging
+        Face Trainer.
     training_args : transformers.TrainingArguments or dict, optional (default=None)
-        Training arguments placeholder for future fine-tuning support. Not used
-        by the current zero-shot implementation.
-    compute_loss_func : callable, optional (default=None)
-        Custom loss function placeholder for future fine-tuning support. Not
-        used by the current zero-shot implementation.
+        Training arguments for Hugging Face Trainer.
+        Custom loss function passed to Hugging Face Trainer during fine-tuning.
     compute_metrics : callable or list of callable, optional (default=None)
-        Metric function or functions placeholder for future fine-tuning support.
-        Not used by the current zero-shot implementation.
+        Metric function or functions passed to Hugging Face Trainer during
+        fine-tuning.
     callbacks : list, optional (default=None)
-        Hugging Face Trainer callbacks placeholder for future fine-tuning
-        support. Not used by the current zero-shot implementation.
+        Hugging Face Trainer callbacks used during fine-tuning.
     device : str, default="cpu"
         Device on which to run the model, for example ``"cpu"``, ``"cuda"``,
         or ``"cuda:0"``.
@@ -153,6 +153,63 @@ class TimesFM2Forecaster(BaseForecaster):
         self.model_ = self._load_model()
         self.context_ = y
 
+        context_length = self.model_.config.context_length
+        horizon_length = self.model_.config.horizon_length
+
+        from transformers import Trainer, TrainingArguments
+
+        if self.validation_split is not None:
+            y_train, y_eval = temporal_train_test_split(
+                y, test_size=self.validation_split
+            )
+        else:
+            y_train = y
+            y_eval = None
+
+        train = _TimesFM2WindowDataset(
+            series_list=[y_train.to_numpy()],
+            context_length=context_length,
+            horizon_length=horizon_length,
+        )
+
+        eval = None
+        if (
+            self.validation_split is not None
+            and len(y_eval) >= context_length + horizon_length
+        ):
+            eval = _TimesFM2WindowDataset(
+                series_list=[y_eval.to_numpy()],
+                context_length=context_length,
+                horizon_length=horizon_length,
+            )
+        elif self.validation_split is not None:
+            warn(
+                "Could not create a TimesFM validation dataset because the "
+                "validation split is shorter than context_length + horizon_length "
+                f"({len(y_eval)} < {context_length + horizon_length}). "
+                "Training will continue without evaluation.",
+                stacklevel=2,
+            )
+
+        training_args = (
+            deepcopy(self.training_args) if self.training_args is not None else {}
+        )
+        training_args = TrainingArguments(**training_args)
+
+        trainer = Trainer(
+            model=self.model_,
+            args=training_args,
+            train_dataset=train,
+            eval_dataset=eval,
+            compute_loss_func=self.compute_loss_func,
+            compute_metrics=self.compute_metrics,
+            callbacks=self.callbacks,
+        )
+
+        trainer.train()
+
+        self.model_ = trainer.model
+
     def _predict(self, fh, X):
         """Forecast time series at future horizon.
 
@@ -184,16 +241,25 @@ class TimesFM2Forecaster(BaseForecaster):
 
         self.model_ = self._load_model()
 
+        if fh is None:
+            fh = self.fh
+        fh = fh.to_relative(self.cutoff)
+        preds_idx = fh._values.values - 1
+
+        horizon_length = self.model_.config.horizon_length
+        if np.max(preds_idx) >= horizon_length:
+            raise ValueError(
+                "The requested forecasting horizon extends beyond the TimesFM "
+                f"model horizon_length. The maximum requested relative horizon "
+                f"is {np.max(preds_idx) + 1}, but model.config.horizon_length is "
+                f"{horizon_length}."
+            )
+
         past_values = self.context_
         past_values = np.expand_dims(past_values, axis=0)
         past_values = torch.from_numpy(past_values)
         past_values = past_values.to(self.model_.dtype)
         past_values = past_values.to(self.model_.device)
-
-        if fh is None:
-            fh = self.fh
-        fh = fh.to_relative(self.cutoff)
-        preds_idx = fh._values.values - 1
 
         forward_kwargs = {} if self.forward_kwargs is None else self.forward_kwargs
         output = self.model_(past_values=past_values, **forward_kwargs)
@@ -274,7 +340,11 @@ class TimesFM2Forecaster(BaseForecaster):
                     "intermediate_size": 16,
                     "head_dim": 8,
                     "num_attention_heads": 4,
+                    "context_length": 8,
+                    "horizon_length": 4,
+                    "patch_length": 2,
                 },
+                "validation_split": 0.1,
                 "device": "cpu",
             },
             {
@@ -286,7 +356,11 @@ class TimesFM2Forecaster(BaseForecaster):
                     "intermediate_size": 4,
                     "head_dim": 2,
                     "num_attention_heads": 1,
+                    "context_length": 8,
+                    "horizon_length": 6,
+                    "patch_length": 2,
                 },
+                "validation_split": 0.1,
             },
         ]
 
@@ -325,3 +399,52 @@ class _CachedTimesFM2:
         self.model_ = AutoModelForTimeSeriesPrediction.from_config(config)
         self.model_ = self.model_.to(self.device)
         return self.model_
+
+
+class _TimesFM2WindowDataset:
+    """Full-window dataset for TimesFM fine-tuning.
+
+    Each item contains a fixed-length context and fixed-length target horizon.
+    Contexts are not padded, matching TimesFM's internal RevIN assumptions.
+    """
+
+    def __init__(self, series_list, context_length, horizon_length):
+        self.context_length = context_length
+        self.horizon_length = horizon_length
+        self.series_list = series_list
+        self.samples = []
+
+        min_length = context_length + horizon_length
+        for series_idx, series in enumerate(series_list):
+            for start in range(len(series) - min_length + 1):
+                self.samples.append((series_idx, start))
+
+        if not self.samples:
+            shortest = min(len(series) for series in series_list)
+            raise ValueError(
+                "Training data is too short for TimesFM fine-tuning. "
+                f"Need at least context_length + horizon_length = {min_length} "
+                f"observations, but the shortest series has {shortest}."
+            )
+
+    def __len__(self):
+        """Return length of dataset."""
+        return len(self.samples)
+
+    def __getitem__(self, i):
+        """Return data point."""
+        import torch
+
+        series_idx, start = self.samples[i]
+        series = self.series_list[series_idx]
+        target_start = start + self.context_length
+        target_end = target_start + self.horizon_length
+
+        return {
+            "past_values": torch.tensor(
+                series[start:target_start], dtype=torch.float32
+            ),
+            "future_values": torch.tensor(
+                series[target_start:target_end], dtype=torch.float32
+            ),
+        }

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -14,6 +14,7 @@ import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster
 from sktime.split import temporal_train_test_split
+from sktime.utils.dependencies import _check_soft_dependencies
 from sktime.utils.singleton import _multiton
 
 
@@ -509,13 +510,11 @@ class _CachedTimesFM2:
         if self.model_ is not None:
             return self.model_
 
-        from transformers import AutoConfig, TimesFmConfig
+        from transformers import TimesFmConfig
 
         if self.model_path is not None:
             config = self.config
-            if config is None:
-                config = AutoConfig.from_pretrained(self.model_path)
-            elif isinstance(config, dict):
+            if isinstance(config, dict):
                 config_class = _get_timesfm_config_class(config)
                 config = config_class.from_dict(config)
 
@@ -547,6 +546,8 @@ def _get_timesfm_model_class(config):
     architectures = getattr(config, "architectures", None) or [
         "TimesFmModelForPrediction"
     ]
+    if architectures[0] == "TimesFm2_5ModelForPrediction":
+        _check_soft_dependencies("transformers>=5.3.0", severity="warning")
     return getattr(transformers, architectures[0])
 
 
@@ -555,6 +556,8 @@ def _get_timesfm_config_class(config):
     import transformers
 
     architectures = config.get("architectures") or ["TimesFmModelForPrediction"]
+    if architectures[0] == "TimesFm2_5ModelForPrediction":
+        _check_soft_dependencies("transformers>=5.3.0", severity="warning")
     config_class_name = architectures[0].replace("ModelForPrediction", "Config")
     return getattr(transformers, config_class_name)
 

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -83,13 +83,13 @@ class TimesFM2Forecaster(BaseForecaster):
     quantization_config : transformers.quantizers.HfQuantizer, optional
         Valid quantization configuration object compatible with
         ``transformers.PreTrainedModel.from_pretrained`` [8]_.
-    peft_config : peft.PeftConfig, optional (default=None)
-        If provided, wraps the loaded base model with PEFT using
-        ``peft.get_peft_model``.
     forward_kwargs : dict, optional (default=None)
         Additional keyword arguments forwarded to ``model(...)`` during
         :meth:`predict` and :meth:`predict_quantiles`; see the TimesFM-2.0 [5]_
         and TimesFM-2.5 [6]_ forward APIs.
+    peft_config : peft.PeftConfig, optional (default=None)
+        If provided, wraps the loaded base model with PEFT using
+        ``peft.get_peft_model``.
     validation_split : float or None, default=0.2
         Fraction of data reserved for evaluation when :meth:`pretrain` is used.
         If ``None``, no evaluation dataset is created.
@@ -260,8 +260,8 @@ class TimesFM2Forecaster(BaseForecaster):
         device_map="cpu",
         dtype=None,
         quantization_config=None,
-        peft_config=None,
         forward_kwargs=None,
+        peft_config=None,
         validation_split=0.2,
         training_args=None,
         compute_loss_func=None,
@@ -273,8 +273,8 @@ class TimesFM2Forecaster(BaseForecaster):
         self.device_map = device_map
         self.dtype = dtype
         self.quantization_config = quantization_config
-        self.peft_config = peft_config
         self.forward_kwargs = forward_kwargs
+        self.peft_config = peft_config
         self.validation_split = validation_split
         self.training_args = training_args
         self.compute_loss_func = compute_loss_func

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -93,6 +93,10 @@ class TimesFM2Forecaster(BaseForecaster):
         Device placement following the ``transformers`` ``device_map`` naming
         convention, for example ``"cpu"``, ``"cuda"``, ``"cuda:0"``, or
         ``"auto"``.
+    dtype : torch.dtype or str, optional (default=None)
+        Data type used for model loading, following the ``transformers``
+        ``dtype`` convention, for example ``torch.float16``,
+        ``torch.bfloat16``, or ``"auto"``.
 
     References
     ----------
@@ -203,6 +207,7 @@ class TimesFM2Forecaster(BaseForecaster):
         callbacks=None,
         peft_config=None,
         device_map="cpu",
+        dtype=None,
     ):
         self.model_path = model_path
         self.config = config
@@ -214,6 +219,7 @@ class TimesFM2Forecaster(BaseForecaster):
         self.callbacks = callbacks
         self.peft_config = peft_config
         self.device_map = device_map
+        self.dtype = dtype
 
         super().__init__()
 
@@ -391,7 +397,7 @@ class TimesFM2Forecaster(BaseForecaster):
         preds = output.mean_predictions
         preds = preds.ravel()
         preds = preds[preds_idx]
-        preds = preds.detach().cpu().numpy()
+        preds = preds.detach().float().cpu().numpy()
         preds = pd.Series(
             preds,
             index=fh.to_absolute(self._cutoff)._values,
@@ -477,7 +483,7 @@ class TimesFM2Forecaster(BaseForecaster):
         preds = preds.squeeze(0)
         preds = preds[preds_idx]
         preds = preds[:, quantiles_idx]
-        preds = preds.detach().cpu().numpy()
+        preds = preds.detach().float().cpu().numpy()
 
         index = fh.to_absolute(self._cutoff)._values
         name = self.context_.name if self.context_.name is not None else 0
@@ -496,8 +502,9 @@ class TimesFM2Forecaster(BaseForecaster):
         Returns
         -------
         model : transformers.PreTrainedModel
-            Loaded model according to ``self.device_map``. If ``self.model_``
-            already exists, it is returned directly.
+            Loaded model according to ``self.device_map`` and
+            ``self.dtype``. If ``self.model_`` already exists, it is
+            returned directly.
         """
         if hasattr(self, "model_") and self.model_ is not None:
             return self.model_
@@ -507,6 +514,7 @@ class TimesFM2Forecaster(BaseForecaster):
             model_path=self.model_path,
             config=self.config,
             device_map=self.device_map,
+            dtype=self.dtype,
             peft_config=self.peft_config,
         ).load()
 
@@ -525,6 +533,7 @@ class TimesFM2Forecaster(BaseForecaster):
             "model_path": self.model_path,
             "config": self.config,
             "device_map": self.device_map,
+            "dtype": self.dtype,
             "peft_config": self.peft_config,
         }
         return str(sorted(key.items()))
@@ -618,14 +627,25 @@ class _CachedTimesFM2:
         Optional PEFT wrapping configuration.
     device_map : str, dict, int, or torch.device
         Device placement for loading models.
+    dtype : torch.dtype or str or None
+        Data type used for model loading.
     """
 
-    def __init__(self, key, model_path, config, peft_config, device_map):
+    def __init__(
+        self,
+        key,
+        model_path,
+        config,
+        peft_config,
+        device_map,
+        dtype,
+    ):
         self.key = key
         self.model_path = model_path
         self.config = config
         self.peft_config = peft_config
         self.device_map = device_map
+        self.dtype = dtype
         self.model_ = None
 
     def load(self):
@@ -634,7 +654,8 @@ class _CachedTimesFM2:
         Returns
         -------
         model : transformers.PreTrainedModel
-            Loaded TimesFM prediction model according to ``self.device_map``.
+            Loaded TimesFM prediction model according to ``self.device_map``
+            and ``self.dtype``.
 
         Notes
         -----
@@ -661,6 +682,7 @@ class _CachedTimesFM2:
                 self.model_path,
                 config=config,
                 device_map=self.device_map,
+                dtype=self.dtype,
             )
         else:
             config = self.config
@@ -673,6 +695,8 @@ class _CachedTimesFM2:
             model_class = _get_timesfm_model_class(config)
             self.model_ = model_class(config)
             self.model_ = self.model_.to(self.device_map)
+            if self.dtype is not None:
+                self.model_ = self.model_.to(dtype=self.dtype)
 
         if self.peft_config is not None:
             self.model_ = self._wrap_with_peft()

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -35,8 +35,8 @@ from sktime.utils.singleton import _multiton
 class TimesFM2Forecaster(BaseForecaster):
     """TimesFM-2.x forecaster via Hugging Face ``transformers``.
 
-    This forecaster wraps TimesFM-2 prediction models from Hugging Face and
-    exposes them through the ``sktime`` forecasting interface.
+    This forecaster wraps TimesFM-2 prediction models [1]_, [2]_ from Hugging
+    Face and exposes them through the ``sktime`` forecasting interface.
 
     Two primary workflows are supported:
 
@@ -58,8 +58,9 @@ class TimesFM2Forecaster(BaseForecaster):
     ----------
     model_path : str, default="google/timesfm-2.5-200m-transformers"
         Hugging Face repository identifier or local path to a TimesFM checkpoint.
-        If ``None``, a model is created from ``config`` (or default
-        ``transformers.TimesFmConfig``).
+        Defaults to the TimesFM-2.5 checkpoint [3]_; TimesFM-2.0 checkpoints
+        are also supported [4]_. If ``None``, a model is created from
+        ``config`` (or default ``transformers.TimesFmConfig``).
     config : transformers.PretrainedConfig or dict, optional (default=None)
         Model configuration used for loading/initialization.
 
@@ -81,25 +82,26 @@ class TimesFM2Forecaster(BaseForecaster):
         ``torch.bfloat16``, or ``"auto"``.
     quantization_config : transformers.quantizers.HfQuantizer, optional
         Valid quantization configuration object compatible with
-        ``transformers.PreTrainedModel.from_pretrained``.
+        ``transformers.PreTrainedModel.from_pretrained`` [8]_.
     peft_config : peft.PeftConfig, optional (default=None)
         If provided, wraps the loaded base model with PEFT using
         ``peft.get_peft_model``.
     forward_kwargs : dict, optional (default=None)
         Additional keyword arguments forwarded to ``model(...)`` during
-        :meth:`predict` and :meth:`predict_quantiles`.
+        :meth:`predict` and :meth:`predict_quantiles`; see the TimesFM-2.0 [5]_
+        and TimesFM-2.5 [6]_ forward APIs.
     validation_split : float or None, default=0.2
         Fraction of data reserved for evaluation when :meth:`pretrain` is used.
         If ``None``, no evaluation dataset is created.
     training_args : dict, optional (default=None)
         Keyword arguments used to construct ``transformers.TrainingArguments``
-        in :meth:`pretrain`.
+        in :meth:`pretrain` [7]_.
     compute_loss_func : callable, optional (default=None)
-        Optional custom loss function passed to ``transformers.Trainer``.
+        Optional custom loss function passed to ``transformers.Trainer`` [7]_.
     compute_metrics : callable or dict, optional (default=None)
-        Metrics callback(s) passed to ``transformers.Trainer``.
+        Metrics callback(s) passed to ``transformers.Trainer`` [7]_.
     callbacks : list, optional (default=None)
-        Trainer callbacks passed to ``transformers.Trainer``.
+        Trainer callbacks passed to ``transformers.Trainer`` [7]_.
 
     References
     ----------

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -490,34 +490,6 @@ class TimesFM2Forecaster(BaseForecaster):
 
         return pred_quantiles
 
-    def __getstate__(self):
-        """Return pickle state without materializing the model object.
-
-        Returns
-        -------
-        state : dict
-            Estimator state dictionary with ``model_`` set to ``None`` when
-            present, so pickling does not include large/unpickleable model state.
-        """
-        state = self.__dict__.copy()
-        if "model_" in state:
-            state["model_"] = None
-        return state
-
-    def __setstate__(self, state):
-        """Restore estimator state after unpickling.
-
-        Parameters
-        ----------
-        state : dict
-            State dictionary produced by :meth:`__getstate__`.
-
-        Notes
-        -----
-        Model weights are reloaded lazily on first subsequent model access.
-        """
-        self.__dict__.update(state)
-
     def _load_model(self):
         """Load or retrieve a cached TimesFM model instance.
 

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -89,7 +89,7 @@ class TimesFM2Forecaster(BaseForecaster):
         "requires-fh-in-fit": False,
         "capability:insample": False,
         "capability:pred_int": False,
-        "capability:pretrain": False,
+        "capability:pretrain": True,
         "authors": ["rajatsen91", "siriuz42", "geetu040"],
         # rajatsen91, siriuz42 for google-research/timesfm
         "maintainers": ["geetu040"],
@@ -119,6 +119,87 @@ class TimesFM2Forecaster(BaseForecaster):
         self.device = device
 
         super().__init__()
+
+    def _pretrain(self, y, X=None, fh=None):
+        """Pretrain forecaster on panel/global data (first batch).
+
+        private _pretrain containing the core logic, called from pretrain
+
+        Writes to self:
+            Sets pretrained model attributes ending in "_".
+
+        Parameters
+        ----------
+        y : pd.DataFrame with MultiIndex (guaranteed Panel or Hierarchical)
+            Panel or hierarchical time series data to pretrain on.
+            The last index level is time, all other levels identify instances.
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series.
+        fh : ForecastingHorizon or None, optional (default=None)
+            Forecasting horizon.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        self.model_ = self._load_model()
+
+        context_length = self.model_.config.context_length
+        horizon_length = self.model_.config.horizon_length
+
+        from transformers import Trainer, TrainingArguments
+
+        if self.validation_split is not None:
+            y_train, y_eval = temporal_train_test_split(
+                y, test_size=self.validation_split
+            )
+        else:
+            y_train = y
+            y_eval = None
+
+        train = _TimesFM2WindowDataset(
+            series_list=_prepare_series_list(y_train),
+            context_length=context_length,
+            horizon_length=horizon_length,
+        )
+
+        eval = None
+        if (
+            self.validation_split is not None
+            and len(y_eval) >= context_length + horizon_length
+        ):
+            eval = _TimesFM2WindowDataset(
+                series_list=_prepare_series_list(y_eval),
+                context_length=context_length,
+                horizon_length=horizon_length,
+            )
+        elif self.validation_split is not None:
+            warn(
+                "Could not create a TimesFM validation dataset because the "
+                "validation split is shorter than context_length + horizon_length "
+                f"({len(y_eval)} < {context_length + horizon_length}). "
+                "Training will continue without evaluation.",
+                stacklevel=2,
+            )
+
+        training_args = (
+            deepcopy(self.training_args) if self.training_args is not None else {}
+        )
+        training_args = TrainingArguments(**training_args)
+
+        trainer = Trainer(
+            model=self.model_,
+            args=training_args,
+            train_dataset=train,
+            eval_dataset=eval,
+            compute_loss_func=self.compute_loss_func,
+            compute_metrics=self.compute_metrics,
+            callbacks=self.callbacks,
+        )
+
+        trainer.train()
+
+        self.model_ = trainer.model
 
     def _fit(self, y, X=None, fh=None):
         """Fit forecaster to training data.
@@ -153,63 +234,6 @@ class TimesFM2Forecaster(BaseForecaster):
         """
         self.model_ = self._load_model()
         self.context_ = y
-
-        context_length = self.model_.config.context_length
-        horizon_length = self.model_.config.horizon_length
-
-        from transformers import Trainer, TrainingArguments
-
-        if self.validation_split is not None:
-            y_train, y_eval = temporal_train_test_split(
-                y, test_size=self.validation_split
-            )
-        else:
-            y_train = y
-            y_eval = None
-
-        train = _TimesFM2WindowDataset(
-            series_list=[y_train.to_numpy()],
-            context_length=context_length,
-            horizon_length=horizon_length,
-        )
-
-        eval = None
-        if (
-            self.validation_split is not None
-            and len(y_eval) >= context_length + horizon_length
-        ):
-            eval = _TimesFM2WindowDataset(
-                series_list=[y_eval.to_numpy()],
-                context_length=context_length,
-                horizon_length=horizon_length,
-            )
-        elif self.validation_split is not None:
-            warn(
-                "Could not create a TimesFM validation dataset because the "
-                "validation split is shorter than context_length + horizon_length "
-                f"({len(y_eval)} < {context_length + horizon_length}). "
-                "Training will continue without evaluation.",
-                stacklevel=2,
-            )
-
-        training_args = (
-            deepcopy(self.training_args) if self.training_args is not None else {}
-        )
-        training_args = TrainingArguments(**training_args)
-
-        trainer = Trainer(
-            model=self.model_,
-            args=training_args,
-            train_dataset=train,
-            eval_dataset=eval,
-            compute_loss_func=self.compute_loss_func,
-            compute_metrics=self.compute_metrics,
-            callbacks=self.callbacks,
-        )
-
-        trainer.train()
-
-        self.model_ = trainer.model
 
     def _predict(self, fh, X):
         """Forecast time series at future horizon.
@@ -408,6 +432,18 @@ class _CachedTimesFM2:
         self.model_ = AutoModelForTimeSeriesPrediction.from_config(config)
         self.model_ = self.model_.to(self.device)
         return self.model_
+
+
+def _prepare_series_list(data):
+    instance_levels = list(range(data.index.nlevels - 1))
+    groupby_level = instance_levels[0] if len(instance_levels) == 1 else instance_levels
+
+    series_list = []
+    for _, group in data.groupby(level=groupby_level):
+        for col in group.columns:
+            series_list.append(group[col].to_numpy())
+
+    return series_list
 
 
 def _pad_series(series, seq_len):

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -56,6 +56,9 @@ class TimesFM2Forecaster(BaseForecaster):
         fine-tuning.
     callbacks : list, optional (default=None)
         Hugging Face Trainer callbacks used during fine-tuning.
+    peft_config : peft.PeftConfig, optional (default=None)
+        Configuration for parameter-efficient fine-tuning. If provided, the
+        loaded TimesFM model is wrapped with PEFT during ``pretrain``.
     device : str, default="cpu"
         Device on which to run the model, for example ``"cpu"``, ``"cuda"``,
         or ``"cuda:0"``.
@@ -108,6 +111,7 @@ class TimesFM2Forecaster(BaseForecaster):
         compute_loss_func=None,
         compute_metrics=None,
         callbacks=None,
+        peft_config=None,
         device="cpu",
     ):
         self.model_path = model_path
@@ -118,6 +122,7 @@ class TimesFM2Forecaster(BaseForecaster):
         self.compute_loss_func = compute_loss_func
         self.compute_metrics = compute_metrics
         self.callbacks = callbacks
+        self.peft_config = peft_config
         self.device = device
 
         super().__init__()
@@ -412,20 +417,19 @@ class TimesFM2Forecaster(BaseForecaster):
             model_path=self.model_path,
             config=self.config,
             device=self.device,
+            peft_config=self.peft_config,
         ).load()
 
         return self.model_
 
     def _get_unique_key(self):
-        return str(
-            sorted(
-                {
-                    "model_path": self.model_path,
-                    "config": self.config,
-                    "device": self.device,
-                }.items()
-            )
-        )
+        key = {
+            "model_path": self.model_path,
+            "config": self.config,
+            "device": self.device,
+            "peft_config": self.peft_config,
+        }
+        return str(sorted(key.items()))
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -499,10 +503,11 @@ class TimesFM2Forecaster(BaseForecaster):
 class _CachedTimesFM2:
     """Cached TimesFM 2.5 model instance."""
 
-    def __init__(self, key, model_path, config, device):
+    def __init__(self, key, model_path, config, peft_config, device):
         self.key = key
         self.model_path = model_path
         self.config = config
+        self.peft_config = peft_config
         self.device = device
         self.model_ = None
 
@@ -510,10 +515,12 @@ class _CachedTimesFM2:
         if self.model_ is not None:
             return self.model_
 
-        from transformers import TimesFmConfig
+        from transformers import AutoConfig, TimesFmConfig
 
         if self.model_path is not None:
             config = self.config
+            if config is None:
+                config = AutoConfig.from_pretrained(self.model_path)
             if isinstance(config, dict):
                 config_class = _get_timesfm_config_class(config)
                 config = config_class.from_dict(config)
@@ -523,20 +530,30 @@ class _CachedTimesFM2:
                 self.model_path,
                 config=config,
             )
-            self.model_ = self.model_.to(self.device)
-            return self.model_
+        else:
+            config = self.config
+            if config is None:
+                config = TimesFmConfig()
+            if isinstance(config, dict):
+                config_class = _get_timesfm_config_class(config)
+                config = config_class.from_dict(config)
 
-        config = self.config
-        if config is None:
-            config = TimesFmConfig()
-        if isinstance(config, dict):
-            config_class = _get_timesfm_config_class(config)
-            config = config_class.from_dict(config)
+            model_class = _get_timesfm_model_class(config)
+            self.model_ = model_class(config)
 
-        model_class = _get_timesfm_model_class(config)
-        self.model_ = model_class(config)
         self.model_ = self.model_.to(self.device)
+
+        if self.peft_config is not None:
+            self.model_ = self._wrap_with_peft()
+
         return self.model_
+
+    def _wrap_with_peft(self):
+        _check_soft_dependencies("peft", severity="error")
+
+        from peft import get_peft_model
+
+        return get_peft_model(self.model_, deepcopy(self.peft_config))
 
 
 def _get_timesfm_model_class(config):

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -1,5 +1,19 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Interface for the HuggingFace TimesFM-2.x forecasting model series."""
+"""TimesFM-2 forecaster adapter for ``sktime``.
+
+This module provides an ``sktime`` forecaster wrapping the Hugging Face
+``transformers`` implementation of Google Research TimesFM-2 models
+(TimesFM-2.0 and TimesFM-2.5). It supports:
+
+- zero-shot prediction through :meth:`fit` + :meth:`predict`
+- global pretraining on panel/hierarchical data through :meth:`pretrain`
+- quantile prediction through :meth:`predict_quantiles`
+- optional PEFT wrapping during model loading
+
+The adapter intentionally keeps the estimator API aligned with ``sktime`` while
+delegating model loading, forward passes, and optional training to
+``transformers`` classes.
+"""
 
 __author__ = ["rajatsen91", "siriuz42", "geetu040"]
 # rajatsen91 for google-research/timesfm
@@ -19,64 +33,88 @@ from sktime.utils.singleton import _multiton
 
 
 class TimesFM2Forecaster(BaseForecaster):
-    """TimesFM-2.x forecaster via Hugging Face transformers.
+    """TimesFM-2.x forecaster via Hugging Face ``transformers``.
 
-    TimesFM is a pretrained time-series foundation model developed by
-    Google Research for zero-shot forecasting. This forecaster wraps the
-    Hugging Face ``transformers`` implementation of TimesFM-2.x and exposes
-    it through the sktime forecasting interface.
+    This forecaster wraps TimesFM-2 prediction models from Hugging Face and
+    exposes them through the ``sktime`` forecasting interface.
+
+    Two primary workflows are supported:
+
+    1. ``fit`` for zero-shot inference setup (loads model and stores history).
+    2. ``pretrain`` for global fine-tuning on panel/hierarchical data.
+
+    Notes
+    -----
+    - Prediction is bounded by ``model.config.horizon_length``. Requested
+      forecast steps beyond this limit raise ``ValueError``.
+    - Quantile prediction is only available for quantiles present in
+      ``model.config.quantiles``.
+    - Loaded models are cached via a multiton helper keyed by model-loading
+      inputs to avoid repeated model instantiation.
+    - For pickling, ``model_`` is excluded from serialized state and reloaded
+      lazily after unpickling.
 
     Parameters
     ----------
     model_path : str, default="google/timesfm-2.5-200m-transformers"
-        Hugging Face model identifier or local path to a TimesFM-2.x checkpoint.
-        If ``None``, a model is initialized from ``config`` or from the default
-        ``transformers.TimesFmConfig``.
-    config : transformers.TimesFmConfig or dict, optional (default=None)
-        Configuration passed to the Hugging Face model loader. If ``model_path``
-        is not ``None``, this overrides or supplies the model configuration in
-        ``from_pretrained``. If ``model_path`` is ``None``, it is used to
-        initialize the model from configuration.
+        Hugging Face repository identifier or local path to a TimesFM checkpoint.
+        If ``None``, a model is created from ``config`` (or default
+        ``transformers.TimesFmConfig``).
+    config : transformers.PretrainedConfig or dict, optional (default=None)
+        Model configuration used for loading/initialization.
+
+        - If ``model_path`` is not ``None``:
+          passed to ``from_pretrained(..., config=config)``.
+        - If ``model_path`` is ``None``:
+          used to instantiate a model from configuration.
+
+        If provided as ``dict``, the architecture entry (for example
+        ``"TimesFmModelForPrediction"`` or ``"TimesFm2_5ModelForPrediction"``)
+        is used to infer the config class.
     forward_kwargs : dict, optional (default=None)
-        Keyword arguments passed directly to the Hugging Face model forward
-        method during inference. See the Hugging Face TimesFM forward
-        documentation for supported model-specific options such as
-        ``forecast_context_len``, ``truncate_negative``, or
-        ``force_flip_invariance``.
-        See [5]_ for TimesFM-2.0 and [6]_ for TimesFM-2.5.
-    validation_split : float, default=0.2
-        Fraction of data reserved for validation when ``training_args`` is
-        supplied. If ``None``, no validation dataset is passed to the Hugging
-        Face Trainer.
-    training_args : transformers.TrainingArguments or dict, optional (default=None)
-        Training arguments for Hugging Face Trainer.
-        Custom loss function passed to Hugging Face Trainer during fine-tuning.
-    compute_metrics : callable or list of callable, optional (default=None)
-        Metric function or functions passed to Hugging Face Trainer during
-        fine-tuning.
+        Additional keyword arguments forwarded to ``model(...)`` during
+        :meth:`predict` and :meth:`predict_quantiles`.
+    validation_split : float or None, default=0.2
+        Fraction of data reserved for evaluation when :meth:`pretrain` is used.
+        If ``None``, no evaluation dataset is created.
+    training_args : dict, optional (default=None)
+        Keyword arguments used to construct ``transformers.TrainingArguments``
+        in :meth:`pretrain`.
+    compute_loss_func : callable, optional (default=None)
+        Optional custom loss function passed to ``transformers.Trainer``.
+    compute_metrics : callable or dict, optional (default=None)
+        Metrics callback(s) passed to ``transformers.Trainer``.
     callbacks : list, optional (default=None)
-        Hugging Face Trainer callbacks used during fine-tuning.
+        Trainer callbacks passed to ``transformers.Trainer``.
     peft_config : peft.PeftConfig, optional (default=None)
-        Configuration for parameter-efficient fine-tuning. If provided, the
-        loaded TimesFM model is wrapped with PEFT during ``pretrain``.
+        If provided, wraps the loaded base model with PEFT using
+        ``peft.get_peft_model``.
     device : str, default="cpu"
-        Device on which to run the model, for example ``"cpu"``, ``"cuda"``,
-        or ``"cuda:0"``.
+        Device string used to move the loaded model, for example ``"cpu"``,
+        ``"cuda"``, or ``"cuda:0"``.
 
     References
     ----------
     .. [1] Das, A., Kong, W., Sen, R., and Zhou, Y. (2024).
-       A decoder-only foundation model for time-series forecasting. CoRR.
-       https://arxiv.org/abs/2310.10688
-    .. [2] https://github.com/google-research/timesfm
-    .. [3] https://huggingface.co/google/timesfm-2.5-200m-transformers
-    .. [4] https://huggingface.co/google/timesfm-2.0-500m-pytorch
-    .. [5] https://huggingface.co/docs/transformers/en/model_doc/timesfm#transformers.TimesFmModelForPrediction.forward
-    .. [6] https://huggingface.co/docs/transformers/en/model_doc/timesfm2_5#transformers.TimesFm2_5ModelForPrediction.forward
-    .. [7] https://huggingface.co/docs/transformers/v5.9.0/en/main_classes/trainer#transformers.TrainingArguments
+       *A Decoder-only Foundation Model for Time-series Forecasting*.
+       CoRR. https://arxiv.org/abs/2310.10688
+    .. [2] Google Research TimesFM repository:
+       https://github.com/google-research/timesfm
+    .. [3] TimesFM-2.5 model card:
+       https://huggingface.co/google/timesfm-2.5-200m-transformers
+    .. [4] TimesFM-2.0 model card:
+       https://huggingface.co/google/timesfm-2.0-500m-pytorch
+    .. [5] TimesFM-2.0 forward API:
+       https://huggingface.co/docs/transformers/en/model_doc/timesfm#transformers.TimesFmModelForPrediction.forward
+    .. [6] TimesFM-2.5 forward API:
+       https://huggingface.co/docs/transformers/en/model_doc/timesfm2_5#transformers.TimesFm2_5ModelForPrediction.forward
+    .. [7] Trainer/TrainingArguments docs:
+       https://huggingface.co/docs/transformers/en/main_classes/trainer
 
     Examples
     --------
+    Basic zero-shot forecasting from a pretrained checkpoint:
+
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
     >>> y = load_airline()
@@ -86,6 +124,58 @@ class TimesFM2Forecaster(BaseForecaster):
     ... )  # doctest: +SKIP
     >>> forecaster.fit(y)  # doctest: +SKIP
     >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
+
+    Quantile prediction using model-supported alphas:
+
+    >>> forecaster = TimesFM2Forecaster(device="cpu")  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> q_pred = forecaster.predict_quantiles(  # doctest: +SKIP
+    ...     fh=[1, 2, 3],
+    ...     alpha=[0.1, 0.5, 0.9],
+    ... )
+
+    Initialize from config only (no pretrained checkpoint):
+
+    >>> cfg = {
+    ...     "architectures": ["TimesFmModelForPrediction"],
+    ...     "num_hidden_layers": 1,
+    ...     "hidden_size": 16,
+    ...     "intermediate_size": 16,
+    ...     "head_dim": 8,
+    ...     "num_attention_heads": 4,
+    ...     "context_length": 8,
+    ...     "horizon_length": 6,
+    ...     "patch_length": 2,
+    ...     "quantiles": [0.1, 0.5, 0.9],
+    ... }
+    >>> forecaster = TimesFM2Forecaster(  # doctest: +SKIP
+    ...     model_path=None,
+    ...     config=cfg,
+    ...     device="cpu",
+    ... )
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1, 2])  # doctest: +SKIP
+
+    Global pretraining on panel data:
+
+    >>> from sktime.datasets import load_tecator
+    >>> y_panel = load_tecator(return_type="pd-multiindex")  # doctest: +SKIP
+    >>> y_panel = y_panel.drop(columns=["class_val"])  # doctest: +SKIP
+    >>> forecaster = TimesFM2Forecaster(  # doctest: +SKIP
+    ...     model_path="google/timesfm-2.5-200m-transformers",
+    ...     training_args={"max_steps": 1, "eval_steps": 1},
+    ...     validation_split=0.1,
+    ... )
+    >>> forecaster.pretrain(y_panel)  # doctest: +SKIP
+
+    Optional PEFT wrapping (requires ``peft``):
+
+    >>> from peft import LoraConfig  # doctest: +SKIP
+    >>> peft_cfg = LoraConfig(r=8, lora_alpha=16)  # doctest: +SKIP
+    >>> forecaster = TimesFM2Forecaster(  # doctest: +SKIP
+    ...     peft_config=peft_cfg,
+    ...     training_args={"max_steps": 1, "eval_steps": 1},
+    ... )
     """
 
     _tags = {
@@ -182,10 +272,11 @@ class TimesFM2Forecaster(BaseForecaster):
             )
         elif self.validation_split is not None:
             warn(
-                "Could not create a TimesFM validation dataset because the "
-                "validation split is shorter than context_length + horizon_length "
-                f"({len(y_eval)} < {context_length + horizon_length}). "
-                "Training will continue without evaluation.",
+                "Skipping TimesFM evaluation dataset creation: validation split "
+                "length is smaller than context_length + horizon_length "
+                f"(observed={len(y_eval)}, required>="
+                f"{context_length + horizon_length}). Training continues "
+                "without evaluation.",
                 stacklevel=2,
             )
 
@@ -281,10 +372,11 @@ class TimesFM2Forecaster(BaseForecaster):
         horizon_length = self.model_.config.horizon_length
         if np.max(preds_idx) >= horizon_length:
             raise ValueError(
-                "The requested forecasting horizon extends beyond the TimesFM "
-                f"model horizon_length. The maximum requested relative horizon "
-                f"is {np.max(preds_idx) + 1}, but model.config.horizon_length is "
-                f"{horizon_length}."
+                "Requested forecasting horizon exceeds TimesFM model capacity: "
+                f"max requested step={np.max(preds_idx) + 1}, "
+                f"configured horizon_length={horizon_length}. "
+                "Use a shorter horizon or a model/config with a larger "
+                "horizon_length."
             )
 
         past_values = self.context_
@@ -355,10 +447,11 @@ class TimesFM2Forecaster(BaseForecaster):
         preds_idx = fh._values.values - 1
         if np.max(preds_idx) >= horizon_length:
             raise ValueError(
-                "The requested forecasting horizon extends beyond the TimesFM "
-                f"model horizon_length. The maximum requested relative horizon "
-                f"is {np.max(preds_idx) + 1}, but model.config.horizon_length is "
-                f"{horizon_length}."
+                "Requested forecasting horizon exceeds TimesFM model capacity: "
+                f"max requested step={np.max(preds_idx) + 1}, "
+                f"configured horizon_length={horizon_length}. "
+                "Use a shorter horizon or a model/config with a larger "
+                "horizon_length."
             )
 
         if alpha is None:
@@ -367,8 +460,8 @@ class TimesFM2Forecaster(BaseForecaster):
         quantiles = [round(i, 3) for i in quantiles]
         if not set(alpha).issubset(set(quantiles)):
             raise ValueError(
-                "The requested quantiles are different than the ones in config "
-                f"alpha: {alpha} and valid quantiles in config: {quantiles}"
+                "Requested quantiles are not all available in model config: "
+                f"requested={alpha}, available={quantiles}."
             )
         quantiles_idx = np.array([quantiles.index(i) for i in alpha])
 
@@ -398,17 +491,42 @@ class TimesFM2Forecaster(BaseForecaster):
         return pred_quantiles
 
     def __getstate__(self):
-        """Return state for pickling, excluding the model object."""
+        """Return pickle state without materializing the model object.
+
+        Returns
+        -------
+        state : dict
+            Estimator state dictionary with ``model_`` set to ``None`` when
+            present, so pickling does not include large/unpickleable model state.
+        """
         state = self.__dict__.copy()
         if "model_" in state:
             state["model_"] = None
         return state
 
     def __setstate__(self, state):
-        """Restore state; the model will be reloaded on next prediction."""
+        """Restore estimator state after unpickling.
+
+        Parameters
+        ----------
+        state : dict
+            State dictionary produced by :meth:`__getstate__`.
+
+        Notes
+        -----
+        Model weights are reloaded lazily on first subsequent model access.
+        """
         self.__dict__.update(state)
 
     def _load_model(self):
+        """Load or retrieve a cached TimesFM model instance.
+
+        Returns
+        -------
+        model : transformers.PreTrainedModel
+            Loaded model on ``self.device``. If ``self.model_`` already exists,
+            it is returned directly.
+        """
         if hasattr(self, "model_") and self.model_ is not None:
             return self.model_
 
@@ -423,6 +541,14 @@ class TimesFM2Forecaster(BaseForecaster):
         return self.model_
 
     def _get_unique_key(self):
+        """Build cache key for the multiton model loader.
+
+        Returns
+        -------
+        key : str
+            Deterministic string representation of model-loading attributes used
+            by :class:`_CachedTimesFM2`.
+        """
         key = {
             "model_path": self.model_path,
             "config": self.config,
@@ -501,7 +627,26 @@ class TimesFM2Forecaster(BaseForecaster):
 
 @_multiton
 class _CachedTimesFM2:
-    """Cached TimesFM 2.5 model instance."""
+    """Multiton-backed cache wrapper for a loaded TimesFM model.
+
+    Instances are keyed externally (via :class:`TimesFM2Forecaster`) so that
+    repeated forecasters with equivalent loading parameters can share a single
+    model instance in memory.
+
+    Parameters
+    ----------
+    key : str
+        Multiton key (stored for traceability).
+    model_path : str or None
+        Model identifier/path for ``from_pretrained``. If ``None``, create model
+        from config only.
+    config : transformers.PretrainedConfig or dict or None
+        Configuration used for model loading/creation.
+    peft_config : peft.PeftConfig or None
+        Optional PEFT wrapping configuration.
+    device : str
+        Device to move the created model to.
+    """
 
     def __init__(self, key, model_path, config, peft_config, device):
         self.key = key
@@ -512,6 +657,20 @@ class _CachedTimesFM2:
         self.model_ = None
 
     def load(self):
+        """Load model if needed and return cached instance.
+
+        Returns
+        -------
+        model : transformers.PreTrainedModel
+            Loaded TimesFM prediction model on ``self.device``.
+
+        Notes
+        -----
+        - If ``model_path`` is set, loads weights via ``from_pretrained``.
+        - If ``model_path`` is ``None``, initializes from config.
+        - If ``peft_config`` is provided, wraps the model with PEFT after base
+          loading and device placement.
+        """
         if self.model_ is not None:
             return self.model_
 
@@ -549,6 +708,18 @@ class _CachedTimesFM2:
         return self.model_
 
     def _wrap_with_peft(self):
+        """Wrap loaded model with PEFT.
+
+        Returns
+        -------
+        model : torch.nn.Module
+            PEFT-wrapped model.
+
+        Raises
+        ------
+        ModuleNotFoundError
+            If ``peft`` is not installed.
+        """
         _check_soft_dependencies("peft", severity="error")
 
         from peft import get_peft_model
@@ -557,7 +728,24 @@ class _CachedTimesFM2:
 
 
 def _get_timesfm_model_class(config):
-    """Return the TimesFM prediction class named by the config architecture."""
+    """Resolve TimesFM prediction model class from a config object.
+
+    Parameters
+    ----------
+    config : transformers.PretrainedConfig
+        Config object expected to contain ``architectures``.
+
+    Returns
+    -------
+    model_class : type
+        ``transformers`` model class referenced by ``config.architectures[0]``.
+
+    Notes
+    -----
+    Defaults to ``TimesFmModelForPrediction`` when ``architectures`` is unset.
+    For TimesFM-2.5 architecture, a soft dependency warning is emitted for
+    ``transformers>=5.3.0``.
+    """
     import transformers
 
     architectures = getattr(config, "architectures", None) or [
@@ -569,7 +757,24 @@ def _get_timesfm_model_class(config):
 
 
 def _get_timesfm_config_class(config):
-    """Return the TimesFM config class named by a config dict architecture."""
+    """Resolve TimesFM config class from a config dictionary.
+
+    Parameters
+    ----------
+    config : dict
+        Config dictionary with optional ``architectures`` entry.
+
+    Returns
+    -------
+    config_class : type
+        Matching ``transformers`` config class.
+
+    Notes
+    -----
+    Maps ``*ModelForPrediction`` architecture names to ``*Config``.
+    For TimesFM-2.5 architecture, a soft dependency warning is emitted for
+    ``transformers>=5.3.0``.
+    """
     import transformers
 
     architectures = config.get("architectures") or ["TimesFmModelForPrediction"]
@@ -580,6 +785,19 @@ def _get_timesfm_config_class(config):
 
 
 def _prepare_series_list(data):
+    """Convert panel/hierarchical DataFrame into list of 1D numpy series.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        MultiIndex time series table where the last index level is time.
+
+    Returns
+    -------
+    series_list : list of np.ndarray
+        Flattened list of univariate instance-column series, each as a
+        ``numpy`` array.
+    """
     instance_levels = list(range(data.index.nlevels - 1))
     groupby_level = instance_levels[0] if len(instance_levels) == 1 else instance_levels
 
@@ -592,6 +810,21 @@ def _prepare_series_list(data):
 
 
 def _pad_series(series, seq_len):
+    """Left-pad a series with zeros to at least a target length.
+
+    Parameters
+    ----------
+    series : np.ndarray
+        Input 1D numeric series.
+    seq_len : int
+        Required minimum sequence length.
+
+    Returns
+    -------
+    padded : np.ndarray
+        ``series`` left-padded with zeros if ``len(series) < seq_len``;
+        otherwise unchanged.
+    """
     pad_length = seq_len - len(series)
     if pad_length >= 0:
         series = np.pad(
@@ -604,6 +837,30 @@ def _pad_series(series, seq_len):
 
 
 class PyTorchDataset:
+    """Sliding-window dataset for TimesFM pretraining with ``transformers.Trainer``.
+
+    Each sample is a contiguous window of length
+    ``context_length + horizon_length`` split into:
+
+    - ``past_values`` (context part)
+    - ``future_values`` (target horizon part)
+
+    Parameters
+    ----------
+    series_list : list of np.ndarray
+        List of 1D training series.
+    context_length : int
+        Number of historical points in each sample.
+    horizon_length : int
+        Number of forecast points in each sample.
+
+    Raises
+    ------
+    ValueError
+        If no valid training samples can be generated. This happens when all
+        input series have length ``<= horizon_length``.
+    """
+
     def __init__(self, series_list, context_length, horizon_length):
         self.series_list = series_list
         self.context_length = context_length
@@ -620,17 +877,35 @@ class PyTorchDataset:
 
         if not self.samples:
             raise ValueError(
-                "No training samples could be generated. "
-                f"Each series must have length greater than horizon_length "
-                f"({horizon_length})."
+                "No training samples were generated for TimesFM pretraining. "
+                "Provide at least one series with length greater than "
+                f"horizon_length (horizon_length={horizon_length})."
             )
 
     def __len__(self):
-        """Return length of dataset."""
+        """Return number of generated samples.
+
+        Returns
+        -------
+        int
+            Dataset size.
+        """
         return len(self.samples)
 
     def __getitem__(self, i):
-        """Return data point."""
+        """Return one training sample as tensors.
+
+        Parameters
+        ----------
+        i : int
+            Sample index.
+
+        Returns
+        -------
+        sample : dict
+            Dictionary with keys ``past_values`` and ``future_values``, both
+            ``torch.float32`` tensors.
+        """
         import torch
 
         sample = self.samples[i]


### PR DESCRIPTION
Fixes #10288

Adds `TimesFM2Forecaster` interfaces for TimesFM 2.0 and 2.5 models through the Hugging Face `transformers` implementation.

Changes:
* Add zero-shot forecasting support for TimesFM 2.0 and 2.5
* Add prediction interval/quantile forecasting
* Add pretraining support, including PEFT
* Support `device_map`, `dtype`, and `quantization_config`
* Add tests, documentation, and examples

CC: @rajatsen91 @siriuz42 @kashif