### PR TITLE
[ENH] remove old deprecated tags `capability:pred_var`, `python_dependencies_alias` and `univariate-metric`

### DIFF
--- a/sktime/forecasting/arar/_arar_forecaster.py
+++ b/sktime/forecasting/arar/_arar_forecaster.py
@@ -475,7 +475,6 @@ class ARARForecaster(BaseForecaster):
         "capability:exogenous": False,
         "capability:missing_values": False,
         "capability:pred_int": True,
-        "capability:pred_var": False,
         "capability:insample": False,
     }
 

--- a/sktime/forecasting/boxcox_bias_adjusted_forecaster.py
+++ b/sktime/forecasting/boxcox_bias_adjusted_forecaster.py
@@ -52,8 +52,12 @@ class BoxCoxBiasAdjustedForecaster(BaseForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": "sanskarmodi8",
+        # estimator type
+        # --------------
         "capability:pred_int": True,
-        "capability:pred_var": True,
     }
 
     def __init__(self, forecaster, lambda_fixed=None):

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -735,7 +735,7 @@ def test_transformed_target_forecaster_predict_proba_delegates():
         """Mock forecaster that natively returns Empirical distribution."""
 
         _tags = {
-            "scitype:y": "univariate",
+            "capability:multivariate": False,
             "y_inner_mtype": "pd.DataFrame",
             "requires-fh-in-fit": False,
             "capability:pred_int": True,

--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -137,7 +137,6 @@ class NaiveForecaster(_BaseWindowForecaster):
         "capability:missing_values": True,
         "capability:exogenous": False,
         "capability:multivariate": False,
-        "capability:pred_var": True,
         "capability:pred_int": True,
         # CI and test flags
         # -----------------
@@ -693,7 +692,6 @@ class NaiveVariance(BaseForecaster):
         "capability:missing_values": False,
         "capability:exogenous": True,
         "capability:pred_int": True,
-        "capability:pred_var": True,
     }
 
     def __init__(self, forecaster, initial_window=1, verbose=False):

--- a/sktime/forecasting/xlstm.py
+++ b/sktime/forecasting/xlstm.py
@@ -64,7 +64,6 @@ class XLSTMForecaster(BaseForecaster):
         # estimator type
         # --------------
         "capability:pred_int": False,
-        "capability:pred_var": False,
         "requires-fh-in-fit": False,
         "X_inner_mtype": "pd.DataFrame",
         "y_inner_mtype": "pd.Series",

--- a/sktime/forecasting/xlstm.py
+++ b/sktime/forecasting/xlstm.py
@@ -67,7 +67,7 @@ class XLSTMForecaster(BaseForecaster):
         "requires-fh-in-fit": False,
         "X_inner_mtype": "pd.DataFrame",
         "y_inner_mtype": "pd.Series",
-        "scitype:y": "univariate",
+        "capability:multivariate": False,
         "capability:exogenous": False,
         "capability:missing_values": False,
         # CI and testing tags

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -3560,7 +3560,7 @@ ESTIMATOR_TAG_REGISTER = [
         "which scitypes does X internally support?",
     ),
     (
-        "scitype:y",  # -> capability:multivariate
+        "scitype:y",
         # the scitype:y tag should be kept but for separate use,
         # a list of the internal scitypes supported by the estimator
         # or the base scitype of the target data

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -1300,6 +1300,7 @@ class capability__unequal_length(_BaseTag):
             "classifier",
             "clusterer",
             "early_classifier",
+            "forecaster",
             "regressor",
             "transformer",
             "transformer-pairwise-panel",
@@ -3723,12 +3724,6 @@ ESTIMATOR_TAG_REGISTER = [
         "can transformer handle multivariate series? True = no",
     ),
     (
-        "univariate-metric",  # -> capability:multivariate, invert
-        "metric",
-        "bool",
-        "Does the metric only work on univariate y data?",
-    ),
-    (
         "handles-missing-data",  # -> capability:missing_values
         "estimator",
         "bool",
@@ -3739,23 +3734,10 @@ ESTIMATOR_TAG_REGISTER = [
     # ---------------------------
     # the following tags are to be deprecated or removed
     (
-        "capability:pred_var",  # redundant with capability:pred_int
-        # because if one of the proba methods is available, all others are too
-        "forecaster",
-        "bool",
-        "does the forecaster implement predict_variance?",
-    ),
-    (
         "capability:global_forecasting",
         ["forecaster"],
         "bool",
         "can the estimator make global forecasting?",
-    ),
-    (
-        "python_dependencies_alias",
-        "object",
-        "dict",
-        "deprecated tag for dependency import aliases",
     ),
     (
         "ignores-exogeneous-X",

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -1229,8 +1229,6 @@ class capability__multivariate(_BaseTag):
     - Values: boolean, ``True`` / ``False``
     - Example: ``True``
     - Default: ``False``
-    - Alias: ``univariate-only``  (transformations, note: boolean is inverted)
-    - Alias: ``univariate-metric`` (performance metrics, note: boolean is inverted)
 
     If the tag is ``True``, the estimator can handle multivariate time series,
     for its main input data, i.e., the ``X`` parameter in ``fit`` of classifiers,

--- a/sktime/registry/tests/test_lookup.py
+++ b/sktime/registry/tests/test_lookup.py
@@ -163,7 +163,7 @@ def _get_tag_fixture():
     # just picked a few valid tags to try out as valid str return_tags args:
     test_str_as_arg = [
         "X-y-must-have-same-index",
-        "capability:pred_var",
+        "capability:pred_int",
         "skip-inverse-transform",
     ]
 


### PR DESCRIPTION
This PR removes old deprecated tags:
* `capability:pred_var`
* `univariate-metric`
* `python_dependencies_alias`

and their occurrences.