### PR TITLE
[DOC] ForecastingGridSearchCV Examples indentation fix in docstring

### DIFF
--- a/sktime/forecasting/model_selection/_gridsearch.py
+++ b/sktime/forecasting/model_selection/_gridsearch.py
@@ -188,8 +188,8 @@ class ForecastingGridSearchCV(BaseGridSearch):
     ForecastingGridSearchCV(...)
     >>> y_pred = gscv.predict(fh)
 
-        Advanced model meta-tuning (model selection) with multiple forecasters
-        together with hyper-parametertuning at same time using sklearn notation:
+    Advanced model meta-tuning (model selection) with multiple forecasters
+    together with hyper-parametertuning at same time using sklearn notation:
 
     >>> from sktime.datasets import load_shampoo_sales
     >>> from sktime.forecasting.exp_smoothing import ExponentialSmoothing


### PR DESCRIPTION
#### Reference Issues/PRs

Follow up cleanup spotted during review of #10294,  same indentation fix that @fkiraly requested there, applied to the narrative bridge text in `ForecastingGridSearchCV`.

#### What does this implement/fix? Explain your changes.

Drops the indentation of the "Advanced model meta-tuning..." bridge text in `ForecastingGridSearchCV`'s `Examples` section from 8 spaces to 4 spaces.

No code-logic changes; whitespace-only.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Just verify the indentation change is what was wanted.

#### Did you add any tests for the change?

N/A , whitespace-only change. Existing doctests still pass.

#### PR checklist

##### For all contributions

- [x] I'm already in `.all-contributorsrc` (added in #10294).
- [x] The PR title starts with `[DOC]`.

##### For new estimators

N/A — no new estimator added.
