### PR TITLE
[DOC] Document `__dynamic_tags__` constructor method in extension templates

### DIFF
--- a/extension_templates/alignment.py
+++ b/extension_templates/alignment.py
@@ -133,6 +133,7 @@ class MyAligner(BaseAligner):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/alignment.py
+++ b/extension_templates/alignment.py
@@ -114,7 +114,24 @@ class MyAligner(BaseAligner):
         super().__init__()
 
         # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
         # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
@@ -123,7 +140,6 @@ class MyAligner(BaseAligner):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here
@@ -137,16 +153,6 @@ class MyAligner(BaseAligner):
         else:
             # estimators should be cloned to avoid side effects
             self._paramc = self.paramc.clone()
-
-        # todo: if tags of estimator depend on component tags, set these here
-        #  only needed if estimator is a composite
-        #  tags set in the constructor apply to the object and override the class
-        #
-        # example 1: conditional setting of a tag
-        # if est.foo == 42:
-        #   self.set_tags(handles-missing-data=True)
-        # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _fit(self, X, Z=None):

--- a/extension_templates/catalogue.py
+++ b/extension_templates/catalogue.py
@@ -70,7 +70,62 @@ class MyCatalogue(BaseCatalogue):
         "info:source": "DOI",
     }
 
-    # implement this
+    # todo: add any hyper-parameters and components to constructor
+    def __init__(self, parama, paramb="default", paramc=None):
+        # estimators should precede parameters
+        #  if estimators have default values, set None and initialize below
+        # todo: write any hyper-parameters and components to self
+        self.parama = parama
+        self.paramb = paramb
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._paramc
+        self.paramc = paramc
+
+        # leave this as is
+        super().__init__()
+
+        # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
+        # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        # todo: optional, parameter checking or coercion should happen here
+        # if writes derived values to self, should *not* overwrite self.paramc etc
+        # instead, write to self._paramc, self._newparam (starting with _)
+        # example of handling conditional parameters or mutable defaults:
+        if self.paramc is None:
+            from sktime.somewhere import MyOtherEstimator
+
+            self._paramc = MyOtherEstimator(foo=42)
+        else:
+            # estimators should be cloned to avoid side effects
+            self._paramc = self.paramc.clone()
+
+    # TODO: implement this
     def _get(self):
         """Return the catalogue mapping of category -> list of items.
 

--- a/extension_templates/catalogue.py
+++ b/extension_templates/catalogue.py
@@ -105,6 +105,7 @@ class MyCatalogue(BaseCatalogue):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/catalogue.py
+++ b/extension_templates/catalogue.py
@@ -74,6 +74,7 @@ class MyCatalogue(BaseCatalogue):
     def __init__(self, parama, paramb="default", paramc=None):
         # estimators should precede parameters
         #  if estimators have default values, set None and initialize below
+
         # todo: write any hyper-parameters and components to self
         self.parama = parama
         self.paramb = paramb

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -125,7 +125,24 @@ class MyTimeSeriesClassifier(BaseClassifier):
         super().__init__()
 
         # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
         # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
@@ -134,7 +151,6 @@ class MyTimeSeriesClassifier(BaseClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here
@@ -148,16 +164,6 @@ class MyTimeSeriesClassifier(BaseClassifier):
         else:
             # estimators should be cloned to avoid side effects
             self._paramc = self.paramc.clone()
-
-        # todo: if tags of estimator depend on component tags, set these here
-        #  only needed if estimator is a composite
-        #  tags set in the constructor apply to the object and override the class
-        #
-        # example 1: conditional setting of a tag
-        # if est.foo == 42:
-        #   self.set_tags(handles-missing-data=True)
-        # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _fit(self, X, y):

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -144,6 +144,7 @@ class MyTimeSeriesClassifier(BaseClassifier):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -121,7 +121,24 @@ class MyClusterer(BaseClusterer):
         super().__init__()
 
         # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
         # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
@@ -130,7 +147,6 @@ class MyClusterer(BaseClusterer):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -140,6 +140,7 @@ class MyClusterer(BaseClusterer):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/detection.py
+++ b/extension_templates/detection.py
@@ -152,7 +152,24 @@ class MyDetector(BaseDetector):
         super().__init__()
 
         # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
         # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
@@ -161,7 +178,6 @@ class MyDetector(BaseDetector):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here
@@ -175,16 +191,6 @@ class MyDetector(BaseDetector):
         else:
             # estimators should be cloned to avoid side effects
             self._paramc = self.paramc.clone()
-
-        # todo: if tags of estimator depend on component tags, set these here
-        #  only needed if estimator is a composite
-        #  tags set in the constructor apply to the object and override the class
-        #
-        # example 1: conditional setting of a tag
-        # if est.foo == 42:
-        #   self.set_tags(handles-missing-data=True)
-        # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _fit(self, X, y=None):

--- a/extension_templates/detection.py
+++ b/extension_templates/detection.py
@@ -171,6 +171,7 @@ class MyDetector(BaseDetector):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -106,6 +106,7 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -86,6 +86,26 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
         # do not put anything else in __init__,
         # use __post_init__ for any further initialization logic
 
+        # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
+        # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
+
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 
@@ -93,7 +113,6 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here
@@ -107,16 +126,6 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
         else:
             # estimators should be cloned to avoid side effects
             self._paramc = self.paramc.clone()
-
-        # todo: if tags of estimator depend on component tags, set these here
-        #  only needed if estimator is a composite
-        #  tags set in the constructor apply to the object and override the class
-        #
-        # example 1: conditional setting of a tag
-        # if est.foo == 42:
-        #   self.set_tags(handles-missing-data=True)
-        # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _transform(self, X, X2=None):

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -106,6 +106,7 @@ class MyTrafoPw(BasePairwiseTransformer):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -86,6 +86,26 @@ class MyTrafoPw(BasePairwiseTransformer):
         # do not put anything else in __init__,
         # use __post_init__ for any further initialization logic
 
+        # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
+        # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
+
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 
@@ -93,7 +113,6 @@ class MyTrafoPw(BasePairwiseTransformer):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here
@@ -107,16 +126,6 @@ class MyTrafoPw(BasePairwiseTransformer):
         else:
             # estimators should be cloned to avoid side effects
             self._paramc = self.paramc.clone()
-
-        # todo: if tags of estimator depend on component tags, set these here
-        #  only needed if estimator is a composite
-        #  tags set in the constructor apply to the object and override the class
-        #
-        # example 1: conditional setting of a tag
-        # if est.foo == 42:
-        #   self.set_tags(handles-missing-data=True)
-        # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _transform(self, X, X2=None):

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -214,6 +214,7 @@ class MyForecaster(BaseForecaster):
         super().__init__()
 
         # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
         # use __post_init__ for any further initialization logic
 
     # todo: add if there is dynamic tag setting logic, otherwise delete this method

--- a/extension_templates/metric_detection.py
+++ b/extension_templates/metric_detection.py
@@ -103,7 +103,24 @@ class MyMetric(BaseDetectionMetric):
         super().__init__()
 
         # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
         # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.

--- a/extension_templates/metric_detection.py
+++ b/extension_templates/metric_detection.py
@@ -122,6 +122,7 @@ class MyMetric(BaseDetectionMetric):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 
@@ -129,7 +130,6 @@ class MyMetric(BaseDetectionMetric):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here

--- a/extension_templates/metric_forecasting.py
+++ b/extension_templates/metric_forecasting.py
@@ -167,7 +167,24 @@ class MyForecastingMetric(BaseForecastingErrorMetric):
         )
 
         # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
         # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.

--- a/extension_templates/metric_forecasting.py
+++ b/extension_templates/metric_forecasting.py
@@ -186,6 +186,7 @@ class MyForecastingMetric(BaseForecastingErrorMetric):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/metric_forecasting_hierarchical.py
+++ b/extension_templates/metric_forecasting_hierarchical.py
@@ -186,7 +186,24 @@ class MyForecastingMetricHierarchical(BaseForecastingErrorMetric):
         )
 
         # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
         # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
@@ -199,6 +216,8 @@ class MyForecastingMetricHierarchical(BaseForecastingErrorMetric):
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
 
     def _evaluate(self, y_true, y_pred, **kwargs):
         """Evaluate the metric on hierarchical inputs.

