### PR TITLE
[ENH] FalconTST forecasting foundation model

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -601,6 +601,14 @@ Pre-trained and foundation models
 
     Chronos2Forecaster
 
+.. currentmodule:: sktime.forecasting.falcon_tst
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    FalconTSTForecaster
+
 .. currentmodule:: sktime.forecasting.hf_transformers
 
 .. autosummary::

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -145,7 +145,6 @@ class FalconTSTForecaster(BaseForecaster):
         # Hongjie Xia (Harryx2019), Yiding Liu (figolyd) for ant-intl/Falcon-TST
         "maintainers": ["geetu040"],
         "python_dependencies": ["transformers[torch]>=4.23.0,<5.0.0"],
-        "tests:vm": True,
     }
 
     def __init__(

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -144,7 +144,7 @@ class FalconTSTForecaster(BaseForecaster):
         "authors": ["Harryx2019", "figolyd", "geetu040"],
         # Hongjie Xia (Harryx2019), Yiding Liu (figolyd) for ant-intl/Falcon-TST
         "maintainers": ["geetu040"],
-        "python_dependencies": ["transformers[torch]>=4.40,<4.41"],
+        "python_dependencies": ["transformers[torch]>=4.23.0,<5.0.0"],
         "tests:vm": True,
     }
 

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -144,7 +144,7 @@ class FalconTSTForecaster(BaseForecaster):
         "authors": ["Harryx2019", "figolyd", "geetu040"],
         # Hongjie Xia (Harryx2019), Yiding Liu (figolyd) for ant-intl/Falcon-TST
         "maintainers": ["geetu040"],
-        "python_dependencies": ["torch", "transformers", "einops"],
+        "python_dependencies": ["transformers[torch]>=4.40,<4.41"],
         "tests:vm": True,
     }
 

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -5,6 +5,12 @@ __author__ = ["geetu040"]
 
 __all__ = ["FalconTSTForecaster"]
 
+from copy import deepcopy
+from warnings import warn
+
+import numpy as np
+import pandas as pd
+
 from sktime.forecasting.base import BaseForecaster
 
 
@@ -45,8 +51,101 @@ class FalconTSTForecaster(BaseForecaster):
 
     def _fit(self, y, X=None, fh=None):
         """Fit forecaster to training data."""
-        raise NotImplementedError
+        self.model_ = self._load_model()
+        self.context_ = y
+
+        return self
 
     def _predict(self, fh, X):
         """Forecast time series at future horizon."""
