### PR TITLE
Fix exogenous X dimension mismatch in ARIMA interval prediction (#7849)

### DIFF
--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -226,6 +226,8 @@ class _PmdArimaAdapter(BaseForecaster):
         Returns series of predicted values.
         """
         n_periods = int(fh.to_relative(self.cutoff)[-1])
+        if X is not None:
+            X = X.iloc[:n_periods]
         result = self._forecaster.predict(
             n_periods=n_periods,
             X=X,

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -216,6 +216,13 @@ class _StatsModelsAdapter(BaseForecaster):
 
         start, end = fh.to_absolute_int(self._y_first_index, self.cutoff)[[0, -1]]
         fh_int = fh.to_absolute_int(self._y_first_index, self.cutoff) - self._y_len
+
+        if X is not None and self._X is not None:
+            ind_drop = self._X.index
+            X = X.loc[~X.index.isin(ind_drop)]
+            # Entire range of the forecast horizon is required
+            X = X.iloc[: (fh_int[-1] + 1)]  # include end point
+
         # if fh > 1 steps ahead of cutoff
         fh_int = fh_int - fh_int[0]
 
@@ -227,7 +234,10 @@ class _StatsModelsAdapter(BaseForecaster):
         if inspect.signature(self._fitted_forecaster.get_prediction).parameters.get(
             "exog"
         ):
-            get_prediction_arguments["exog"] = X
+            if self._X is None:
+                get_prediction_arguments["exog"] = None
+            else:
+                get_prediction_arguments["exog"] = X
 
         prediction_results = self._fitted_forecaster.get_prediction(
             **get_prediction_arguments

--- a/sktime/forecasting/tests/test_pmdarima.py
+++ b/sktime/forecasting/tests/test_pmdarima.py
@@ -20,3 +20,29 @@ def test_ARIMA_pred_quantiles_insample():
     forecaster = ARIMA(order=(1, 1, 0), seasonal_order=(0, 1, 0, 12))
     forecaster.fit(y)
     forecaster.predict_quantiles(fh=y.index, X=None, alpha=[0.05, 0.95])
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ARIMA),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_ARIMA_exogenous_probabilistic():
+    """Test ARIMA predict_interval and predict_quantiles with exogenous variables.
+
+    Failure condition of #7849.
+    """
+    import numpy as np
+    from sktime.datasets import load_longley
+    from sktime.split import temporal_train_test_split
+
+    y, X = load_longley()
+    y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
+    forecaster = ARIMA()
+    forecaster.fit(y_train, X=X_train)
+    # X_test has length 4, but fh has length 2.
+    # predict_interval and predict_quantiles should slice X_test to match fh size
+    fh = [1, 2]
+    forecaster.predict_interval(fh=fh, X=X_test, coverage=[0.90])
+    forecaster.predict_quantiles(fh=fh, X=X_test, alpha=[0.05, 0.95])
+
+

--- a/sktime/forecasting/tests/test_sarimax.py
+++ b/sktime/forecasting/tests/test_sarimax.py
@@ -139,3 +139,29 @@ def test_SARIMAX_update_with_exogenous_variables():
     # Verify that the forecaster state is correctly updated
     assert forecaster2.cutoff == y_test.index[-1]
     assert forecaster2._is_fitted
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SARIMAX),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_SARIMAX_exogenous_probabilistic():
+    """Test SARIMAX predict_interval and predict_quantiles with exogenous variables.
+
+    Failure condition of #7849.
+    """
+    import numpy as np
+    from sktime.datasets import load_longley
+    from sktime.split import temporal_train_test_split
+
+    y, X = load_longley()
+    y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
+    forecaster = SARIMAX()
+    forecaster.fit(y_train, X=X_train)
+    # X_test has length 4, but fh has length 2.
+    # predict_interval and predict_quantiles should slice X_test to match fh size
+    fh = [1, 2]
+    forecaster.predict_interval(fh=fh, X=X_test, coverage=[0.90])
+    forecaster.predict_quantiles(fh=fh, X=X_test, alpha=[0.05, 0.95])
+
+


### PR DESCRIPTION
Fixes #7849
When you use ARIMA or SARIMAX with exogenous features (X) and ask for probabilistic predictions (intervals, quantiles). For example inside a grid search or cross-validation, we get a ValueError like this:

**ValueError**: X array dims (n_rows) != n_periods. Received n_rows=5 and n_periods=2

or for statsmodels:
**ValueError**: Provided exogenous values are not of the appropriate shape. Required (2, 5), got (5, 5).

**What was happening**
When the evaluation splitter passes X_test to the forecaster during cross-validation, it gives the full test window which can be longer than the actual forecast horizon. Point forecasting already handled this correctly by slicing X down to the right length. But the probabilistic path (_predict_interval) was passing the full unsliced X straight to the underlying library, which then complained about the shape mismatch.

**What was changed**
_pmdarima.py: slice X to n_periods rows in _predict_fixed_cutoff before passing to pmdarima's predict
_statsmodels.py: same fix in _predict_interval, mirroring the slicing logic that already existed in _predict

**Tests added**
test_ARIMA_exogenous_probabilistic in test_pmdarima.py
test_SARIMAX_exogenous_probabilistic in test_sarimax.py

Both tests reproduce the original failure condition (X longer than fh) and confirm it no longer errors.