### PR TITLE
[DOC] add mentions of python 3.14 in missing documentation locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ sktime also provides **interfaces to related libraries**, for example [scikit-le
 For troubleshooting and detailed installation instructions, see the [documentation](https://www.sktime.net/en/latest/installation.html).
 
 - **Operating system**: macOS X · Linux · Windows 8.1 or higher
-- **Python version**: Python 3.10, 3.11, 3.12, and 3.13 (only 64-bit)
+- **Python version**: Python 3.10, 3.11, 3.12, 3.13, and 3.14 (only 64-bit)
 - **Package managers**: [pip] · [conda] (via `conda-forge`)
 
 [pip]: https://pip.pypa.io/en/stable/

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,7 @@ Installation
 
 ``sktime`` currently supports:
 
-* Python versions 3.10, 3.11, 3.12, and 3.13.
+* Python versions 3.10, 3.11, 3.12, 3.13, and 3.14.
 * Operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 
 See here for a `full list of precompiled wheels available on PyPI <https://pypi.org/simple/sktime/>`_.


### PR DESCRIPTION
Some parts of the documentation were missing mention of the compatibility with python 3.14 (present since late 2025).

This PR adds the mention of 3.14 compatibility to those places in the docs.