### PR TITLE
[BUG] Fix ThetaLinesTransformer return type for scalar theta

### DIFF
--- a/sktime/transformations/theta.py
+++ b/sktime/transformations/theta.py
@@ -112,7 +112,7 @@ class ThetaLinesTransformer(BaseTransformer):
         theta_lines = np.zeros((X.shape[0], len(theta)))
         for i, theta_i in enumerate(theta):
             theta_lines[:, i] = _theta_transform(X, trend, theta_i)
-        if isinstance(self.theta, (float, int)):
+        if len(theta) == 1:
             return pd.Series(theta_lines.flatten(), index=X.index)
         else:
             return pd.DataFrame(theta_lines, columns=self.theta, index=X.index)


### PR DESCRIPTION
Reference Issues/PRs
Closes #10387

What does this implement/fix?
`_check_theta()` converts `int`/`float` to a list on line 105, making
the `isinstance(self.theta, (float, int))` branch on line 115 always
`False` — so `pd.Series` was never returned for scalar theta inputs.

Fix: replace `isinstance` check with `len(theta) == 1`.

Does your contribution introduce a new dependency?
No.

Did you add any tests for the change?
No — documentation-only behaviour fix. Existing tests cover the transform output.

PR checklist:
- [x] The PR title starts with [BUG]
- [x] Fixes a documented issue (#10387)