### PR TITLE
[BUG] fix `TimesFMForecaster` multiton method name

### DIFF
--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -296,7 +296,7 @@ class TimesFMForecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
             timesfm_kwargs=self._get_timesfm_kwargs(),
             use_source_package=self.use_source_package,
             repo_id=self.repo_id,
-        ).load()
+        ).load_from_checkpoint()
 
     def _get_timesfm_kwargs(self):
         """Get the kwargs for TimesFM model."""
@@ -434,7 +434,7 @@ class _CachedTimesFM:
         self.use_source_package = use_source_package
         self.tfm = None
 
-    def load(self):
+    def load_from_checkpoint(self):
         if self.tfm is None:
             if self.use_source_package:
                 from timesfm import TimesFm


### PR DESCRIPTION
The multiton used in `sktime` is intended to follow an implicit API convention where the cached methods have an equal name to the multiton methods.

This was changed in #10265 by accident, this PR reverts the change.

Nothing breaks if the name is different, but in case we want to refactor later to a consistent API, reverting would be a less problematic starting point.