### PR TITLE
[BUG] fix return of `get_tag` if `tag_value_default` is not `None`

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -548,6 +548,12 @@ class TagAliaserMixin(_TagAliaserMixin):
         tag_val = super().get_class_tag(
             tag_name=tag_name, tag_value_default=tag_value_default
         )
+        # Fix: _get_class_flag uses dict.get(), which returns the stored
+        # None value instead of tag_value_default when a tag is explicitly
+        # set to None (e.g. "python_version": None in _tags).
+        # When a non-None default is provided, treat None as "not set".
+        if tag_val is None and tag_value_default is not None:
+            return tag_value_default
         return tag_val
 
     def get_tag(self, tag_name, tag_value_default=None, raise_error=True):
@@ -670,6 +676,12 @@ class TagAliaserMixin(_TagAliaserMixin):
             tag_value_default=tag_value_default,
             raise_error=raise_error,
         )
+        # Fix: _get_flag uses dict.get(), which returns the stored
+        # None value instead of tag_value_default when a tag is explicitly
+        # set to None (e.g. "python_version": None in _tags).
+        # When a non-None default is provided, treat None as "not set".
+        if tag_val is None and tag_value_default is not None:
+            return tag_value_default
         return tag_val
 
     def set_tags(self, **tag_dict):

--- a/sktime/base/tests/test_base_sktime.py
+++ b/sktime/base/tests/test_base_sktime.py
@@ -3,6 +3,10 @@
 
 __author__ = ["fkiraly"]
 
