### PR TITLE
[ENH] passing `fh: int` to forecast `range(1, fh + 1)`

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -2201,10 +2201,10 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         Parameters
         ----------
         fh : int, list, pd.Index coercible, or ``ForecastingHorizon``, default=None
-             If fh is not None and not of type ForecastingHorizon it is coerced to
-             ForecastingHorizon (e.g. in sktime.utils.validation.forecasting.check_fh)
-             In particular, if fh is of type pd.Index it is coerced via
-             ForecastingHorizon(fh, is_relative=False)
+            If fh is not None and not of type ForecastingHorizon it is coerced to
+            ForecastingHorizon (e.g. in sktime.utils.validation.forecasting.check_fh)
+            In particular, if fh is of type pd.Index it is coerced via
+            ForecastingHorizon(fh, is_relative=False)
         pred_int: Check pred_int:insample tag instead of insample tag.
 
         Returns

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -207,6 +207,21 @@ class ForecastingHorizon:
     values : pd.Index, pd.TimedeltaIndex, np.array, list, pd.Timedelta, or int
         Values of forecasting horizon
 
+        * int, positive: interpreted as forecasting horizon at period offsets
+          1, 2, ..., int.
+        * int, non-positive: interpreted as forecasting horizon at number of periods
+          in the past or present relative to the cutoff, with a single period offset,
+          the integer. At the default ``is_relative=True``,
+          zero is the cutoff itself, i.e., nowcasting the last observation.
+          Negative integers are interpreted as in-sample forecasting horizon values.
+        * range: interpreted as forecasting horizon with values in the range
+        * pd.Index of supported type: interpreted as forecasting horizon with values
+          as in the index. 
+        * iterable of int or pd.Timedelta or date offset:
+          interpreted as forecasting horizon with values in the iterable.
+          Whether relative or absolute forecasting horizon is determined by the
+          type of the values.
+
     is_relative : bool, optional (default=None)
 
         - If True, a relative ForecastingHorizon is created:
@@ -214,8 +229,10 @@ class ForecastingHorizon:
         - If False, an absolute ForecastingHorizon is created:
           values are absolute.
         - if None, the flag is determined automatically:
-          relative, if values are of supported relative index type
-          absolute, if not relative and values of supported absolute index type
+          relative, if values are of supported relative index type:
+          integer-like, timedelta-like, or date offset-like types.
+          absolute, if not relative and values of supported absolute index type:
+          time index types, e.g., DatetimeIndex or PeriodIndex.
 
     freq : str, pd.Index, pandas offset, or sktime forecaster, optional (default=None)
         object carrying frequency information on values

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -216,7 +216,7 @@ class ForecastingHorizon:
           Negative integers are interpreted as in-sample forecasting horizon values.
         * range: interpreted as forecasting horizon with values in the range
         * pd.Index of supported type: interpreted as forecasting horizon with values
-          as in the index. 
+          as in the index.
         * iterable of int or pd.Timedelta or date offset:
           interpreted as forecasting horizon with values in the iterable.
           Whether relative or absolute forecasting horizon is determined by the

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -102,10 +102,9 @@ def _check_values(values) -> pd.Index:
     if is_in_valid_index_types(values):
         pass
 
-    # convert single integer or timedelta or dateoffset
-    # to pandas index, no further checks needed
+    # convert single integer to range index 1 ... integer, no further checks needed
     elif is_int(values):
-        values = pd.Index([values], dtype=int)
+        values = pd.Index(range(1, values + 1), dtype=int)
 
     # convert range object to pandas.RangeIndex
     # range has to be for integers, no need to separate check

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -102,9 +102,15 @@ def _check_values(values) -> pd.Index:
     if is_in_valid_index_types(values):
         pass
 
-    # convert single integer to range index 1 ... integer, no further checks needed
-    elif is_int(values):
+    # convert single positive integer to range index 1 ... integer,
+    # no further checks needed
+    elif is_int(values) and values > 0:
         values = pd.Index(range(1, values + 1), dtype=int)
+
+    # convert single non-positive integer to index with one value,
+    # no further checks needed
+    elif is_int(values) and values <= 0:
+        values = pd.Index([values], dtype=int)
 
     # convert range object to pandas.RangeIndex
     # range has to be for integers, no need to separate check

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -254,7 +254,7 @@ def test_linear_extrapolation_endogenous_only(
     not run_test_module_changed(["sktime.forecasting", "sktime.split"]),
     reason="run test only if forecasting or split module has changed",
 )
-@pytest.mark.parametrize("fh", [1, 3, 5])
+@pytest.mark.parametrize("fh", [[1], [3], [5]])
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
 @pytest.mark.parametrize("strategy", STRATEGIES)
 @pytest.mark.parametrize("scitype", ["time-series-regressor", "tabular-regressor"])


### PR DESCRIPTION
This PR adds a coercion of interpreting `fh: int` as the `range(1, fh + 1)`, allowing convenient and quick passing of contiguous integer ranges.