### PR TITLE
[ENH] Fix constructor dependency handling in catalogues

### DIFF
--- a/extension_templates/catalogue.py
+++ b/extension_templates/catalogue.py
@@ -70,7 +70,28 @@ class MyCatalogue(BaseCatalogue):
         "info:source": "DOI",
     }
 
-    # implement this
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        # todo: optional, parameter checking or coercion should happen here
+        # if writes derived values to self, should *not* overwrite self.paramc etc
+        # instead, write to self._paramc, self._newparam (starting with _)
+        # example of handling conditional parameters or mutable defaults:
+        if self.paramc is None:
+            from sktime.somewhere import MyOtherEstimator
+
+            self._paramc = MyOtherEstimator(foo=42)
+        else:
+            # estimators should be cloned to avoid side effects
+            self._paramc = self.paramc.clone()
+
+    # TODO: implement this
     def _get(self):
         """Return the catalogue mapping of category -> list of items.
 

--- a/sktime/catalogues/base/_base.py
+++ b/sktime/catalogues/base/_base.py
@@ -6,6 +6,8 @@ __all__ = ["BaseCatalogue"]
 
 from abc import abstractmethod
 
+from skbase.utils.dependencies import _check_estimator_deps
+
 from sktime.base import BaseObject
 from sktime.registry import craft
 
@@ -27,6 +29,20 @@ class BaseCatalogue(BaseObject):
     def __init__(self):
         super().__init__()
         self._cached_objects = None
+
+        if _check_estimator_deps(self, severity="warning"):
+            self.__post_init__()
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        pass
 
     @abstractmethod
     def _get(self):


### PR DESCRIPTION
Fix constructor dependency handling in catalogues.

Previously, checkers for dependency handling in catalogues were not called. This PR fixes that.