### PR TITLE
[DOC] Document PanelDask mtype

### DIFF
--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -985,6 +985,34 @@ def _check_numpyflat_Panel(obj, return_metadata=False, var_name="obj"):
 class PanelDask(ScitypePanel):
     """Data type: dask data frame based specification of panel of time series.
 
+    Name: ``"dask_panel"``
+
+    Short description:
+    A ``dask.dataframe.DataFrame`` representation of a panel of time series,
+    with panel instance and time indices stored as explicit columns.
+
+    Long description:
+    The ``"dask_panel"`` :term:`mtype` is a concrete specification of the
+    ``Panel`` :term:`scitype`, which represents a collection of time series.
+
+    An object ``obj: dask.dataframe.DataFrame`` follows the specification iff:
+
+    * structure convention: ``obj`` has exactly two index columns.
+    * index columns: index columns are named with the ``__index__*`` convention
+      used by :mod:`sktime.datatypes._adapter.dask_to_pd`.
+    * instances: the first index column identifies the time-series instance.
+    * time index: the second index column identifies time points within each
+      instance.
+    * variables: all columns that are not index columns correspond to variables.
+    * variable names: variable names are taken from the non-index columns of
+      ``obj``.
+
+    Capabilities:
+
+    * can represent multivariate panels.
+    * can represent unequally spaced panels.
+    * can represent missing values.
+
     Parameters
     ----------
     is_univariate: bool


### PR DESCRIPTION
#### Reference Issues/PRs

Refs #7386.

#### What does this implement/fix? Explain your changes.

This PR expands the `PanelDask` mtype docstring in `sktime/datatypes/_panel/_check.py`.

It adds a structured description of:

- the `dask_panel` mtype name
- how panel instance and time indices are represented with `__index__*` columns
- how variables are represented by non-index columns
- the supported capabilities

This is one focused item under #7386.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the description matches the dask-to-pandas index-column convention.
- Whether the wording is consistent with nearby datatype docstrings.

#### Did you add any tests for the change?

No new tests. This is a documentation-only change.

Local checks run:

- `python -m compileall -q sktime\datatypes\_panel\_check.py`
- `git diff --check`

#### Any other comments?

I used AI assistance for documentation wording and repository navigation, and reviewed the change before submitting.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors (optional for first PR)
- [ ] Optionally, for added estimators: N/A
- [x] The PR title starts with [DOC]

##### For new estimators
- [ ] N/A