### PR TITLE
[DOC] Document SeriesGluontsList mtype

### DIFF
--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -908,8 +908,8 @@ class SeriesGluontsList(ScitypeSeries):
     * target values: the ``"target"`` value is array-like and contains the
       observed values of the series.
     * variables: columns of the ``"target"`` array correspond to variables.
-    * variable names: feature names are generated as ``"value_0"``,
-      ``"value_1"``, ..., ``"value_n"``.
+    * variable names: feature names are assigned as ``"value_{k}"``,
+      where ``k`` is the feature column index.
     * time index: GluonTS represents timing through the start date and
       frequency metadata rather than an explicit index on each observation.
 

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -890,6 +890,35 @@ class SeriesPolarsEager(ScitypeSeries):
 class SeriesGluontsList(ScitypeSeries):
     """Data type: gluonts ListDataset based specification of single time series.
 
+    Name: ``"gluonts_ListDataset_series"``
+
+    Short description:
+    A GluonTS ``ListDataset``-style representation of a single time series,
+    stored as a list of dictionaries with a ``"target"`` entry.
+
+    Long description:
+    The ``"gluonts_ListDataset_series"`` :term:`mtype` is a concrete
+    specification of the ``Series`` :term:`scitype`, which represents a single
+    time series.
+
+    An object ``obj: list`` follows the specification iff:
+
+    * structure convention: ``obj`` is a list of dictionaries containing a
+      ``"target"`` key.
+    * target values: the ``"target"`` value is array-like and contains the
+      observed values of the series.
+    * variables: columns of the ``"target"`` array correspond to variables.
+    * variable names: feature names are generated as ``"value_0"``,
+      ``"value_1"``, ..., ``"value_n"``.
+    * time index: GluonTS represents timing through the start date and
+      frequency metadata rather than an explicit index on each observation.
+
+    Capabilities:
+
+    * can represent univariate and multivariate series.
+    * can represent equally spaced series.
+    * can represent missing values.
+
     Parameters
     ----------
     is_univariate: bool


### PR DESCRIPTION
#### Reference Issues/PRs

Refs #7386.

#### What does this implement/fix? Explain your changes.

This PR expands the `SeriesGluontsList` mtype docstring in `sktime/datatypes/_series/_check.py`.

It adds a structured description of:

- the `gluonts_ListDataset_series` mtype name
- how the mtype is represented as a GluonTS `ListDataset`-style list of dictionaries
- how the `target` entry maps observations and variables
- how feature names and time metadata are represented
- the supported capabilities

This is one focused item under #7386.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the description matches the current `ListDataset` checker behavior.
- Whether the wording is consistent with nearby datatype docstrings.

#### Did you add any tests for the change?

No new tests. This is a documentation-only change.

Local checks run:

- `python -m compileall -q sktime\datatypes\_series\_check.py`
- `git diff --check`

#### Any other comments?

I used AI assistance for documentation wording and repository navigation, and reviewed the change before submitting.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors (optional for first PR)
- [ ] Optionally, for added estimators: N/A
- [x] The PR title starts with [DOC]

##### For new estimators
- [ ] N/A