--- a/extension_templates/metric_forecasting_hierarchical.py
+++ b/extension_templates/metric_forecasting_hierarchical.py
@@ -205,6 +205,7 @@ class MyForecastingMetricHierarchical(BaseForecastingErrorMetric):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -171,6 +171,7 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -152,7 +152,24 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         super().__init__()
 
         # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
         # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
@@ -161,7 +178,6 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here
@@ -175,16 +191,6 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         else:
             # estimators should be cloned to avoid side effects
             self._paramc = self.paramc.clone()
-
-        # todo: if tags of estimator depend on component tags, set these here
-        #  only needed if estimator is a composite
-        #  tags set in the constructor apply to the object and override the class
-        #
-        # example 1: conditional setting of a tag
-        # if est.foo == 42:
-        #   self.set_tags(capability:missing_values=True)
-        # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["capability:missing_values", "other_tag"])
 
     # todo: implement this, mandatory
     def _fit(self, X):

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -160,6 +160,7 @@ class MySplitter(BaseSplitter):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -141,7 +141,24 @@ class MySplitter(BaseSplitter):
         super().__init__()
 
         # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
         # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
@@ -150,7 +167,6 @@ class MySplitter(BaseSplitter):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here
@@ -164,16 +180,6 @@ class MySplitter(BaseSplitter):
         else:
             # estimators should be cloned to avoid side effects
             self._paramc = self.paramc.clone()
