### PR TITLE
[DOC] Fix WDTW docstring typo

### DIFF
--- a/sktime/alignment/dtw_numba.py
+++ b/sktime/alignment/dtw_numba.py
@@ -14,7 +14,7 @@ class AlignerDtwNumba(BaseAligner):
     Interface to simple dynamic time warping (DTW) alignment,
     and the following weighted/derivative versions:
 
-    * WDTW - weighted dynamic tyme warping - ``weighted=True, derivative=False`
+    * WDTW - weighted dynamic time warping - ``weighted=True, derivative=False`
     * DDTW - derivative dynamic time warping - ``weighted=False, derivative=True``
     * WDDTW - weighted derivative dynamic time
       warping - ``weighted=True, derivative=True``

--- a/sktime/dists_kernels/dtw/_dtw_sktime.py
+++ b/sktime/dists_kernels/dtw/_dtw_sktime.py
@@ -15,7 +15,7 @@ class DtwDist(BasePairwiseTransformerPanel):
     Interface to simple dynamic time warping (DTW) distance,
     and the following weighted/derivative versions:
 
-    * WDTW - weighted dynamic tyme warping - ``weighted=True, derivative=False`
+    * WDTW - weighted dynamic time warping - ``weighted=True, derivative=False`
     * DDTW - derivative dynamic time warping - ``weighted=False, derivative=True``
     * WDDTW - weighted derivative dynamic time
       warping - ``weighted=True, derivative=True``


### PR DESCRIPTION
#### What does this implement/fix?

Fixes a typo in WDTW docstrings: `tyme` -> `time`.

#### Does your contribution introduce a new dependency?

No.

#### Did you add any tests?

No, documentation-only change.