### PR TITLE
[BUG] fix cutoff in `evaluate` global mode, use `y_hist` not global `y_train`

### DIFF
--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -282,7 +282,16 @@ def _evaluate_window(x, meta):
                 temp_result[result_key] = [score]
 
         # get cutoff
-        cutoff = forecaster.cutoff
+        if global_mode:
+            # in global mode, cutoff should reflect y_hist (per-fold history),
+            # not the global y_train which may span more timepoints
+            if isinstance(y_hist.index, pd.MultiIndex):
+                last_time = y_hist.index.get_level_values(-1).max()
+            else:
+                last_time = y_hist.index[-1]
+            cutoff = pd.Index([last_time])
+        else:
+            cutoff = forecaster.cutoff
 
     except Exception as e:
         if error_score == "raise":


### PR DESCRIPTION
Fixes #10366

**Root cause:** In `_evaluate_window`, `forecaster.cutoff` reflects the last timepoint of the global `y_train` (e.g., 2000-01-05), but in global mode the cutoff should be the last timepoint of `y_hist` (the per-fold prediction window, e.g., 2000-01-04 with window_length=4). This caused a one-day offset.

**Fix:** When `global_mode=True`, derive cutoff from `y_hist`'s last temporal index instead of `forecaster.cutoff`.
