### PR TITLE
[ENH] exclude sktime.libs from estimator discovery

### DIFF
--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -177,6 +177,7 @@ def all_estimators(
         "registry",
         "normal",
         "_normal",
+        "libs",
     )
 
     ROOT = str(Path(__file__).parent.parent)  # sktime package root directory


### PR DESCRIPTION
Fixes #10399

Added `"libs"` to `MODULES_TO_IGNORE` in `sktime/registry/_lookup.py`.

Root cause: `all_objects()` walks all submodules and imports each via `importlib.import_module`. `sktime.libs` was not excluded, so vendored modules with top-level dependency imports (e.g. `from transformers import ...`) were triggered during every `all_estimators()` call, crashing in environments where those deps aren't installed.

Fix: adding `"libs"` to `MODULES_TO_IGNORE` stops `all_objects()` from walking into `sktime/libs` entirely, eliminating the need to patch vendored code with `_safe_import` workarounds.
