### PR TITLE
[BUG] Fix apply_method_per_series for scalar group keys in 2-level MultiIndex

### DIFF
--- a/sktime/detection/costs/_linear_trend_cost.py
+++ b/sktime/detection/costs/_linear_trend_cost.py
@@ -101,6 +101,31 @@ class LinearTrendCost(BaseCost):
     share_fixed_trend : bool, optional (default=False)
         If True, a single ``[slope, intercept]`` pair is broadcast
         to all data columns.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.detection.costs import LinearTrendCost
+    >>>
+    >>> # Example 1: Basic usage with auto-fitted parameters
+    >>> # Create synthetic data with a linear trend
+    >>> X = np.array([[1.0], [2.0], [3.0], [4.0], [5.0]])
+    >>> cost = LinearTrendCost()
+    >>>
+    >>> # Evaluate cost for a single segment [0, 5)
+    >>> cuts = np.array([[0, 5]])  # [start, end] format
+    >>> result = cost.evaluate(X, cuts)
+    >>> print(f"Cost: {result[0, 0]:.4f}")  # doctest: +SKIP
+    >>>
+    >>> # Example 2: With fixed trend parameters
+    >>> # Use a fixed slope and intercept
+    >>> cost_fixed = LinearTrendCost(param=np.array([[1.0, 0.5]]))
+    >>> result_fixed = cost_fixed.evaluate(X, cuts)
+    >>>
+    >>> # Example 3: Multiple segments
+    >>> cuts_multi = np.array([[0, 3], [2, 5]])  # Multiple [start, end] pairs
+    >>> result_multi = cost.evaluate(X, cuts_multi)
+    >>> print(f"Costs: {result_multi.flatten()}")  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/utils/multiindex.py
+++ b/sktime/utils/multiindex.py
@@ -159,6 +159,10 @@ def apply_method_per_series(y, method_name, *args, **kwargs):
         y_series = y.loc[group_keys]
         y_series = getattr(y_series, method_name)(*args, **kwargs)
         # Add multiindex
+        # Ensure group_keys is always a tuple for unpacking
+        # For 2-level MultiIndex, droplevel(-1).unique() returns scalars
+        if not isinstance(group_keys, tuple):
+            group_keys = (group_keys,)
         y_series.index = pd.MultiIndex.from_tuples(
             [(*group_keys, idx) for idx in y_series.index], names=y.index.names
         )

