### PR TITLE
[DOC] Document dask Series data format

### DIFF
--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -742,6 +742,35 @@ class SeriesXarray(ScitypeSeries):
 class SeriesDask(ScitypeSeries):
     """Data type: dask.DataFrame based specification of single time series.
 
+    Name: ``"dask_series"``
+
+    Short description:
+
+    a uni- or multivariate ``dask.dataframe.DataFrame``,
+    with rows = time points, cols = variables
+
+    Long description:
+
+    The ``"dask_series"`` :term:`mtype` is a concrete specification
+    that implements the ``Series`` :term:`scitype`, i.e., the abstract
+    type of a single time series.
+
+    An object ``obj: dask.dataframe.DataFrame`` follows the specification iff:
+
+    * structure convention: ``obj.index`` must be monotonic increasing.
+      For compatibility with the dask/pandas adapter convention, ``obj`` may
+      have at most one column whose name starts with ``"__index__"``.
+    * variables: columns of ``obj`` correspond to different variables.
+    * variable names: column names ``obj.columns``.
+    * time points: rows of ``obj`` correspond to different, distinct time points.
+    * time index: ``obj.index`` is interpreted as the time index.
+
+    Capabilities:
+
+    * can represent multivariate series
+    * can represent unequally spaced series
+    * can represent missing values
+
     Parameters
     ----------
     is_univariate: bool


### PR DESCRIPTION
#### Reference Issues/PRs

Refs #7386.

#### What does this implement/fix? Explain your changes.

Documents the `SeriesDask` in-memory data format with the same structure used by the common Series mtypes, covering the mtype name, expected Dask DataFrame layout, time index convention, and supported capabilities.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Whether the dask/pandas adapter convention and capabilities are described accurately.

#### Did you add any tests for the change?

No new tests; documentation-only change. Verified with:

- `python -m pytest sktime/datatypes/tests/test_check.py -q -n 0`
- `python -m pytest sktime/datatypes/tests/test_lookup.py -q -n 0`
- `git diff --check`

#### Any other comments?

None.
