### PR TITLE
[DOC] Clarify ExpandingWindowSplitter fold definitions

### DIFF
--- a/sktime/split/expandingwindow.py
+++ b/sktime/split/expandingwindow.py
@@ -35,7 +35,8 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
 
     .. math:: [t_1, t_1 + w), [t_1, t_1 + w + s), [t_1, t_1 + w + 2s), \ldots
 
-    where :math:`w` is the initial window length and :math:`s` is the step length.
+    where :math:`w` is the value of ``initial_window`` and :math:`s` is the
+    value of ``step_length``.
 
     The test windows are defined by forecasting horizons
     relative to the end of the training windows.
@@ -43,10 +44,11 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
     The test window will contain as many indices
     as there are forecasting horizons provided to the ``fh`` argument.
 
-    For a forecasting horizon :math:`(h_1,\ldots,h_H)`, the test indices for the
-    n-th split will consist of the indices :math:`(k_n+h_1,\ldots,k_n+h_H)`,
-    where :math:`k_n = t_1 + w + (n - 1) \cdot s`
-    is the end of the n-th training window.
+    For ``fh`` equal to the forecasting horizon :math:`(h_1,\ldots,h_H)`, the
+    test indices for the n-th split will consist of the indices
+    :math:`(k_n+h_1,\ldots,k_n+h_H)`, where
+    :math:`k_n = t_1 + w + (n - 1) \cdot s` is the end of the n-th training
+    window.
 
     The number of splits is determined by the total length of the time series,
     up until the last test window that lies within the observed time indices,

--- a/sktime/split/expandingwindow.py
+++ b/sktime/split/expandingwindow.py
@@ -25,14 +25,32 @@ from sktime.utils.validation import (
 class ExpandingWindowSplitter(BaseWindowSplitter):
     r"""Expanding window splitter.
 
-    Split time series repeatedly into an growing training set and a fixed-size test set.
+    Split time series repeatedly into a growing training set and a fixed-size test set.
 
-    Test window is defined by forecasting horizons
-    relative to the end of the training window.
-    It will contain as many indices
+    The training windows start at the first available time index in the data.
+    Each split expands the previous training window by ``step_length``.
+
+    If the time points in the data are :math:`(t_1, t_2, \ldots, t_N)`, the
+    training windows will be all indices in the intervals
+
+    .. math:: [t_1, t_1 + w), [t_1, t_1 + w + s), [t_1, t_1 + w + 2s), \ldots
+
+    where :math:`w` is the initial window length and :math:`s` is the step length.
+
+    The test windows are defined by forecasting horizons
+    relative to the end of the training windows.
+
+    The test window will contain as many indices
     as there are forecasting horizons provided to the ``fh`` argument.
-    For a forecasating horizon :math:`(h_1,\ldots,h_H)`, the training window will
-    consist of the indices :math:`(k_n+h_1,\ldots,k_n+h_H)`.
+
+    For a forecasting horizon :math:`(h_1,\ldots,h_H)`, the test indices for the
+    n-th split will consist of the indices :math:`(k_n+h_1,\ldots,k_n+h_H)`,
+    where :math:`k_n = t_1 + w + (n - 1) \cdot s`
+    is the end of the n-th training window.
+
+    The number of splits is determined by the total length of the time series,
+    up until the last test window that lies within the observed time indices,
+    i.e., the largest integer :math:`n` such that :math:`k_n + h_H < t_N`.
 
     For example for ``initial_window = 5``, ``step_length = 1`` and ``fh = [1, 2, 3]``
     here is a representation of the folds::


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses part of #7196.

#### What does this implement/fix? Explain your changes.

This PR improves the `ExpandingWindowSplitter` docstring by clarifying how training and test folds are constructed.

It adds a formal description of:

- how the expanding training windows are generated from `initial_window` and `step_length`
- how test indices are derived from the forecasting horizon relative to each training window
- how the number of splits is determined

It also fixes a small typo and changes the previous wording that accidentally described the forecasting-horizon indices as the training window.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the mathematical description matches the intended splitter behavior.
- Whether the notation is consistent with `SlidingWindowSplitter`.

#### Did you add any tests for the change?

No new tests. This is a documentation-only change.

Local checks run:

- `python -m compileall -q sktime\split\expandingwindow.py`
- `git diff --check`

#### Any other comments?

I used AI assistance for documentation wording and repository navigation, and reviewed the change before submitting.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors (optional for first PR)
- [ ] Optionally, for added estimators: N/A
- [x] The PR title starts with [DOC]

##### For new estimators
- [ ] N/A