--- a/sktime/utils/tests/test_multiindex.py
+++ b/sktime/utils/tests/test_multiindex.py
@@ -164,3 +164,155 @@ def test_is_hierarchical():
 
     assert result_true
     assert not result_false
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils.multiindex"]),
+    reason="Run if multiindex module has changed.",
+)
+def test_apply_method_per_series_integer_instance_ids():
+    """Test apply_method_per_series with integer instance IDs.
+
+    This is a regression test for a bug where apply_method_per_series
+    would fail with TypeError when the MultiIndex had 2 levels with
+    integer instance IDs, because droplevel(-1).unique().to_list()
+    returns scalar integers instead of tuples.
+
+    The unpacking operator (*group_keys) fails on non-iterable scalars.
+    """
+    from sktime.utils.multiindex import apply_method_per_series
+
+    # Create a 2-level MultiIndex with integer instance IDs
+    index = pd.MultiIndex.from_product(
+        [[0, 1, 2], [0, 1, 2, 3, 4]], names=["instance", "time"]
+    )
+    y = pd.Series(range(15), index=index, name="value")
+
+    # This should not raise TypeError
+    result = apply_method_per_series(y, "shift", periods=1)
+
+    # Verify the result is correct
+    assert isinstance(result, pd.Series)
+    assert len(result) == len(y)
+    assert result.index.equals(y.index)
+    assert result.index.names == y.index.names
+
+    # Verify shift worked correctly per series
+    expected = y.groupby(level=0).shift(periods=1)
+    pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils.multiindex"]),
+    reason="Run if multiindex module has changed.",
+)
+def test_apply_method_per_series_float_instance_ids():
+    """Test apply_method_per_series with float instance IDs."""
+    from sktime.utils.multiindex import apply_method_per_series
+
+    index = pd.MultiIndex.from_product(
+        [[0.0, 1.0, 2.0], [0, 1, 2]], names=["instance", "time"]
+    )
+    y = pd.Series(range(9), index=index, name="value")
+
+    result = apply_method_per_series(y, "shift", periods=1)
+
+    assert isinstance(result, pd.Series)
+    assert len(result) == len(y)
+    assert result.index.names == y.index.names
+
+    expected = y.groupby(level=0).shift(periods=1)
+    pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils.multiindex"]),
+    reason="Run if multiindex module has changed.",
+)
+def test_apply_method_per_series_string_instance_ids():
+    """Test apply_method_per_series with string instance IDs."""
+    from sktime.utils.multiindex import apply_method_per_series
+
+    index = pd.MultiIndex.from_product(
+        [["a", "b", "c"], [0, 1, 2]], names=["instance", "time"]
+    )
+    y = pd.Series(range(9), index=index, name="value")
+
+    result = apply_method_per_series(y, "shift", periods=1)
+
+    assert isinstance(result, pd.Series)
+    assert len(result) == len(y)
+    assert result.index.names == y.index.names
+
+    expected = y.groupby(level=0).shift(periods=1)
+    pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils.multiindex"]),
+    reason="Run if multiindex module has changed.",
+)
+def test_apply_method_per_series_hierarchical():
+    """Test apply_method_per_series with 3-level hierarchical MultiIndex."""
+    from sktime.utils.multiindex import apply_method_per_series
+
+    index = pd.MultiIndex.from_product(
+        [["region_A", "region_B"], [0, 1], [0, 1, 2]],
+        names=["region", "instance", "time"],
+    )
+    y = pd.Series(range(12), index=index, name="value")
+
+    result = apply_method_per_series(y, "shift", periods=1)
+
+    assert isinstance(result, pd.Series)
+    assert len(result) == len(y)
+    assert result.index.names == y.index.names
+
+    # Verify shift worked correctly per series (grouped by first 2 levels)
+    expected = y.groupby(level=[0, 1]).shift(periods=1)
+    pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils.multiindex"]),
+    reason="Run if multiindex module has changed.",
+)
+def test_apply_method_per_series_dataframe():
+    """Test apply_method_per_series with DataFrame and integer instance IDs."""
+    from sktime.utils.multiindex import apply_method_per_series
+
+    index = pd.MultiIndex.from_product(
+        [[0, 1], [0, 1, 2, 3]], names=["instance", "time"]
+    )
+    df = pd.DataFrame({"col1": range(8), "col2": range(10, 18)}, index=index)
+
+    result = apply_method_per_series(df, "shift", periods=1)
+
+    assert isinstance(result, pd.DataFrame)
+    assert result.shape == df.shape
+    assert result.index.names == df.index.names
+
+    # Verify shift worked correctly per series
+    expected = df.groupby(level=0).shift(periods=1)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils.multiindex"]),
+    reason="Run if multiindex module has changed.",
+)
+def test_apply_method_per_series_single_level():
+    """Test apply_method_per_series with single-level index."""
+    from sktime.utils.multiindex import apply_method_per_series
+
+    index = pd.Index([0, 1, 2, 3, 4], name="time")
+    y = pd.Series([10, 20, 30, 40, 50], index=index, name="value")
+
+    result = apply_method_per_series(y, "shift", periods=1)
+
+    assert isinstance(result, pd.Series)
+    assert len(result) == len(y)
+
+    # For single-level index, should apply method directly
+    expected = y.shift(periods=1)
+    pd.testing.assert_series_equal(result, expected)


### PR DESCRIPTION
## Description

For 2-level MultiIndex objects, pandas returns scalar group keys after
`droplevel(-1).unique()`.

The current implementation assumes tuple-like keys during MultiIndex
reconstruction, which causes failures for scalar values and incorrect
handling of string keys.

This patch normalizes scalar group keys to single-element tuples before
unpacking and adds regression tests covering integer, float, string,
and hierarchical MultiIndex cases.