### PR TITLE
[ENH] Add validation warning for zero or negative values in relative ForecastingHorizon #8525

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -324,6 +324,22 @@ class ForecastingHorizon:
                 raise TypeError(error_msg)
         self._is_relative = is_relative
 
+        #  Check for zero or negative values in relative forecasting horizon (Issue #8525) ---
+        if self._is_relative and len(self._values) > 0:
+            from sktime.utils.warnings import warn
+            
+            # Determine the appropriate zero baseline depending on index type
+            null_value = 0 if is_integer_index(self._values) else pd.Timedelta(0)
+            
+            # Trigger a warning if any value is less than or equal to zero
+            if (self._values <= null_value).any():
+                warn(
+                    "Relative forecasting horizon `fh` contains values that are less than "
+                    "or equal to zero. This implies in-sample or backcasting predictions.",
+                    obj=self,
+                    stacklevel=2,
+                )
+
     def _new(self, values=None, is_relative=None, freq=None):
         """Construct new ForecastingHorizon based on current object.
 

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -1071,3 +1071,22 @@ def test_timestamp_format_to_absolute():
     fh = ForecastingHorizon([1, 2, 3], freq="D")
     y_pred_idx = fh.to_absolute_index(cutoff)
     assert "12:00:00" in str(y_pred_idx)
+    
+
+def test_fh_zero_or_negative_relative_warning():
+    """Test that a warning is correctly raised for zero or negative relative horizons."""
+    import pytest
+    import pandas as pd
+    from sktime.forecasting.base import ForecastingHorizon
+
+    # Case 1: Check that an integer list containing zero triggers the warning
+    with pytest.warns(UserWarning, match="Relative forecasting horizon `fh` contains values"):
+        ForecastingHorizon([0, 1, 2], is_relative=True)
+
+    # Case 2: Check that an integer list containing a negative value triggers the warning
+    with pytest.warns(UserWarning, match="Relative forecasting horizon `fh` contains values"):
+        ForecastingHorizon([-3, -1, 5], is_relative=True)
+
+    # Case 3: Check that a pandas TimedeltaIndex containing zero duration triggers the warning
+    with pytest.warns(UserWarning, match="Relative forecasting horizon `fh` contains values"):
+        ForecastingHorizon(pd.TimedeltaIndex(["0D", "1D", "2D"]), is_relative=True)


### PR DESCRIPTION
### Summary of Changes
This Pull Request addresses issue #8525 by introducing a runtime mathematical validation warning inside the `ForecastingHorizon` class initialization. 

When a user accidentally passes values that are less than or equal to zero (0 or negative) into a **relative** forecasting horizon, the system will now raise a clear `UserWarning`. This helps notify users that their input implies an in-sample overlap or backcasting prediction, preventing downstream model confusion.

### What was changed:
* **`sktime/forecasting/base/_fh.py`**: Added an explicit check at the end of `__init__` that triggers a professional `UserWarning` if `self._is_relative` is True and any value matches `<= 0` (handled safely for both integer indices and `pd.Timedelta` intervals).
* **`sktime/forecasting/base/tests/test_fh.py`**: Created a dedicated unit test `test_fh_zero_or_negative_relative_warning` covering edge cases for zero lists, negative inputs, and zero-duration `pd.TimedeltaIndex` layouts.

### Testing Done
* Ran the new test locally using: `python -m pytest sktime/forecasting/base/tests/test_fh.py -k test_fh_zero_or_negative_relative_warning -n0`
* **Result:** 1 passed successfully in 0.81s.

Fixes #8525