+import pytest
+
+from sktime.base._base import _BaseObject, BaseObject
+
 
 def test_get_fitted_params_sklearn():
     """Tests fitted parameter retrieval with sklearn components.
@@ -64,3 +68,71 @@ def test_clone_nested_sklearn():
 
     # failure condition, see issue #4704: the setting of the copy also sets the orig
     assert original_model.get_params()["estimator__random_state"] == 5
+
+
+class NoneTagTestClass(_BaseObject):
+    """Class for testing tag_value_default when tag is None."""
+
+    _tags = {
+        "none_tag": None,
+        "real_tag": "real_value",
+    }
+
+
+class NoneTagTestClass2(BaseObject):
+    """Class for testing tag_value_default when tag is None."""
+
+    _tags = {
+        "none_tag": None,
+        "real_tag": "real_value",
+    }
+
+
+@pytest.mark.parametrize("cls", [NoneTagTestClass, NoneTagTestClass2])
+def test_get_class_tag_default_when_none(cls):
+    """Test that tag_value_default is returned when tag value is None.
+
+    Regression test for #10305: get_class_tag returns None even if
+    tag_value_default is passed, when the tag is explicitly set to None
+    in _tags (e.g. "python_version": None).
+    """
+    # When tag is None and a non-None default is provided, return the default
+    result = cls.get_class_tag("none_tag", "fallback")
+    assert result == "fallback", f"Expected 'fallback', got {result!r}"
+
+    # When tag is None and no default is provided, return None
+    result = cls.get_class_tag("none_tag")
+    assert result is None, f"Expected None, got {result!r}"
+
+    # When tag has a real value, return that value even if default is provided
+    result = cls.get_class_tag("real_tag", "fallback")
+    assert result == "real_value", f"Expected 'real_value', got {result!r}"
+
+    # Non-existent tag with default returns the default
+    result = cls.get_class_tag("nonexistent", "fallback")
+    assert result == "fallback", f"Expected 'fallback', got {result!r}"
+
+    # Non-existent tag without default returns None
+    result = cls.get_class_tag("nonexistent")
+    assert result is None, f"Expected None, got {result!r}"
+
+
+@pytest.mark.parametrize("cls", [NoneTagTestClass, NoneTagTestClass2])
+def test_get_tag_default_when_none(cls):
+    """Test that tag_value_default is returned when tag value is None for get_tag.
+
+    Same regression as #10305 but for the instance-level get_tag method.
+    """
+    obj = cls()
+
+    # When tag is None and a non-None default is provided, return the default
+    result = obj.get_tag("none_tag", "fallback")
+    assert result == "fallback", f"Expected 'fallback', got {result!r}"
+
+    # When tag is None and no default is provided, return None
+    result = obj.get_tag("none_tag")
+    assert result is None, f"Expected None, got {result!r}"
+
+    # When tag has a real value, return that value even if default is provided
+    result = obj.get_tag("real_tag", "fallback")
+    assert result == "real_value", f"Expected 'real_value', got {result!r}"

--- a/sktime/base/tests/test_tagaliaser.py
+++ b/sktime/base/tests/test_tagaliaser.py
@@ -82,3 +82,60 @@ def test_tag_aliaser():
     assert all_tags_cls["old_tag_2"] == "new_tag_2_value"
     assert all_tags_cls["new_tag_3"] == "old_tag_3_value"
     assert all_tags_cls["old_tag_3"] == "old_tag_3_value"
+
+
+class NoneTagTestClass(_BaseObject):
+    """Class for testing tag_value_default when tag is None."""
+
+    _tags = {
+        "none_tag": None,
+        "real_tag": "real_value",
+    }
+
+
+def test_get_class_tag_default_when_none():
+    """Test that tag_value_default is returned when tag value is None.
+
+    Regression test for #10305: get_class_tag returns None even if
+    tag_value_default is passed, when the tag is explicitly set to None
+    in _tags (e.g. "python_version": None).
+    """
+    # When tag is None and a non-None default is provided, return the default
+    result = NoneTagTestClass.get_class_tag("none_tag", "fallback")
+    assert result == "fallback", f"Expected 'fallback', got {result!r}"
+
+    # When tag is None and no default is provided, return None
+    result = NoneTagTestClass.get_class_tag("none_tag")
+    assert result is None, f"Expected None, got {result!r}"
+
+    # When tag has a real value, return that value even if default is provided
+    result = NoneTagTestClass.get_class_tag("real_tag", "fallback")
+    assert result == "real_value", f"Expected 'real_value', got {result!r}"
+
+    # Non-existent tag with default returns the default
+    result = NoneTagTestClass.get_class_tag("nonexistent", "fallback")
+    assert result == "fallback", f"Expected 'fallback', got {result!r}"
+
+    # Non-existent tag without default returns None
+    result = NoneTagTestClass.get_class_tag("nonexistent")
+    assert result is None, f"Expected None, got {result!r}"
+
+
+def test_get_tag_default_when_none():
+    """Test that tag_value_default is returned when tag value is None for get_tag.
+
+    Same regression as #10305 but for the instance-level get_tag method.
+    """
+    obj = NoneTagTestClass()
+
+    # When tag is None and a non-None default is provided, return the default
+    result = obj.get_tag("none_tag", "fallback")
+    assert result == "fallback", f"Expected 'fallback', got {result!r}"
+
+    # When tag is None and no default is provided, return None
+    result = obj.get_tag("none_tag")
+    assert result is None, f"Expected None, got {result!r}"
+
+    # When tag has a real value, return that value even if default is provided
+    result = obj.get_tag("real_tag", "fallback")
+    assert result == "real_value", f"Expected 'real_value', got {result!r}"


### PR DESCRIPTION
## Description

Fixes #10305

`get_class_tag` and `get_tag` return `None` when a tag is explicitly set to `None` in `_tags` (e.g. `"python_version": None`), even when a non-None `tag_value_default` is provided.

### Root cause

`_get_class_flag` / `_get_flag` in `skbase` use `dict.get()`, which returns the stored `None` value instead of the default when the key exists with value `None`:

```python
# skbase _tagmanager.py
collected_flags = cls._get_class_flags(flag_attr_name=flag_attr_name)
return collected_flags.get(flag_name, flag_value_default)
# Returns None when flag_name exists with value None, ignoring flag_value_default
```

### Fix

In `TagAliaserMixin.get_class_tag` and `TagAliaserMixin.get_tag`, after calling `super()`, check if the result is `None` and a non-None default was provided. If so, return the default. This treats `None` as "not set" for the purpose of default value fallback.

### Reproducer

```python
from sktime.base import BaseObject

class MyObj(BaseObject):
    _tags = {"my_tag": None}

# Before fix: returns None
# After fix: returns "fallback"
print(MyObj.get_class_tag("my_tag", "fallback"))
```

### Tests

Added `test_get_class_tag_default_when_none` and `test_get_tag_default_when_none` in `sktime/base/tests/test_tagaliaser.py` covering:
- `None` tag with non-None default → returns default
- `None` tag without default → returns `None`
- Real value tag with default → returns real value
- Non-existent tag with default → returns default
- Non-existent tag without default → returns `None`