-        raise NotImplementedError
+        import torch
+
+        self.model_ = self._load_model()
+
+        if fh is None:
+            fh = self.fh
+        fh = fh.to_relative(self.cutoff)
+        preds_idx = fh._values.values - 1
+        forecast_horizon = np.max(preds_idx) + 1
+
+        past_values = self.context_.to_numpy()
+        is_univariate = past_values.shape[1] == 1
+        if is_univariate:
+            past_values = past_values[:, 0]
+
+        past_values = np.expand_dims(past_values, axis=0)
+        past_values = torch.from_numpy(past_values)
+        past_values = past_values.to(self.model_.dtype)
+        past_values = past_values.to(self.model_.device)
+
+        output = self.model_.predict(
+            past_values,
+            forecast_horizon=forecast_horizon,
+            revin=self.revin,
+        )
+        preds = output.detach().float().cpu().numpy()
+
+        index = fh.to_absolute(self._cutoff)._values
+        if is_univariate:
+            preds = preds.squeeze(axis=0)
+            preds = preds[preds_idx]
+            name = self.context_.columns[0]
+            return pd.Series(preds, index=index, name=name)
+
+        preds = preds.squeeze(axis=0)
+        preds = preds[preds_idx, :]
+        return pd.DataFrame(preds, index=index, columns=self.context_.columns)
+
+    def _load_model(self):
+        """Load a Falcon-TST model instance."""
+        if hasattr(self, "model_") and self.model_ is not None:
+            return self.model_
+
+        if self.model_path is not None:
+            self.model_ = self._load_model_from_path()
+        else:
+            self.model_ = self._load_model_from_config()
+
+        return self.model_
+
+    def _load_model_from_path(self):
+        """Load pretrained Falcon-TST weights from ``self.model_path``."""
+        from sktime.libs.falcon_tst import FalconTSTForPrediction
+
+        model_kwargs = {
+            "device_map": self.device_map,
+            "quantization_config": self.quantization_config,
+        }
+        if self.dtype is not None:
+            model_kwargs["torch_dtype"] = self.dtype
+
+        return FalconTSTForPrediction.from_pretrained(
+            self.model_path,
+            **model_kwargs,
+        )
+
+    def _load_model_from_config(self):
+        """Initialize a Falcon-TST model from config without pretrained weights."""
+        from sktime.libs.falcon_tst import FalconTSTConfig, FalconTSTForPrediction
+
+        warn(
+            "Initializing Falcon-TST from config creates random weights. "
+            "Falcon-TST training is not supported by this estimator, so these "
+            "weights will stay random and are only suitable for tests or local "
+            "experimentation.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+        config = deepcopy(self.config)
+        if not config:
+            config = FalconTSTConfig()
+        if isinstance(config, dict):
+            config = FalconTSTConfig.from_dict(config)
+
+        model = FalconTSTForPrediction(config)
+        model = model.to(self.device_map)
+        if self.dtype is not None:
+            model = model.to(dtype=self.dtype)
+
+        return model

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -262,7 +262,7 @@ class FalconTSTForecaster(BaseForecaster):
         if is_univariate:
             preds = preds.squeeze(axis=0)
             preds = preds[preds_idx]
-            name = self.context_.columns[0]
+            name = self._converter_store_y.get("name", self.context_.columns[0])
             return pd.Series(preds, index=index, name=name)
 
         preds = preds.squeeze(axis=0)

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -145,6 +145,7 @@ class FalconTSTForecaster(BaseForecaster):
         # Hongjie Xia (Harryx2019), Yiding Liu (figolyd) for ant-intl/Falcon-TST
         "maintainers": ["geetu040"],
         "python_dependencies": ["transformers[torch]>=4.23.0,<5.0.0"],
+        "tests:vm": True,
     }
 
     def __init__(

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -1,0 +1,52 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Falcon-TST forecaster for ``sktime``."""
+
+__author__ = ["geetu040"]
+
+__all__ = ["FalconTSTForecaster"]
+
+from sktime.forecasting.base import BaseForecaster
+
+
+class FalconTSTForecaster(BaseForecaster):
+    """Falcon-TST forecaster via Hugging Face ``transformers``."""
+
+    _tags = {
+        "y_inner_mtype": "pd.DataFrame",
+        "capability:multivariate": True,
+        "capability:exogenous": False,
+        "requires-fh-in-fit": False,
+        "capability:insample": False,
+        "capability:pred_int": False,
+        "capability:pretrain": False,
+        "authors": ["geetu040"],
+        "maintainers": ["geetu040"],
+        "python_dependencies": ["torch", "transformers", "einops"],
+        "tests:vm": True,
+    }
+
+    def __init__(
+        self,
+        model_path="ant-intl/Falcon-TST_Large",
+        config=None,
+        device_map="cpu",
+        dtype=None,
+        quantization_config=None,
+        revin=True,
+    ):
+        self.model_path = model_path
+        self.config = config
+        self.device_map = device_map
+        self.dtype = dtype
+        self.quantization_config = quantization_config
+        self.revin = revin
+
+        super().__init__()
+
+    def _fit(self, y, X=None, fh=None):
+        """Fit forecaster to training data."""
+        raise NotImplementedError
+
+    def _predict(self, fh, X):
+        """Forecast time series at future horizon."""
+        raise NotImplementedError

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster
+from sktime.utils.singleton import _multiton
 
 
 class FalconTSTForecaster(BaseForecaster):
@@ -101,14 +102,63 @@ class FalconTSTForecaster(BaseForecaster):
         if hasattr(self, "model_") and self.model_ is not None:
             return self.model_
 
-        if self.model_path is not None:
-            self.model_ = self._load_model_from_path()
-        else:
-            self.model_ = self._load_model_from_config()
+        self.model_ = _CachedFalconTST(
+            key=self._get_unique_key(),
+            model_path=self.model_path,
+            config=self.config,
+            device_map=self.device_map,
+            dtype=self.dtype,
+            quantization_config=self.quantization_config,
+        ).load()
 
         return self.model_
 
-    def _load_model_from_path(self):
+    def _get_unique_key(self):
+        """Build cache key for the multiton model loader."""
+        key = {
+            "model_path": self.model_path,
+            "config": self.config,
+            "device_map": self.device_map,
+            "dtype": self.dtype,
+            "quantization_config": self.quantization_config,
+        }
+        return str(sorted(key.items()))
+
+
+@_multiton
+class _CachedFalconTST:
+    """Multiton-backed cache wrapper for a loaded Falcon-TST model."""
+
+    def __init__(
+        self,
+        key,
+        model_path,
+        config,
+        device_map,
+        dtype,
+        quantization_config,
+    ):
+        self.key = key
+        self.model_path = model_path
+        self.config = config
+        self.device_map = device_map
+        self.dtype = dtype
+        self.quantization_config = quantization_config
+        self.model_ = None
+
+    def load(self):
+        """Load model if needed and return cached instance."""
+        if self.model_ is not None:
+            return self.model_
+
+        if self.model_path is not None:
+            self.model_ = self._load_from_path()
+        else:
+            self.model_ = self._load_randomly()
+
+        return self.model_
+
+    def _load_from_path(self):
         """Load pretrained Falcon-TST weights from ``self.model_path``."""
         from sktime.libs.falcon_tst import FalconTSTForPrediction
 
@@ -124,7 +174,7 @@ class FalconTSTForecaster(BaseForecaster):
             **model_kwargs,
         )
 
-    def _load_model_from_config(self):
+    def _load_randomly(self):
         """Initialize a Falcon-TST model from config without pretrained weights."""
         from sktime.libs.falcon_tst import FalconTSTConfig, FalconTSTForPrediction
 
@@ -146,6 +196,19 @@ class FalconTSTForecaster(BaseForecaster):
         model = FalconTSTForPrediction(config)
         model = model.to(self.device_map)
         if self.dtype is not None:
-            model = model.to(dtype=self.dtype)
+            dtype = _coerce_torch_dtype(self.dtype)
+            if dtype is not None:
+                model = model.to(dtype=dtype)
 
         return model
+
+
+def _coerce_torch_dtype(dtype):
+    """Coerce string dtype names to ``torch.dtype`` for local initialization."""
+    if dtype == "auto":
+        return None
+    if isinstance(dtype, str):
+        import torch
+
+        return getattr(torch, dtype)
+    return dtype

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -1,7 +1,17 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Falcon-TST forecaster for ``sktime``."""
+"""Falcon-TST forecaster for ``sktime``.
 
-__author__ = ["geetu040"]
+This module provides an ``sktime`` forecaster wrapping the local Falcon-TST
+``transformers`` model implementation. It supports:
+
+- zero-shot prediction through :meth:`fit` + :meth:`predict`
+- univariate and multivariate target forecasting
+
+Model training and fine-tuning are not supported. Calling :meth:`fit` only
+loads the model and stores the observed series as forecasting context.
+"""
+
+__author__ = ["figolyd", "geetu040"]
 
 __all__ = ["FalconTSTForecaster"]
 
@@ -20,36 +30,50 @@ class FalconTSTForecaster(BaseForecaster):
 
     This forecaster wraps Falcon-TST prediction models [1]_, [2]_ from Hugging
     Face and exposes them through the ``sktime`` forecasting interface.
-    ``fit`` loads the model and stores the observed series as forecasting
-    context; it does not train or fine-tune Falcon-TST weights.
+
+    The primary workflow is ``fit`` for zero-shot inference setup, which loads
+    the model and stores history. It does not train or fine-tune model weights.
+    Passing ``model_path=None`` initializes a Falcon-TST model from ``config``
+    instead of loading pretrained weights. These random weights cannot be
+    trained through this estimator and are mainly useful for tests or local
+    experimentation.
+
+    Notes
+    -----
+    - Falcon-TST training is not supported. The estimator performs only
+      zero-shot forecasting from a loaded or randomly initialized model.
+    - Falcon-TST supports multivariate targets, handled as independent
+      channels by the model.
+    - Exogenous data and quantile prediction are not supported.
+    - Loaded models are cached via a multiton helper keyed by model-loading
+      inputs to avoid repeated model instantiation.
+    - For reduced-memory loading, use ``dtype`` and ``quantization_config``,
+      or a pre-quantized checkpoint.
 
     Parameters
     ----------
     model_path : str, default="ant-intl/Falcon-TST_Large"
         Hugging Face repository identifier or local path to a Falcon-TST
-        checkpoint. If ``None``, a model is created from ``config`` with random
-        weights.
+        checkpoint. If ``None``, a model is created from ``config``.
     config : FalconTSTConfig or dict, optional (default=None)
         Model configuration used when ``model_path=None``. If provided as a
-        ``dict``, it is converted with ``FalconTSTConfig.from_dict``.
+        ``dict``, it is converted with ``FalconTSTConfig.from_dict``. If
+        ``None`` and ``model_path=None``, the default ``FalconTSTConfig`` is
+        used. This path creates random weights; the estimator does not provide
+        training for those weights.
     device_map : str, dict, int, or torch.device, default="cpu"
-        Device placement used for model loading or local initialization.
+        Device placement following the ``transformers`` ``device_map`` naming
+        convention, for example ``"cpu"``, ``"cuda"``, ``"cuda:0"``, or
+        ``"auto"``.
     dtype : torch.dtype or str, optional (default=None)
-        Data type used for model loading, for example ``torch.float16``,
+        Data type used for model loading, following the ``transformers``
+        ``dtype`` convention, for example ``torch.float16``,
         ``torch.bfloat16``, or ``"auto"``.
     quantization_config : transformers.quantizers.HfQuantizer, optional
-        Quantization configuration compatible with
-        ``transformers.PreTrainedModel.from_pretrained``.
+        Valid quantization configuration object compatible with
+        ``transformers.PreTrainedModel.from_pretrained`` [3]_.
     revin : bool, default=True
         Whether to use RevIN normalization during Falcon-TST prediction.
-
-    Notes
-    -----
-    - Falcon-TST training and fine-tuning are not supported by this estimator.
-    - Falcon-TST supports multivariate targets, handled as channels.
-    - Exogenous data and quantile prediction are not supported.
-    - Loaded models are cached by model-loading inputs to avoid repeated model
-      instantiation.
 
     References
     ----------
@@ -57,34 +81,71 @@ class FalconTSTForecaster(BaseForecaster):
        https://github.com/AntGroup/Falcon-TST
     .. [2] Falcon-TST model card:
        https://huggingface.co/ant-intl/Falcon-TST_Large
+    .. [3] Quantization docs:
+       https://huggingface.co/docs/transformers/en/main_classes/quantization
 
     Examples
     --------
-    Univariate zero-shot forecasting:
+    Simple zero-shot forecasting with the default Falcon-TST checkpoint:
 
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.falcon_tst import FalconTSTForecaster
     >>> y = load_airline()
+    >>> # By default, loads ant-intl/Falcon-TST_Large.
     >>> forecaster = FalconTSTForecaster()  # doctest: +SKIP
     >>> forecaster.fit(y)  # doctest: +SKIP
     >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
 
-    Multivariate zero-shot forecasting:
+    Multivariate zero-shot forecasting with RevIN disabled:
 
+    >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.falcon_tst import FalconTSTForecaster
-    >>> y = y.to_frame("a").assign(b=lambda x: x["a"])  # doctest: +SKIP
+    >>> y_uni = load_airline()  # doctest: +SKIP
+    >>> y = y_uni.to_frame("a").assign(b=lambda x: x["a"])  # doctest: +SKIP
     >>> forecaster = FalconTSTForecaster(revin=False)  # doctest: +SKIP
     >>> forecaster.fit(y)  # doctest: +SKIP
     >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
 
-    Quantized loading:
+    Reduced-memory inference with device placement, dtype, and quantization:
 
     >>> import torch  # doctest: +SKIP
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.falcon_tst import FalconTSTForecaster
     >>> from transformers import BitsAndBytesConfig  # doctest: +SKIP
+    >>> y = load_airline()
     >>> forecaster = FalconTSTForecaster(  # doctest: +SKIP
+    ...     model_path="ant-intl/Falcon-TST_Large",
     ...     device_map="auto",
     ...     dtype=torch.bfloat16,
     ...     quantization_config=BitsAndBytesConfig(load_in_8bit=True),
+    ... )
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
+
+    Randomly initialized local model, useful for tests or local experimentation.
+    This model is not trained by ``fit``; the weights stay random and should not
+    be used as a trained forecaster:
+
+    >>> from sktime.forecasting.falcon_tst import FalconTSTForecaster
+    >>> forecaster = FalconTSTForecaster(  # doctest: +SKIP
+    ...     model_path=None,
+    ...     config={
+    ...         "num_hidden_layers": 1,
+    ...         "hidden_size": 4,
+    ...         "ffn_hidden_size": 8,
+    ...         "num_attention_heads": 1,
+    ...         "seq_length": 8,
+    ...         "shared_patch_size": 2,
+    ...         "patch_size_list": [4],
+    ...         "expert_num_layers": 1,
+    ...         "multi_forecast_head_list": [2],
+    ...         "autoregressive_step_list": [1],
+    ...         "num_experts": 1,
+    ...         "moe_router_topk": 1,
+    ...         "moe_ffn_hidden_size": 8,
+    ...         "moe_shared_expert_intermediate_size": 8,
+    ...         "use_cpu_initialization": True,
+    ...     },
     ... )
     """
 
@@ -96,7 +157,7 @@ class FalconTSTForecaster(BaseForecaster):
         "capability:insample": False,
         "capability:pred_int": False,
         "capability:pretrain": False,
-        "authors": ["geetu040"],
+        "authors": ["figolyd", "geetu040"],
         "maintainers": ["geetu040"],
         "python_dependencies": ["torch", "transformers", "einops"],
         "tests:vm": True,

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -242,10 +242,6 @@ class FalconTSTForecaster(BaseForecaster):
         forecast_horizon = np.max(preds_idx) + 1
 
         past_values = self.context_.to_numpy()
-        is_univariate = past_values.shape[1] == 1
-        if is_univariate:
-            past_values = past_values[:, 0]
-
         past_values = np.expand_dims(past_values, axis=0)
         past_values = torch.from_numpy(past_values)
         past_values = past_values.to(self.model_.dtype)
@@ -256,18 +252,17 @@ class FalconTSTForecaster(BaseForecaster):
             forecast_horizon=forecast_horizon,
             revin=self.revin,
         )
+
         preds = output.detach().float().cpu().numpy()
-
-        index = fh.to_absolute(self._cutoff)._values
-        if is_univariate:
-            preds = preds.squeeze(axis=0)
-            preds = preds[preds_idx]
-            name = self._converter_store_y.get("name", self.context_.columns[0])
-            return pd.Series(preds, index=index, name=name)
-
         preds = preds.squeeze(axis=0)
         preds = preds[preds_idx, :]
-        return pd.DataFrame(preds, index=index, columns=self.context_.columns)
+        preds = pd.DataFrame(
+            preds,
+            index=fh.to_absolute(self._cutoff)._values,
+            columns=self.context_.columns,
+        )
+
+        return preds
 
     def _load_model(self):
         """Load or retrieve a cached Falcon-TST model instance.

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -425,9 +425,9 @@ class _CachedFalconTST:
 
         kwargs = {}
         if self.device_map is not None:
-            kwargs["device_map"]: self.device_map
+            kwargs["device_map"] = self.device_map
         if self.quantization_config is not None:
-            kwargs["quantization_config"]: self.quantization_config
+            kwargs["quantization_config"] = self.quantization_config
 
         model = FalconTSTForPrediction.from_pretrained(self.model_path, **kwargs)
 

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -424,11 +424,13 @@ class _CachedFalconTST:
         """Load Falcon-TST model weights from ``self.model_path``."""
         from sktime.libs.falcon_tst import FalconTSTForPrediction
 
-        model = FalconTSTForPrediction.from_pretrained(
-            self.model_path,
-            device_map=self.device_map,
-            quantization_config=self.quantization_config,
-        )
+        kwargs = {}
+        if self.device_map is not None:
+            kwargs["device_map"]: self.device_map
+        if self.quantization_config is not None:
+            kwargs["quantization_config"]: self.quantization_config
+
+        model = FalconTSTForPrediction.from_pretrained(self.model_path, **kwargs)
 
         return model
 

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -11,7 +11,8 @@ Model training and fine-tuning are not supported. Calling :meth:`fit` only
 loads the model and stores the observed series as forecasting context.
 """
 
-__author__ = ["figolyd", "geetu040"]
+__author__ = ["Harryx2019", "figolyd", "geetu040"]
+# Hongjie Xia (Harryx2019), Yiding Liu (figolyd) for ant-intl/Falcon-TST
 
 __all__ = ["FalconTSTForecaster"]
 
@@ -142,7 +143,8 @@ class FalconTSTForecaster(BaseForecaster):
         "capability:insample": False,
         "capability:pred_int": False,
         "capability:pretrain": False,
-        "authors": ["figolyd", "geetu040"],
+        "authors": ["Harryx2019", "figolyd", "geetu040"],
+        # Hongjie Xia (Harryx2019), Yiding Liu (figolyd) for ant-intl/Falcon-TST
         "maintainers": ["geetu040"],
         "python_dependencies": ["torch", "transformers", "einops"],
         "tests:vm": True,

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -127,6 +127,7 @@ class FalconTSTForecaster(BaseForecaster):
     ...         "seq_length": 8,
     ...         "shared_patch_size": 2,
     ...         "patch_size_list": [4],
+    ...         "transformer_input_layernorm": True,
     ...         "expert_num_layers": 1,
     ...         "multi_forecast_head_list": [2],
     ...         "autoregressive_step_list": [1],
@@ -347,6 +348,7 @@ class FalconTSTForecaster(BaseForecaster):
             "seq_length": 8,
             "shared_patch_size": 2,
             "patch_size_list": [4],
+            "transformer_input_layernorm": True,
             "expert_num_layers": 1,
             "multi_forecast_head_list": [2],
             "autoregressive_step_list": [1],
@@ -445,9 +447,13 @@ class _CachedFalconTST:
         model = FalconTSTForPrediction.from_pretrained(
             self.model_path,
             device_map=self.device_map,
-            dtype=self.dtype,
+            torch_dtype=self.dtype,
             quantization_config=self.quantization_config,
         )
+        if self.dtype is not None and self.quantization_config is None:
+            dtype = _coerce_torch_dtype(self.dtype)
+            if dtype is not None:
+                model = model.to(dtype=dtype)
 
         return model
 
@@ -473,6 +479,20 @@ class _CachedFalconTST:
         model = FalconTSTForPrediction(config)
         model = model.to(self.device_map)
         if self.dtype is not None:
-            model = model.to(dtype=self.dtype)
+            dtype = _coerce_torch_dtype(self.dtype)
+            if dtype is not None:
+                model = model.to(dtype=dtype)
 
         return model
+
+
+def _coerce_torch_dtype(dtype):
+    """Coerce string dtype names to ``torch.dtype`` for local initialization."""
+    if dtype == "auto":
+        return None
+    if isinstance(dtype, str):
+        import torch
+
+        dtype = dtype.removeprefix("torch.")
+        return getattr(torch, dtype)
+    return dtype

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -442,16 +442,11 @@ class _CachedFalconTST:
         """Load Falcon-TST model weights from ``self.model_path``."""
         from sktime.libs.falcon_tst import FalconTSTForPrediction
 
-        model_kwargs = {
-            "device_map": self.device_map,
-            "quantization_config": self.quantization_config,
-        }
-        if self.dtype is not None:
-            model_kwargs["torch_dtype"] = self.dtype
-
         model = FalconTSTForPrediction.from_pretrained(
             self.model_path,
-            **model_kwargs,
+            device_map=self.device_map,
+            dtype=self.dtype,
+            quantization_config=self.quantization_config,
         )
 
         return model
@@ -478,20 +473,6 @@ class _CachedFalconTST:
         model = FalconTSTForPrediction(config)
         model = model.to(self.device_map)
         if self.dtype is not None:
-            dtype = _coerce_torch_dtype(self.dtype)
-            if dtype is not None:
-                model = model.to(dtype=dtype)
+            model = model.to(dtype=self.dtype)
 
         return model
-
-
-def _coerce_torch_dtype(dtype):
-    """Coerce string dtype names to ``torch.dtype`` for local initialization."""
-    if dtype == "auto":
-        return None
-    if isinstance(dtype, str):
-        import torch
-
-        dtype = dtype.removeprefix("torch.")
-        return getattr(torch, dtype)
-    return dtype

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -96,16 +96,6 @@ class FalconTSTForecaster(BaseForecaster):
     >>> forecaster.fit(y)  # doctest: +SKIP
     >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
 
-    Multivariate zero-shot forecasting with RevIN disabled:
-
-    >>> from sktime.datasets import load_airline
-    >>> from sktime.forecasting.falcon_tst import FalconTSTForecaster
-    >>> y_uni = load_airline()  # doctest: +SKIP
-    >>> y = y_uni.to_frame("a").assign(b=lambda x: x["a"])  # doctest: +SKIP
-    >>> forecaster = FalconTSTForecaster(revin=False)  # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
-    >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
-
     Reduced-memory inference with device placement, dtype, and quantization:
 
     >>> import torch  # doctest: +SKIP
@@ -182,14 +172,72 @@ class FalconTSTForecaster(BaseForecaster):
         super().__init__()
 
     def _fit(self, y, X=None, fh=None):
-        """Fit forecaster to training data."""
+        """Load the model and store history for zero-shot forecasting.
+
+        private _fit containing the core logic, called from fit
+
+        This method does not train or fine-tune Falcon-TST weights.
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        y : sktime time series object
+            guaranteed to be of an mtype in self.get_tag("y_inner_mtype")
+            Time series to which to fit the forecaster.
+
+            * if self.get_tag("capability:multivariate")==False:
+              guaranteed to be univariate (e.g., single-column for DataFrame)
+            * if self.get_tag("capability:multivariate")==True: no restrictions
+              apply, the method should handle uni- and multivariate y
+              appropriately
+
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            Required (non-optional) here if self.get_tag("requires-fh-in-fit")
+            == True. Otherwise, if not passed in _fit, guaranteed to be passed
+            in _predict.
+        X : sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series to fit to.
+
+        Returns
+        -------
+        self : reference to self
+        """
         self.model_ = self._load_model()
         self.context_ = y
 
         return self
 
     def _predict(self, fh, X):
-        """Forecast time series at future horizon."""
+        """Forecast time series at future horizon.
+
+        private _predict containing the core logic, called from predict
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            If not passed in _fit, guaranteed to be passed here.
+        X : sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series for the forecast.
+
+        Returns
+        -------
+        y_pred : sktime time series object
+            should be of the same type as seen in _fit, as in "y_inner_mtype"
+            tag. Point predictions.
+        """
         import torch
 
         self.model_ = self._load_model()
@@ -229,7 +277,15 @@ class FalconTSTForecaster(BaseForecaster):
         return pd.DataFrame(preds, index=index, columns=self.context_.columns)
 
     def _load_model(self):
-        """Load a Falcon-TST model instance."""
+        """Load or retrieve a cached Falcon-TST model instance.
+
+        Returns
+        -------
+        model : transformers.PreTrainedModel
+            Loaded model according to ``self.device_map`` and
+            ``self.dtype``. If ``self.model_`` already exists, it is
+            returned directly.
+        """
         if hasattr(self, "model_") and self.model_ is not None:
             return self.model_
 
@@ -245,7 +301,14 @@ class FalconTSTForecaster(BaseForecaster):
         return self.model_
 
     def _get_unique_key(self):
-        """Build cache key for the multiton model loader."""
+        """Build cache key for the multiton model loader.
+
+        Returns
+        -------
+        key : str
+            Deterministic string representation of model-loading attributes used
+            by :class:`_CachedFalconTST`.
+        """
         key = {
             "model_path": self.model_path,
             "config": self.config,
@@ -257,7 +320,25 @@ class FalconTSTForecaster(BaseForecaster):
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
-        """Return testing parameter settings for the estimator."""
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If
+            no special parameters are defined for a value, will return
+            `"default"` set. There are currently no reserved values for
+            forecasters.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class. Each dict is a
+            parameter set to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test
+            instance. `create_test_instance` uses the first (or only)
+            dictionary in `params`.
+        """
         config = {
             "num_hidden_layers": 1,
             "hidden_size": 4,
@@ -292,7 +373,28 @@ class FalconTSTForecaster(BaseForecaster):
 
 @_multiton
 class _CachedFalconTST:
-    """Multiton-backed cache wrapper for a loaded Falcon-TST model."""
+    """Multiton-backed cache wrapper for a loaded Falcon-TST model.
+
+    Instances are keyed externally (via :class:`FalconTSTForecaster`) so that
+    repeated forecasters with equivalent loading parameters can share a single
+    model instance in memory.
+
+    Parameters
+    ----------
+    key : str
+        Multiton key (stored for traceability).
+    model_path : str or None
+        Model identifier/path for ``from_pretrained``. If ``None``, create model
+        from config only.
+    config : transformers.PretrainedConfig or dict or None
+        Configuration used for model loading/creation.
+    device_map : str, dict, int, or torch.device
+        Device placement for loading models.
+    dtype : torch.dtype or str or None
+        Data type used for model loading.
+    quantization_config : transformers.quantizers.HfQuantizer or None
+        Quantization configuration used for model loading.
+    """
 
     def __init__(
         self,
@@ -312,7 +414,20 @@ class _CachedFalconTST:
         self.model_ = None
 
     def load(self):
-        """Load model if needed and return cached instance."""
+        """Load model if needed and return cached instance.
+
+        Returns
+        -------
+        model : transformers.PreTrainedModel
+            Loaded Falcon-TST prediction model according to ``self.device_map``,
+            ``self.dtype``, and ``self.quantization_config``.
+
+        Notes
+        -----
+        - If ``model_path`` is set, loads weights via ``from_pretrained``.
+        - If ``model_path`` is ``None``, initializes from config with random
+          weights. These weights are not trained by the estimator.
+        """
         if self.model_ is not None:
             return self.model_
 
@@ -324,7 +439,7 @@ class _CachedFalconTST:
         return self.model_
 
     def _load_from_path(self):
-        """Load pretrained Falcon-TST weights from ``self.model_path``."""
+        """Load Falcon-TST model weights from ``self.model_path``."""
         from sktime.libs.falcon_tst import FalconTSTForPrediction
 
         model_kwargs = {
@@ -334,13 +449,15 @@ class _CachedFalconTST:
         if self.dtype is not None:
             model_kwargs["torch_dtype"] = self.dtype
 
-        return FalconTSTForPrediction.from_pretrained(
+        model = FalconTSTForPrediction.from_pretrained(
             self.model_path,
             **model_kwargs,
         )
 
+        return model
+
     def _load_randomly(self):
-        """Initialize a Falcon-TST model from config without pretrained weights."""
+        """Initialize a Falcon-TST model randomly from config."""
         from sktime.libs.falcon_tst import FalconTSTConfig, FalconTSTForPrediction
 
         warn(

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -47,8 +47,8 @@ class FalconTSTForecaster(BaseForecaster):
     - Exogenous data and quantile prediction are not supported.
     - Loaded models are cached via a multiton helper keyed by model-loading
       inputs to avoid repeated model instantiation.
-    - For reduced-memory loading, use ``dtype`` and ``quantization_config``,
-      or a pre-quantized checkpoint.
+    - For reduced-memory loading, use ``quantization_config`` or a
+      pre-quantized checkpoint.
 
     Parameters
     ----------
@@ -65,10 +65,6 @@ class FalconTSTForecaster(BaseForecaster):
         Device placement following the ``transformers`` ``device_map`` naming
         convention, for example ``"cpu"``, ``"cuda"``, ``"cuda:0"``, or
         ``"auto"``.
-    dtype : torch.dtype or str, optional (default=None)
-        Data type used for model loading, following the ``transformers``
-        ``dtype`` convention, for example ``torch.float16``,
-        ``torch.bfloat16``, or ``"auto"``.
     quantization_config : transformers.quantizers.HfQuantizer, optional
         Valid quantization configuration object compatible with
         ``transformers.PreTrainedModel.from_pretrained`` [3]_.
@@ -96,9 +92,8 @@ class FalconTSTForecaster(BaseForecaster):
     >>> forecaster.fit(y)  # doctest: +SKIP
     >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
 
-    Reduced-memory inference with device placement, dtype, and quantization:
+    Reduced-memory inference with device placement and quantization:
 
-    >>> import torch  # doctest: +SKIP
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.falcon_tst import FalconTSTForecaster
     >>> from transformers import BitsAndBytesConfig  # doctest: +SKIP
@@ -106,7 +101,6 @@ class FalconTSTForecaster(BaseForecaster):
     >>> forecaster = FalconTSTForecaster(  # doctest: +SKIP
     ...     model_path="ant-intl/Falcon-TST_Large",
     ...     device_map="auto",
-    ...     dtype=torch.bfloat16,
     ...     quantization_config=BitsAndBytesConfig(load_in_8bit=True),
     ... )
     >>> forecaster.fit(y)  # doctest: +SKIP
@@ -159,14 +153,12 @@ class FalconTSTForecaster(BaseForecaster):
         model_path="ant-intl/Falcon-TST_Large",
         config=None,
         device_map="cpu",
-        dtype=None,
         quantization_config=None,
         revin=True,
     ):
         self.model_path = model_path
         self.config = config
         self.device_map = device_map
-        self.dtype = dtype
         self.quantization_config = quantization_config
         self.revin = revin
 
@@ -283,9 +275,8 @@ class FalconTSTForecaster(BaseForecaster):
         Returns
         -------
         model : transformers.PreTrainedModel
-            Loaded model according to ``self.device_map`` and
-            ``self.dtype``. If ``self.model_`` already exists, it is
-            returned directly.
+            Loaded model according to ``self.device_map``. If ``self.model_``
+            already exists, it is returned directly.
         """
         if hasattr(self, "model_") and self.model_ is not None:
             return self.model_
@@ -295,7 +286,6 @@ class FalconTSTForecaster(BaseForecaster):
             model_path=self.model_path,
             config=self.config,
             device_map=self.device_map,
-            dtype=self.dtype,
             quantization_config=self.quantization_config,
         ).load()
 
@@ -314,7 +304,6 @@ class FalconTSTForecaster(BaseForecaster):
             "model_path": self.model_path,
             "config": self.config,
             "device_map": self.device_map,
-            "dtype": self.dtype,
             "quantization_config": self.quantization_config,
         }
         return str(sorted(key.items()))
@@ -392,8 +381,6 @@ class _CachedFalconTST:
         Configuration used for model loading/creation.
     device_map : str, dict, int, or torch.device
         Device placement for loading models.
-    dtype : torch.dtype or str or None
-        Data type used for model loading.
     quantization_config : transformers.quantizers.HfQuantizer or None
         Quantization configuration used for model loading.
     """
@@ -404,14 +391,12 @@ class _CachedFalconTST:
         model_path,
         config,
         device_map,
-        dtype,
         quantization_config,
     ):
         self.key = key
         self.model_path = model_path
         self.config = config
         self.device_map = device_map
-        self.dtype = dtype
         self.quantization_config = quantization_config
         self.model_ = None
 
@@ -422,7 +407,7 @@ class _CachedFalconTST:
         -------
         model : transformers.PreTrainedModel
             Loaded Falcon-TST prediction model according to ``self.device_map``,
-            ``self.dtype``, and ``self.quantization_config``.
+            and ``self.quantization_config``.
 
         Notes
         -----
@@ -447,7 +432,6 @@ class _CachedFalconTST:
         model = FalconTSTForPrediction.from_pretrained(
             self.model_path,
             device_map=self.device_map,
-            torch_dtype=self.dtype,
             quantization_config=self.quantization_config,
         )
 
@@ -474,7 +458,5 @@ class _CachedFalconTST:
 
         model = FalconTSTForPrediction(config)
         model = model.to(self.device_map)
-        if self.dtype is not None:
-            model = model.to(dtype=self.dtype)
 
         return model

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -450,10 +450,6 @@ class _CachedFalconTST:
             torch_dtype=self.dtype,
             quantization_config=self.quantization_config,
         )
-        if self.dtype is not None and self.quantization_config is None:
-            dtype = _coerce_torch_dtype(self.dtype)
-            if dtype is not None:
-                model = model.to(dtype=dtype)
 
         return model
 
@@ -479,20 +475,6 @@ class _CachedFalconTST:
         model = FalconTSTForPrediction(config)
         model = model.to(self.device_map)
         if self.dtype is not None:
-            dtype = _coerce_torch_dtype(self.dtype)
-            if dtype is not None:
-                model = model.to(dtype=dtype)
+            model = model.to(dtype=self.dtype)
 
         return model
-
-
-def _coerce_torch_dtype(dtype):
-    """Coerce string dtype names to ``torch.dtype`` for local initialization."""
-    if dtype == "auto":
-        return None
-    if isinstance(dtype, str):
-        import torch
-
-        dtype = dtype.removeprefix("torch.")
-        return getattr(torch, dtype)
-    return dtype

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -16,7 +16,77 @@ from sktime.utils.singleton import _multiton
 
 
 class FalconTSTForecaster(BaseForecaster):
-    """Falcon-TST forecaster via Hugging Face ``transformers``."""
+    """Falcon-TST forecaster via Hugging Face ``transformers``.
+
+    This forecaster wraps Falcon-TST prediction models [1]_, [2]_ from Hugging
+    Face and exposes them through the ``sktime`` forecasting interface.
+    ``fit`` loads the model and stores the observed series as forecasting
+    context; it does not train or fine-tune Falcon-TST weights.
+
+    Parameters
+    ----------
+    model_path : str, default="ant-intl/Falcon-TST_Large"
+        Hugging Face repository identifier or local path to a Falcon-TST
+        checkpoint. If ``None``, a model is created from ``config`` with random
+        weights.
+    config : FalconTSTConfig or dict, optional (default=None)
+        Model configuration used when ``model_path=None``. If provided as a
+        ``dict``, it is converted with ``FalconTSTConfig.from_dict``.
+    device_map : str, dict, int, or torch.device, default="cpu"
+        Device placement used for model loading or local initialization.
+    dtype : torch.dtype or str, optional (default=None)
+        Data type used for model loading, for example ``torch.float16``,
+        ``torch.bfloat16``, or ``"auto"``.
+    quantization_config : transformers.quantizers.HfQuantizer, optional
+        Quantization configuration compatible with
+        ``transformers.PreTrainedModel.from_pretrained``.
+    revin : bool, default=True
+        Whether to use RevIN normalization during Falcon-TST prediction.
+
+    Notes
+    -----
+    - Falcon-TST training and fine-tuning are not supported by this estimator.
+    - Falcon-TST supports multivariate targets, handled as channels.
+    - Exogenous data and quantile prediction are not supported.
+    - Loaded models are cached by model-loading inputs to avoid repeated model
+      instantiation.
+
+    References
+    ----------
+    .. [1] Falcon-TST repository:
+       https://github.com/AntGroup/Falcon-TST
+    .. [2] Falcon-TST model card:
+       https://huggingface.co/ant-intl/Falcon-TST_Large
+
+    Examples
+    --------
+    Univariate zero-shot forecasting:
+
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.falcon_tst import FalconTSTForecaster
+    >>> y = load_airline()
+    >>> forecaster = FalconTSTForecaster()  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
+
+    Multivariate zero-shot forecasting:
+
+    >>> from sktime.forecasting.falcon_tst import FalconTSTForecaster
+    >>> y = y.to_frame("a").assign(b=lambda x: x["a"])  # doctest: +SKIP
+    >>> forecaster = FalconTSTForecaster(revin=False)  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
+
+    Quantized loading:
+
+    >>> import torch  # doctest: +SKIP
+    >>> from transformers import BitsAndBytesConfig  # doctest: +SKIP
+    >>> forecaster = FalconTSTForecaster(  # doctest: +SKIP
+    ...     device_map="auto",
+    ...     dtype=torch.bfloat16,
+    ...     quantization_config=BitsAndBytesConfig(load_in_8bit=True),
+    ... )
+    """
 
     _tags = {
         "y_inner_mtype": "pd.DataFrame",
@@ -124,6 +194,40 @@ class FalconTSTForecaster(BaseForecaster):
         }
         return str(sorted(key.items()))
 
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        config = {
+            "num_hidden_layers": 1,
+            "hidden_size": 4,
+            "ffn_hidden_size": 8,
+            "num_attention_heads": 1,
+            "seq_length": 8,
+            "shared_patch_size": 2,
+            "patch_size_list": [4],
+            "expert_num_layers": 1,
+            "multi_forecast_head_list": [2],
+            "autoregressive_step_list": [1],
+            "num_experts": 1,
+            "moe_router_topk": 1,
+            "moe_ffn_hidden_size": 8,
+            "moe_shared_expert_intermediate_size": 8,
+            "use_cpu_initialization": True,
+        }
+        return [
+            {
+                "model_path": None,
+                "config": config,
+                "device_map": "cpu",
+            },
+            {
+                "model_path": None,
+                "config": config,
+                "device_map": "cpu",
+                "revin": False,
+            },
+        ]
+
 
 @_multiton
 class _CachedFalconTST:
@@ -210,5 +314,6 @@ def _coerce_torch_dtype(dtype):
     if isinstance(dtype, str):
         import torch
 
+        dtype = dtype.removeprefix("torch.")
         return getattr(torch, dtype)
     return dtype

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -141,8 +141,6 @@ class FalconTSTForecaster(BaseForecaster):
         "capability:exogenous": False,
         "requires-fh-in-fit": False,
         "capability:insample": False,
-        "capability:pred_int": False,
-        "capability:pretrain": False,
         "authors": ["Harryx2019", "figolyd", "geetu040"],
         # Hongjie Xia (Harryx2019), Yiding Liu (figolyd) for ant-intl/Falcon-TST
         "maintainers": ["geetu040"],

--- a/sktime/libs/falcon_tst/__init__.py
+++ b/sktime/libs/falcon_tst/__init__.py
@@ -1,20 +1,220 @@
 """Python implementation of Falcon-TST.
 
-Unofficial fork of the ``ant-intl/Falcon-TST_Large`` model code from
-Hugging Face, available at https://huggingface.co/ant-intl/Falcon-TST_Large.
+Unofficial fork of the ``ant-intl/Falcon-TST_Large`` model code from huggingface,
+available at https://huggingface.co/ant-intl/Falcon-TST_Large.
 
 sktime migration: 2026, Jun
+Version 344bb5c86c1b3e7d68b331dad236bfd33f869ba2 release: 2025, Oct
+
+Original authors: Hongjie Xia, Yiding Liu
+
+2026 releases subject to following license:
+
+All code contained is released under the license below.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 """
 
-from sktime.utils.dependencies import _check_soft_dependencies
-
-if _check_soft_dependencies("torch", "transformers", "einops", severity="none"):
-    from sktime.libs.falcon_tst.configuration_FalconTST import FalconTSTConfig
-    from sktime.libs.falcon_tst.modeling_FalconTST import FalconTSTForPrediction
-else:
-
-    class FalconTSTConfig:
-        """Placeholder for FalconTSTConfig."""
-
-    class FalconTSTForPrediction:
-        """Placeholder for FalconTSTForPrediction."""
+from sktime.libs.falcon_tst.configuration_FalconTST import FalconTSTConfig
+from sktime.libs.falcon_tst.modeling_FalconTST import FalconTSTForPrediction

--- a/sktime/libs/falcon_tst/__init__.py
+++ b/sktime/libs/falcon_tst/__init__.py
@@ -1,0 +1,20 @@
+"""Python implementation of Falcon-TST.
+
+Unofficial fork of the ``ant-intl/Falcon-TST_Large`` model code from
+Hugging Face, available at https://huggingface.co/ant-intl/Falcon-TST_Large.
+
+sktime migration: 2026, Jun
+"""
+
+from sktime.utils.dependencies import _check_soft_dependencies
+
+if _check_soft_dependencies("torch", "transformers", "einops", severity="none"):
+    from sktime.libs.falcon_tst.configuration_FalconTST import FalconTSTConfig
+    from sktime.libs.falcon_tst.modeling_FalconTST import FalconTSTForPrediction
+else:
+
+    class FalconTSTConfig:
+        """Placeholder for FalconTSTConfig."""
+
+    class FalconTSTForPrediction:
+        """Placeholder for FalconTSTForPrediction."""

--- a/sktime/libs/falcon_tst/configuration_FalconTST.py
+++ b/sktime/libs/falcon_tst/configuration_FalconTST.py
@@ -6,7 +6,9 @@ This module defines the configuration for FalconTST, a large-scale time series f
 that utilizes Mixture of Experts (MoE) architecture with multiple patch tokenizers.
 """
 
-from transformers import PretrainedConfig
+from sktime.utils.dependencies import _safe_import
+
+PretrainedConfig = _safe_import("transformers.PretrainedConfig")
 
 
 class FalconTSTConfig(PretrainedConfig):

--- a/sktime/libs/falcon_tst/configuration_FalconTST.py
+++ b/sktime/libs/falcon_tst/configuration_FalconTST.py
@@ -1,0 +1,201 @@
+# ruff: noqa
+"""
+Configuration class for FalconTST model.
+
+This module defines the configuration for FalconTST, a large-scale time series foundation model
+that utilizes Mixture of Experts (MoE) architecture with multiple patch tokenizers.
+"""
+
+from transformers import PretrainedConfig
+
+
+class FalconTSTConfig(PretrainedConfig):
+    """
+    Configuration class for FalconTST model.
+
+    FalconTST is a time series foundation model that uses Mixture of Experts architecture
+    with multiple patch tokenizers for efficient time series forecasting.
+
+    This configuration inherits from [`PretrainedConfig`] and can be used to control the model
+    output. Read the documentation from [`PretrainedConfig`] for more information.
+
+    Args:
+        hidden_size (`int`, *optional*, defaults to 1024):
+            Dimensionality of the encoder layers and the pooler layer.
+        ffn_hidden_size (`int`, *optional*, defaults to 4096):
+            Dimensionality of the feed-forward networks in the transformer layers.
+        seq_length (`int`, *optional*, defaults to 2880):
+            Maximum sequence length that the model can handle.
+        add_bias_linear (`bool`, *optional*, defaults to `False`):
+            Whether to add bias in linear layers.
+        rope_theta (`int`, *optional*, defaults to 10000):
+            The base period of the RoPE embeddings.
+        num_hidden_layers (`int`, *optional*, defaults to 3):
+            Number of hidden layers in the transformer encoder.
+        num_attention_heads (`int`, *optional*, defaults to 16):
+            Number of attention heads for each attention layer in the transformer encoder.
+        mask_pad_value (`float`, *optional*, defaults to 255.0):
+            Value used for padding/masking in input sequences.
+        expert_num_layers (`int`, *optional*, defaults to 4):
+            Number of transformer layers within each expert.
+        shared_patch_size (`int`, *optional*, defaults to 64):
+            Size of patches for the shared expert.
+        patch_size_list (`List[int]`, *optional*, defaults to [96, 64, 48, 24]):
+            List of patch sizes for different experts.
+        multi_forecast_head_list (`List[int]`, *optional*, defaults to [24, 96, 336]):
+            List of forecast lengths for multi-head prediction.
+        is_revin (`bool`, *optional*, defaults to `True`):
+            Whether to use RevIN (Reversible Instance Normalization).
+        params_dtype (`str`, *optional*, defaults to "bfloat16"):
+            Data type for model parameters.
+        use_cpu_initialization (`bool`, *optional*, defaults to `False`):
+            Whether to initialize model parameters on CPU.
+        rotary_interleaved (`bool`, *optional*, defaults to `False`):
+            Whether to use interleaved rotary position embeddings.
+        do_expert_forecast (`bool`, *optional*, defaults to `True`):
+            Whether experts perform forecasting.
+        residual_backcast (`bool`, *optional*, defaults to `True`):
+            Whether to use residual connections for backcast.
+        do_base_forecast (`bool`, *optional*, defaults to `False`):
+            Whether to use base forecasting.
+        heterogeneous_moe_layer (`bool`, *optional*, defaults to `True`):
+            Whether to use heterogeneous MoE layers.
+        test_data_seq_len (`int`, *optional*, defaults to 2880):
+            Sequence length for test data.
+        test_data_test_len (`int`, *optional*, defaults to 720):
+            Test length for test data.
+        autoregressive_step_list (`List[int]`, *optional*, defaults to [2, 4, 1]):
+            List of autoregressive steps for different forecast heads.
+        multi_forecast_head_type (`str`, *optional*, defaults to "single"):
+            Type of multi-forecast head aggregation.
+        num_experts (`int`, *optional*, defaults to 4):
+            Number of experts in the MoE layer.
+        moe_router_topk (`int`, *optional*, defaults to 2):
+            Number of top experts to route each token to.
+        moe_ffn_hidden_size (`int`, *optional*, defaults to 4096):
+            Hidden size for MoE feed-forward networks.
+        moe_shared_expert_intermediate_size (`int`, *optional*, defaults to 4096):
+            Intermediate size for shared experts.
+        init_method_std (`float`, *optional*, defaults to 0.06):
+            Standard deviation for weight initialization.
+        initializer_range (`float`, *optional*, defaults to 0.02):
+            Range for weight initialization.
+        moe_router_enable_expert_bias (`bool`, *optional*, defaults to `False`):
+            Whether to enable expert bias in routing.
+        moe_expert_final_layernorm (`bool`, *optional*, defaults to `True`):
+            Whether to apply layer normalization at the end of each expert.
+        transformer_input_layernorm (`bool`, *optional*, defaults to `True`):
+            Whether to apply layer normalization to transformer inputs.
+        moe_router_pre_softmax (`bool`, *optional*, defaults to `True`):
+            Whether to apply softmax before routing.
+        q_layernorm (`bool`, *optional*, defaults to `False`):
+            Whether to apply layer normalization to query vectors.
+        k_layernorm (`bool`, *optional*, defaults to `False`):
+            Whether to apply layer normalization to key vectors.
+        moe_router_score_function (`str`, *optional*, defaults to "softmax"):
+            Score function for MoE routing ("softmax" or "sigmoid").
+        tie_word_embeddings (`bool`, *optional*, defaults to `False`):
+            Whether to tie word embeddings.
+    """
+
+    model_type = "FalconTST"
+
+    def __init__(
+        self,
+        # model configs
+        add_bias_linear: bool = False,
+        num_hidden_layers: int = 3,
+        hidden_size: int = 1024,
+        ffn_hidden_size: int = 4096,
+        num_attention_heads: int = 16,
+        seq_length: int = 2880,
+        mask_pad_value: float = 255.0,
+        is_revin: bool = True,
+        shared_patch_size: int = 32,
+        patch_size_list: list[int] | None = None,
+        residual_backcast: bool = True,
+        do_base_forecast: bool = False,
+        do_expert_forecast: bool = True,
+        heterogeneous_moe_layer: bool = False,
+        expert_num_layers: int = 4,
+        multi_forecast_head_list: list[int] | None = None,
+        multi_forecast_head_type: str = "single",
+        rope_theta: int = 1000000,
+        rotary_interleaved: bool = False,
+        block_input_layernorm: bool = True,
+        # moe configs
+        num_experts: int = 4,
+        moe_router_topk: int = 2,
+        moe_router_pre_softmax: bool = True,
+        moe_router_score_function: str = "softmax",
+        moe_ffn_hidden_size: int = 4096,
+        moe_shared_expert_intermediate_size: int = 4096,
+        moe_router_enable_expert_bias: bool = False,
+        moe_expert_final_layernorm: bool = True,
+        # initial configs
+        use_cpu_initialization: bool = False,
+        init_method_std: float = 0.06,
+        initializer_range: float = 0.02,
+        # test configs
+        test_data_seq_len: int = 2880,
+        test_data_test_len: int = 720,
+        autoregressive_step_list: list[int] | None = None,
+        **kwargs,
+    ):
+        """Initialize FalconTST configuration."""
+        # model configs
+        self.add_bias_linear = add_bias_linear
+        self.num_hidden_layers = num_hidden_layers
+        self.hidden_size = hidden_size
+        self.ffn_hidden_size = ffn_hidden_size
+        self.num_attention_heads = num_attention_heads
+        self.kv_channels = self.hidden_size // self.num_attention_heads
+        self.seq_length = seq_length
+        self.mask_pad_value = mask_pad_value
+        self.is_revin = is_revin
+        self.shared_patch_size = shared_patch_size
+        if patch_size_list is None:
+            patch_size_list = [96, 64, 48, 24]
+        self.patch_size_list = patch_size_list
+        self.residual_backcast = residual_backcast
+        self.do_base_forecast = do_base_forecast
+        self.do_expert_forecast = do_expert_forecast
+        self.heterogeneous_moe_layer = heterogeneous_moe_layer
+        self.expert_num_layers = expert_num_layers
+        if multi_forecast_head_list is None:
+            multi_forecast_head_list = [24, 96, 336]
+        self.multi_forecast_head_list = multi_forecast_head_list
+        self.pred_length = max(self.multi_forecast_head_list)
+        self.multi_forecast_head_type = multi_forecast_head_type
+        self.rotary_base = rope_theta
+        self.rotary_interleaved = rotary_interleaved
+        self.block_input_layernorm = block_input_layernorm
+
+        # moe configs
+        self.num_moe_experts = num_experts
+        self.moe_router_topk = moe_router_topk
+        self.moe_router_input_size = self.seq_length
+        self.moe_router_pre_softmax = moe_router_pre_softmax
+        self.moe_router_score_function = moe_router_score_function
+        self.moe_ffn_hidden_size = moe_ffn_hidden_size
+        self.moe_shared_expert_intermediate_size = moe_shared_expert_intermediate_size
+        self.moe_router_enable_expert_bias = moe_router_enable_expert_bias
+        self.moe_expert_final_layernorm = moe_expert_final_layernorm
+
+        # initial configs
+        self.use_cpu_initialization = use_cpu_initialization
+        self.init_method_std = init_method_std
+        self.initializer_range = initializer_range
+
+        # test configs
+        self.test_data_seq_len = test_data_seq_len
+        self.inference_length = test_data_test_len
+        if autoregressive_step_list is None:
+            autoregressive_step_list = [2, 4, 1]
+        self.autoregressive_step_list = autoregressive_step_list
+
+        self.use_cache = True
+
+        super().__init__(
+            **kwargs,
+        )

--- a/sktime/libs/falcon_tst/configuration_FalconTST.py
+++ b/sktime/libs/falcon_tst/configuration_FalconTST.py
@@ -123,6 +123,7 @@ class FalconTSTConfig(PretrainedConfig):
         rope_theta: int = 1000000,
         rotary_interleaved: bool = False,
         block_input_layernorm: bool = True,
+        transformer_input_layernorm: bool = True,
         # moe configs
         num_experts: int = 4,
         moe_router_topk: int = 2,
@@ -170,6 +171,7 @@ class FalconTSTConfig(PretrainedConfig):
         self.rotary_base = rope_theta
         self.rotary_interleaved = rotary_interleaved
         self.block_input_layernorm = block_input_layernorm
+        self.transformer_input_layernorm = transformer_input_layernorm
 
         # moe configs
         self.num_moe_experts = num_experts

--- a/sktime/libs/falcon_tst/configuration_FalconTST.py
+++ b/sktime/libs/falcon_tst/configuration_FalconTST.py
@@ -1,9 +1,9 @@
-# ruff: noqa
 """
 Configuration class for FalconTST model.
 
-This module defines the configuration for FalconTST, a large-scale time series foundation model
-that utilizes Mixture of Experts (MoE) architecture with multiple patch tokenizers.
+This module defines the configuration for FalconTST, a large-scale time series
+foundation model that utilizes Mixture of Experts (MoE) architecture with
+multiple patch tokenizers.
 """
 
 from sktime.utils.dependencies import _safe_import
@@ -15,11 +15,13 @@ class FalconTSTConfig(PretrainedConfig):
     """
     Configuration class for FalconTST model.
 
-    FalconTST is a time series foundation model that uses Mixture of Experts architecture
-    with multiple patch tokenizers for efficient time series forecasting.
+    FalconTST is a time series foundation model that uses Mixture of Experts
+    architecture with multiple patch tokenizers for efficient time series
+    forecasting.
 
-    This configuration inherits from [`PretrainedConfig`] and can be used to control the model
-    output. Read the documentation from [`PretrainedConfig`] for more information.
+    This configuration inherits from [`PretrainedConfig`] and can be used to
+    control the model output. Read the documentation from [`PretrainedConfig`]
+    for more information.
 
     Args:
         hidden_size (`int`, *optional*, defaults to 1024):
@@ -35,7 +37,8 @@ class FalconTSTConfig(PretrainedConfig):
         num_hidden_layers (`int`, *optional*, defaults to 3):
             Number of hidden layers in the transformer encoder.
         num_attention_heads (`int`, *optional*, defaults to 16):
-            Number of attention heads for each attention layer in the transformer encoder.
+            Number of attention heads for each attention layer in the
+            transformer encoder.
         mask_pad_value (`float`, *optional*, defaults to 255.0):
             Value used for padding/masking in input sequences.
         expert_num_layers (`int`, *optional*, defaults to 4):

--- a/sktime/libs/falcon_tst/modeling_FalconTST.py
+++ b/sktime/libs/falcon_tst/modeling_FalconTST.py
@@ -4,15 +4,48 @@ from functools import reduce
 # ruff: noqa
 """PyTorch model definitions for Falcon-TST forecasting models."""
 
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
+from sktime.utils.dependencies import _check_soft_dependencies
 
 # import transformer_engine as te
-from torch import Tensor
-from transformers import PreTrainedModel
 
 from .configuration_FalconTST import FalconTSTConfig
+
+if _check_soft_dependencies("torch", "transformers", severity="none"):
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+    from torch import Tensor
+    from transformers import PreTrainedModel
+else:
+
+    class _FalconTSTDependencyStub:
+        """Placeholder base used when Falcon-TST dependencies are unavailable."""
+
+    class _FalconTSTNNStub:
+        """Minimal ``torch.nn`` placeholder for import-time class definitions."""
+
+        Module = object
+
+    class _FalconTSTTorchStub:
+        """Minimal ``torch`` placeholder for import-time annotations."""
+
+        Tensor = object
+        nn = _FalconTSTNNStub
+
+        @staticmethod
+        def no_grad():
+            """Return a no-op decorator for import-time method definitions."""
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+    torch = _FalconTSTTorchStub()
+    F = None
+    nn = _FalconTSTNNStub
+    Tensor = object
+    PreTrainedModel = _FalconTSTDependencyStub
 
 
 def _rotate_half(x: Tensor, rotary_interleaved: bool) -> Tensor:

--- a/sktime/libs/falcon_tst/modeling_FalconTST.py
+++ b/sktime/libs/falcon_tst/modeling_FalconTST.py
@@ -1,13 +1,11 @@
+"""PyTorch model definitions for Falcon-TST forecasting models."""
+
 import math
 from functools import reduce
-
-# ruff: noqa
-"""PyTorch model definitions for Falcon-TST forecasting models."""
 
 from sktime.utils.dependencies import _check_soft_dependencies
 
 # import transformer_engine as te
-
 from .configuration_FalconTST import FalconTSTConfig
 
 if _check_soft_dependencies("torch", "transformers", severity="none"):
@@ -49,7 +47,7 @@ else:
 
 
 def _rotate_half(x: Tensor, rotary_interleaved: bool) -> Tensor:
-    """Change sign so the last dimension becomes [-odd, +even]
+    """Change sign so the last dimension becomes [-odd, +even].
 
     Args:
         x (Tensor): Input tensor
@@ -81,7 +79,8 @@ def _apply_rotary_pos_emb_bshd(
 
     Args:
         t (Tensor): Input tensor T is of shape [seq_length, ... , dim]
-        freqs (Tensor): Rotary Positional embedding tensor freq is of shape [seq_length, ..., dim]
+        freqs (Tensor): Rotary Positional embedding tensor freq is of shape
+            [seq_length, ..., dim]
 
     Returns
     -------
@@ -111,14 +110,14 @@ class RotaryEmbedding(nn.Module):
     """Rotary Embedding.
 
     Args:
-        kv_channels (int): Projection weights dimension in multi-head attention. Obtained
-            from transformer config
-        rotary_interleaved (bool, optional): If True, interleaved rotary position embeddings.
-            Defaults to False.
-        rotary_base (int, optional): Base period for rotary position embeddings. Defaults to
-            10000.
-        use_cpu_initialization (bool, optional): If False, initialize the inv_freq directly
-            on the GPU. Defaults to False
+        kv_channels (int): Projection weights dimension in multi-head
+            attention, obtained from transformer config.
+        rotary_interleaved (bool, optional): If True, interleaved rotary
+            position embeddings. Defaults to False.
+        rotary_base (int, optional): Base period for rotary position embeddings.
+            Defaults to 10000.
+        use_cpu_initialization (bool, optional): If False, initialize the
+            inv_freq directly on the GPU. Defaults to False.
     """
 
     def __init__(
@@ -142,9 +141,7 @@ class RotaryEmbedding(nn.Module):
         )
 
     def get_freqs_non_repeated(self, max_seq_len: int, offset: int = 0) -> Tensor:
-        """Generates matrix of frequencies based on positions in the sequence,
-        used to create positional encodings
-        """
+        """Generate matrix of frequencies based on positions in the sequence."""
         seq = (
             torch.arange(
                 max_seq_len, device=self.inv_freq.device, dtype=self.inv_freq.dtype
@@ -162,7 +159,8 @@ class RotaryEmbedding(nn.Module):
         Args:
             max_seq_len (int): Maximum size of sequence
             offset (int, optional): RoPE offset. Defaults to 0.
-            packed_seq (bool, optional): Whether to use packed sequence. Defaults to False.
+            packed_seq (bool, optional): Whether to use packed sequence.
+                Defaults to False.
 
         Returns
         -------
@@ -195,10 +193,13 @@ class RotaryEmbedding(nn.Module):
         self,
         transformer_input: Tensor,
     ) -> float:
-        """Function to get the rotary sequence length.
+        """Return the rotary sequence length.
+
         Args:
             transformer_input (Tensor): Input tensor to the transformer
-        Returns:
+
+        Returns
+        -------
             float: The rotary sequence length
         """
         rotary_seq_len = transformer_input.size(0)
@@ -206,20 +207,23 @@ class RotaryEmbedding(nn.Module):
 
 
 class IdentityOp(nn.Module):
+    """Identity operation."""
+
     def forward(self, x):
+        """Return input unchanged."""
         return x
 
 
 class RMSNorm(nn.Module):
+    """Root mean square normalization layer."""
+
     def __init__(self, hidden_size, eps=1e-5):
         super().__init__()
         self.weight = nn.Parameter(torch.ones(hidden_size))
         self.variance_epsilon = eps
 
     def forward(self, hidden_states):
-        """
-        hidden_states [bs, patch_num, d_model]
-        """
+        """Normalize hidden states of shape [bs, patch_num, d_model]."""
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)
         variance = hidden_states.pow(2).mean(-1, keepdim=True)
@@ -229,6 +233,7 @@ class RMSNorm(nn.Module):
 
 class TEDotProductAttention(nn.Module):
     """Implement the scaled dot product attention with softmax.
+
     Arguments
     ---------
         softmax_scale: The temperature to use for the softmax attention.
@@ -245,12 +250,15 @@ class TEDotProductAttention(nn.Module):
         self.drop = nn.Dropout(attention_dropout)
 
     def forward(self, q, k, v, attention_mask):
-        """Implements the multihead softmax attention.
+        """Implement the multihead softmax attention.
+
         Arguments
         ---------
-            q,k,v: The tensor containing the query, key, and value.  [seq_len, batch_size, hidden_size]
-            attention_mask: boolean mask to apply to the attention weights. True means to keep,
-                False means to mask out. [batch_size, 1, seq_len, seq_len]
+            q,k,v: The tensor containing the query, key, and value.
+                Shape: [seq_len, batch_size, hidden_size]
+            attention_mask: boolean mask to apply to the attention weights.
+                True means to keep, False means to mask out.
+                Shape: [batch_size, 1, seq_len, seq_len]
         """
         q = q.transpose(0, 1).contiguous()
         k = k.transpose(0, 1).contiguous()
@@ -273,6 +281,8 @@ class TEDotProductAttention(nn.Module):
 
 
 class SelfAttention(nn.Module):
+    """Self-attention block."""
+
     def __init__(
         self,
         config,
@@ -293,11 +303,7 @@ class SelfAttention(nn.Module):
         )
 
     def forward(self, x, attention_mask, rotary_pos_emb):
-        """
-        x: [seq_len, batch_size, hidden_size]
-        attention_mask: [batch_size, 1, seq_len, seq_len]
-        rotary_pos_emb: [seq_len, 1, 1, kv_channels(hidden_size // num_heads)]
-        """
+        """Apply self-attention to hidden states."""
         qkv = self.linear_qkv(x)
         qkv = qkv.view(qkv.size(0), qkv.size(1), self.config.num_attention_heads, -1)
         q, k, v = qkv.chunk(3, dim=-1)
@@ -315,6 +321,8 @@ class SelfAttention(nn.Module):
 
 
 class MLP(nn.Module):
+    """Feed-forward network."""
+
     def __init__(self, config, in_features):
         super().__init__()
         self.config = config
@@ -330,25 +338,29 @@ class MLP(nn.Module):
         )
 
     def forward(self, x):
+        """Apply feed-forward transformation."""
         x = self.swiglu(self.linear_fc1(x))
         x = self.linear_fc2(x)
         return x
 
     def swiglu(self, y):
-        """Performs SwiGLU (Swish-Gated Linear Unit) activation function.
+        """Perform SwiGLU activation.
 
         Args:
-            y (torch.Tensor): Input tensor to be split into two halves along the last dimension.
+            y (torch.Tensor): Input tensor to split into two halves along the
+                last dimension.
 
         Returns
         -------
-            torch.Tensor: Result of SwiGLU activation: SiLU(y1) * y2, where y1, y2 are the split halves.
+            torch.Tensor: Result of SwiGLU activation.
         """
         y_1, y_2 = torch.chunk(y, 2, -1)
         return F.silu(y_1) * y_2
 
 
 class TransformerLayer(nn.Module):
+    """Transformer layer."""
+
     def __init__(self, config, input_layernorm):
         super().__init__()
         self.config = config
@@ -361,11 +373,7 @@ class TransformerLayer(nn.Module):
         self.mlp = MLP(config, self.config.hidden_size)
 
     def forward(self, x, attention_mask, rotary_pos_emb):
-        """
-        x: [seq_len, batch_size, hidden_size]
-        attention_mask: [batch_size, 1, seq_len, seq_len]
-        rotary_pos_emb: [seq_len, 1, 1, kv_channels(hidden_size // num_heads)]
-        """
+        """Apply one transformer layer."""
         residual = x
         x = self.input_layernorm(x)
         x = self.self_attention(x, attention_mask, rotary_pos_emb)
@@ -378,6 +386,8 @@ class TransformerLayer(nn.Module):
 
 
 class FalconTSTExpert(nn.Module):
+    """Falcon-TST expert module."""
+
     def __init__(
         self, config, patch_input_size=32, expert_output_size=336, final_layernorm=True
     ):
@@ -441,11 +451,10 @@ class FalconTSTExpert(nn.Module):
         hidden_states = self.patch_embedding(
             input_data
         )  # hidden_states [batch_size, patch_num, hidden_size]
-        hidden_states = hidden_states.transpose(
-            0, 1
-        ).contiguous()  # hidden_states [patch_num, batch_size, hidden_size], To adapt to the Megatron
+        hidden_states = hidden_states.transpose(0, 1).contiguous()
+        # hidden_states: [patch_num, batch_size, hidden_size]
 
-        # Patchify the mask: only the entire time points in a patch are masked then this patch is masked
+        # Patchify mask: only fully masked patches are masked.
         attention_mask = input_mask.unfold(
             dimension=-1, size=self.patch_size, step=self.patch_size
         ).contiguous()  # [batch_size, patch_num, patch_size]
@@ -466,22 +475,27 @@ class FalconTSTExpert(nn.Module):
         return hidden_states, attention_mask, input_mask
 
     def _forward_output(self, hidden_states, output_scale=None, input_mask=None):
-        """
-        Perform a forward pass through the output layer.
+        """Perform a forward pass through the output layer.
 
         Args:
-            hidden_states (Tensor): Transformed hidden states of shape [patch_num, batch_size, hidden_size]
-            output_scale (Tensor, optional): Expert probabilities for the output layer  [batch_size]
-            input_mask (Tensor, optional): Expert input mask of shape [batch_size, seq_len], 0:mask, 1:unmask
+            hidden_states (Tensor): Transformed hidden states of shape
+                [patch_num, batch_size, hidden_size].
+            output_scale (Tensor, optional): Expert probabilities for the
+                output layer [batch_size].
+            input_mask (Tensor, optional): Expert input mask of shape
+                [batch_size, seq_len], where 0 means mask and 1 means unmask.
 
         Returns
         -------
-            expert_output (Tensor): Expert output of shape [batch_size, expert_output_size]
+            expert_output (Tensor): Expert output of shape
+                [batch_size, expert_output_size].
         """
-        # [patch_num, batch_size, hidden_size] -> [batch_size, flatten_size (patch_num * hidden_size)]
+        # [patch_num, batch_size, hidden_size] ->
+        # [batch_size, flatten_size (patch_num * hidden_size)]
         patch_num, batch_size, hidden_size = hidden_states.shape
         assert (patch_num * hidden_size) == self.flatten_size, (
-            f"patch_num ({patch_num}) * hidden_size ({hidden_size}) != flatten_size ({self.flatten_size})"
+            f"patch_num ({patch_num}) * hidden_size ({hidden_size}) != "
+            f"flatten_size ({self.flatten_size})"
         )
         hidden_states = (
             hidden_states.transpose(0, 1).reshape(-1, self.flatten_size).contiguous()
@@ -497,6 +511,7 @@ class FalconTSTExpert(nn.Module):
         return expert_output
 
     def forward(self, expert_input, rotary_pos_emb, expert_probs=None):
+        """Run expert forward pass."""
         hidden_states, attention_mask, input_mask = self._forward_patch_embedding(
             expert_input
         )
@@ -516,6 +531,8 @@ class FalconTSTExpert(nn.Module):
 
 
 class SequentialFalconTST(nn.Module):
+    """Sequential container for Falcon-TST experts."""
+
     def __init__(self, config, expert_output_size=336):
         super().__init__()
         self.config = config
@@ -533,6 +550,7 @@ class SequentialFalconTST(nn.Module):
         )
 
     def forward(self, input, routing_map, rotary_pos_emb, expert_probs):
+        """Dispatch inputs to local experts and combine their outputs."""
         expert_output_list = []
         batch_size, seq_len = input.size()
 
@@ -562,6 +580,8 @@ class SequentialFalconTST(nn.Module):
 
 
 class TopKRouter(nn.Module):
+    """Top-k router for Falcon-TST experts."""
+
     def __init__(self, config: FalconTSTConfig):
         super().__init__()
         self.config = config
@@ -576,9 +596,11 @@ class TopKRouter(nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self):
+        """Reset router parameters."""
         nn.init.normal_(self.weight, mean=0, std=self.config.init_method_std)
 
     def routing(self, logits: torch.Tensor):
+        """Route logits to top-k experts."""
         score_function = self.config.moe_router_score_function
 
         if score_function == "softmax":
@@ -603,6 +625,7 @@ class TopKRouter(nn.Module):
         return routing_probs, routing_map
 
     def forward(self, input: torch.Tensor):
+        """Compute routing probabilities and map."""
         if self.weight.device != input.device:
             self.weight.data = self.weight.data.to(input.device)
 
@@ -616,6 +639,8 @@ class TopKRouter(nn.Module):
 
 
 class FalconTSTMoELayer(nn.Module):
+    """Mixture-of-experts layer for Falcon-TST."""
+
     def __init__(self, config, layer_number):
         super().__init__()
         self.config = config
@@ -650,19 +675,18 @@ class FalconTSTMoELayer(nn.Module):
         )
 
     def time_series_preprocess(self, input: torch.Tensor):
-        """
-        Preprocess time series(sample) for dispatch.
+        """Preprocess time series sample for dispatch.
 
-        Applies RevIN to input time series(sample), and process the input mask (0: mask, 1: unmask)
+        Applies RevIN to input time series samples, and processes the input
+        mask, where 0 means mask and 1 means unmask.
 
         Args:
-            input (torch.Tensor): The input time series (samples) to the MoE layer. [batch_size, seq_len]
+            input (torch.Tensor): Input time series samples to the MoE layer.
+                Shape: [batch_size, seq_len].
 
         Returns
         -------
-            input (torch.Tensor): The (RevIN) backcast time series (samples). [batch_size, seq_len]
-            means (torch.Tensor): The means of the non-masked backcast time series (samples). [batch_size, 1]
-            stdev (torch.Tensor): The standard deviation of the non-masked backcast time series (samples). [batch_size, 1]
+            input (torch.Tensor): Backcast time series samples.
         """
         batch_size, seq_len = input.shape
         assert seq_len == self.seq_length, (
@@ -680,19 +704,18 @@ class FalconTSTMoELayer(nn.Module):
         return input
 
     def router_and_preprocess(self, backcast: torch.Tensor):
-        """Compute and preprocess time series(sample) routing for dispatch.
+        """Compute and preprocess time series sample routing for dispatch.
 
-        This method uses the router to determine which experts to send each time series(sample) to,
-        producing routing probabilities and a mapping. It then preprocesses the
-        input time series (samples) and probabilities for the time series(sample) dispatcher. The original
-        input time series (samples) are returned as a residual connection.
+        This method uses the router to determine which experts to send each
+        time series sample to, producing routing probabilities and a mapping.
+        The original input time series samples are returned as a residual
+        connection.
         """
         # backcast [batch_size, seq_len]    means/stdev [batch_size, 1]
         backcast = self.time_series_preprocess(backcast)
 
-        residual = (
-            backcast  # residual: [batch_size, seq_len], the input to the shared experts
-        )
+        # residual: [batch_size, seq_len], the input to the shared experts
+        residual = backcast
 
         # TODO: Check the effective of the masked value to the router
         probs, routing_map = self.router(
@@ -707,22 +730,23 @@ class FalconTSTMoELayer(nn.Module):
         probs: torch.Tensor,  # [num_permuted_samples_after_dispatch]
         residual: torch.Tensor,  # [batch_size, seq_len]
         rotary_pos_emb: torch.Tensor,
-        routing_map: torch.Tensor,  # [seq_len, 1, 1, kv_channels(hidden_size // num_heads)]
+        routing_map: torch.Tensor,
     ):
-        """Computes the output of the experts on the dispatched time series(sample).
+        """Compute expert outputs on dispatched time series samples.
 
-        This method first post-processes the dispatched input to get permuted time series(sample)
-        for each expert. It then passes the time series(sample) through the local experts.
-        If a shared expert is configured and not overlapped with communication,
-        it is also applied. The output from the experts is preprocessed for the
-        combine step.
+        This method first post-processes the dispatched input to get permuted
+        time series samples for each expert. It then passes the samples through
+        the local experts. If a shared expert is configured and not overlapped
+        with communication, it is also applied.
         """
         # shared_expert_output: [batch_size, seq_len (+ pred_len)]
         shared_experts_output = self.shared_experts(residual, rotary_pos_emb)
 
-        # dispatched_input (global_input_tokens):   [num_permuted_samples_after_dispatch_postprocess(sorted), seq_len]
+        # dispatched_input (global_input_tokens):
+        # [num_permuted_samples_after_dispatch_postprocess(sorted), seq_len]
         # tokens_per_expert (global_probs):         [num_experts]
-        # permuted_probs (global_probs):            [num_permuted_samples_after_dispatch_postprocess(sorted)]
+        # permuted_probs (global_probs):
+        # [num_permuted_samples_after_dispatch_postprocess(sorted)]
 
         experts_output = self.experts(input, routing_map, rotary_pos_emb, probs)
 
@@ -733,13 +757,15 @@ class FalconTSTMoELayer(nn.Module):
         experts_output: torch.Tensor,
         shared_experts_output: torch.Tensor,
     ):
-        """Combines expert outputs via communication and adds shared expert output.
+        """Combine expert outputs and add shared expert output.
 
-        This method uses the time series(sample) dispatcher to combine the outputs from different
-        experts. It then adds the output from the shared expert if it exists.
+        This method uses the time series sample dispatcher to combine the
+        outputs from different experts. It then adds the output from the shared
+        expert if it exists.
         """
         assert experts_output.shape == shared_experts_output.shape, (
-            f"experts_output shape {experts_output.shape} doesn't equal to shared_experts_output shape:{shared_experts_output.shape}"
+            f"experts_output shape {experts_output.shape} doesn't equal "
+            f"shared_experts_output shape:{shared_experts_output.shape}"
         )
         output = experts_output + shared_experts_output
 
@@ -747,16 +773,21 @@ class FalconTSTMoELayer(nn.Module):
             output_backcast = None
             output_forecast = output
             assert output_forecast.shape[1] == self.pred_length, (
-                f"heterogeneous_moe_layer=True, expected the last moe layer's output pred len: {self.pred_length}, but got {output_forecast.shape[1]}"
+                "heterogeneous_moe_layer=True, expected the last moe layer's "
+                f"output pred len: {self.pred_length}, but got "
+                f"{output_forecast.shape[1]}"
             )
         else:
-            #  Noting: the mask time point there maybe not mask_pad_value(default:255.), it will be postprocessed
+            # The masked time point may not be mask_pad_value(default:255.);
+            # it will be postprocessed.
             output_backcast = output[:, : self.seq_length]  # [batch_size, seq_len]
 
             if self.config.do_expert_forecast:
                 output_forecast = output[:, self.seq_length :]  # [batch_size, pred_len]
                 assert output_forecast.shape[1] == self.pred_length, (
-                    f"do_expert_forecast=True, expected the last moe layer's output pred len: {self.pred_length}, but got {output_forecast.shape[1]}"
+                    "do_expert_forecast=True, expected the last moe layer's "
+                    f"output pred len: {self.pred_length}, but got "
+                    f"{output_forecast.shape[1]}"
                 )
             else:
                 output_forecast = None
@@ -770,23 +801,24 @@ class FalconTSTMoELayer(nn.Module):
         output_backcast: torch.Tensor,  # [batch_size, seq_len]
         output_forecast: torch.Tensor,  # [batch_size, pred_len]
     ):
-        """
+        """Postprocess MoE layer outputs.
+
         Args:
-            backcast (torch.Tensor): The previous layer's backcast time series (samples).                   [batch_size, seq_len]
-            forecast (torch.Tensor): The previous layer's forecast time series (samples).                   [batch_size, pred_len]
-            output_backcast (torch.Tensor): The current layer's output backcast time series (samples).      [batch_size, seq_len]
-            output_forecast (torch.Tensor): The current layer's output forecast time series (samples).      [batch_size, pred_len]
+            backcast (torch.Tensor): Previous layer backcast samples.
+            forecast (torch.Tensor): Previous layer forecast samples.
+            output_backcast (torch.Tensor): Current layer backcast samples.
+            output_forecast (torch.Tensor): Current layer forecast samples.
         """
         if output_backcast is not None:
-            # 25/8/14 @modified by xiaming replace the revin with layernorm after the moe layer
-            # And if we multiply the output_backcast with the input mask, the performance will be hurted
+            # 25/8/14 @modified by xiaming replace the revin with layernorm
+            # after the moe layer. Multiplying output_backcast with the input
+            # mask hurts performance.
             output_backcast = self.backcast_layernorm(output_backcast)  # LayerNorm
             if self.config.residual_backcast:
                 output_backcast = backcast - output_backcast
 
-            output_backcast[~self.input_mask] = (
-                self.config.mask_pad_value
-            )  # Important! Recover the mask time point back to mask_pad_value(default:255.)
+            output_backcast[~self.input_mask] = self.config.mask_pad_value
+            # Recover masked time points back to mask_pad_value(default:255.).
 
         if (
             self.config.do_expert_forecast and forecast is not None
@@ -796,6 +828,7 @@ class FalconTSTMoELayer(nn.Module):
         return output_backcast, output_forecast
 
     def forward(self, backcast, forecast, rotary_pos_emb):
+        """Run MoE layer forward pass."""
         inputs, probs, residual, routing_map = self.router_and_preprocess(backcast)
         experts_output, shared_experts_output = self.experts_compute(
             inputs, probs, residual, rotary_pos_emb, routing_map
@@ -810,6 +843,8 @@ class FalconTSTMoELayer(nn.Module):
 
 
 class FalconTSTBlock(nn.Module):
+    """Falcon-TST block."""
+
     def __init__(self, config, input_layernorm=True):
         super().__init__()
         self.config = config
@@ -827,6 +862,7 @@ class FalconTSTBlock(nn.Module):
         )
 
     def forward(self, x, rotary_pos_emb):
+        """Run block forward pass."""
         backcast = x
         forecast = None
 
@@ -840,6 +876,8 @@ class FalconTSTBlock(nn.Module):
 
 
 class FalconTSTPreTrainedModel(PreTrainedModel):
+    """Falcon-TST pretrained model base class."""
+
     config_class = FalconTSTConfig
     base_model_prefix = "model"
     supports_gradient_checkpointing = True
@@ -861,6 +899,8 @@ class FalconTSTPreTrainedModel(PreTrainedModel):
 
 
 class FalconTSTModel(FalconTSTPreTrainedModel):
+    """Falcon-TST backbone model."""
+
     def __init__(self, config: FalconTSTConfig):
         super().__init__(config)
         self.config = config
@@ -888,7 +928,7 @@ class FalconTSTModel(FalconTSTPreTrainedModel):
         input: Tensor,  # [batch_size, seq_len]
         input_mask: Tensor,  # [batch_size, seq_len] 0:mask, 1:unmask
     ):
-        """Normalization from Non-stationary Transformer"""
+        """Normalize input using Non-stationary Transformer normalization."""
         input_data = input * input_mask
         sum_per_sample = torch.sum(
             input_data, dim=1, keepdim=True
@@ -896,8 +936,9 @@ class FalconTSTModel(FalconTSTPreTrainedModel):
         count_per_sample = torch.sum(
             input_mask, dim=1, keepdim=True
         ).detach()  # [batch_size, 1], torch.int64
-        assert torch.any(count_per_sample == 0) == False, (
-            f"There is zero in count_per_sample, shape: {input[torch.where(count_per_sample.squeeze(1) == 0)[0]]}"
+        assert not torch.any(count_per_sample == 0), (
+            "There is zero in count_per_sample, shape: "
+            f"{input[torch.where(count_per_sample.squeeze(1) == 0)[0]]}"
         )
         means = sum_per_sample / count_per_sample  # [batch_size, 1]
         input_data = input_data - means
@@ -915,6 +956,7 @@ class FalconTSTModel(FalconTSTPreTrainedModel):
         return input, means, stdev
 
     def forward(self, input, revin):
+        """Run Falcon-TST forward pass."""
         batch_size, input_len = input.shape
         # realize varied input length
         if input_len > self.seq_length:
@@ -939,7 +981,8 @@ class FalconTSTModel(FalconTSTPreTrainedModel):
         # rotary_pos_emb [input_len, 1, 1, kv_channels(hidden_size // num_heads)]
         rotary_pos_emb = self.rotary_pos_emb(input_len, device=input.device)
 
-        # Step3. Do one-step inference to get mixed forecasts from multiple forecast heads
+        # Step3. Do one-step inference to get mixed forecasts from multiple
+        # forecast heads.
         # mixed_pred: [batch_size, max(multi_forecast_head)]
         mixed_pred = self._inference_step(
             input=input, input_mask=input_mask, rotary_pos_emb=rotary_pos_emb
@@ -974,6 +1017,7 @@ class FalconTSTModel(FalconTSTPreTrainedModel):
         input_mask,
         rotary_pos_emb,
     ):
+        """Run one inference step."""
         if self.config.do_base_forecast:
             base_forecast, _ = self.base_output_layer(input * input_mask)
         else:
@@ -981,7 +1025,7 @@ class FalconTSTModel(FalconTSTPreTrainedModel):
 
         decoder_backcast, decoder_forecast = self.decoder(
             input,  # [batch_size, seq_len]
-            rotary_pos_emb,  # [input_len, 1, 1, kv_channels(hidden_size // num_heads)]
+            rotary_pos_emb,
         )
 
         if self.config.do_expert_forecast:
@@ -1011,9 +1055,10 @@ class FalconTSTModel(FalconTSTPreTrainedModel):
         rotary_pos_emb,  # [seq_len, 1, 1, kv_channels(hidden_size // num_heads)]
         auto_regressive_strategy="from_long_to_short",
     ):
-        """Auto regressive prediction with [single] head"""
+        """Run auto-regressive prediction with a single head."""
         assert self.config.multi_forecast_head_type == "single", (
-            "_auto_regressive_single_head only support multi_forecast_head_type==single "
+            "_auto_regressive_single_head only support "
+            "multi_forecast_head_type==single "
         )
 
         if auto_regressive_strategy == "from_long_to_short":
@@ -1047,7 +1092,8 @@ class FalconTSTModel(FalconTSTPreTrainedModel):
                         ),
                     ],
                     dim=1,
-                )[:, -self.seq_length :].contiguous()  # 0:mask, 1:unmask
+                )[:, -self.seq_length :].contiguous()
+                # 0: mask, 1: unmask
 
                 FalconTST_forecast = self._inference_step(
                     input=input,
@@ -1070,6 +1116,8 @@ class FalconTSTModel(FalconTSTPreTrainedModel):
 
 
 class FalconTSTForPrediction(FalconTSTPreTrainedModel):
+    """Falcon-TST prediction model."""
+
     def __init__(self, config: FalconTSTConfig):
         super().__init__(config)
         self.config = config
@@ -1083,17 +1131,18 @@ class FalconTSTForPrediction(FalconTSTPreTrainedModel):
         forecast_horizon: int,
         revin: bool = True,
     ) -> torch.Tensor:
-        """
-        Generates time series forecasts autoregressively.
+        """Generate time series forecasts autoregressively.
 
         Args:
             time_series (torch.Tensor): Input time series data.
-                                        Shape: [batch_size, seq_len] or [batch_size, seq_len, channels].
+                Shape: [batch_size, seq_len] or
+                [batch_size, seq_len, channels].
             forecast_horizon (int): The number of future time steps to predict.
 
         Returns
         -------
-            torch.Tensor: The forecasted time series. Shape: [batch_size, forecast_horizon, channels].
+            torch.Tensor: Forecasted time series with shape
+                [batch_size, forecast_horizon, channels].
         """
         self.eval()
 

--- a/sktime/libs/falcon_tst/modeling_FalconTST.py
+++ b/sktime/libs/falcon_tst/modeling_FalconTST.py
@@ -1,0 +1,1091 @@
+import math
+from functools import reduce
+
+# ruff: noqa
+"""PyTorch model definitions for Falcon-TST forecasting models."""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# import transformer_engine as te
+from torch import Tensor
+from transformers import PreTrainedModel
+
+from .configuration_FalconTST import FalconTSTConfig
+
+
+def _rotate_half(x: Tensor, rotary_interleaved: bool) -> Tensor:
+    """Change sign so the last dimension becomes [-odd, +even]
+
+    Args:
+        x (Tensor): Input tensor
+
+    Returns
+    -------
+        Tensor: Tensor rotated half
+    """
+    if not rotary_interleaved:
+        x1, x2 = torch.chunk(x, 2, dim=-1)
+        return torch.cat((-x2, x1), dim=-1)
+    else:
+        x1 = x[:, :, :, ::2]
+        x2 = x[:, :, :, 1::2]
+        x_new = torch.stack((-x2, x1), dim=-1)
+        return x_new.view(x_new.shape[0], x_new.shape[1], x_new.shape[2], -1)
+
+
+def _apply_rotary_pos_emb_bshd(
+    t: Tensor,
+    freqs: Tensor,
+    rotary_interleaved: bool = False,
+    multi_latent_attention: bool = False,
+    mscale: float = 1.0,
+) -> Tensor:
+    """Apply rotary positional embedding to input tensor T.
+
+    check https://kexue.fm/archives/8265 for detailed formulas
+
+    Args:
+        t (Tensor): Input tensor T is of shape [seq_length, ... , dim]
+        freqs (Tensor): Rotary Positional embedding tensor freq is of shape [seq_length, ..., dim]
+
+    Returns
+    -------
+        Tensor: The input tensor after applying RoPE
+    """
+    freqs = freqs.to(t.device)
+    rot_dim = freqs.shape[-1]
+
+    # ideally t_pass is empty so rotary pos embedding is applied to all tensor t
+    t, t_pass = t[..., :rot_dim], t[..., rot_dim:]
+
+    if multi_latent_attention:
+        x1 = t[..., 0::2]
+        x2 = t[..., 1::2]
+        t = torch.cat((x1, x2), dim=-1)
+
+    # first part is cosine component
+    # second part is sine component, need to change signs with _rotate_half method
+    cos_ = (torch.cos(freqs) * mscale).to(t.dtype)
+    sin_ = (torch.sin(freqs) * mscale).to(t.dtype)
+
+    t = (t * cos_) + (_rotate_half(t, rotary_interleaved) * sin_)
+    return torch.cat((t, t_pass), dim=-1)
+
+
+class RotaryEmbedding(nn.Module):
+    """Rotary Embedding.
+
+    Args:
+        kv_channels (int): Projection weights dimension in multi-head attention. Obtained
+            from transformer config
+        rotary_interleaved (bool, optional): If True, interleaved rotary position embeddings.
+            Defaults to False.
+        rotary_base (int, optional): Base period for rotary position embeddings. Defaults to
+            10000.
+        use_cpu_initialization (bool, optional): If False, initialize the inv_freq directly
+            on the GPU. Defaults to False
+    """
+
+    def __init__(
+        self,
+        kv_channels: int,
+        rotary_interleaved: bool = False,
+        rotary_base: int = 10000,
+        use_cpu_initialization: bool = False,
+    ) -> None:
+        super().__init__()
+
+        dim = kv_channels
+        self.rotary_interleaved = rotary_interleaved
+        if use_cpu_initialization or not torch.cuda.is_available():
+            device = "cpu"
+        else:
+            device = torch.cuda.current_device()
+        self.inv_freq = 1.0 / (
+            rotary_base
+            ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
+        )
+
+    def get_freqs_non_repeated(self, max_seq_len: int, offset: int = 0) -> Tensor:
+        """Generates matrix of frequencies based on positions in the sequence,
+        used to create positional encodings
+        """
+        seq = (
+            torch.arange(
+                max_seq_len, device=self.inv_freq.device, dtype=self.inv_freq.dtype
+            )
+            + offset
+        )
+        freqs = torch.outer(seq, self.inv_freq)  # [seq len, dim]
+        return freqs
+
+    def forward(
+        self, max_seq_len: int, offset: int = 0, packed_seq: bool = False, device=None
+    ) -> Tensor:
+        """Forward pass of RoPE embedding.
+
+        Args:
+            max_seq_len (int): Maximum size of sequence
+            offset (int, optional): RoPE offset. Defaults to 0.
+            packed_seq (bool, optional): Whether to use packed sequence. Defaults to False.
+
+        Returns
+        -------
+            Tensor: Embeddings after applying RoPE.
+        """
+        if device is None:
+            device = self.inv_freq.device
+        if self.inv_freq.device.type == "cpu":
+            # move `inv_freq` to GPU once at the first micro-batch forward pass
+            self.inv_freq = self.inv_freq.to(device=device)
+
+        freqs = self.get_freqs_non_repeated(max_seq_len, offset).to(device)
+        # first part even vector components, second part odd vector components,
+        #  2 * dim in dimension size
+        if not self.rotary_interleaved:
+            emb = torch.cat((freqs, freqs), dim=-1)
+        else:
+            emb = torch.stack((freqs.view(-1, 1), freqs.view(-1, 1)), dim=-1).view(
+                freqs.shape[0], -1
+            )
+        # emb [seq_length, .., dim]
+        emb = emb[:, None, None, :]
+        return emb.to(device)
+
+    def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
+        state_dict.pop(f"{prefix}inv_freq", None)
+        return super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
+
+    def get_rotary_seq_len(
+        self,
+        transformer_input: Tensor,
+    ) -> float:
+        """Function to get the rotary sequence length.
+        Args:
+            transformer_input (Tensor): Input tensor to the transformer
+        Returns:
+            float: The rotary sequence length
+        """
+        rotary_seq_len = transformer_input.size(0)
+        return rotary_seq_len
+
+
+class IdentityOp(nn.Module):
+    def forward(self, x):
+        return x
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-5):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        """
+        hidden_states [bs, patch_num, d_model]
+        """
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+class TEDotProductAttention(nn.Module):
+    """Implement the scaled dot product attention with softmax.
+    Arguments
+    ---------
+        softmax_scale: The temperature to use for the softmax attention.
+                      (default: 1/sqrt(d_keys) where d_keys is computed at
+                      runtime)
+        attention_dropout: The dropout rate to apply to the attention
+                           (default: 0.0)
+    """
+
+    def __init__(self, causal=False, softmax_scale=None, attention_dropout=0.0):
+        super().__init__()
+        self.causal = causal
+        self.softmax_scale = softmax_scale
+        self.drop = nn.Dropout(attention_dropout)
+
+    def forward(self, q, k, v, attention_mask):
+        """Implements the multihead softmax attention.
+        Arguments
+        ---------
+            q,k,v: The tensor containing the query, key, and value.  [seq_len, batch_size, hidden_size]
+            attention_mask: boolean mask to apply to the attention weights. True means to keep,
+                False means to mask out. [batch_size, 1, seq_len, seq_len]
+        """
+        q = q.transpose(0, 1).contiguous()
+        k = k.transpose(0, 1).contiguous()
+        v = v.transpose(0, 1).contiguous()
+
+        batch_size, seq_len = q.shape[0], q.shape[1]
+        softmax_scale = self.softmax_scale or 1.0 / math.sqrt(q.shape[-1])
+        # scores
+        scores = torch.einsum("bthd,bshd->bhts", q, k * softmax_scale)
+        scores = scores.masked_fill(attention_mask == 0, float("-1e9"))
+        # Softmax
+        attention = torch.softmax(scores, dim=-1, dtype=v.dtype)
+        # Dropout
+        attention_drop = self.drop(attention)
+        output = torch.einsum("bhts,bshd->bthd", attention_drop, v)
+        output = output.reshape(batch_size, seq_len, -1)
+
+        output = output.transpose(0, 1).contiguous()
+        return output
+
+
+class SelfAttention(nn.Module):
+    def __init__(
+        self,
+        config,
+    ):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.core_attention = TEDotProductAttention()
+        self.linear_proj = nn.Linear(
+            self.hidden_size,
+            self.hidden_size,
+            bias=config.add_bias_linear,
+        )
+        self.linear_qkv = nn.Linear(
+            self.hidden_size,
+            3 * self.hidden_size,
+            bias=config.add_bias_linear,
+        )
+
+    def forward(self, x, attention_mask, rotary_pos_emb):
+        """
+        x: [seq_len, batch_size, hidden_size]
+        attention_mask: [batch_size, 1, seq_len, seq_len]
+        rotary_pos_emb: [seq_len, 1, 1, kv_channels(hidden_size // num_heads)]
+        """
+        qkv = self.linear_qkv(x)
+        qkv = qkv.view(qkv.size(0), qkv.size(1), self.config.num_attention_heads, -1)
+        q, k, v = qkv.chunk(3, dim=-1)
+
+        # Apply rotary encoding to q and k
+        rotary_pos_emb = (rotary_pos_emb,) * 2
+        q_pos_emb, k_pos_emb = rotary_pos_emb
+        q = _apply_rotary_pos_emb_bshd(q, q_pos_emb)
+        k = _apply_rotary_pos_emb_bshd(k, k_pos_emb)
+
+        # attention
+        attn_output = self.core_attention(q, k, v, attention_mask)
+        output = self.linear_proj(attn_output)
+        return output
+
+
+class MLP(nn.Module):
+    def __init__(self, config, in_features):
+        super().__init__()
+        self.config = config
+        self.linear_fc1 = nn.Linear(
+            in_features,
+            self.config.moe_ffn_hidden_size * 2,
+            bias=self.config.add_bias_linear,
+        )
+        self.linear_fc2 = nn.Linear(
+            self.config.moe_ffn_hidden_size,
+            self.config.hidden_size,
+            bias=self.config.add_bias_linear,
+        )
+
+    def forward(self, x):
+        x = self.swiglu(self.linear_fc1(x))
+        x = self.linear_fc2(x)
+        return x
+
+    def swiglu(self, y):
+        """Performs SwiGLU (Swish-Gated Linear Unit) activation function.
+
+        Args:
+            y (torch.Tensor): Input tensor to be split into two halves along the last dimension.
+
+        Returns
+        -------
+            torch.Tensor: Result of SwiGLU activation: SiLU(y1) * y2, where y1, y2 are the split halves.
+        """
+        y_1, y_2 = torch.chunk(y, 2, -1)
+        return F.silu(y_1) * y_2
+
+
+class TransformerLayer(nn.Module):
+    def __init__(self, config, input_layernorm):
+        super().__init__()
+        self.config = config
+        if input_layernorm:
+            self.input_layernorm = RMSNorm(self.config.hidden_size)
+        else:
+            self.input_layernorm = IdentityOp()
+        self.self_attention = SelfAttention(config)
+        self.pre_mlp_layernorm = RMSNorm(self.config.hidden_size)
+        self.mlp = MLP(config, self.config.hidden_size)
+
+    def forward(self, x, attention_mask, rotary_pos_emb):
+        """
+        x: [seq_len, batch_size, hidden_size]
+        attention_mask: [batch_size, 1, seq_len, seq_len]
+        rotary_pos_emb: [seq_len, 1, 1, kv_channels(hidden_size // num_heads)]
+        """
+        residual = x
+        x = self.input_layernorm(x)
+        x = self.self_attention(x, attention_mask, rotary_pos_emb)
+        x = x + residual
+        residual = x
+        x = self.pre_mlp_layernorm(x)
+        x = self.mlp(x)
+        x = x + residual
+        return x
+
+
+class FalconTSTExpert(nn.Module):
+    def __init__(
+        self, config, patch_input_size=32, expert_output_size=336, final_layernorm=True
+    ):
+        super().__init__()
+        self.config = config
+        self.patch_size = patch_input_size
+        self.seq_length = config.seq_length
+        assert self.seq_length % self.patch_size == 0, (
+            f"invalid patch_size: {self.patch_size} when seq_length={self.seq_length}"
+        )
+        self.patch_num = self.seq_length // self.patch_size
+        self.flatten_size = self.patch_num * self.config.hidden_size
+
+        self.layers = nn.ModuleList(
+            [
+                TransformerLayer(
+                    config, input_layernorm=config.transformer_input_layernorm
+                )
+                for _ in range(self.config.expert_num_layers)
+            ]
+        )
+        if final_layernorm:
+            self.final_layernorm = RMSNorm(self.config.hidden_size)
+        else:
+            self.final_layernorm = IdentityOp()
+        self.patch_embedding = MLP(config, in_features=patch_input_size)
+        self.output_layer = nn.Linear(
+            in_features=self.flatten_size,
+            out_features=expert_output_size,
+            bias=False,
+        )
+
+    def _forward_patch_embedding(
+        self,
+        input: Tensor,  # [batch_size, seq_len]
+    ):
+        """
+        Perform patch embedding on the input time series.
+
+        This method applies a linear transformation to the input tensor to
+        convert it into patches and then embeds these patches using a linear layer.
+        """
+        batch_size, seq_len = input.shape
+        assert seq_len == self.seq_length, (
+            f"Expected sequence length {self.seq_length}, but got {seq_len}"
+        )
+
+        # Create input_mask based on pad_length
+        # When a time point is masked, its value is mask_pad_value(default:255.)
+        input_mask = (
+            input != self.config.mask_pad_value
+        )  # 0: mask, 1: unmask   [batch_size, seq_len]
+
+        # so whether the masked value 0 has the same effective of attention_mask
+        input_data = input * input_mask  # [batch_size, seq_len]
+
+        # Patchify the input
+        input_data = input_data.unfold(
+            dimension=-1, size=self.patch_size, step=self.patch_size
+        ).contiguous()  # input [batch_size, patch_num, patch_size]
+        hidden_states = self.patch_embedding(
+            input_data
+        )  # hidden_states [batch_size, patch_num, hidden_size]
+        hidden_states = hidden_states.transpose(
+            0, 1
+        ).contiguous()  # hidden_states [patch_num, batch_size, hidden_size], To adapt to the Megatron
+
+        # Patchify the mask: only the entire time points in a patch are masked then this patch is masked
+        attention_mask = input_mask.unfold(
+            dimension=-1, size=self.patch_size, step=self.patch_size
+        ).contiguous()  # [batch_size, patch_num, patch_size]
+        attention_mask = (
+            attention_mask.sum(-1) == self.patch_size
+        )  # [batch_size, patch_num]   # 0: mask, 1: unmask
+        attention_mask[:, -1] = True  # The last patch is not masked
+        _, patch_num = attention_mask.shape
+        attention_mask = attention_mask.unsqueeze(2).repeat(
+            1, 1, patch_num
+        ) * attention_mask.unsqueeze(1).repeat(
+            1, patch_num, 1
+        )  # [batch_size, patch_num, patch_num]
+        attention_mask = attention_mask.unsqueeze(
+            1
+        ).contiguous()  # [batch_size, 1, patch_num, patch_num]
+
+        return hidden_states, attention_mask, input_mask
+
+    def _forward_output(self, hidden_states, output_scale=None, input_mask=None):
+        """
+        Perform a forward pass through the output layer.
+
+        Args:
+            hidden_states (Tensor): Transformed hidden states of shape [patch_num, batch_size, hidden_size]
+            output_scale (Tensor, optional): Expert probabilities for the output layer  [batch_size]
+            input_mask (Tensor, optional): Expert input mask of shape [batch_size, seq_len], 0:mask, 1:unmask
+
+        Returns
+        -------
+            expert_output (Tensor): Expert output of shape [batch_size, expert_output_size]
+        """
+        # [patch_num, batch_size, hidden_size] -> [batch_size, flatten_size (patch_num * hidden_size)]
+        patch_num, batch_size, hidden_size = hidden_states.shape
+        assert (patch_num * hidden_size) == self.flatten_size, (
+            f"patch_num ({patch_num}) * hidden_size ({hidden_size}) != flatten_size ({self.flatten_size})"
+        )
+        hidden_states = (
+            hidden_states.transpose(0, 1).reshape(-1, self.flatten_size).contiguous()
+        )
+        expert_output = self.output_layer(
+            hidden_states
+        )  # [batch_size, expert_output_size]
+        if output_scale is not None:
+            original_dtype = expert_output.dtype
+            expert_output = expert_output * output_scale.unsqueeze(-1)
+            expert_output = expert_output.to(original_dtype)
+
+        return expert_output
+
+    def forward(self, expert_input, rotary_pos_emb, expert_probs=None):
+        hidden_states, attention_mask, input_mask = self._forward_patch_embedding(
+            expert_input
+        )
+        # hidden_states:  [patch_num, batch_size, hidden_size]
+        # attention_mask: [batch_size, 1, patch_num, patch_num]
+        # input_mask:     [batch_size, seq_len]
+
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states, attention_mask, rotary_pos_emb[: hidden_states.shape[0]]
+            )
+
+        hidden_states = self.final_layernorm(hidden_states)
+
+        expert_output = self._forward_output(hidden_states, expert_probs, input_mask)
+        return expert_output
+
+
+class SequentialFalconTST(nn.Module):
+    def __init__(self, config, expert_output_size=336):
+        super().__init__()
+        self.config = config
+        self.expert_output_size = expert_output_size
+        self.local_experts = nn.ModuleList(
+            [
+                FalconTSTExpert(
+                    config,
+                    expert_output_size=expert_output_size,
+                    patch_input_size=config.patch_size_list[expert_id],
+                    final_layernorm=config.moe_expert_final_layernorm,
+                )
+                for expert_id in range(config.num_moe_experts)
+            ]
+        )
+
+    def forward(self, input, routing_map, rotary_pos_emb, expert_probs):
+        expert_output_list = []
+        batch_size, seq_len = input.size()
+
+        for i, expert in enumerate(self.local_experts):
+            token_mask = routing_map[:, i].bool()  # shape (batch,)
+            current_inputs = input[token_mask]  # (num_tokens_for_expert, seq_len)
+            current_probs = expert_probs[token_mask, i]
+
+            if current_inputs.numel() == 0:
+                expert_output = torch.zeros(
+                    0, self.expert_output_size, device=input.device, dtype=input.dtype
+                )
+            else:
+                expert_output = expert(current_inputs, rotary_pos_emb, current_probs)
+
+            full_output = torch.zeros(
+                batch_size,
+                self.expert_output_size,
+                device=input.device,
+                dtype=input.dtype,
+            )
+            full_output[token_mask] = expert_output
+            expert_output_list.append(full_output)
+
+        expert_output = reduce(torch.add, expert_output_list)
+        return expert_output
+
+
+class TopKRouter(nn.Module):
+    def __init__(self, config: FalconTSTConfig):
+        super().__init__()
+        self.config = config
+        self.topk = config.moe_router_topk
+
+        self.weight = nn.Parameter(
+            torch.empty(
+                (config.num_moe_experts, config.moe_router_input_size),
+                dtype=torch.float32,
+            )
+        )
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        nn.init.normal_(self.weight, mean=0, std=self.config.init_method_std)
+
+    def routing(self, logits: torch.Tensor):
+        score_function = self.config.moe_router_score_function
+
+        if score_function == "softmax":
+            if self.config.moe_router_pre_softmax:
+                scores = torch.softmax(logits, dim=-1, dtype=torch.float32).type_as(
+                    logits
+                )
+                probs, top_indices = torch.topk(scores, self.topk, dim=1)
+            else:
+                scores, top_indices = torch.topk(logits, self.topk, dim=1)
+                probs = torch.softmax(scores, dim=-1, dtype=torch.float32).type_as(
+                    logits
+                )
+        else:
+            raise NotImplementedError
+
+        routing_probs = torch.zeros_like(logits).scatter_(1, top_indices, probs)
+        routing_map = torch.zeros_like(logits, dtype=torch.bool).scatter_(
+            1, top_indices, True
+        )
+
+        return routing_probs, routing_map
+
+    def forward(self, input: torch.Tensor):
+        if self.weight.device != input.device:
+            self.weight.data = self.weight.data.to(input.device)
+
+        gating_logits = F.linear(input, self.weight)
+        num_tokens = gating_logits.shape[:-1].numel()
+        gating_logits = gating_logits.view(num_tokens, self.config.num_moe_experts)
+
+        scores, routing_map = self.routing(gating_logits)
+
+        return scores, routing_map
+
+
+class FalconTSTMoELayer(nn.Module):
+    def __init__(self, config, layer_number):
+        super().__init__()
+        self.config = config
+        self.seq_length = config.seq_length
+        self.router = TopKRouter(config)
+        self.layer_number = layer_number
+        self.pred_length = config.pred_length
+        self.is_last_layer = self.layer_number == config.num_hidden_layers
+        if self.is_last_layer and self.config.heterogeneous_moe_layer:
+            self.expert_output_size = config.pred_length
+        else:
+            if self.config.do_expert_forecast:
+                self.expert_output_size = config.seq_length + config.pred_length
+            else:
+                self.expert_output_size = config.seq_length
+
+        if self.is_last_layer and self.config.heterogeneous_moe_layer:
+            # If heterogeneous_moe_layer is True, the backcast will be None
+            self.backcast_layernorm = None
+        else:
+            self.backcast_layernorm = RMSNorm(self.seq_length)
+
+        self.experts = SequentialFalconTST(
+            config,
+            expert_output_size=self.expert_output_size,
+        )
+        self.shared_experts = FalconTSTExpert(
+            config,
+            expert_output_size=self.expert_output_size,
+            patch_input_size=config.shared_patch_size,
+            final_layernorm=config.moe_expert_final_layernorm,
+        )
+
+    def time_series_preprocess(self, input: torch.Tensor):
+        """
+        Preprocess time series(sample) for dispatch.
+
+        Applies RevIN to input time series(sample), and process the input mask (0: mask, 1: unmask)
+
+        Args:
+            input (torch.Tensor): The input time series (samples) to the MoE layer. [batch_size, seq_len]
+
+        Returns
+        -------
+            input (torch.Tensor): The (RevIN) backcast time series (samples). [batch_size, seq_len]
+            means (torch.Tensor): The means of the non-masked backcast time series (samples). [batch_size, 1]
+            stdev (torch.Tensor): The standard deviation of the non-masked backcast time series (samples). [batch_size, 1]
+        """
+        batch_size, seq_len = input.shape
+        assert seq_len == self.seq_length, (
+            f"seq_len {seq_len} != self.seq_length {self.seq_length}"
+        )
+
+        # Create input_mask based on pad_length
+        # When a time point is masked, its value is mask_pad_value(default:255.)
+        input_mask = (
+            input != self.config.mask_pad_value
+        )  # 0: mask, 1: unmask   [batch_size, seq_len]
+
+        self.input_mask = input_mask
+
+        return input
+
+    def router_and_preprocess(self, backcast: torch.Tensor):
+        """Compute and preprocess time series(sample) routing for dispatch.
+
+        This method uses the router to determine which experts to send each time series(sample) to,
+        producing routing probabilities and a mapping. It then preprocesses the
+        input time series (samples) and probabilities for the time series(sample) dispatcher. The original
+        input time series (samples) are returned as a residual connection.
+        """
+        # backcast [batch_size, seq_len]    means/stdev [batch_size, 1]
+        backcast = self.time_series_preprocess(backcast)
+
+        residual = (
+            backcast  # residual: [batch_size, seq_len], the input to the shared experts
+        )
+
+        # TODO: Check the effective of the masked value to the router
+        probs, routing_map = self.router(
+            backcast * self.input_mask
+        )  # probs/routing_map: [batch_size, num_experts]
+
+        return backcast, probs, residual, routing_map
+
+    def experts_compute(
+        self,
+        input: torch.Tensor,  # [num_permuted_samples_after_dispatch, seq_len]
+        probs: torch.Tensor,  # [num_permuted_samples_after_dispatch]
+        residual: torch.Tensor,  # [batch_size, seq_len]
+        rotary_pos_emb: torch.Tensor,
+        routing_map: torch.Tensor,  # [seq_len, 1, 1, kv_channels(hidden_size // num_heads)]
+    ):
+        """Computes the output of the experts on the dispatched time series(sample).
+
+        This method first post-processes the dispatched input to get permuted time series(sample)
+        for each expert. It then passes the time series(sample) through the local experts.
+        If a shared expert is configured and not overlapped with communication,
+        it is also applied. The output from the experts is preprocessed for the
+        combine step.
+        """
+        # shared_expert_output: [batch_size, seq_len (+ pred_len)]
+        shared_experts_output = self.shared_experts(residual, rotary_pos_emb)
+
+        # dispatched_input (global_input_tokens):   [num_permuted_samples_after_dispatch_postprocess(sorted), seq_len]
+        # tokens_per_expert (global_probs):         [num_experts]
+        # permuted_probs (global_probs):            [num_permuted_samples_after_dispatch_postprocess(sorted)]
+
+        experts_output = self.experts(input, routing_map, rotary_pos_emb, probs)
+
+        return experts_output, shared_experts_output
+
+    def combine(
+        self,
+        experts_output: torch.Tensor,
+        shared_experts_output: torch.Tensor,
+    ):
+        """Combines expert outputs via communication and adds shared expert output.
+
+        This method uses the time series(sample) dispatcher to combine the outputs from different
+        experts. It then adds the output from the shared expert if it exists.
+        """
+        assert experts_output.shape == shared_experts_output.shape, (
+            f"experts_output shape {experts_output.shape} doesn't equal to shared_experts_output shape:{shared_experts_output.shape}"
+        )
+        output = experts_output + shared_experts_output
+
+        if self.is_last_layer and self.config.heterogeneous_moe_layer:
+            output_backcast = None
+            output_forecast = output
+            assert output_forecast.shape[1] == self.pred_length, (
+                f"heterogeneous_moe_layer=True, expected the last moe layer's output pred len: {self.pred_length}, but got {output_forecast.shape[1]}"
+            )
+        else:
+            #  Noting: the mask time point there maybe not mask_pad_value(default:255.), it will be postprocessed
+            output_backcast = output[:, : self.seq_length]  # [batch_size, seq_len]
+
+            if self.config.do_expert_forecast:
+                output_forecast = output[:, self.seq_length :]  # [batch_size, pred_len]
+                assert output_forecast.shape[1] == self.pred_length, (
+                    f"do_expert_forecast=True, expected the last moe layer's output pred len: {self.pred_length}, but got {output_forecast.shape[1]}"
+                )
+            else:
+                output_forecast = None
+
+        return output_backcast, output_forecast
+
+    def postprocess(
+        self,
+        backcast: torch.Tensor,  # [batch_size, seq_len]
+        forecast: torch.Tensor,  # [batch_size, pred_len]
+        output_backcast: torch.Tensor,  # [batch_size, seq_len]
+        output_forecast: torch.Tensor,  # [batch_size, pred_len]
+    ):
+        """
+        Args:
+            backcast (torch.Tensor): The previous layer's backcast time series (samples).                   [batch_size, seq_len]
+            forecast (torch.Tensor): The previous layer's forecast time series (samples).                   [batch_size, pred_len]
+            output_backcast (torch.Tensor): The current layer's output backcast time series (samples).      [batch_size, seq_len]
+            output_forecast (torch.Tensor): The current layer's output forecast time series (samples).      [batch_size, pred_len]
+        """
+        if output_backcast is not None:
+            # 25/8/14 @modified by xiaming replace the revin with layernorm after the moe layer
+            # And if we multiply the output_backcast with the input mask, the performance will be hurted
+            output_backcast = self.backcast_layernorm(output_backcast)  # LayerNorm
+            if self.config.residual_backcast:
+                output_backcast = backcast - output_backcast
+
+            output_backcast[~self.input_mask] = (
+                self.config.mask_pad_value
+            )  # Important! Recover the mask time point back to mask_pad_value(default:255.)
+
+        if (
+            self.config.do_expert_forecast and forecast is not None
+        ):  # The first layer's forecast is None
+            output_forecast = forecast + output_forecast
+
+        return output_backcast, output_forecast
+
+    def forward(self, backcast, forecast, rotary_pos_emb):
+        inputs, probs, residual, routing_map = self.router_and_preprocess(backcast)
+        experts_output, shared_experts_output = self.experts_compute(
+            inputs, probs, residual, rotary_pos_emb, routing_map
+        )
+        output_backcast, output_forecast = self.combine(
+            experts_output, shared_experts_output
+        )
+        output_backcast, output_forecast = self.postprocess(
+            backcast, forecast, output_backcast, output_forecast
+        )
+        return output_backcast, output_forecast
+
+
+class FalconTSTBlock(nn.Module):
+    def __init__(self, config, input_layernorm=True):
+        super().__init__()
+        self.config = config
+
+        if input_layernorm:
+            self.input_layernorm = RMSNorm(self.config.seq_length)
+        else:
+            self.input_layernorm = IdentityOp()
+
+        self.layers = nn.ModuleList(
+            [
+                FalconTSTMoELayer(config, layer_num + 1)
+                for layer_num in range(self.config.num_hidden_layers)
+            ]
+        )
+
+    def forward(self, x, rotary_pos_emb):
+        backcast = x
+        forecast = None
+
+        input_mask = backcast != self.config.mask_pad_value
+        backcast = self.input_layernorm(backcast * input_mask)
+        backcast[~input_mask] = self.config.mask_pad_value
+
+        for layer in self.layers:
+            backcast, forecast = layer(backcast, forecast, rotary_pos_emb)
+        return backcast, forecast
+
+
+class FalconTSTPreTrainedModel(PreTrainedModel):
+    config_class = FalconTSTConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["FalconTSTMoELayer"]
+    _skip_keys_device_placement = "past_key_values"
+    _supports_flash_attn_2 = True
+    _supports_sdpa = False
+    _supports_cache_class = True
+
+    def _init_weights(self, module):
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=self.config.initializer_range)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=self.config.initializer_range)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+
+class FalconTSTModel(FalconTSTPreTrainedModel):
+    def __init__(self, config: FalconTSTConfig):
+        super().__init__(config)
+        self.config = config
+        self.seq_length = self.config.seq_length
+        self.rotary_pos_emb = RotaryEmbedding(
+            kv_channels=self.config.kv_channels,
+            rotary_base=self.config.rotary_base,
+            use_cpu_initialization=self.config.use_cpu_initialization,
+            rotary_interleaved=self.config.rotary_interleaved,
+        )
+        self.decoder = FalconTSTBlock(
+            config=config, input_layernorm=self.config.block_input_layernorm
+        )
+        if self.config.do_expert_forecast and self.config.heterogeneous_moe_layer:
+            self.output_layer = IdentityOp()
+        else:
+            self.output_layer = nn.Linear(
+                in_features=self.seq_length,
+                out_features=self.config.pred_length,
+                bias=self.config.add_bias_linear,
+            )
+
+    def revin(
+        self,
+        input: Tensor,  # [batch_size, seq_len]
+        input_mask: Tensor,  # [batch_size, seq_len] 0:mask, 1:unmask
+    ):
+        """Normalization from Non-stationary Transformer"""
+        input_data = input * input_mask
+        sum_per_sample = torch.sum(
+            input_data, dim=1, keepdim=True
+        ).detach()  # [batch_size, 1], torch.bfloat16
+        count_per_sample = torch.sum(
+            input_mask, dim=1, keepdim=True
+        ).detach()  # [batch_size, 1], torch.int64
+        assert torch.any(count_per_sample == 0) == False, (
+            f"There is zero in count_per_sample, shape: {input[torch.where(count_per_sample.squeeze(1) == 0)[0]]}"
+        )
+        means = sum_per_sample / count_per_sample  # [batch_size, 1]
+        input_data = input_data - means
+        input_data = input_data * input_mask
+        var_per_sample = (
+            torch.sum(input_data**2, dim=1, keepdim=True).detach() / count_per_sample
+        )  # [batch_size, 1]
+        stdev = torch.sqrt(var_per_sample + 1e-9)
+        input_data = input_data / stdev
+        input_data = input_data * input_mask
+
+        # recover the mask_pad_value(default:255.)
+        input = input * ~(input_mask) + input_data
+
+        return input, means, stdev
+
+    def forward(self, input, revin):
+        batch_size, input_len = input.shape
+        # realize varied input length
+        if input_len > self.seq_length:
+            input = input[:, -self.seq_length :]
+        elif input_len < self.seq_length:
+            pad_len = self.seq_length - input_len
+            input = F.pad(
+                input,
+                pad=(pad_len, 0),
+                mode="constant",
+                value=self.config.mask_pad_value,
+            )
+        input_len = self.seq_length
+
+        input_mask = input != self.config.mask_pad_value
+
+        # Step1. RevIN
+        if revin:
+            input, means, stdev = self.revin(input, input_mask)
+
+        # Step2. Get rotary_pos_emb
+        # rotary_pos_emb [input_len, 1, 1, kv_channels(hidden_size // num_heads)]
+        rotary_pos_emb = self.rotary_pos_emb(input_len, device=input.device)
+
+        # Step3. Do one-step inference to get mixed forecasts from multiple forecast heads
+        # mixed_pred: [batch_size, max(multi_forecast_head)]
+        mixed_pred = self._inference_step(
+            input=input, input_mask=input_mask, rotary_pos_emb=rotary_pos_emb
+        )
+
+        # Step4. Based on the mixed forecasts, do auto-regressive inference according to
+        # the step list of each forecast head
+        if self.config.multi_forecast_head_type == "single":
+            final_output = self._auto_regressive_single_head(
+                input=input,
+                input_mask=input_mask,
+                FalconTST_forecast=mixed_pred,
+                rotary_pos_emb=rotary_pos_emb,
+            )
+        else:
+            raise NotImplementedError
+
+        # Step5. RevIN
+        if revin:
+            final_output = final_output * (
+                stdev.repeat(1, self.config.inference_length)
+            )
+            final_output = final_output + (
+                means.repeat(1, self.config.inference_length)
+            )
+
+        return final_output.detach().float()
+
+    def _inference_step(
+        self,
+        input,
+        input_mask,
+        rotary_pos_emb,
+    ):
+        if self.config.do_base_forecast:
+            base_forecast, _ = self.base_output_layer(input * input_mask)
+        else:
+            base_forecast = None
+
+        decoder_backcast, decoder_forecast = self.decoder(
+            input,  # [batch_size, seq_len]
+            rotary_pos_emb,  # [input_len, 1, 1, kv_channels(hidden_size // num_heads)]
+        )
+
+        if self.config.do_expert_forecast:
+            assert decoder_forecast is not None, "decoder_forecast is None"
+            if self.config.heterogeneous_moe_layer:
+                decoder_forecast = self.output_layer(decoder_forecast)  # IdentityOp
+            else:
+                final_forecast = self.output_layer(decoder_backcast * input_mask)
+                decoder_forecast = decoder_forecast + final_forecast
+        else:
+            # The decoder_backcast contains the mask_pad_val(default:255.)
+            decoder_forecast, _ = self.output_layer(decoder_backcast * input_mask)
+
+        if self.config.do_base_forecast:
+            assert base_forecast is not None, "base_forecast is None"
+            FalconTST_forecast = base_forecast + decoder_forecast
+        else:
+            FalconTST_forecast = decoder_forecast
+
+        return FalconTST_forecast
+
+    def _auto_regressive_single_head(
+        self,
+        input,  # [batch_size, seq_len]
+        input_mask,  # [batch_size, seq_len]
+        FalconTST_forecast,  # [batch_size, max(multi_forecast_head)]
+        rotary_pos_emb,  # [seq_len, 1, 1, kv_channels(hidden_size // num_heads)]
+        auto_regressive_strategy="from_long_to_short",
+    ):
+        """Auto regressive prediction with [single] head"""
+        assert self.config.multi_forecast_head_type == "single", (
+            "_auto_regressive_single_head only support multi_forecast_head_type==single "
+        )
+
+        if auto_regressive_strategy == "from_long_to_short":
+            # From long to short
+            multi_forecast_head_list = sorted(
+                self.config.multi_forecast_head_list, reverse=True
+            )
+
+            final_output = FalconTST_forecast
+            while final_output.shape[1] < self.config.inference_length:
+                # adaptive choose the forecast head
+                remain_pred_len = self.config.inference_length - final_output.shape[1]
+                for idx, head_pred_len in enumerate(multi_forecast_head_list):
+                    if head_pred_len <= remain_pred_len:
+                        break
+                if idx == len(multi_forecast_head_list):
+                    idx = len(multi_forecast_head_list) - 1
+                head_pred_len = multi_forecast_head_list[idx]
+
+                # one-step model prediction
+                input = torch.cat([input, FalconTST_forecast], dim=1)[
+                    :, -self.seq_length :
+                ].contiguous()
+                input_mask = torch.cat(
+                    [
+                        input_mask,
+                        torch.ones(
+                            FalconTST_forecast.shape,
+                            dtype=input_mask.dtype,
+                            device=input_mask.device,
+                        ),
+                    ],
+                    dim=1,
+                )[:, -self.seq_length :].contiguous()  # 0:mask, 1:unmask
+
+                FalconTST_forecast = self._inference_step(
+                    input=input,
+                    input_mask=input_mask,
+                    rotary_pos_emb=rotary_pos_emb,
+                )
+
+                # the core idea of multi forecast head type of [single]
+                FalconTST_forecast = FalconTST_forecast[:, :head_pred_len]
+
+                final_output = torch.cat([final_output, FalconTST_forecast], dim=1)
+
+            final_output = final_output[:, : self.config.inference_length]
+
+        else:
+            raise NotImplementedError
+
+        assert final_output.shape[1] == self.config.inference_length
+        return final_output
+
+
+class FalconTSTForPrediction(FalconTSTPreTrainedModel):
+    def __init__(self, config: FalconTSTConfig):
+        super().__init__(config)
+        self.config = config
+        self.model = FalconTSTModel(self.config)
+        self.post_init()
+
+    @torch.no_grad()
+    def predict(
+        self,
+        time_series: torch.Tensor,
+        forecast_horizon: int,
+        revin: bool = True,
+    ) -> torch.Tensor:
+        """
+        Generates time series forecasts autoregressively.
+
+        Args:
+            time_series (torch.Tensor): Input time series data.
+                                        Shape: [batch_size, seq_len] or [batch_size, seq_len, channels].
+            forecast_horizon (int): The number of future time steps to predict.
+
+        Returns
+        -------
+            torch.Tensor: The forecasted time series. Shape: [batch_size, forecast_horizon, channels].
+        """
+        self.eval()
+
+        assert time_series.ndim == 2 or time_series.ndim == 3, (
+            "Input shape must be [batch, seq_len, channel] or [batch, seq_len]"
+        )
+        is_multichannel = time_series.ndim == 3
+        if is_multichannel:
+            batch_size, seq_len, num_channels = time_series.shape
+            # [B, L, C] -> [B * C, L]
+            input_flat = time_series.permute(0, 2, 1).reshape(
+                batch_size * num_channels, seq_len
+            )
+        else:
+            batch_size, seq_len = time_series.shape
+            num_channels = 1
+            input_flat = time_series
+
+        self.config.inference_length = forecast_horizon
+        forecast_flat = self.model(input=input_flat, revin=revin)  # Shape: [B * C, H]
+
+        if is_multichannel:
+            forecast = forecast_flat.reshape(batch_size, num_channels, forecast_horizon)
+            forecast = forecast.permute(0, 2, 1).contiguous()
+        else:
+            forecast = forecast_flat
+
+        return forecast


### PR DESCRIPTION
Fixes #10351

Adds `FalconTSTForecaster`, a new `sktime` interface for Ant International's Falcon-TST model using a local `transformers` implementation.

Changes:

* Add zero-shot forecasting support for Falcon-TST
* Add multivariate forecasting support
* Support `device_map`, `quantization_config`, and RevIN control
* Add vendored Falcon-TST configuration and model code under `sktime.libs`
* Add docs, examples, and VM test support

CC: @Harryx2019 @figolyd