### PR TITLE
[ENH] add change conditional test skips to new tests in `detection` module

### DIFF
--- a/sktime/detection/tests/test_anomaly_detectors.py
+++ b/sktime/detection/tests/test_anomaly_detectors.py
@@ -10,6 +10,7 @@ from sktime.detection._capa import CAPA
 from sktime.detection._circular_binseg import CircularBinarySegmentation
 from sktime.detection._moving_window import MovingWindow
 from sktime.detection._stat_threshold_anomaliser import StatThresholdAnomaliser
+from sktime.tests.test_switch import run_test_module_changed
 
 SEGMENT_ANOMALY_DETECTORS = [
     CAPA,
@@ -33,6 +34,10 @@ def _make_anomaly_data(n=200, shift=15.0, seed=42):
     return X
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection"),
+    reason="Test only runs when detection module has changed",
+)
 @pytest.mark.parametrize("Detector", SEGMENT_ANOMALY_DETECTORS)
 def test_anomaly_detector_predict_returns_intervals(Detector):
     """All segment anomaly detectors should return DataFrame with Interval ilocs."""
@@ -47,6 +52,10 @@ def test_anomaly_detector_predict_returns_intervals(Detector):
         assert hasattr(result["ilocs"].iloc[0], "right")
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection"),
+    reason="Test only runs when detection module has changed",
+)
 @pytest.mark.parametrize("Detector", TRANSFORM_TESTABLE_DETECTORS)
 def test_anomaly_detector_transform_returns_dense(Detector):
     """All segment anomaly detectors' transform should return dense labels."""
@@ -59,6 +68,10 @@ def test_anomaly_detector_transform_returns_dense(Detector):
     assert len(labels) == len(X)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection"),
+    reason="Test only runs when detection module has changed",
+)
 def test_stat_threshold_anomaliser_stat_lower_above_upper():
     """Test StatThresholdAnomaliser rejects stat_lower > stat_upper."""
     with pytest.raises(ValueError, match="must be less than or equal to stat_upper"):

--- a/sktime/detection/tests/test_capa.py
+++ b/sktime/detection/tests/test_capa.py
@@ -11,6 +11,7 @@ from sktime.detection._capa import CAPA
 from sktime.detection._change_scores._from_cost import ChangeScore
 from sktime.detection._compose import PenalisedScore
 from sktime.detection._costs import L1Cost, L2Cost, MultivariateGaussianCost
+from sktime.tests.test_switch import run_test_module_changed
 
 
 def _make_anomaly_data(
@@ -23,6 +24,10 @@ def _make_anomaly_data(
     return X
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection"),
+    reason="Test only runs when detection module has changed",
+)
 class TestCAPADetection:
     """Tests for CAPA anomaly detection quality."""
 
@@ -123,6 +128,10 @@ class TestCAPADetection:
         assert len(result) == 0
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection"),
+    reason="Test only runs when detection module has changed",
+)
 class TestCAPAValidation:
     """Tests for CAPA parameter and input validation."""
 

--- a/sktime/detection/tests/test_circular_binseg.py
+++ b/sktime/detection/tests/test_circular_binseg.py
@@ -9,6 +9,7 @@ import pytest
 from sktime.detection._change_scores._from_cost import ChangeScore
 from sktime.detection._circular_binseg import CircularBinarySegmentation
 from sktime.detection._costs import L2Cost
+from sktime.tests.test_switch import run_test_module_changed
 
 
 def _make_anomaly_data(
@@ -21,18 +22,30 @@ def _make_anomaly_data(
     return X
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection"),
+    reason="Test only runs when detection module has changed",
+)
 def test_cbs_invalid_score_string():
     """Test CBS rejects a string as anomaly_score."""
     with pytest.raises(ValueError, match="anomaly_score"):
         CircularBinarySegmentation("l2")
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection"),
+    reason="Test only runs when detection module has changed",
+)
 def test_cbs_invalid_score_change_score():
     """Test CBS rejects a ChangeScore as anomaly_score."""
     with pytest.raises(ValueError, match="anomaly_score"):
         CircularBinarySegmentation(ChangeScore(L2Cost()))
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection"),
+    reason="Test only runs when detection module has changed",
+)
 def test_cbs_detects_anomaly():
     """Test CBS detects a clear segment anomaly."""
     X = _make_anomaly_data(n=100, anomaly_start=30, anomaly_end=50, shift=20.0)
@@ -45,6 +58,10 @@ def test_cbs_detects_anomaly():
     assert found
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection"),
+    reason="Test only runs when detection module has changed",
+)
 def test_cbs_multiple_anomalies():
     """Test CBS detects multiple non-overlapping anomalies."""
     rng = np.random.default_rng(42)
@@ -59,6 +76,10 @@ def test_cbs_multiple_anomalies():
     assert all(hasattr(a, "left") for a in anomalies)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection"),
+    reason="Test only runs when detection module has changed",
+)
 def test_cbs_empty_result():
     """Test CBS with very high penalty produces no anomalies."""
     rng = np.random.default_rng(42)


### PR DESCRIPTION
Adds change conditional test skips to new tests in `detection` module, so that recently added tests in the `detection` module are only run in CI on change of the `detection` module..