### PR TITLE
[ENH] deduplicate `ARIMA` test skips

### DIFF
--- a/sktime/forecasting/arima/_pmdarima.py
+++ b/sktime/forecasting/arima/_pmdarima.py
@@ -712,7 +712,7 @@ class ARIMA(_PmdArimaAdapter):
         # -----------------
         "tests:skip_by_name": [
             "test_predict_time_index_with_X",  # bug report #9081
-            "test_predict_time_index_in_sample_full",  # bug report #10299
+            "test_predict_time_index_in_sample_full",  # bug report #10299 and #4765
         ],
     }
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -104,9 +104,6 @@ EXCLUDED_TESTS = {
     "DynamicFactor": [
         "test_predict_time_index_in_sample_full",  # refer to #4765
     ],
-    "ARIMA": [
-        "test_predict_time_index_in_sample_full",  # refer to #4765
-    ],
     "Pipeline": ["test_inheritance"],  # does not inherit from intermediate base classes
     # networks do not support negative fh
     "HFTransformersForecaster": ["test_predict_time_index_in_sample_full"],


### PR DESCRIPTION
This PR deduplicates duplicate `ARIMA` test skips.