### PR TITLE
[DOC] Add usage examples to LinearTrendCost docstring (#4264)

### DIFF
--- a/sktime/detection/costs/_linear_trend_cost.py
+++ b/sktime/detection/costs/_linear_trend_cost.py
@@ -101,6 +101,31 @@ class LinearTrendCost(BaseCost):
     share_fixed_trend : bool, optional (default=False)
         If True, a single ``[slope, intercept]`` pair is broadcast
         to all data columns.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.detection.costs import LinearTrendCost
+    >>>
+    >>> # Example 1: Basic usage with auto-fitted parameters
+    >>> # Create synthetic data with a linear trend
+    >>> X = np.array([[1.0], [2.0], [3.0], [4.0], [5.0]])
+    >>> cost = LinearTrendCost()
+    >>>
+    >>> # Evaluate cost for a single segment [0, 5)
+    >>> cuts = np.array([[0, 5]])  # [start, end] format
+    >>> result = cost.evaluate(X, cuts)
+    >>> print(f"Cost: {result[0, 0]:.4f}")  # doctest: +SKIP
+    >>>
+    >>> # Example 2: With fixed trend parameters
+    >>> # Use a fixed slope and intercept
+    >>> cost_fixed = LinearTrendCost(param=np.array([[1.0, 0.5]]))
+    >>> result_fixed = cost_fixed.evaluate(X, cuts)
+    >>>
+    >>> # Example 3: Multiple segments
+    >>> cuts_multi = np.array([[0, 3], [2, 5]])  # Multiple [start, end] pairs
+    >>> result_multi = cost.evaluate(X, cuts_multi)
+    >>> print(f"Costs: {result_multi.flatten()}")  # doctest: +SKIP
     """
 
     _tags = {


### PR DESCRIPTION
### Reference Issues/PRs


Related to #4264.


### What does this implement/fix? Please describe your changes.


Added Examples section to the docstring of `LinearTrendCost`.


There are three examples provided detailing:


1. Basic usage of `LinearTrendCost` with fitted trend parameters determined by the algorithm.
2. Using `LinearTrendCost` with trend parameters provided by user input (typically previous periods).
3. Evaluating multiple segments of time using the segment option with `LinearTrendCost`.


No code changes were made; only additions to the docstring.


### Did you introduce any dependencies with your contribution? If so, what are they?


No.


### What should the reviewer focus on when reviewing this PR?


- Does the Examples section conform to current examples in sktime documentation?
- Do the examples sufficiently demonstrate the functionality and intended usage of `LinearTrendCost`?
- Are the examples chosen illustrative enough for a new user to understand how to use `LinearTrendCost`?


### Did you add tests for this change?


The examples provided in the docstring were validated via local doctests.


### Additional comments


The `LinearTrendCost` docstring did not previously include an Examples section.


### PR Checklist


- [x] The title of this PR begins with [DOC].


### For new estimators:


N/A - No new estimator added.