### PR TITLE
[ENH] make `show_versions` normalization proof, e.g., for `huggingface-hub`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
   "numpy>=1.21,<2.5",  # required for framework layer and base class logic
   "packaging",  # for estimator specific dependency parsing
   "pandas<3.0.0,>=1.1",  # pandas is the main in-memory data container
-  "scikit-base>=0.13.1,<1.1.0",  # base module for sklearn compatible base API
+  "scikit-base>=1.0.0,<1.1.0",  # base module for sklearn compatible base API
   "scikit-learn>=0.24,<1.8.0",  # required for estimators and framework layer
   "scipy<2.0.0,>=1.2",  # required for estimators and framework layer
 ]

--- a/sktime/utils/_maint/_show_versions.py
+++ b/sktime/utils/_maint/_show_versions.py
@@ -78,13 +78,17 @@ def _get_deps_info(deps=None):
     if deps is None:
         deps = ["sktime"]
 
-    from skbase.utils.dependencies._dependencies import _get_installed_packages
+    from skbase.utils.dependencies._dependencies import (
+        _get_installed_packages,
+        _norm_pkgname,
+    )
 
-    pkgs = _get_installed_packages()
+    pkgs = _get_installed_packages(lowercase=True)
 
     deps_info = {}
     for modname in deps:
-        deps_info[modname] = pkgs.get(modname, None)
+        modname_norm = _norm_pkgname(modname)
+        deps_info[modname] = pkgs.get(modname_norm, None)
 
     return deps_info
 


### PR DESCRIPTION
This PR makes `show_versions` robust against packages that have different normalization in pypi package name and `distributions` metadata, e.g., `huggingface-hub` on pypi, which appears as `huggingface_hub` in the `distributions` mechanism (or also on import path).

Fixes a secondary bug that would be caused by discrepancy of `distributions` and pypi name in `show_versions` with regards to `huggingface-hub`, if using the new package name normalization mechanism for dependency handling in `scikit-base` 1.0.