### PR TITLE
[DOC] fix readthedocs build

### DIFF
--- a/docs/source/api_reference/performance_metrics.rst
+++ b/docs/source/api_reference/performance_metrics.rst
@@ -214,19 +214,3 @@ Segment detection
     :template: function.rst
 
     RandIndex
-
-
-Legacy detection metrics
-------------------------
-
-These metrics do not follow the standard API and will be deprecated in the future.
-
-.. currentmodule:: sktime.performance_metrics.annotation
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: function.rst
-
-    count_error
-    hausdorff_error
-    prediction_ratio


### PR DESCRIPTION
The readthedocs documentation was not building due to legacy objects removed in 1.0 still being linked.

In order to restore proper build of stable docs, references to the legacy objects are removed.