### PR TITLE
[ENH] Prevent dataset downloads in catalogue tests

### DIFF
--- a/sktime/catalogues/classification/dummy/_dummy_classification.py
+++ b/sktime/catalogues/classification/dummy/_dummy_classification.py
@@ -24,7 +24,6 @@ class DummyClassificationCatalogue(BaseCatalogue):
     def _get(self):
         """Return a dict of items (datasets, forecasters, metrics)."""
         datasets = [
-            "Beef",
             "ArrowHead",
         ]
 
@@ -35,7 +34,7 @@ class DummyClassificationCatalogue(BaseCatalogue):
         cv_splitters = [KFold(n_splits=3)]
 
         all_objects = {
-            "dataset": [f"UCRUEADataset('{dataset}')" for dataset in datasets],
+            "dataset": datasets,
             "classifier": classifiers,
             "metric": metrics,
             "cv_splitter": cv_splitters,

--- a/sktime/catalogues/forecasting/dummy/_dummy_forecasting.py
+++ b/sktime/catalogues/forecasting/dummy/_dummy_forecasting.py
@@ -21,8 +21,7 @@ class DummyForecastingCatalogue(BaseCatalogue):
     def _get(self):
         """Return a dict of items (datasets, forecasters, metrics)."""
         datasets = [
-            "cif_2016_dataset",
-            "hospital_dataset",
+            "Airline",
         ]
 
         forecasters = [{"NaiveForecaster": "NaiveForecaster(strategy='last')"}]
@@ -34,7 +33,7 @@ class DummyForecastingCatalogue(BaseCatalogue):
         ]
 
         all_objects = {
-            "dataset": [f"ForecastingData('{dataset}')" for dataset in datasets],
+            "dataset": datasets,
             "forecaster": forecasters,
             "metric": metrics,
             "cv_splitter": cv_splitters,

--- a/sktime/catalogues/tests/test_dummy_catalogues_benchmarking.py
+++ b/sktime/catalogues/tests/test_dummy_catalogues_benchmarking.py
@@ -29,8 +29,7 @@ def test_benchmarking_dummy_forecasting_catalogue(tmp_path):
     pd.testing.assert_series_equal(
         pd.Series(
             [
-                "[dataset=cif_2016_dataset]_[cv_splitter=ExpandingWindowSplitter]",
-                "[dataset=hospital_dataset]_[cv_splitter=ExpandingWindowSplitter]",
+                "[dataset=Airline]_[cv_splitter=ExpandingWindowSplitter]",
             ],
             name="validation_id",
         ),
@@ -55,7 +54,6 @@ def test_benchmarking_dummy_classification_catalogue(tmp_path):
     pd.testing.assert_series_equal(
         pd.Series(
             [
-                "[dataset=Beef]_[cv_splitter=KFold]",
                 "[dataset=ArrowHead]_[cv_splitter=KFold]",
             ],
             name="validation_id",


### PR DESCRIPTION
The dummy catalogues had datasets that were downloaded and those dummy catalogues were used in the tests testing benchmarking via catalogues directly. As a result those tests used to fail sporadically in the CI because of the rate limits from the dataset hosts.
I have fixed those tests here by using datasets that already come shipped with the package.