-
-        # todo: if tags of estimator depend on component tags, set these here
-        #  only needed if estimator is a composite
-        #  tags set in the constructor apply to the object and override the class
-        #
-        # example 1: conditional setting of a tag
-        # if est.foo == 42:
-        #   self.set_tags(handles-missing-data=True)
-        # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _split(self, y):

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -300,7 +300,24 @@ class MyTransformer(BaseTransformer):
         super().__init__()
 
         # do not put anything else in __init__,
+        # use __dynamic_tags__ for dynamic tag setting
         # use __post_init__ for any further initialization logic
+
+    # todo: add if there is dynamic tag setting logic, otherwise delete this method
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # todo: if tags of estimator depend on component tags, set these here
+        #  typically only needed if estimator is a composite
+        #  tags set here apply to the instance, and override the class tags
+        #
+        # example 1: conditional setting of a tag based on parameter foo
+        # if self.foo == 42:
+        #   self.set_tags(**{"capability:missing_values": True})
+        # example 2: cloning tags from component estimator component_estimator
+        #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
@@ -309,7 +326,6 @@ class MyTransformer(BaseTransformer):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here
@@ -323,16 +339,6 @@ class MyTransformer(BaseTransformer):
         else:
             # estimators should be cloned to avoid side effects
             self._paramc = self.paramc.clone()
-
-        # todo: if tags of estimator depend on component tags, set these here
-        #  only needed if estimator is a composite
-        #  tags set in the constructor apply to the object and override the class
-        #
-        # example 1: conditional setting of a tag
-        # if est.foo == 42:
-        #   self.set_tags(handles-missing-data=True)
-        # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory (except in special case below)
     def _fit(self, X, y=None):

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -319,6 +319,7 @@ class MyTransformer(BaseTransformer):
         # example 2: cloning tags from component estimator component_estimator
         #   self.clone_tags(self.component_estimator, ["capability:missing_values"])
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -211,6 +211,7 @@ class MyTransformer(BaseTransformer):
         # do not put anything else in __init__,
         # use __post_init__ for any further initialization logic
 
+    # todo: add any post-init logic here, otherwise delete this method
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 


### PR DESCRIPTION
Improves documentation in the extension templates: documents `__dynamic_tags__` constructor method, which was previously only documented for forecasters.

The hook was already working for all estimator types, but was not documented yet.