### PR TITLE
[BUG] raise ValueError for invalid y in _BaseGlobalForecaster (#10200)

### DIFF
--- a/sktime/forecasting/base/_deprecation_global.py
+++ b/sktime/forecasting/base/_deprecation_global.py
@@ -420,7 +420,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
 
         # handle inputs
         self.check_is_fitted()
@@ -565,7 +565,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
 
         self.check_is_fitted()
         if y is None:
@@ -697,7 +697,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
 
         self.check_is_fitted()
         if y is None:
@@ -825,7 +825,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
         self.check_is_fitted()
         if y is None:
             self._global_forecasting = False
@@ -934,7 +934,7 @@ class _BaseGlobalForecaster(BaseForecaster):
             "capability:global_forecasting", tag_value_default=False, raise_error=False
         )
         if not gf and y is not None:
-            ValueError("no global forecasting support!")
+            raise ValueError("no global forecasting support!")
 
         self.check_is_fitted()
         if y is None:

--- a/sktime/forecasting/base/tests/test_base_bugs.py
+++ b/sktime/forecasting/base/tests/test_base_bugs.py
@@ -79,3 +79,46 @@ def test_predict_residuals_conversion():
     result = pipe.predict_residuals()
 
     assert type(result) is type(y_train)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.forecasting.base"),
+    reason="run only if base module has changed",
+)
+def test_base_global_forecaster_rejects_y_without_capability():
+    """Regression test for bugfix #10200.
+
+    ``_BaseGlobalForecaster`` constructed a ``ValueError("no global forecasting
+    support!")`` without ``raise`` in ``predict``, ``predict_quantiles``,
+    ``predict_interval``, ``predict_var`` and ``predict_proba``. Passing ``y`` to
+    a forecaster lacking global forecasting capability therefore silently passed
+    through instead of erroring. All five methods must now raise ``ValueError``.
+    """
+    import pandas as pd
+
+    from sktime.forecasting.base._deprecation_global import _BaseGlobalForecaster
+
+    class _NonGlobalForecaster(_BaseGlobalForecaster):
+        # capability:global_forecasting is left at its default of False;
+        # capability:pred_int is enabled so the probabilistic predict methods
+        # reach the y-rejection check rather than their own capability guard.
+        _tags = {"capability:pred_int": True}
+
+        def _fit(self, y, X, fh):
+            return self
+
+        def _predict(self, fh, X=None):
+            return pd.Series([0.0])
+
+    forecaster = _NonGlobalForecaster()
+    y = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+
+    for method in [
+        "predict",
+        "predict_quantiles",
+        "predict_interval",
+        "predict_var",
+        "predict_proba",
+    ]:
+        with pytest.raises(ValueError, match="no global forecasting support"):
+            getattr(forecaster, method)(fh=[1], y=y)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10200.

#### What does this implement/fix? Explain your changes.

`_BaseGlobalForecaster` constructed `ValueError("no global forecasting support!")` as a bare expression (without `raise`) in five predict-family methods — `predict`, `predict_quantiles`, `predict_interval`, `predict_var` and `predict_proba` (lines 423, 568, 700, 828, 937). As a result, passing `y` to a forecaster whose `capability:global_forecasting` tag is `False` was silently ignored instead of erroring, and execution continued with potentially incorrect behaviour.

This PR adds the missing `raise` at all five call sites, and adds a regression test (`test_base_global_forecaster_rejects_y_without_capability`) asserting that each of the five methods raises `ValueError` when `y` is supplied to a non-global forecaster.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their time on?

- Confirming that these sites should `raise` (rather than warn) — the issue and the method contracts indicate raising is intended.
- Behaviour for genuine global forecasters (`capability:global_forecasting=True`) is unchanged: they skip this guard entirely.

#### Any other comments?

Verified locally: the new test passes with the fix and fails without it; `sktime/forecasting/compose/tests/test_reduce_global.py` (17 tests) and `sktime/forecasting/base/tests/test_base_bugs.py` continue to pass, so the added raises do not regress existing global-forecasting behaviour.

#### PR checklist

- [x] Added a regression test for the fix.
- [x] Linked the issue this PR fixes.
