### PR TITLE
[ENH] fix deprecated import in `test_hf_transformers_forecaster.py`

### DIFF
--- a/sktime/forecasting/tests/test_hf_transformers_forecaster.py
+++ b/sktime/forecasting/tests/test_hf_transformers_forecaster.py
@@ -5,7 +5,7 @@ __author__ = ["Spinachboul"]
 import pytest
 
 from sktime.datasets import load_airline
-from sktime.forecasting.hf_transformers_forecaster import HFTransformersForecaster
+from sktime.forecasting.hf_transformers import HFTransformersForecaster
 from sktime.tests.test_switch import run_test_for_class
 
 


### PR DESCRIPTION
fixes a deprecated import path in `test_hf_transformers_forecaster.py`