### PR TITLE
[ENH] temporarily skip failing test for `BoxCoxBiasAdjustedForecaster`

### DIFF
--- a/sktime/forecasting/boxcox_bias_adjusted_forecaster.py
+++ b/sktime/forecasting/boxcox_bias_adjusted_forecaster.py
@@ -60,7 +60,8 @@ class BoxCoxBiasAdjustedForecaster(BaseForecaster):
         "capability:pred_int": True,
         # CI and test flags
         # -----------------
-        "tests:skip_by_name": ["test_update_with_exogenous_variables"],  # see 10301
+        "tests:skip_by_name": ["test_update_with_exogenous_variables"],
+        # sporadic scipy.optimize bracketing failures, bug report #10301
     }
 
     def __init__(self, forecaster, lambda_fixed=None):

--- a/sktime/forecasting/boxcox_bias_adjusted_forecaster.py
+++ b/sktime/forecasting/boxcox_bias_adjusted_forecaster.py
@@ -58,6 +58,9 @@ class BoxCoxBiasAdjustedForecaster(BaseForecaster):
         # estimator type
         # --------------
         "capability:pred_int": True,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_update_with_exogenous_variables"],  # see 10301
     }
 
     def __init__(self, forecaster, lambda_fixed=None):


### PR DESCRIPTION
Temporarily skips the failing test `test_update_with_exogenous_variables` for ``BoxCoxBiasAdjustedForecaster`, the bug is tracked in https://github.com/sktime/sktime/issues/10301.