### PR TITLE
[DOC] Document SeriesGluontsPandas mtype

### DIFF
--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -1035,6 +1035,33 @@ class SeriesGluontsList(ScitypeSeries):
 class SeriesGluontsPandas(ScitypeSeries):
     """Data type: gluonts PandasDataset based specification of single time series.
 
+    Name: ``"gluonts_PandasDataset_series"``
+
+    Short description:
+    A ``gluonts.dataset.pandas.PandasDataset`` representation of a single
+    time series, backed by a pandas ``DataFrame``.
+
+    Long description:
+    The ``"gluonts_PandasDataset_series"`` :term:`mtype` is a concrete
+    specification of the ``Series`` :term:`scitype`, which represents a single
+    time series.
+
+    An object ``obj: gluonts.dataset.pandas.PandasDataset`` follows the
+    specification iff:
+
+    * structure convention: ``obj`` is a GluonTS ``PandasDataset`` containing
+      one pandas ``DataFrame`` data entry.
+    * time index: the pandas ``DataFrame`` index represents the time index.
+    * variables: columns of the pandas ``DataFrame`` correspond to variables.
+    * variable names: variable names are taken from the pandas ``DataFrame``
+      columns.
+
+    Capabilities:
+
+    * can represent univariate and multivariate series.
+    * can represent unequally spaced series.
+    * can represent missing values.
+
     Parameters
     ----------
     is_univariate: bool


### PR DESCRIPTION
#### Reference Issues/PRs

Refs #7386.

#### What does this implement/fix? Explain your changes.

This PR expands the `SeriesGluontsPandas` mtype docstring in `sktime/datatypes/_series/_check.py`.

It adds a structured description of:

- the `gluonts_PandasDataset_series` mtype name
- how the mtype is represented by a GluonTS `PandasDataset`
- how the backing pandas `DataFrame` maps time index and variables
- the supported capabilities

This is one focused item under #7386.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the description matches the current `PandasDataset` checker behavior.
- Whether the wording is consistent with nearby datatype docstrings.

#### Did you add any tests for the change?

No new tests. This is a documentation-only change.

Local checks run:

- `python -m compileall -q sktime\datatypes\_series\_check.py`
- `git diff --check`

#### Any other comments?

I used AI assistance for documentation wording and repository navigation, and reviewed the change before submitting.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors (optional for first PR)
- [ ] Optionally, for added estimators: N/A
- [x] The PR title starts with [DOC]

##### For new estimators
- [ ] N/A