### PR TITLE
[BUG] fix get_tag/get_class_tag ignoring tag_value_default when tag is None

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -548,7 +548,7 @@ class TagAliaserMixin(_TagAliaserMixin):
         tag_val = super().get_class_tag(
             tag_name=tag_name, tag_value_default=tag_value_default
         )
-        return tag_val
+        return tag_val if tag_val is not None else tag_value_default
 
     def get_tag(self, tag_name, tag_value_default=None, raise_error=True):
         """Get tag value from instance, with tag level inheritance and overrides.
@@ -670,7 +670,7 @@ class TagAliaserMixin(_TagAliaserMixin):
             tag_value_default=tag_value_default,
             raise_error=raise_error,
         )
-        return tag_val
+        return tag_val if tag_val is not None else tag_value_default
 
     def set_tags(self, **tag_dict):
         """Set instance level tag overrides to given values.

--- a/sktime/base/tests/test_tagaliaser.py
+++ b/sktime/base/tests/test_tagaliaser.py
@@ -82,3 +82,24 @@ def test_tag_aliaser():
     assert all_tags_cls["old_tag_2"] == "new_tag_2_value"
     assert all_tags_cls["new_tag_3"] == "old_tag_3_value"
     assert all_tags_cls["old_tag_3"] == "old_tag_3_value"
+
+
+class NoneTagTestClass(_BaseObject):
+    """Class for testing tag_value_default when tag value is None."""
+
+    _tags = {"none_tag": None, "real_tag": "real_value"}
+
+
+def test_get_class_tag_default_when_none():
+    """Regression test for #10305: tag_value_default ignored when tag is None."""
+    assert NoneTagTestClass.get_class_tag("none_tag", "fallback") == "fallback"
+    assert NoneTagTestClass.get_class_tag("none_tag") is None
+    assert NoneTagTestClass.get_class_tag("real_tag", "fallback") == "real_value"
+
+
+def test_get_tag_default_when_none():
+    """Regression test for #10305: tag_value_default ignored when tag is None."""
+    obj = NoneTagTestClass()
+    assert obj.get_tag("none_tag", "fallback") == "fallback"
+    assert obj.get_tag("none_tag") is None
+    assert obj.get_tag("real_tag", "fallback") == "real_value"


### PR DESCRIPTION
## Reference Issues/PRs: Fixes #10305

### What does this implement/fix?

get_tag and get_class_tag use dict.get(key, default) internally. When a tag is explicitly set to None in _tags (e.g. "python_version": None in the base class), the key exists in the dict, so .get() returns None and ignores tag_value_default entirely.

### Fixed by treating a stored None as "not set" and falling back to the default:
pythonreturn tag_val if tag_val is not None else tag_value_default
Two lines changed in sktime/base/_base.py.

### Did you add any tests?
Yes, added two regression tests in sktime/base/tests/test_tagaliaser.py covering get_class_tag and get_tag with a None tag value.
### Any other comments?
This is my first PR on this repo, though I've been exploring the codebase since January. Happy to receive any feedback or guidance if anything isn't following the contribution guidelines correctly