### PR TITLE
[DOC] `ForecastingRandomizedSearchCV` usage example in docstring

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2858,6 +2858,16 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "SajeelHussain",
+      "name": "Sajeel-Awan",
+      "avatar_url": "https://avatars.githubusercontent.com/u/75925740?v=4",
+      "profile": "https://github.com/SajeelHussain",
+      "contributions": [
+        "code",
+        "doc"
+      ]
     }
   ]
 }

--- a/sktime/forecasting/model_selection/_randomsearch.py
+++ b/sktime/forecasting/model_selection/_randomsearch.py
@@ -170,6 +170,57 @@ class ForecastingRandomizedSearchCV(BaseGridSearch):
         and at least one of the two is applicable.
         In this case, the other attributes are not present in self,
         only in the fields of forecasters_.
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_shampoo_sales
+    >>> from sktime.forecasting.model_selection import ForecastingRandomizedSearchCV
+    >>> from sktime.split import ExpandingWindowSplitter
+    >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> y = load_shampoo_sales()
+    >>> fh = [1, 2, 3]
+    >>> cv = ExpandingWindowSplitter(fh=fh)
+    >>> forecaster = NaiveForecaster()
+    >>> param_distributions = {"strategy": ["last", "mean", "drift"]}
+    >>> rscv = ForecastingRandomizedSearchCV(
+    ...     forecaster=forecaster,
+    ...     param_distributions=param_distributions,
+    ...     cv=cv,
+    ...     n_iter=3,
+    ...     random_state=42)
+    >>> rscv.fit(y)
+    ForecastingRandomizedSearchCV(...)
+    >>> y_pred = rscv.predict(fh)
+
+        Advanced randomized search with a ``scipy.stats`` distribution for a
+        continuous hyperparameter, on a pipeline forecaster:
+
+    >>> from scipy.stats import randint
+    >>> from sktime.datasets import load_shampoo_sales
+    >>> from sktime.forecasting.compose import TransformedTargetForecaster
+    >>> from sktime.forecasting.model_selection import ForecastingRandomizedSearchCV
+    >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> from sktime.split import ExpandingWindowSplitter
+    >>> from sktime.transformations.series.detrend import Detrender
+    >>> y = load_shampoo_sales()
+    >>> pipe = TransformedTargetForecaster(steps=[
+    ...     ("detrender", Detrender()),
+    ...     ("forecaster", NaiveForecaster(strategy="mean"))])
+    >>> param_distributions = {
+    ...     "forecaster__window_length": randint(2, 12),
+    ...     "forecaster__strategy": ["mean", "last", "drift"],
+    ... }
+    >>> cv = ExpandingWindowSplitter(
+    ...     initial_window=18, step_length=6, fh=[1, 2, 3])
+    >>> rscv = ForecastingRandomizedSearchCV(
+    ...     forecaster=pipe,
+    ...     param_distributions=param_distributions,
+    ...     cv=cv,
+    ...     n_iter=5,
+    ...     random_state=42)
+    >>> rscv.fit(y)
+    ForecastingRandomizedSearchCV(...)
+    >>> y_pred = rscv.predict(fh=[1, 2, 3])
     """
 
     _tags = {

--- a/sktime/forecasting/model_selection/_randomsearch.py
+++ b/sktime/forecasting/model_selection/_randomsearch.py
@@ -192,8 +192,8 @@ class ForecastingRandomizedSearchCV(BaseGridSearch):
     ForecastingRandomizedSearchCV(...)
     >>> y_pred = rscv.predict(fh)
 
-        Advanced randomized search with a ``scipy.stats`` distribution for a
-        continuous hyperparameter, on a pipeline forecaster:
+    Advanced randomized search with a ``scipy.stats`` distribution for a
+    continuous hyperparameter, on a pipeline forecaster:
 
     >>> from scipy.stats import randint
     >>> from sktime.datasets import load_shampoo_sales


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #4264.

#### What does this implement/fix? Explain your changes.

Adds an Examples section to the `ForecastingRandomizedSearchCV` docstring.

Two examples are included, mirroring the structure of the sister class `ForecastingGridSearchCV`:

- **basic** — `NaiveForecaster` with a discrete-list `param_distributions`; exercises the `n_iter` and `random_state` parameters that distinguish this class from `ForecastingGridSearchCV`
- **advanced** — `scipy.stats.randint` continuous distribution combined with a `TransformedTargetForecaster` (`Detrender` + `NaiveForecaster`) pipeline; demonstrates the distinguishing value of randomized search (continuous distributions, which grid search cannot accept)

No `# doctest: +SKIP` markers, all imports are hard dependencies

No code-logic changes; docstring-only addition. 

#### Does your contribution introduce a new dependency? If yes, which one?

No. Only existing hard dependencies are imported in the doctest.

#### What should a reviewer concentrate their feedback on?

- Whether the Examples section follows the style you want for the model_selection family (basic example matches `ForecastingGridSearchCV` line-for-line; advanced example diverges only on the new `n_iter` / `random_state` / `scipy.stats` features)
- Whether `n_iter=5` is an appropriate budget for the advanced example, or if a smaller/larger value would be preferred
- Whether the advanced example's pipeline choice (`Detrender` + `NaiveForecaster`) is illustrative enough?

#### Did you add any tests for the change?

The docstring examples themselves act as doctests. Verified locally using `skbase.utils.doctest_run.run_doctest()` (the same runner the sktime test framework uses).

#### Any other comments?

<!-- ← Your Path A/B/C disclosure choice goes here (or leave blank) -->

#### PR checklist

##### For all contributions

- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) — added entry to `.all-contributorsrc` with badges `code` and `doc`.
- [x] The PR title starts with `[DOC]`.

##### For new estimators

N/A — no new estimator added.
