### PR TITLE
[ENH] point duplicative `sktime.dependencies` imports to `scikit-base`

### DIFF
--- a/_contrib/_plot_path.py
+++ b/_contrib/_plot_path.py
@@ -1,12 +1,12 @@
 """Alignment path plotting utilities."""
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.dists_kernels._numba_distances._distance import (
     distance_alignment_path,
     pairwise_distance,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 _check_soft_dependencies("matplotlib", severity="warning")
 

--- a/_contrib/_plot_path.py
+++ b/_contrib/_plot_path.py
@@ -6,7 +6,7 @@ from sktime.dists_kernels._numba_distances._distance import (
     distance_alignment_path,
     pairwise_distance,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 _check_soft_dependencies("matplotlib", severity="warning")
 

--- a/sktime/alignment/base.py
+++ b/sktime/alignment/base.py
@@ -30,7 +30,7 @@ from sktime.alignment.utils.utils_align import convert_align_to_align_loc, reind
 from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_scitype, convert
 from sktime.datatypes._dtypekind import DtypeKind
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 class BaseAligner(BaseEstimator):

--- a/sktime/alignment/base.py
+++ b/sktime/alignment/base.py
@@ -26,11 +26,12 @@ State:
 __author__ = ["fkiraly"]
 
 
+from skbase.utils.dependencies import _check_estimator_deps
+
 from sktime.alignment.utils.utils_align import convert_align_to_align_loc, reindex_iloc
 from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_scitype, convert
 from sktime.datatypes._dtypekind import DtypeKind
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 class BaseAligner(BaseEstimator):

--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.alignment.base import BaseAligner
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class AlignerDTW(BaseAligner):

--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -7,9 +7,9 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.alignment.base import BaseAligner
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class AlignerDTW(BaseAligner):

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -290,7 +290,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         from pathlib import Path
         from zipfile import ZipFile
 
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         if serialization_format not in SERIALIZATION_FORMATS:
             raise ValueError(

--- a/sktime/base/_proba/_base.py
+++ b/sktime/base/_proba/_base.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.base import BaseObject
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.pandas import df_map
 
 

--- a/sktime/base/_proba/_base.py
+++ b/sktime/base/_proba/_base.py
@@ -9,9 +9,9 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.base import BaseObject
-from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.pandas import df_map
 
 

--- a/sktime/base/_proba/_mixin.py
+++ b/sktime/base/_proba/_mixin.py
@@ -315,7 +315,7 @@ class _PredictProbaMixin:
         # pred_mean and pred_var now have the same format
 
         # default is normal with predict as mean and pred_var as variance
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         # silent fork of Normal in sktime if skpro is not installed
         if _check_soft_dependencies("skpro", severity="none"):

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -40,7 +40,7 @@ from copy import deepcopy
 import pytest
 
 from sktime.base import BaseEstimator, BaseObject
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 # Fixture class for testing tag system

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -38,9 +38,9 @@ __all__ = [
 from copy import deepcopy
 
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.base import BaseEstimator, BaseObject
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 # Fixture class for testing tag system

--- a/sktime/benchmarking/critical_difference.py
+++ b/sktime/benchmarking/critical_difference.py
@@ -5,7 +5,6 @@ __author__ = ["SveaMeyer13"]
 import math
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
 
 

--- a/sktime/benchmarking/critical_difference.py
+++ b/sktime/benchmarking/critical_difference.py
@@ -6,7 +6,7 @@ import math
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def _check_friedman(n_strategies, n_datasets, ranked_data, alpha):

--- a/sktime/benchmarking/evaluation.py
+++ b/sktime/benchmarking/evaluation.py
@@ -12,7 +12,7 @@ from scipy.stats import ranksums, ttest_ind
 
 from sktime.benchmarking.base import BaseResults
 from sktime.exceptions import NotEvaluatedError
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class Evaluator:

--- a/sktime/benchmarking/evaluation.py
+++ b/sktime/benchmarking/evaluation.py
@@ -9,10 +9,10 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 from scipy.stats import ranksums, ttest_ind
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.benchmarking.base import BaseResults
 from sktime.exceptions import NotEvaluatedError
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class Evaluator:

--- a/sktime/benchmarking/tests/test_evaluator.py
+++ b/sktime/benchmarking/tests/test_evaluator.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.metrics import accuracy_score
 
 from sktime.benchmarking.evaluation import Evaluator
@@ -10,7 +11,6 @@ from sktime.benchmarking.metrics import PairwiseMetric
 from sktime.benchmarking.results import RAMResults
 from sktime.split import PresplitFilesCV
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def dummy_results():

--- a/sktime/benchmarking/tests/test_evaluator.py
+++ b/sktime/benchmarking/tests/test_evaluator.py
@@ -10,7 +10,7 @@ from sktime.benchmarking.metrics import PairwiseMetric
 from sktime.benchmarking.results import RAMResults
 from sktime.split import PresplitFilesCV
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def dummy_results():

--- a/sktime/benchmarking/tests/test_experiments.py
+++ b/sktime/benchmarking/tests/test_experiments.py
@@ -1,6 +1,7 @@
 """Functions to test the functions in experiments.py."""
 
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.benchmarking.experiments import (
     run_classification_experiment,
@@ -10,7 +11,6 @@ from sktime.classification.interval_based import TimeSeriesForestClassifier
 from sktime.clustering.k_means import TimeSeriesKMeans
 from sktime.datasets import load_unit_test
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/benchmarking/tests/test_experiments.py
+++ b/sktime/benchmarking/tests/test_experiments.py
@@ -10,7 +10,7 @@ from sktime.classification.interval_based import TimeSeriesForestClassifier
 from sktime.clustering.k_means import TimeSeriesKMeans
 from sktime.datasets import load_unit_test
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/benchmarking/tests/test_forecasting.py
+++ b/sktime/benchmarking/tests/test_forecasting.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.model_selection import KFold
 
 from sktime.benchmarking.benchmarks import _coerce_estimator_and_id
@@ -23,7 +24,6 @@ from sktime.performance_metrics.forecasting import (
 from sktime.split import ExpandingWindowSplitter, InstanceSplitter, SingleWindowSplitter
 from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils._testing.hierarchical import _make_hierarchical
-from skbase.utils.dependencies import _check_soft_dependencies
 
 # TODO:
 # Manual test is labor intensive, need to refactor the tests for fast iteration

--- a/sktime/benchmarking/tests/test_forecasting.py
+++ b/sktime/benchmarking/tests/test_forecasting.py
@@ -23,7 +23,7 @@ from sktime.performance_metrics.forecasting import (
 from sktime.split import ExpandingWindowSplitter, InstanceSplitter, SingleWindowSplitter
 from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils._testing.hierarchical import _make_hierarchical
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # TODO:
 # Manual test is labor intensive, need to refactor the tests for fast iteration

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -25,10 +25,10 @@ __author__ = ["mloning", "fkiraly", "TonyBagnall", "MatthewMiddlehurst", "ksharm
 import time
 
 import numpy as np
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.base import BasePanelMixin
 from sktime.datatypes import VectorizedDF, check_is_scitype
-from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.sklearn import is_sklearn_transformer
 
 

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from sktime.base import BasePanelMixin
 from sktime.datatypes import VectorizedDF, check_is_scitype
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.sklearn import is_sklearn_transformer
 
 

--- a/sktime/classification/deep_learning/base/_base_tf.py
+++ b/sktime/classification/deep_learning/base/_base_tf.py
@@ -10,12 +10,12 @@ import os
 from abc import abstractmethod
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.preprocessing import LabelEncoder, OneHotEncoder
 from sklearn.utils import check_random_state
 
 from sktime.base._base import SERIALIZATION_FORMATS
 from sktime.classification.base import BaseClassifier
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class BaseDeepClassifier(BaseClassifier):

--- a/sktime/classification/deep_learning/base/_base_tf.py
+++ b/sktime/classification/deep_learning/base/_base_tf.py
@@ -15,7 +15,7 @@ from sklearn.utils import check_random_state
 
 from sktime.base._base import SERIALIZATION_FORMATS
 from sktime.classification.base import BaseClassifier
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class BaseDeepClassifier(BaseClassifier):

--- a/sktime/classification/deep_learning/cnn/_cnn_tf.py
+++ b/sktime/classification/deep_learning/cnn/_cnn_tf.py
@@ -290,7 +290,7 @@ class CNNClassifier(BaseDeepClassifier):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 10,

--- a/sktime/classification/deep_learning/cntc.py
+++ b/sktime/classification/deep_learning/cntc.py
@@ -371,7 +371,7 @@ class CNTCClassifier(BaseDeepClassifier):
 
         params = [param0, param1]
 
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         if _check_soft_dependencies("tensorflow", severity="none"):
             from tensorflow import keras

--- a/sktime/classification/deep_learning/fcn.py
+++ b/sktime/classification/deep_learning/fcn.py
@@ -235,7 +235,7 @@ class FCNClassifier(BaseDeepClassifier):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 10,

--- a/sktime/classification/deep_learning/inceptiontime/_inceptiontime_tf.py
+++ b/sktime/classification/deep_learning/inceptiontime/_inceptiontime_tf.py
@@ -321,7 +321,7 @@ class InceptionTimeClassifier(BaseDeepClassifier):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 10,

--- a/sktime/classification/deep_learning/lstmfcn/_lstmfcn_tf.py
+++ b/sktime/classification/deep_learning/lstmfcn/_lstmfcn_tf.py
@@ -239,7 +239,7 @@ class LSTMFCNClassifier(BaseDeepClassifier):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 25,

--- a/sktime/classification/deep_learning/mlp/_mlp_tf.py
+++ b/sktime/classification/deep_learning/mlp/_mlp_tf.py
@@ -237,7 +237,7 @@ class MLPClassifier(BaseDeepClassifier):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 10,

--- a/sktime/classification/deep_learning/mlp/_mlp_tf.py
+++ b/sktime/classification/deep_learning/mlp/_mlp_tf.py
@@ -8,7 +8,6 @@ from sklearn.utils import check_random_state
 
 from sktime.classification.deep_learning.base import BaseDeepClassifier
 from sktime.networks.mlp import MLPNetwork
-from sktime.utils.dependencies import _check_dl_dependencies
 
 
 class MLPClassifier(BaseDeepClassifier):
@@ -105,8 +104,6 @@ class MLPClassifier(BaseDeepClassifier):
         n_layers=3,
         hidden_dim=500,
     ):
-        _check_dl_dependencies(severity="error")
-
         self.callbacks = callbacks
         self.n_epochs = n_epochs
         self.batch_size = batch_size

--- a/sktime/classification/deep_learning/mlp/_mlp_torch.py
+++ b/sktime/classification/deep_learning/mlp/_mlp_torch.py
@@ -322,7 +322,7 @@ class MLPClassifierTorch(BaseDeepClassifierPytorch):
         }  # functionally equivalent to params2 for multi-class classification
         params = [params1, params2, params3, params4, params5]
 
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         if _check_soft_dependencies("torchmetrics", severity="none"):
             params.append(

--- a/sktime/classification/deep_learning/resnet.py
+++ b/sktime/classification/deep_learning/resnet.py
@@ -230,7 +230,7 @@ class ResNetClassifier(BaseDeepClassifier):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 10,

--- a/sktime/classification/deep_learning/tapnet/_tapnet_tf.py
+++ b/sktime/classification/deep_learning/tapnet/_tapnet_tf.py
@@ -300,7 +300,7 @@ class TapNetClassifier(BaseDeepClassifier):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 20,

--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -19,7 +19,7 @@ from sklearn.utils.validation import _num_samples
 
 from sktime.classification.base import BaseClassifier
 from sktime.transformations.dictionary_based import SFAFast
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation.panel import check_X_y
 
 # delayed was moved from utils.fixes to utils.parallel in scikit-learn 1.3

--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -11,6 +11,7 @@ from copy import copy
 from itertools import compress
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.metrics import pairwise
 from sklearn.utils import check_random_state, gen_even_slices
 from sklearn.utils.extmath import safe_sparse_dot
@@ -19,7 +20,6 @@ from sklearn.utils.validation import _num_samples
 
 from sktime.classification.base import BaseClassifier
 from sktime.transformations.dictionary_based import SFAFast
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation.panel import check_X_y
 
 # delayed was moved from utils.fixes to utils.parallel in scikit-learn 1.3

--- a/sktime/classification/dictionary_based/_tde_numba.py
+++ b/sktime/classification/dictionary_based/_tde_numba.py
@@ -3,6 +3,7 @@
 __author__ = ["MatthewMiddlehurst"]
 
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/classification/dictionary_based/_tde_numba.py
+++ b/sktime/classification/dictionary_based/_tde_numba.py
@@ -2,7 +2,7 @@
 
 __author__ = ["MatthewMiddlehurst"]
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -310,7 +310,7 @@ class ProbabilityThresholdEarlyClassifier(BaseClassifier):
         """
         from sktime.classification.dummy import DummyClassifier
         from sktime.classification.feature_based import Catch22Classifier
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         if _check_estimator_deps(Catch22Classifier, severity="none"):
             est = Catch22Classifier(estimator=RandomForestClassifier(n_estimators=2))

--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -308,9 +308,10 @@ class ProbabilityThresholdEarlyClassifier(BaseClassifier):
         params : dict or list of dict, default = {}
             Parameters to create testing instances of the class.
         """
+        from skbase.utils.dependencies import _check_estimator_deps
+
         from sktime.classification.dummy import DummyClassifier
         from sktime.classification.feature_based import Catch22Classifier
-        from skbase.utils.dependencies import _check_estimator_deps
 
         if _check_estimator_deps(Catch22Classifier, severity="none"):
             est = Catch22Classifier(estimator=RandomForestClassifier(n_estimators=2))

--- a/sktime/classification/early_classification/_teaser.py
+++ b/sktime/classification/early_classification/_teaser.py
@@ -612,7 +612,7 @@ class TEASER(BaseEarlyClassifier):
         """
         from sktime.classification.dummy import DummyClassifier
         from sktime.classification.feature_based import Catch22Classifier
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         if _check_estimator_deps(Catch22Classifier, severity="none"):
             est = Catch22Classifier(estimator=RandomForestClassifier(n_estimators=2))

--- a/sktime/classification/early_classification/_teaser.py
+++ b/sktime/classification/early_classification/_teaser.py
@@ -610,9 +610,10 @@ class TEASER(BaseEarlyClassifier):
         params : dict or list of dict, default = {}
             Parameters to create testing instances of the class.
         """
+        from skbase.utils.dependencies import _check_estimator_deps
+
         from sktime.classification.dummy import DummyClassifier
         from sktime.classification.feature_based import Catch22Classifier
-        from skbase.utils.dependencies import _check_estimator_deps
 
         if _check_estimator_deps(Catch22Classifier, severity="none"):
             est = Catch22Classifier(estimator=RandomForestClassifier(n_estimators=2))

--- a/sktime/classification/early_classification/base.py
+++ b/sktime/classification/early_classification/base.py
@@ -32,7 +32,7 @@ import numpy as np
 
 from sktime.base import BaseEstimator
 from sktime.classification import BaseClassifier
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 class BaseEarlyClassifier(BaseEstimator):

--- a/sktime/classification/early_classification/base.py
+++ b/sktime/classification/early_classification/base.py
@@ -29,10 +29,10 @@ __author__ = ["mloning", "fkiraly", "TonyBagnall", "MatthewMiddlehurst"]
 from abc import abstractmethod
 
 import numpy as np
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.base import BaseEstimator
 from sktime.classification import BaseClassifier
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 class BaseEarlyClassifier(BaseEstimator):

--- a/sktime/classification/ensemble/_weighted.py
+++ b/sktime/classification/ensemble/_weighted.py
@@ -259,12 +259,13 @@ class WeightedEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
+        from skbase.utils.dependencies import _check_estimator_deps
+
         from sktime.classification.distance_based import (
             KNeighborsTimeSeriesClassifier,
         )
         from sktime.classification.dummy import DummyClassifier
         from sktime.classification.kernel_based import RocketClassifier
-        from skbase.utils.dependencies import _check_estimator_deps
 
         params0 = {"classifiers": [DummyClassifier()]}
 

--- a/sktime/classification/ensemble/_weighted.py
+++ b/sktime/classification/ensemble/_weighted.py
@@ -264,7 +264,7 @@ class WeightedEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
         )
         from sktime.classification.dummy import DummyClassifier
         from sktime.classification.kernel_based import RocketClassifier
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         params0 = {"classifiers": [DummyClassifier()]}
 

--- a/sktime/classification/foundation_models/mantis.py
+++ b/sktime/classification/foundation_models/mantis.py
@@ -5,9 +5,9 @@ __author__ = ["vedantag17"]
 __all__ = ["MantisClassifier"]
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.classification.base import BaseClassifier
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.singleton import _multiton
 
 

--- a/sktime/classification/foundation_models/mantis.py
+++ b/sktime/classification/foundation_models/mantis.py
@@ -7,7 +7,7 @@ __all__ = ["MantisClassifier"]
 import numpy as np
 
 from sktime.classification.base import BaseClassifier
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.singleton import _multiton
 
 

--- a/sktime/classification/interval_based/_rise_numba.py
+++ b/sktime/classification/interval_based/_rise_numba.py
@@ -3,8 +3,8 @@
 __author__ = ["TonyBagnall"]
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import jit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/classification/interval_based/_rise_numba.py
+++ b/sktime/classification/interval_based/_rise_numba.py
@@ -4,7 +4,7 @@ __author__ = ["TonyBagnall"]
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import jit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/classification/model_evaluation/_functions.py
+++ b/sktime/classification/model_evaluation/_functions.py
@@ -15,7 +15,7 @@ import pandas as pd
 
 from sktime.datatypes import check_is_scitype, convert
 from sktime.exceptions import FitFailedWarning
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.parallel import parallelize
 
 PANDAS_MTYPES = ["pd.DataFrame", "pd.Series", "pd-multiindex", "pd_multiindex_hier"]

--- a/sktime/classification/model_evaluation/_functions.py
+++ b/sktime/classification/model_evaluation/_functions.py
@@ -12,10 +12,10 @@ import warnings
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datatypes import check_is_scitype, convert
 from sktime.exceptions import FitFailedWarning
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.parallel import parallelize
 
 PANDAS_MTYPES = ["pd.DataFrame", "pd.Series", "pd-multiindex", "pd_multiindex_hier"]

--- a/sktime/classification/plotting/temporal_importance_diagram.py
+++ b/sktime/classification/plotting/temporal_importance_diagram.py
@@ -3,10 +3,10 @@
 __author__ = ["MatthewMiddlehurst"]
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.transformations import catch22
-from skbase.utils.dependencies import _check_soft_dependencies
 
 _check_soft_dependencies("matplotlib", severity="warning")
 

--- a/sktime/classification/plotting/temporal_importance_diagram.py
+++ b/sktime/classification/plotting/temporal_importance_diagram.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.transformations import catch22
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 _check_soft_dependencies("matplotlib", severity="warning")
 

--- a/sktime/classification/shapelet_based/_mrseql.py
+++ b/sktime/classification/shapelet_based/_mrseql.py
@@ -134,7 +134,7 @@ class MrSEQL(_DelegatedClassifier):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         params1 = {}
 

--- a/sktime/classification/tests/test_all_classifiers.py
+++ b/sktime/classification/tests/test_all_classifiers.py
@@ -6,6 +6,7 @@ __author__ = ["mloning", "TonyBagnall", "fkiraly"]
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 
 from sktime.base import BaseObject
 from sktime.classification.tests._expected_outputs import (
@@ -20,7 +21,6 @@ from sktime.utils._testing.panel import make_classification_problem
 from sktime.utils._testing.scenarios_classification import (
     ClassifierFitPredictMultivariate,
 )
-from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 
 
 class ClassifierFixtureGenerator(BaseFixtureGenerator):

--- a/sktime/classification/tests/test_all_classifiers.py
+++ b/sktime/classification/tests/test_all_classifiers.py
@@ -20,7 +20,7 @@ from sktime.utils._testing.panel import make_classification_problem
 from sktime.utils._testing.scenarios_classification import (
     ClassifierFitPredictMultivariate,
 )
-from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
+from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 
 
 class ClassifierFixtureGenerator(BaseFixtureGenerator):

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -20,7 +20,7 @@ from sktime.utils._testing.panel import (
     _make_panel,
     make_classification_problem,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class _DummyClassifier(BaseClassifier):

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -7,6 +7,7 @@ import pickle
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.model_selection import KFold
 
 from sktime.classification.base import BaseClassifier
@@ -20,7 +21,6 @@ from sktime.utils._testing.panel import (
     _make_panel,
     make_classification_problem,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class _DummyClassifier(BaseClassifier):

--- a/sktime/classification/tests/test_sklearn_compatibility.py
+++ b/sktime/classification/tests/test_sklearn_compatibility.py
@@ -38,7 +38,7 @@ from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.tests.test_switch import run_test_module_changed
 from sktime.transformations.pca import PCATransformer
 from sktime.utils._testing.panel import _make_panel_X, make_classification_problem
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 DATA_ARGS = [
     {"return_numpy": True, "n_columns": 2, "n_instances": 7, "n_timepoints": 12},

--- a/sktime/classification/tests/test_sklearn_compatibility.py
+++ b/sktime/classification/tests/test_sklearn_compatibility.py
@@ -10,6 +10,7 @@ __all__ = [
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.ensemble import VotingClassifier
 from sklearn.model_selection import (
@@ -38,7 +39,6 @@ from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.tests.test_switch import run_test_module_changed
 from sktime.transformations.pca import PCATransformer
 from sktime.utils._testing.panel import _make_panel_X, make_classification_problem
-from skbase.utils.dependencies import _check_soft_dependencies
 
 DATA_ARGS = [
     {"return_numpy": True, "n_columns": 2, "n_instances": 7, "n_timepoints": 12},

--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -10,7 +10,7 @@ import numpy as np
 from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_scitype, convert_to, scitype_to_mtype
 from sktime.datatypes._dtypekind import DtypeKind
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.sklearn import is_sklearn_transformer
 from sktime.utils.warnings import warn
 

--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -6,11 +6,11 @@ __all__ = ["BaseClusterer"]
 import time
 
 import numpy as np
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_scitype, convert_to, scitype_to_mtype
 from sktime.datatypes._dtypekind import DtypeKind
-from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.sklearn import is_sklearn_transformer
 from sktime.utils.warnings import warn
 

--- a/sktime/clustering/compose/_as_transform.py
+++ b/sktime/clustering/compose/_as_transform.py
@@ -209,7 +209,7 @@ class ClustererAsTransformer(BaseTransformer):
         # imports
         from sktime.clustering.dbscan import TimeSeriesDBSCAN
         from sktime.clustering.k_means import TimeSeriesKMeansTslearn
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         params = []
 

--- a/sktime/clustering/compose/_as_transform.py
+++ b/sktime/clustering/compose/_as_transform.py
@@ -207,9 +207,10 @@ class ClustererAsTransformer(BaseTransformer):
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
         # imports
+        from skbase.utils.dependencies import _check_estimator_deps
+
         from sktime.clustering.dbscan import TimeSeriesDBSCAN
         from sktime.clustering.k_means import TimeSeriesKMeansTslearn
-        from skbase.utils.dependencies import _check_estimator_deps
 
         params = []
 

--- a/sktime/clustering/compose/_pipeline.py
+++ b/sktime/clustering/compose/_pipeline.py
@@ -335,7 +335,7 @@ class ClustererPipeline(_HeterogenousMetaEstimator, BaseClusterer):
         from sktime.clustering.dbscan import TimeSeriesDBSCAN
         from sktime.clustering.k_means import TimeSeriesKMeans
         from sktime.transformations.exponent import ExponentTransformer
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         params = []
 

--- a/sktime/clustering/compose/_pipeline.py
+++ b/sktime/clustering/compose/_pipeline.py
@@ -332,10 +332,11 @@ class ClustererPipeline(_HeterogenousMetaEstimator, BaseClusterer):
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
         # imports
+        from skbase.utils.dependencies import _check_estimator_deps
+
         from sktime.clustering.dbscan import TimeSeriesDBSCAN
         from sktime.clustering.k_means import TimeSeriesKMeans
         from sktime.transformations.exponent import ExponentTransformer
-        from skbase.utils.dependencies import _check_estimator_deps
 
         params = []
 

--- a/sktime/clustering/utils/plotting/_plot_partitions.py
+++ b/sktime/clustering/utils/plotting/_plot_partitions.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.datatypes import convert_to
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def _plot(cluster_values, center, axes):

--- a/sktime/clustering/utils/plotting/_plot_partitions.py
+++ b/sktime/clustering/utils/plotting/_plot_partitions.py
@@ -5,9 +5,9 @@ __all__ = ["plot_cluster_algorithm"]
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datatypes import convert_to
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def _plot(cluster_values, center, axes):

--- a/sktime/datasets/_dataset_downloader.py
+++ b/sktime/datasets/_dataset_downloader.py
@@ -15,7 +15,7 @@ from urllib.request import urlretrieve
 
 from skbase.base import BaseObject
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class DatasetDownloadStrategy(BaseObject):

--- a/sktime/datasets/_dataset_downloader.py
+++ b/sktime/datasets/_dataset_downloader.py
@@ -14,7 +14,6 @@ from urllib.error import HTTPError, URLError
 from urllib.request import urlretrieve
 
 from skbase.base import BaseObject
-
 from skbase.utils.dependencies import _check_soft_dependencies
 
 

--- a/sktime/datasets/_fpp3_loaders.py
+++ b/sktime/datasets/_fpp3_loaders.py
@@ -355,7 +355,7 @@ def _load_fpp3(dataset, temp_folder=None, robust=True):
     The public function is robust (robust=True) and will use the non-latest version,
     protecting users from failures.
     """
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     _check_soft_dependencies(["requests", "rdata"])
 

--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -48,6 +48,7 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datasets._data_io import (
     _list_available_datasets,
@@ -58,7 +59,6 @@ from sktime.datasets._data_io import (
 from sktime.datasets._dataset_downloader import DatasetDownloader
 from sktime.datasets._readers_writers.tsf import load_tsf_to_dataframe
 from sktime.datasets.tsf_dataset_names import tsf_all, tsf_all_datasets
-from skbase.utils.dependencies import _check_soft_dependencies
 
 DIRNAME = "data"
 MODULE = os.path.dirname(__file__)

--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -58,7 +58,7 @@ from sktime.datasets._data_io import (
 from sktime.datasets._dataset_downloader import DatasetDownloader
 from sktime.datasets._readers_writers.tsf import load_tsf_to_dataframe
 from sktime.datasets.tsf_dataset_names import tsf_all, tsf_all_datasets
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 DIRNAME = "data"
 MODULE = os.path.dirname(__file__)

--- a/sktime/datasets/base/_base.py
+++ b/sktime/datasets/base/_base.py
@@ -20,8 +20,9 @@ import shutil
 from inspect import isfunction, signature
 from pathlib import Path
 
-from sktime.base import BaseObject
 from skbase.utils.dependencies import _check_estimator_deps
+
+from sktime.base import BaseObject
 
 
 class BaseDataset(BaseObject):

--- a/sktime/datasets/base/_base.py
+++ b/sktime/datasets/base/_base.py
@@ -21,7 +21,7 @@ from inspect import isfunction, signature
 from pathlib import Path
 
 from sktime.base import BaseObject
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 class BaseDataset(BaseObject):

--- a/sktime/datasets/tests/test_datadownload.py
+++ b/sktime/datasets/tests/test_datadownload.py
@@ -5,6 +5,7 @@ from urllib.request import Request, urlopen
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datasets import (
     _load_fpp3,
@@ -16,7 +17,6 @@ from sktime.datasets import (
 )
 from sktime.datasets.tsf_dataset_names import tsf_all, tsf_all_datasets
 from sktime.datatypes import check_is_mtype, check_raise
-from skbase.utils.dependencies import _check_soft_dependencies
 
 # test tsf download only on a random uniform subsample of datasets
 N_TSF_SUBSAMPLE = 3

--- a/sktime/datasets/tests/test_datadownload.py
+++ b/sktime/datasets/tests/test_datadownload.py
@@ -16,7 +16,7 @@ from sktime.datasets import (
 )
 from sktime.datasets.tsf_dataset_names import tsf_all, tsf_all_datasets
 from sktime.datatypes import check_is_mtype, check_raise
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # test tsf download only on a random uniform subsample of datasets
 N_TSF_SUBSAMPLE = 3

--- a/sktime/datasets/tests/test_loaders.py
+++ b/sktime/datasets/tests/test_loaders.py
@@ -7,7 +7,7 @@ __all__ = []
 
 import pytest
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/datasets/tests/test_loaders.py
+++ b/sktime/datasets/tests/test_loaders.py
@@ -6,7 +6,6 @@ __all__ = []
 
 
 import pytest
-
 from skbase.utils.dependencies import _check_soft_dependencies
 
 

--- a/sktime/datatypes/_adapter/tests/test_dask_pd.py
+++ b/sktime/datatypes/_adapter/tests/test_dask_pd.py
@@ -5,13 +5,13 @@ from copy import deepcopy
 
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datatypes._adapter.dask_to_pd import (
     check_dask_frame,
     convert_dask_to_pandas,
     convert_pandas_to_dask,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 # simple pd.DataFrame fixture
 pd_fixture_simple = pd.DataFrame({"foo": [2, 3, 4], "bar": [3, 4, 5]})

--- a/sktime/datatypes/_adapter/tests/test_dask_pd.py
+++ b/sktime/datatypes/_adapter/tests/test_dask_pd.py
@@ -11,7 +11,7 @@ from sktime.datatypes._adapter.dask_to_pd import (
     convert_dask_to_pandas,
     convert_pandas_to_dask,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # simple pd.DataFrame fixture
 pd_fixture_simple = pd.DataFrame({"foo": [2, 3, 4], "bar": [3, 4, 5]})

--- a/sktime/datatypes/_adapter/tests/test_gluonts.py
+++ b/sktime/datatypes/_adapter/tests/test_gluonts.py
@@ -8,7 +8,7 @@ from sktime.datatypes._adapter.gluonts import (
     convert_pandas_multiindex_to_pandasDataset,
     convert_pandas_to_listDataset,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/datatypes/_adapter/tests/test_gluonts.py
+++ b/sktime/datatypes/_adapter/tests/test_gluonts.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datatypes._adapter.gluonts import (
     convert_pandas_collection_to_pandasDataset,
@@ -8,7 +9,6 @@ from sktime.datatypes._adapter.gluonts import (
     convert_pandas_multiindex_to_pandasDataset,
     convert_pandas_to_listDataset,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/datatypes/_adapter/tests/test_polars.py
+++ b/sktime/datatypes/_adapter/tests/test_polars.py
@@ -6,12 +6,12 @@ from copy import deepcopy
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datatypes._adapter.polars import (
     convert_pandas_to_polars,
     convert_polars_to_pandas,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 # simple pd.DataFrame fixture
 pd_fixture_simple = pd.DataFrame({"foo": [2, 3, 4], "bar": [3, 4, 5]})

--- a/sktime/datatypes/_adapter/tests/test_polars.py
+++ b/sktime/datatypes/_adapter/tests/test_polars.py
@@ -11,7 +11,7 @@ from sktime.datatypes._adapter.polars import (
     convert_pandas_to_polars,
     convert_polars_to_pandas,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # simple pd.DataFrame fixture
 pd_fixture_simple = pd.DataFrame({"foo": [2, 3, 4], "bar": [3, 4, 5]})

--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -28,8 +28,9 @@ __all__ = [
 @lru_cache(maxsize=1)
 def generate_example_dicts(soft_deps="present"):
     """Generate example dicts using lookup."""
-    from sktime.datatypes._base import BaseExample
     from skbase.utils.dependencies import _check_estimator_deps
+
+    from sktime.datatypes._base import BaseExample
     from sktime.utils.retrieval import _all_classes
 
     classes = _all_classes("sktime.datatypes")

--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -29,7 +29,7 @@ __all__ = [
 def generate_example_dicts(soft_deps="present"):
     """Generate example dicts using lookup."""
     from sktime.datatypes._base import BaseExample
-    from sktime.utils.dependencies import _check_estimator_deps
+    from skbase.utils.dependencies import _check_estimator_deps
     from sktime.utils.retrieval import _all_classes
 
     classes = _all_classes("sktime.datatypes")

--- a/sktime/datatypes/_hierarchical/_convert.py
+++ b/sktime/datatypes/_hierarchical/_convert.py
@@ -4,7 +4,7 @@ __all__ = [
 
 from sktime.datatypes._convert_utils._coerce import _coerce_df_dtypes
 from sktime.datatypes._convert_utils._convert import _extend_conversions
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # this needs to be refactored with the convert module
 MTYPE_LIST_HIERARCHICAL = [

--- a/sktime/datatypes/_hierarchical/_convert.py
+++ b/sktime/datatypes/_hierarchical/_convert.py
@@ -2,9 +2,10 @@ __all__ = [
     "convert_dict",
 ]
 
+from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.datatypes._convert_utils._coerce import _coerce_df_dtypes
 from sktime.datatypes._convert_utils._convert import _extend_conversions
-from skbase.utils.dependencies import _check_soft_dependencies
 
 # this needs to be refactored with the convert module
 MTYPE_LIST_HIERARCHICAL = [

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -33,9 +33,10 @@ __all__ = [
     "convert_dict",
 ]
 
+from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.datatypes._convert_utils._coerce import _coerce_df_dtypes
 from sktime.datatypes._convert_utils._convert import _extend_conversions
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.pandas import df_map
 
 # this needs to be refactored with the convert module

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -35,7 +35,7 @@ __all__ = [
 
 from sktime.datatypes._convert_utils._coerce import _coerce_df_dtypes
 from sktime.datatypes._convert_utils._convert import _extend_conversions
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.pandas import df_map
 
 # this needs to be refactored with the convert module

--- a/sktime/datatypes/_registry.py
+++ b/sktime/datatypes/_registry.py
@@ -369,7 +369,7 @@ def scitype_to_mtype(scitype: str, softdeps: str = "exclude"):
         return mtypes
 
     if softdeps == "present":
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         def present(x):
             """Return True if x has satisfied soft dependency or has no soft dep."""

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -38,7 +38,7 @@ import pandas as pd
 ##############################################################
 from sktime.datatypes._convert_utils._coerce import _coerce_df_dtypes
 from sktime.datatypes._convert_utils._convert import _extend_conversions
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # this needs to be refactored with the convert module
 MTYPE_LIST_SERIES = [

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -32,13 +32,13 @@ __all__ = ["convert_dict"]
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 ##############################################################
 # methods to convert one machine type to another machine type
 ##############################################################
 from sktime.datatypes._convert_utils._coerce import _coerce_df_dtypes
 from sktime.datatypes._convert_utils._convert import _extend_conversions
-from skbase.utils.dependencies import _check_soft_dependencies
 
 # this needs to be refactored with the convert module
 MTYPE_LIST_SERIES = [

--- a/sktime/datatypes/_table/_convert.py
+++ b/sktime/datatypes/_table/_convert.py
@@ -32,9 +32,9 @@ __all__ = ["convert_dict"]
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datatypes._convert_utils._convert import _extend_conversions
-from skbase.utils.dependencies import _check_soft_dependencies
 
 # this needs to be refactored with the convert module
 MTYPE_LIST_TABLE = [

--- a/sktime/datatypes/_table/_convert.py
+++ b/sktime/datatypes/_table/_convert.py
@@ -34,7 +34,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.datatypes._convert_utils._convert import _extend_conversions
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # this needs to be refactored with the convert module
 MTYPE_LIST_TABLE = [

--- a/sktime/datatypes/tests/test_feature_kind_inference.py
+++ b/sktime/datatypes/tests/test_feature_kind_inference.py
@@ -3,6 +3,7 @@
 __author__ = ["Abhay-Lejith"]
 
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datatypes._dtypekind import (
     DtypeKind,
@@ -11,7 +12,6 @@ from sktime.datatypes._dtypekind import (
     _get_series_dtypekind,
     _get_table_dtypekind,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def test_feature_kind_for_series():

--- a/sktime/datatypes/tests/test_feature_kind_inference.py
+++ b/sktime/datatypes/tests/test_feature_kind_inference.py
@@ -11,7 +11,7 @@ from sktime.datatypes._dtypekind import (
     _get_series_dtypekind,
     _get_table_dtypekind,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def test_feature_kind_for_series():

--- a/sktime/datatypes/tests/test_lookup.py
+++ b/sktime/datatypes/tests/test_lookup.py
@@ -2,13 +2,14 @@
 
 __author__ = ["fkiraly"]
 
+from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.datatypes._registry import (
     MTYPE_SOFT_DEPS,
     generate_mtype_register,
     mtype_to_scitype,
     scitype_to_mtype,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def pytest_generate_tests(metafunc):

--- a/sktime/datatypes/tests/test_lookup.py
+++ b/sktime/datatypes/tests/test_lookup.py
@@ -8,7 +8,7 @@ from sktime.datatypes._registry import (
     mtype_to_scitype,
     scitype_to_mtype,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def pytest_generate_tests(metafunc):

--- a/sktime/datatypes/tests/test_panel_converters.py
+++ b/sktime/datatypes/tests/test_panel_converters.py
@@ -22,7 +22,7 @@ from sktime.datatypes._panel._convert import (
 )
 from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils._testing.panel import make_classification_problem
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 N_INSTANCES = [10, 15]
 N_COLUMNS = [3, 5]

--- a/sktime/datatypes/tests/test_panel_converters.py
+++ b/sktime/datatypes/tests/test_panel_converters.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datasets import generate_example_long_table, make_multi_index_dataframe
 from sktime.datatypes._adapter import convert_from_multiindex_to_listdataset
@@ -22,7 +23,6 @@ from sktime.datatypes._panel._convert import (
 )
 from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils._testing.panel import make_classification_problem
-from skbase.utils.dependencies import _check_soft_dependencies
 
 N_INSTANCES = [10, 15]
 N_COLUMNS = [3, 5]

--- a/sktime/detection/adapters/_pyod.py
+++ b/sktime/detection/adapters/_pyod.py
@@ -3,10 +3,10 @@
 """Implements outlier detection from pyOD."""
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.base import clone
 
 from sktime.detection.base import BaseDetector
-from skbase.utils.dependencies import _check_soft_dependencies
 
 __author__ = ["mloning", "satya-pattnaik", "fkiraly"]
 

--- a/sktime/detection/adapters/_pyod.py
+++ b/sktime/detection/adapters/_pyod.py
@@ -6,7 +6,7 @@ import numpy as np
 from sklearn.base import clone
 
 from sktime.detection.base import BaseDetector
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 __author__ = ["mloning", "satya-pattnaik", "fkiraly"]
 

--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -24,11 +24,11 @@ __all__ = ["BaseDetector"]
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_error_msg, check_is_scitype, convert
 from sktime.utils.adapters._safe_call import _method_has_arg
-from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.validation.series import check_series
 
 

--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -28,7 +28,7 @@ import pandas as pd
 from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_error_msg, check_is_scitype, convert
 from sktime.utils.adapters._safe_call import _method_has_arg
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.validation.series import check_series
 
 

--- a/sktime/detection/igts.py
+++ b/sktime/detection/igts.py
@@ -22,7 +22,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from sktime.base import BaseEstimator
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 __all__ = ["InformationGainSegmentation"]
 __author__ = ["lmmentel"]

--- a/sktime/detection/igts.py
+++ b/sktime/detection/igts.py
@@ -20,9 +20,9 @@ from dataclasses import dataclass, field
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.base import BaseEstimator
-from skbase.utils.dependencies import _check_estimator_deps
 
 __all__ = ["InformationGainSegmentation"]
 __author__ = ["lmmentel"]

--- a/sktime/detection/plotting/utils.py
+++ b/sktime/detection/plotting/utils.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation.forecasting import check_X
 
 __all__ = [

--- a/sktime/detection/plotting/utils.py
+++ b/sktime/detection/plotting/utils.py
@@ -3,8 +3,8 @@
 """Utility class for plotting functionality."""
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.validation.forecasting import check_X
 
 __all__ = [

--- a/sktime/detection/tests/test_plotting.py
+++ b/sktime/detection/tests/test_plotting.py
@@ -6,7 +6,7 @@ from sktime.detection.plotting.utils import (
     plot_time_series_with_change_points,
     plot_time_series_with_profiles,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.fixture

--- a/sktime/detection/tests/test_plotting.py
+++ b/sktime/detection/tests/test_plotting.py
@@ -1,12 +1,12 @@
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.detection.plotting.utils import (
     plot_time_series_with_change_points,
     plot_time_series_with_profiles,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.fixture

--- a/sktime/dists_kernels/_numba_distances/_dtw_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_dtw_numba.py
@@ -6,7 +6,7 @@ import warnings
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_dtw_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_dtw_numba.py
@@ -5,8 +5,8 @@ __author__ = ["chrisholder", "TonyBagnall"]
 import warnings
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_edr_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_edr_numba.py
@@ -6,7 +6,7 @@ import warnings
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_edr_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_edr_numba.py
@@ -5,8 +5,8 @@ __author__ = ["chrisholder", "TonyBagnall"]
 import warnings
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_erp_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_erp_numba.py
@@ -6,7 +6,7 @@ import warnings
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_erp_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_erp_numba.py
@@ -5,8 +5,8 @@ __author__ = ["chrisholder", "TonyBagnall"]
 import warnings
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_lcss_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_lcss_numba.py
@@ -7,7 +7,7 @@ import warnings
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_lcss_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_lcss_numba.py
@@ -6,8 +6,8 @@ __author__ = ["chrisholder", "TonyBagnall"]
 import warnings
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_msm_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_msm_numba.py
@@ -6,7 +6,7 @@ import warnings
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_msm_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_msm_numba.py
@@ -5,8 +5,8 @@ __author__ = ["chrisholder", "jlines", "TonyBagnall"]
 import warnings
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_twe_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_twe_numba.py
@@ -6,7 +6,7 @@ import warnings
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_twe_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_twe_numba.py
@@ -5,8 +5,8 @@ __author__ = ["chrisholder", "TonyBagnall"]
 import warnings
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_wdtw_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_wdtw_numba.py
@@ -6,7 +6,7 @@ import warnings
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/_wdtw_numba.py
+++ b/sktime/dists_kernels/_numba_distances/_wdtw_numba.py
@@ -5,8 +5,8 @@ __author__ = ["chrisholder", "TonyBagnall"]
 import warnings
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/dists_kernels/_numba_distances/tests/test_distance_alignment_path.py
+++ b/sktime/dists_kernels/_numba_distances/tests/test_distance_alignment_path.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.dists_kernels._numba_distances._distance import (
     _METRIC_INFOS,
@@ -12,7 +13,6 @@ from sktime.dists_kernels._numba_distances.tests._utils import (
     create_test_distance_numpy,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def _validate_distance_alignment_path_result(

--- a/sktime/dists_kernels/_numba_distances/tests/test_distance_alignment_path.py
+++ b/sktime/dists_kernels/_numba_distances/tests/test_distance_alignment_path.py
@@ -12,7 +12,7 @@ from sktime.dists_kernels._numba_distances.tests._utils import (
     create_test_distance_numpy,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def _validate_distance_alignment_path_result(

--- a/sktime/dists_kernels/_numba_distances/tests/test_distance_correctness.py
+++ b/sktime/dists_kernels/_numba_distances/tests/test_distance_correctness.py
@@ -8,11 +8,11 @@ __author__ = ["chrisholder", "TonyBagnall", "fkiraly"]
 
 import pytest
 from numpy.testing import assert_almost_equal
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datasets import load_basic_motions, load_unit_test
 from sktime.dists_kernels._numba_distances._distance import _METRIC_INFOS
 from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 distance_parameters = {
     "dtw": [0.0, 0.1, 1.0],  # window

--- a/sktime/dists_kernels/_numba_distances/tests/test_distance_correctness.py
+++ b/sktime/dists_kernels/_numba_distances/tests/test_distance_correctness.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_almost_equal
 from sktime.datasets import load_basic_motions, load_unit_test
 from sktime.dists_kernels._numba_distances._distance import _METRIC_INFOS
 from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 distance_parameters = {
     "dtw": [0.0, 0.1, 1.0],  # window

--- a/sktime/dists_kernels/_numba_distances/tests/test_numba_distance_parameters.py
+++ b/sktime/dists_kernels/_numba_distances/tests/test_numba_distance_parameters.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.dists_kernels._numba_distances import distance, distance_factory
 from sktime.dists_kernels._numba_distances._distance import _METRIC_INFOS
@@ -16,7 +17,6 @@ from sktime.dists_kernels._numba_distances.tests._utils import (
     create_test_distance_numpy,
 )
 from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 

--- a/sktime/dists_kernels/_numba_distances/tests/test_numba_distance_parameters.py
+++ b/sktime/dists_kernels/_numba_distances/tests/test_numba_distance_parameters.py
@@ -16,7 +16,7 @@ from sktime.dists_kernels._numba_distances.tests._utils import (
     create_test_distance_numpy,
 )
 from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 

--- a/sktime/dists_kernels/_numba_distances/tests/test_numba_distances.py
+++ b/sktime/dists_kernels/_numba_distances/tests/test_numba_distances.py
@@ -25,7 +25,7 @@ from sktime.dists_kernels._numba_distances.tests._utils import (
     create_test_distance_numpy,
 )
 from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 _ran_once = False
 

--- a/sktime/dists_kernels/_numba_distances/tests/test_numba_distances.py
+++ b/sktime/dists_kernels/_numba_distances/tests/test_numba_distances.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.dists_kernels._numba_distances._distance import (
     _METRIC_INFOS,
@@ -25,7 +26,6 @@ from sktime.dists_kernels._numba_distances.tests._utils import (
     create_test_distance_numpy,
 )
 from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 _ran_once = False
 

--- a/sktime/dists_kernels/_numba_distances/tests/test_pairwise_distances.py
+++ b/sktime/dists_kernels/_numba_distances/tests/test_pairwise_distances.py
@@ -21,7 +21,7 @@ from sktime.dists_kernels._numba_distances.tests._utils import (
     create_test_distance_numpy,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def _check_symmetric(x: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:

--- a/sktime/dists_kernels/_numba_distances/tests/test_pairwise_distances.py
+++ b/sktime/dists_kernels/_numba_distances/tests/test_pairwise_distances.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.dists_kernels._numba_distances._distance import (
     _METRIC_INFOS,
@@ -21,7 +22,6 @@ from sktime.dists_kernels._numba_distances.tests._utils import (
     create_test_distance_numpy,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def _check_symmetric(x: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:

--- a/sktime/dists_kernels/base/_base.py
+++ b/sktime/dists_kernels/base/_base.py
@@ -32,11 +32,12 @@ Inspection methods:
 
 __author__ = ["fkiraly"]
 
+from skbase.utils.dependencies import _check_estimator_deps
+
 from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_scitype, convert_to
 from sktime.datatypes._dtypekind import DtypeKind
 from sktime.datatypes._series_as_panel import convert_Series_to_Panel
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 class BasePairwiseTransformer(BaseEstimator):

--- a/sktime/dists_kernels/base/_base.py
+++ b/sktime/dists_kernels/base/_base.py
@@ -36,7 +36,7 @@ from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_scitype, convert_to
 from sktime.datatypes._dtypekind import DtypeKind
 from sktime.datatypes._series_as_panel import convert_Series_to_Panel
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 class BasePairwiseTransformer(BaseEstimator):

--- a/sktime/dists_kernels/compose_from_align.py
+++ b/sktime/dists_kernels/compose_from_align.py
@@ -89,8 +89,9 @@ class DistFromAligner(BasePairwiseTransformerPanel):
     def get_test_params(cls, parameter_set="default"):
         """Test parameters for DistFromAligner."""
         # importing inside to avoid circular dependencies
-        from sktime.alignment.dtw_python import AlignerDTW
         from skbase.utils.dependencies import _check_estimator_deps
+
+        from sktime.alignment.dtw_python import AlignerDTW
 
         if _check_estimator_deps(AlignerDTW, severity="none"):
             return {"aligner": AlignerDTW()}

--- a/sktime/dists_kernels/compose_from_align.py
+++ b/sktime/dists_kernels/compose_from_align.py
@@ -90,7 +90,7 @@ class DistFromAligner(BasePairwiseTransformerPanel):
         """Test parameters for DistFromAligner."""
         # importing inside to avoid circular dependencies
         from sktime.alignment.dtw_python import AlignerDTW
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         if _check_estimator_deps(AlignerDTW, severity="none"):
             return {"aligner": AlignerDTW()}

--- a/sktime/forecasting/adapters/_hcrystalball.py
+++ b/sktime/forecasting/adapters/_hcrystalball.py
@@ -184,7 +184,7 @@ class HCrystalBallAdapter(BaseForecaster):
         -------
         params : dict or list of dict
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         if _check_soft_dependencies(["hcrystalball", "statsmodels"], severity="none"):
             from hcrystalball.wrappers import HoltSmoothingWrapper

--- a/sktime/forecasting/ardl.py
+++ b/sktime/forecasting/ardl.py
@@ -8,7 +8,7 @@ import pandas as pd
 from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.base.adapters import _StatsModelsAdapter
 from sktime.forecasting.base.adapters._statsmodels import _coerce_int_to_range_index
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 _all_ = ["ARDL"]
 __author__ = ["kcc-lion"]

--- a/sktime/forecasting/ardl.py
+++ b/sktime/forecasting/ardl.py
@@ -4,11 +4,11 @@
 import warnings
 
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.base.adapters import _StatsModelsAdapter
 from sktime.forecasting.base.adapters._statsmodels import _coerce_int_to_range_index
-from skbase.utils.dependencies import _check_soft_dependencies
 
 _all_ = ["ARDL"]
 __author__ = ["kcc-lion"]

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -66,7 +66,7 @@ from sktime.datatypes._dtypekind import DtypeKind
 from sktime.forecasting.base._clone_plugin import _PretrainedCloner
 from sktime.forecasting.base._fh import ForecastingHorizon
 from sktime.utils.datetime import _shift
-from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
+from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.validation.forecasting import check_alpha, check_cv, check_fh, check_X
 from sktime.utils.validation.series import check_equal_time_index
 from sktime.utils.warnings import warn

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -49,6 +49,7 @@ from itertools import product
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 
 from sktime.base import BaseEstimator
 from sktime.base._proba import _PredictProbaMixin
@@ -66,7 +67,6 @@ from sktime.datatypes._dtypekind import DtypeKind
 from sktime.forecasting.base._clone_plugin import _PretrainedCloner
 from sktime.forecasting.base._fh import ForecastingHorizon
 from sktime.utils.datetime import _shift
-from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.validation.forecasting import check_alpha, check_cv, check_fh, check_X
 from sktime.utils.validation.series import check_equal_time_index
 from sktime.utils.warnings import warn

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -11,9 +11,9 @@ import numpy as np
 import pandas as pd
 from pandas import Timedelta
 from pandas.tseries.frequencies import to_offset
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.utils.datetime import _coerce_duration_to_int
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation import (
     array_is_int,
     array_is_timedelta_or_date_offset,

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -13,7 +13,7 @@ from pandas import Timedelta
 from pandas.tseries.frequencies import to_offset
 
 from sktime.utils.datetime import _coerce_duration_to_int
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation import (
     array_is_int,
     array_is_timedelta_or_date_offset,

--- a/sktime/forecasting/base/adapters/_darts.py
+++ b/sktime/forecasting/base/adapters/_darts.py
@@ -6,7 +6,7 @@ import abc
 import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
 __author__ = ["yarnabrina", "fnhirwa"]

--- a/sktime/forecasting/base/adapters/_darts.py
+++ b/sktime/forecasting/base/adapters/_darts.py
@@ -4,9 +4,9 @@
 import abc
 
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
 __author__ = ["yarnabrina", "fnhirwa"]

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -632,7 +632,7 @@ class StatsForecastBackAdapter:
         """
         from sktime.forecasting.theta import ThetaForecaster
         from sktime.forecasting.var import VAR
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         del parameter_set  # to avoid being detected as unused by ``vulture`` etc.
 

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -630,9 +630,10 @@ class StatsForecastBackAdapter:
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+        from skbase.utils.dependencies import _check_estimator_deps
+
         from sktime.forecasting.theta import ThetaForecaster
         from sktime.forecasting.var import VAR
-        from skbase.utils.dependencies import _check_estimator_deps
 
         del parameter_set  # to avoid being detected as unused by ``vulture`` etc.
 

--- a/sktime/forecasting/base/adapters/_neuralforecast.py
+++ b/sktime/forecasting/base/adapters/_neuralforecast.py
@@ -9,13 +9,13 @@ from typing import Literal
 
 import numpy as np
 import pandas
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import (
     BaseForecaster,
     ForecastingHorizon,
     _GlobalForecastingDeprecationMixin,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
 __all__ = ["_NeuralForecastAdapter"]

--- a/sktime/forecasting/base/adapters/_neuralforecast.py
+++ b/sktime/forecasting/base/adapters/_neuralforecast.py
@@ -15,7 +15,7 @@ from sktime.forecasting.base import (
     ForecastingHorizon,
     _GlobalForecastingDeprecationMixin,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
 __all__ = ["_NeuralForecastAdapter"]

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -23,7 +23,7 @@ from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_panel
 from sktime.utils._testing.series import _make_series
-from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
+from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.parallel import _get_parallel_test_fixtures
 
 PANEL_MTYPES = ["pd-multiindex", "nested_univ", "numpy3D"]

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from pandas.testing import assert_series_equal
+from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 
 from sktime.datatypes import check_is_mtype, convert
 from sktime.datatypes._utilities import get_cutoff, get_window
@@ -23,7 +24,6 @@ from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_panel
 from sktime.utils._testing.series import _make_series
-from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.parallel import _get_parallel_test_fixtures
 
 PANEL_MTYPES = ["pd-multiindex", "nested_univ", "numpy3D"]

--- a/sktime/forecasting/base/tests/test_base_bugs.py
+++ b/sktime/forecasting/base/tests/test_base_bugs.py
@@ -15,7 +15,7 @@ from sktime.tests.test_switch import run_test_module_changed
 from sktime.transformations.difference import Differencer
 from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.utils._testing.hierarchical import _make_hierarchical
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/forecasting/base/tests/test_base_bugs.py
+++ b/sktime/forecasting/base/tests/test_base_bugs.py
@@ -3,6 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 import pytest
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.forecasting.compose import ForecastByLevel, TransformedTargetForecaster
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
@@ -15,7 +16,6 @@ from sktime.tests.test_switch import run_test_module_changed
 from sktime.transformations.difference import Differencer
 from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.utils._testing.hierarchical import _make_hierarchical
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -41,7 +41,7 @@ from sktime.utils.datetime import (
     _shift,
     infer_freq,
 )
-from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
+from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.validation.series import is_in_valid_index_types, is_integer_index
 
 

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 from numpy.testing._private.utils import assert_array_equal
 from pytest import raises
+from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 
 from sktime.datasets import load_airline
 from sktime.datatypes._utilities import get_cutoff
@@ -41,7 +42,6 @@ from sktime.utils.datetime import (
     _shift,
     infer_freq,
 )
-from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.validation.series import is_in_valid_index_types, is_integer_index
 
 

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -418,9 +418,10 @@ class BaggingForecaster(BaseForecaster):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
+        from skbase.utils.dependencies import _check_soft_dependencies
+
         from sktime.forecasting.compose import YfromX
         from sktime.transformations.bootstrap import MovingBlockBootstrapTransformer
-        from skbase.utils.dependencies import _check_soft_dependencies
 
         mbb = MovingBlockBootstrapTransformer(block_length=6, n_series=3)
         fcst = YfromX.create_test_instance()

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -420,7 +420,7 @@ class BaggingForecaster(BaseForecaster):
         """
         from sktime.forecasting.compose import YfromX
         from sktime.transformations.bootstrap import MovingBlockBootstrapTransformer
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         mbb = MovingBlockBootstrapTransformer(block_length=6, n_series=3)
         fcst = YfromX.create_test_instance()

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1366,7 +1366,7 @@ class TransformedTargetForecaster(_Pipeline):
 
         # if the inner forecaster natively supports _predict_proba,
         # delegate and wrap in a TransformedDistribution
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         if not _check_soft_dependencies("skpro", severity="none"):
             raise RuntimeError(

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -333,7 +333,7 @@ class _Reducer(_BaseWindowForecaster):
         from sklearn.pipeline import make_pipeline
 
         from sktime.transformations.reduce import Tabularizer
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         # naming convention is as follows:
         #   reducers with Tabular take an sklearn estimator, e.g., LinearRegressor
@@ -3155,7 +3155,7 @@ class YfromX(BaseForecaster, _ReducerMixin):
         from sklearn.ensemble import RandomForestRegressor
         from sklearn.linear_model import LinearRegression
 
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         params1 = {
             "estimator": LinearRegression(),

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -329,11 +329,11 @@ class _Reducer(_BaseWindowForecaster):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
+        from skbase.utils.dependencies import _check_soft_dependencies
         from sklearn.linear_model import LinearRegression
         from sklearn.pipeline import make_pipeline
 
         from sktime.transformations.reduce import Tabularizer
-        from skbase.utils.dependencies import _check_soft_dependencies
 
         # naming convention is as follows:
         #   reducers with Tabular take an sklearn estimator, e.g., LinearRegressor
@@ -3152,10 +3152,9 @@ class YfromX(BaseForecaster, _ReducerMixin):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
+        from skbase.utils.dependencies import _check_soft_dependencies
         from sklearn.ensemble import RandomForestRegressor
         from sklearn.linear_model import LinearRegression
-
-        from skbase.utils.dependencies import _check_soft_dependencies
 
         params1 = {
             "estimator": LinearRegression(),

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -713,7 +713,7 @@ def test_transformed_target_forecaster_predict_proba_delegates():
     2. Inner forecaster without native _predict_proba (only quantiles/intervals):
        the pipeline should fall back to the default Normal distribution.
     """
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     if not _check_soft_dependencies("skpro", severity="none"):
         pytest.skip("skpro required for this test")
@@ -829,7 +829,7 @@ def test_transformed_target_forecaster_predict_proba_dunder():
     Addresses issue #9287: pipelines built with transformer * forecaster
     should also correctly delegate predict_proba.
     """
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     if not _check_soft_dependencies("skpro", severity="none"):
         pytest.skip("skpro required for this test")

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -37,7 +37,7 @@ from sktime.split.tests.test_split import _get_windows
 from sktime.tests.test_switch import run_test_module_changed
 from sktime.transformations.reduce import Tabularizer
 from sktime.utils._testing.forecasting import make_forecasting_problem
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation.forecasting import check_fh
 
 N_TIMEPOINTS = [13, 17]

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -7,6 +7,7 @@ __author__ = ["Lovkush-A", "mloning", "LuisZugasti", "AyushmaanSeth"]
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.dummy import DummyRegressor
 from sklearn.linear_model import LinearRegression
@@ -37,7 +38,6 @@ from sktime.split.tests.test_split import _get_windows
 from sktime.tests.test_switch import run_test_module_changed
 from sktime.transformations.reduce import Tabularizer
 from sktime.utils._testing.forecasting import make_forecasting_problem
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation.forecasting import check_fh
 
 N_TIMEPOINTS = [13, 17]

--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -25,7 +25,7 @@ from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.summarize import WindowSummarizer
 from sktime.utils._testing.hierarchical import _make_hierarchical
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # HistGradientBoostingRegressor requires experimental flag in old sklearn versions
 sklearn_zero_x = _check_soft_dependencies("scikit-learn<1.4", severity="none")

--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -7,6 +7,7 @@ import random
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.ensemble import (
     GradientBoostingRegressor,
     HistGradientBoostingRegressor,
@@ -25,7 +26,6 @@ from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.summarize import WindowSummarizer
 from sktime.utils._testing.hierarchical import _make_hierarchical
-from skbase.utils.dependencies import _check_soft_dependencies
 
 # HistGradientBoostingRegressor requires experimental flag in old sklearn versions
 sklearn_zero_x = _check_soft_dependencies("scikit-learn<1.4", severity="none")

--- a/sktime/forecasting/enbpi.py
+++ b/sktime/forecasting/enbpi.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.base import clone
 from sklearn.utils import check_random_state
 
@@ -13,7 +14,6 @@ from sktime.transformations.bootstrap import (
     MovingBlockBootstrapTransformer,
     TSBootstrapAdapter,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 __all__ = ["EnbPIForecaster"]
 __author__ = ["benheid"]

--- a/sktime/forecasting/enbpi.py
+++ b/sktime/forecasting/enbpi.py
@@ -13,7 +13,7 @@ from sktime.transformations.bootstrap import (
     MovingBlockBootstrapTransformer,
     TSBootstrapAdapter,
 )
-from sktime.utils.dependencies._dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 __all__ = ["EnbPIForecaster"]
 __author__ = ["benheid"]

--- a/sktime/forecasting/es_rnn.py
+++ b/sktime/forecasting/es_rnn.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from sktime.forecasting.base.adapters._pytorch import BaseDeepNetworkPyTorch
 from sktime.networks.es_rnn import ESRNN
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 torch = _safe_import("torch")
 Dataset = _safe_import("torch.utils.data.Dataset")

--- a/sktime/forecasting/es_rnn.py
+++ b/sktime/forecasting/es_rnn.py
@@ -1,10 +1,10 @@
 """Interface for ES RNN for Time Series Forecasting."""
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.forecasting.base.adapters._pytorch import BaseDeepNetworkPyTorch
 from sktime.networks.es_rnn import ESRNN
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 torch = _safe_import("torch")
 Dataset = _safe_import("torch.utils.data.Dataset")

--- a/sktime/forecasting/mantis.py
+++ b/sktime/forecasting/mantis.py
@@ -12,7 +12,7 @@ from sklearn.linear_model import Ridge
 from sklearn.multioutput import MultiOutputRegressor
 
 from sktime.forecasting.base import BaseForecaster
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.singleton import _multiton
 
 

--- a/sktime/forecasting/mantis.py
+++ b/sktime/forecasting/mantis.py
@@ -8,11 +8,11 @@ from copy import deepcopy
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.linear_model import Ridge
 from sklearn.multioutput import MultiOutputRegressor
 
 from sktime.forecasting.base import BaseForecaster
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.singleton import _multiton
 
 

--- a/sktime/forecasting/mapa.py
+++ b/sktime/forecasting/mapa.py
@@ -2,9 +2,9 @@
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import BaseForecaster
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
 

--- a/sktime/forecasting/mapa.py
+++ b/sktime/forecasting/mapa.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster
-from sktime.utils.dependencies._dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
 

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -12,11 +12,11 @@ from copy import deepcopy
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datatypes import check_is_scitype, convert
 from sktime.exceptions import FitFailedWarning
 from sktime.forecasting.base import ForecastingHorizon
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.parallel import parallelize
 from sktime.utils.validation.forecasting import check_cv, check_scoring
 

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -16,7 +16,7 @@ import pandas as pd
 from sktime.datatypes import check_is_scitype, convert
 from sktime.exceptions import FitFailedWarning
 from sktime.forecasting.base import ForecastingHorizon
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.parallel import parallelize
 from sktime.utils.validation.forecasting import check_cv, check_scoring
 

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -17,6 +17,7 @@ __all__ = [
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.linear_model import LinearRegression
 from sklearn.model_selection import KFold
 
@@ -62,7 +63,6 @@ from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 from sktime.utils._testing.forecasting import make_forecasting_problem
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.series import _make_series
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.parallel import _get_parallel_test_fixtures
 
 METRICS = [MeanAbsolutePercentageError(symmetric=True), MeanAbsoluteScaledError()]

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -62,7 +62,7 @@ from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 from sktime.utils._testing.forecasting import make_forecasting_problem
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.series import _make_series
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.parallel import _get_parallel_test_fixtures
 
 METRICS = [MeanAbsolutePercentageError(symmetric=True), MeanAbsoluteScaledError()]

--- a/sktime/forecasting/model_selection/_optuna.py
+++ b/sktime/forecasting/model_selection/_optuna.py
@@ -323,7 +323,7 @@ class ForecastingOptunaSearchCV(BaseGridSearch):
         params : dict or list of dict
         """
         from sktime.forecasting.naive import NaiveForecaster
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         if not _check_soft_dependencies("optuna", severity="none"):
             return {

--- a/sktime/forecasting/model_selection/_optuna.py
+++ b/sktime/forecasting/model_selection/_optuna.py
@@ -322,8 +322,9 @@ class ForecastingOptunaSearchCV(BaseGridSearch):
         -------
         params : dict or list of dict
         """
-        from sktime.forecasting.naive import NaiveForecaster
         from skbase.utils.dependencies import _check_soft_dependencies
+
+        from sktime.forecasting.naive import NaiveForecaster
 
         if not _check_soft_dependencies("optuna", severity="none"):
             return {

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -9,6 +9,7 @@ from functools import reduce
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.model_selection import ParameterGrid, ParameterSampler
 
 from sktime.datasets import load_airline, load_longley
@@ -41,7 +42,6 @@ from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.detrend import Detrender
 from sktime.transformations.impute import Imputer
 from sktime.utils._testing.hierarchical import _make_hierarchical
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.parallel import _get_parallel_test_fixtures
 
 TEST_METRICS = [MeanAbsolutePercentageError(symmetric=True), MeanSquaredError()]

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -41,7 +41,7 @@ from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.detrend import Detrender
 from sktime.transformations.impute import Imputer
 from sktime.utils._testing.hierarchical import _make_hierarchical
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.parallel import _get_parallel_test_fixtures
 
 TEST_METRICS = [MeanAbsolutePercentageError(symmetric=True), MeanSquaredError()]

--- a/sktime/forecasting/neuralforecast.py
+++ b/sktime/forecasting/neuralforecast.py
@@ -7,7 +7,7 @@ from sktime.forecasting.base.adapters._neuralforecast import (
     _SUPPORTED_LOCAL_SCALAR_TYPES,
     _NeuralForecastAdapter,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 __author__ = ["yarnabrina", "geetu040", "pranavvp16"]
 

--- a/sktime/forecasting/neuralforecast.py
+++ b/sktime/forecasting/neuralforecast.py
@@ -3,11 +3,12 @@
 
 import functools
 
+from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.forecasting.base.adapters._neuralforecast import (
     _SUPPORTED_LOCAL_SCALAR_TYPES,
     _NeuralForecastAdapter,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 __author__ = ["yarnabrina", "geetu040", "pranavvp16"]
 

--- a/sktime/forecasting/online_learning/tests/test_online_learning.py
+++ b/sktime/forecasting/online_learning/tests/test_online_learning.py
@@ -6,6 +6,7 @@ __author__ = ["magittan"]
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.metrics import mean_squared_error
 
 from sktime.datasets import load_airline
@@ -18,7 +19,6 @@ from sktime.forecasting.online_learning._prediction_weighted_ensembler import (
 )
 from sktime.split import SlidingWindowSplitter, temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-from skbase.utils.dependencies import _check_soft_dependencies
 
 cv = SlidingWindowSplitter(start_with_window=True, window_length=1, fh=1)
 

--- a/sktime/forecasting/online_learning/tests/test_online_learning.py
+++ b/sktime/forecasting/online_learning/tests/test_online_learning.py
@@ -18,7 +18,7 @@ from sktime.forecasting.online_learning._prediction_weighted_ensembler import (
 )
 from sktime.split import SlidingWindowSplitter, temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 cv = SlidingWindowSplitter(start_with_window=True, window_length=1, fh=1)
 

--- a/sktime/forecasting/pykan.py
+++ b/sktime/forecasting/pykan.py
@@ -4,10 +4,10 @@
 __author__ = ["benheid"]
 
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import BaseForecaster
 from sktime.split import temporal_train_test_split
-from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies(["pykan", "torch"], severity="none"):
     import torch

--- a/sktime/forecasting/pykan.py
+++ b/sktime/forecasting/pykan.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster
 from sktime.split import temporal_train_test_split
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies(["pykan", "torch"], severity="none"):
     import torch

--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -4,10 +4,11 @@
 import functools
 from typing import Any
 
+from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.forecasting.base.adapters._pytorchforecasting import (
     _PytorchForecastingAdapter,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 __author__ = ["XinyuWu"]
 

--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -7,7 +7,7 @@ from typing import Any
 from sktime.forecasting.base.adapters._pytorchforecasting import (
     _PytorchForecastingAdapter,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 __author__ = ["XinyuWu"]
 

--- a/sktime/forecasting/rbf.py
+++ b/sktime/forecasting/rbf.py
@@ -8,7 +8,7 @@ from sklearn.preprocessing import StandardScaler
 
 from sktime.forecasting.base.adapters._pytorch import BaseDeepNetworkPyTorch
 from sktime.networks.rbf import RBFNetwork
-from sktime.utils.dependencies._dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
 

--- a/sktime/forecasting/rbf.py
+++ b/sktime/forecasting/rbf.py
@@ -4,11 +4,11 @@ __author__ = ["phoeenniixx"]
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.preprocessing import StandardScaler
 
 from sktime.forecasting.base.adapters._pytorch import BaseDeepNetworkPyTorch
 from sktime.networks.rbf import RBFNetwork
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
 

--- a/sktime/forecasting/statsforecast.py
+++ b/sktime/forecasting/statsforecast.py
@@ -20,7 +20,7 @@ from sktime.forecasting.base.adapters._generalised_statsforecast import (
     StatsForecastBackAdapter,
     _GeneralisedStatsForecastAdapter,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class StatsForecastAutoARIMA(_GeneralisedStatsForecastAdapter):

--- a/sktime/forecasting/statsforecast.py
+++ b/sktime/forecasting/statsforecast.py
@@ -14,13 +14,13 @@ __all__ = [
 ]
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
 from sktime.forecasting.base.adapters._generalised_statsforecast import (
     StatsForecastBackAdapter,
     _GeneralisedStatsForecastAdapter,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class StatsForecastAutoARIMA(_GeneralisedStatsForecastAdapter):

--- a/sktime/forecasting/tests/test_autots_custom.py
+++ b/sktime/forecasting/tests/test_autots_custom.py
@@ -2,9 +2,9 @@
 
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.forecasting.autots import AutoTS
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/forecasting/tests/test_autots_custom.py
+++ b/sktime/forecasting/tests/test_autots_custom.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 from sktime.forecasting.autots import AutoTS
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/forecasting/tests/test_categorical.py
+++ b/sktime/forecasting/tests/test_categorical.py
@@ -17,7 +17,7 @@ from sktime.forecasting.compose import SkforecastAutoreg
 from sktime.forecasting.compose._reduce import YfromX
 from sktime.forecasting.dummy import ForecastKnownValues
 from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def test_dummy_est_with_categorical_capability():

--- a/sktime/forecasting/tests/test_categorical.py
+++ b/sktime/forecasting/tests/test_categorical.py
@@ -11,13 +11,13 @@ __author__ = ["Abhay-Lejith"]
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 from sktime.forecasting.compose import SkforecastAutoreg
 from sktime.forecasting.compose._reduce import YfromX
 from sktime.forecasting.dummy import ForecastKnownValues
 from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def test_dummy_est_with_categorical_capability():

--- a/sktime/forecasting/tests/test_chronos2.py
+++ b/sktime/forecasting/tests/test_chronos2.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 from sktime.forecasting.chronos2 import Chronos2Forecaster
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/forecasting/tests/test_chronos2.py
+++ b/sktime/forecasting/tests/test_chronos2.py
@@ -3,9 +3,9 @@
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.forecasting.chronos2 import Chronos2Forecaster
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/forecasting/tests/test_darts.py
+++ b/sktime/forecasting/tests/test_darts.py
@@ -8,6 +8,7 @@ import re
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datasets import load_longley
 from sktime.forecasting.darts import (
@@ -17,7 +18,6 @@ from sktime.forecasting.darts import (
 )
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-from skbase.utils.dependencies import _check_soft_dependencies
 
 __author__ = ["fnhirwa"]
 

--- a/sktime/forecasting/tests/test_darts.py
+++ b/sktime/forecasting/tests/test_darts.py
@@ -17,7 +17,7 @@ from sktime.forecasting.darts import (
 )
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 __author__ = ["fnhirwa"]
 

--- a/sktime/forecasting/tests/test_mapa.py
+++ b/sktime/forecasting/tests/test_mapa.py
@@ -188,7 +188,7 @@ base_forecaster_params = [
     },
 ]
 
-from sktime.utils.dependencies._dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("statsmodels", severity="none"):
     from sktime.forecasting.exp_smoothing import ExponentialSmoothing

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
@@ -20,7 +21,6 @@ from sktime.utils._testing.hierarchical import (
     _make_hierarchical,
     _make_index,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 # get all the methods
 METHOD_LIST = [x for x in ReconcilerForecaster.METHOD_LIST if not x.endswith("nonneg")]

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -20,7 +20,7 @@ from sktime.utils._testing.hierarchical import (
     _make_hierarchical,
     _make_index,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # get all the methods
 METHOD_LIST = [x for x in ReconcilerForecaster.METHOD_LIST if not x.endswith("nonneg")]

--- a/sktime/forecasting/tests/test_var.py
+++ b/sktime/forecasting/tests/test_var.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_allclose
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import ForecastingHorizon
 
@@ -12,7 +13,6 @@ from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.var import VAR
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/forecasting/tests/test_var.py
+++ b/sktime/forecasting/tests/test_var.py
@@ -12,7 +12,7 @@ from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.var import VAR
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/forecasting/tests/test_varmax.py
+++ b/sktime/forecasting/tests/test_varmax.py
@@ -11,7 +11,7 @@ from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.varmax import VARMAX
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skip(reason="undiagnosed failure, see #6260")

--- a/sktime/forecasting/tests/test_varmax.py
+++ b/sktime/forecasting/tests/test_varmax.py
@@ -6,12 +6,12 @@ import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_allclose
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.varmax import VARMAX
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skip(reason="undiagnosed failure, see #6260")

--- a/sktime/forecasting/tests/test_vecm.py
+++ b/sktime/forecasting/tests/test_vecm.py
@@ -5,12 +5,12 @@ import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_allclose
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.vecm import VECM
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/forecasting/tests/test_vecm.py
+++ b/sktime/forecasting/tests/test_vecm.py
@@ -10,7 +10,7 @@ from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.vecm import VECM
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -6,6 +6,7 @@ __author__ = ["big-o", "mloning", "kejsitake", "fkiraly", "GuzalBulatova"]
 import numpy as np
 import pandas as pd
 from scipy.stats import norm
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.compose import ColumnEnsembleForecaster
@@ -15,7 +16,6 @@ from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.transformations.detrend import Deseasonalizer
 from sktime.transformations.theta import ThetaLinesTransformer
-from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.slope_and_trend import _fit_trend
 from sktime.utils.validation.forecasting import check_sp
 from sktime.utils.warnings import warn

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -15,7 +15,7 @@ from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.transformations.detrend import Deseasonalizer
 from sktime.transformations.theta import ThetaLinesTransformer
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.slope_and_trend import _fit_trend
 from sktime.utils.validation.forecasting import check_sp
 from sktime.utils.warnings import warn

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -26,7 +26,7 @@ import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster
 from sktime.split import temporal_train_test_split
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.singleton import _multiton
 
 

--- a/sktime/forecasting/timesfm2_forecaster.py
+++ b/sktime/forecasting/timesfm2_forecaster.py
@@ -23,10 +23,10 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import BaseForecaster
 from sktime.split import temporal_train_test_split
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.singleton import _multiton
 
 

--- a/sktime/forecasting/trend/_stl_forecaster.py
+++ b/sktime/forecasting/trend/_stl_forecaster.py
@@ -6,9 +6,9 @@ __author__ = ["tensorflow-as-tf", "mloning", "aiwalter", "fkiraly"]
 __all__ = ["STLForecaster"]
 
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import BaseForecaster
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class STLForecaster(BaseForecaster):

--- a/sktime/forecasting/trend/_stl_forecaster.py
+++ b/sktime/forecasting/trend/_stl_forecaster.py
@@ -8,7 +8,7 @@ __all__ = ["STLForecaster"]
 import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class STLForecaster(BaseForecaster):

--- a/sktime/forecasting/trend/tests/test_stl.py
+++ b/sktime/forecasting/trend/tests/test_stl.py
@@ -9,7 +9,7 @@ import pytest
 from sktime.datasets import load_airline
 from sktime.forecasting.trend import STLForecaster
 from sktime.tests.test_switch import run_test_for_class
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 # zero trend does not work without intercept

--- a/sktime/forecasting/trend/tests/test_stl.py
+++ b/sktime/forecasting/trend/tests/test_stl.py
@@ -5,11 +5,11 @@
 __author__ = ["ericjb"]
 
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datasets import load_airline
 from sktime.forecasting.trend import STLForecaster
 from sktime.tests.test_switch import run_test_for_class
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 # zero trend does not work without intercept

--- a/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_history.py
+++ b/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_history.py
@@ -3,7 +3,7 @@ import pytest
 
 from sktime.libs._keras_self_attention import ScaledDotProductAttention
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_history.py
+++ b/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_history.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._keras_self_attention import ScaledDotProductAttention
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_real_former.py
+++ b/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_real_former.py
@@ -3,10 +3,10 @@ import tempfile
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._keras_self_attention import ResidualScaledDotProductAttention
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_real_former.py
+++ b/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_real_former.py
@@ -6,7 +6,7 @@ import pytest
 
 from sktime.libs._keras_self_attention import ResidualScaledDotProductAttention
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_sample.py
+++ b/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_sample.py
@@ -3,7 +3,7 @@ import pytest
 
 from sktime.libs._keras_self_attention import ScaledDotProductAttention
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_sample.py
+++ b/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_sample.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._keras_self_attention import ScaledDotProductAttention
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_save_load.py
+++ b/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_save_load.py
@@ -3,10 +3,10 @@ import tempfile
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._keras_self_attention import ScaledDotProductAttention
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_save_load.py
+++ b/sktime/libs/_keras_self_attention/tests/scaled_dot_attention/test_save_load.py
@@ -6,7 +6,7 @@ import pytest
 
 from sktime.libs._keras_self_attention import ScaledDotProductAttention
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_activation.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_activation.py
@@ -5,7 +5,7 @@ from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_activation.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_activation.py
@@ -1,11 +1,11 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._keras_self_attention import SeqSelfAttention
 from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_bias.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_bias.py
@@ -5,7 +5,7 @@ from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_bias.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_bias.py
@@ -1,11 +1,11 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._keras_self_attention import SeqSelfAttention
 from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_history.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_history.py
@@ -5,7 +5,7 @@ from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_history.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_history.py
@@ -1,11 +1,11 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.libs._keras_self_attention import SeqSelfAttention
 from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_local.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_local.py
@@ -5,7 +5,7 @@ from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_local.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_local.py
@@ -1,11 +1,11 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._keras_self_attention import SeqSelfAttention
 from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_loss.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_loss.py
@@ -6,7 +6,7 @@ from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_loss.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_loss.py
@@ -1,12 +1,12 @@
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._keras_self_attention import SeqSelfAttention
 from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_mask.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_mask.py
@@ -5,7 +5,7 @@ from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_mask.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_mask.py
@@ -1,11 +1,11 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._keras_self_attention import SeqSelfAttention
 from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_mul.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_mul.py
@@ -5,7 +5,7 @@ from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_mul.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_mul.py
@@ -1,11 +1,11 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._keras_self_attention import SeqSelfAttention
 from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_save_load.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_save_load.py
@@ -3,13 +3,13 @@ import tempfile
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._keras_self_attention import SeqSelfAttention
 from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_save_load.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/test_save_load.py
@@ -9,7 +9,7 @@ from sktime.libs._keras_self_attention.tests.seq_self_attention.util import (
     TestMaskShape,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/util.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/util.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_self_attention/util.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_self_attention/util.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_weighted_attention/test_save_load.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_weighted_attention/test_save_load.py
@@ -3,10 +3,10 @@ import tempfile
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._keras_self_attention import SeqWeightedAttention as Attention
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_keras_self_attention/tests/seq_weighted_attention/test_save_load.py
+++ b/sktime/libs/_keras_self_attention/tests/seq_weighted_attention/test_save_load.py
@@ -6,7 +6,7 @@ import pytest
 
 from sktime.libs._keras_self_attention import SeqWeightedAttention as Attention
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 keras = _safe_import("tensorflow.keras")
 

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_activation.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_activation.py
@@ -1,10 +1,10 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.libs._torch_self_attention.tests.seq_self_attention.util import (
     TestMaskShapeTorch,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_activation.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_activation.py
@@ -4,7 +4,7 @@ from sktime.libs._torch_self_attention.tests.seq_self_attention.util import (
     TestMaskShapeTorch,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_bias.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_bias.py
@@ -1,10 +1,10 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.libs._torch_self_attention.tests.seq_self_attention.util import (
     TestMaskShapeTorch,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_bias.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_bias.py
@@ -4,7 +4,7 @@ from sktime.libs._torch_self_attention.tests.seq_self_attention.util import (
     TestMaskShapeTorch,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_history.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_history.py
@@ -1,10 +1,10 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.libs._torch_self_attention.tests.seq_self_attention.util import (
     TestMaskShapeTorch,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_history.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_history.py
@@ -4,7 +4,7 @@ from sktime.libs._torch_self_attention.tests.seq_self_attention.util import (
     TestMaskShapeTorch,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_local.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_local.py
@@ -1,10 +1,10 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.libs._torch_self_attention.tests.seq_self_attention.util import (
     TestMaskShapeTorch,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_local.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_local.py
@@ -4,7 +4,7 @@ from sktime.libs._torch_self_attention.tests.seq_self_attention.util import (
     TestMaskShapeTorch,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_loss.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_loss.py
@@ -1,7 +1,7 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_loss.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_loss.py
@@ -1,7 +1,7 @@
 import pytest
 
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_mask.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_mask.py
@@ -1,10 +1,10 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.libs._torch_self_attention.tests.seq_self_attention.util import (
     TestMaskShapeTorch,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_mask.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_mask.py
@@ -4,7 +4,7 @@ from sktime.libs._torch_self_attention.tests.seq_self_attention.util import (
     TestMaskShapeTorch,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_mul.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_mul.py
@@ -1,10 +1,10 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.libs._torch_self_attention.tests.seq_self_attention.util import (
     TestMaskShapeTorch,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_mul.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_mul.py
@@ -4,7 +4,7 @@ from sktime.libs._torch_self_attention.tests.seq_self_attention.util import (
     TestMaskShapeTorch,
 )
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_save_load.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_save_load.py
@@ -1,7 +1,7 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_save_load.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_save_load.py
@@ -1,7 +1,7 @@
 import pytest
 
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_validation.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_validation.py
@@ -1,7 +1,7 @@
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_validation.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_validation.py
@@ -1,7 +1,7 @@
 import pytest
 
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 pytestmark = pytest.mark.skipif(
     not run_test_module_changed("sktime.libs._torch_self_attention")

--- a/sktime/libs/chronos/chronos.py
+++ b/sktime/libs/chronos/chronos.py
@@ -11,7 +11,7 @@ import warnings
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 torch = _safe_import("torch")
 nn = _safe_import("torch.nn")

--- a/sktime/libs/chronos/chronos_bolt.py
+++ b/sktime/libs/chronos/chronos_bolt.py
@@ -14,7 +14,7 @@ import warnings
 from dataclasses import dataclass
 from typing import Any
 
-from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 torch = _safe_import("torch")
 nn = _safe_import("torch.nn")

--- a/sktime/libs/falcon_tst/modeling_FalconTST.py
+++ b/sktime/libs/falcon_tst/modeling_FalconTST.py
@@ -3,7 +3,7 @@
 import math
 from functools import reduce
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # import transformer_engine as te
 from .configuration_FalconTST import FalconTSTConfig

--- a/sktime/libs/timer_s1/__init__.py
+++ b/sktime/libs/timer_s1/__init__.py
@@ -216,7 +216,7 @@ All code contained is released under the license below.
    limitations under the License.
 """
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", "transformers", severity="none"):
     from sktime.libs.timer_s1.configuration_TimerS1 import TimerS1Config

--- a/sktime/libs/timer_s1/modeling_TimerS1.py
+++ b/sktime/libs/timer_s1/modeling_TimerS1.py
@@ -17,7 +17,7 @@
 import math
 from dataclasses import dataclass
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from .configuration_TimerS1 import TimerS1Config
 from .ts_generation_mixin import TSGenerationMixin

--- a/sktime/libs/vmdpy/tests/test_readme_example.py
+++ b/sktime/libs/vmdpy/tests/test_readme_example.py
@@ -1,9 +1,9 @@
 """Tests for vmdpy package - readme example."""
 
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/libs/vmdpy/tests/test_readme_example.py
+++ b/sktime/libs/vmdpy/tests/test_readme_example.py
@@ -3,7 +3,7 @@
 import pytest
 
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/networks/base.py
+++ b/sktime/networks/base.py
@@ -3,7 +3,7 @@
 __author__ = ["Withington", "TonyBagnall", "fkiraly"]
 
 from sktime.base import BaseObject
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 class BaseDeepNetwork(BaseObject):

--- a/sktime/networks/base.py
+++ b/sktime/networks/base.py
@@ -2,8 +2,9 @@
 
 __author__ = ["Withington", "TonyBagnall", "fkiraly"]
 
-from sktime.base import BaseObject
 from skbase.utils.dependencies import _check_estimator_deps
+
+from sktime.base import BaseObject
 
 
 class BaseDeepNetwork(BaseObject):

--- a/sktime/networks/es_rnn.py
+++ b/sktime/networks/es_rnn.py
@@ -4,7 +4,7 @@ __author__ = ["Ankit-1204"]
 
 from warnings import warn
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch

--- a/sktime/networks/ltsf/data/dataset.py
+++ b/sktime/networks/ltsf/data/dataset.py
@@ -1,6 +1,6 @@
 """Implements Pytorch Dataset class for LTSF-Formers."""
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch

--- a/sktime/networks/ltsf/layers/attention.py
+++ b/sktime/networks/ltsf/layers/attention.py
@@ -1,6 +1,6 @@
 """Extra LTSF Model Layers."""
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch

--- a/sktime/networks/ltsf/layers/auto_correlation.py
+++ b/sktime/networks/ltsf/layers/auto_correlation.py
@@ -1,6 +1,6 @@
 """Extra LTSF Model Layers."""
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch.nn as nn

--- a/sktime/networks/ltsf/layers/embed.py
+++ b/sktime/networks/ltsf/layers/embed.py
@@ -1,6 +1,6 @@
 """Extra LTSF Model Layers."""
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch

--- a/sktime/networks/ltsf/layers/enc_dec.py
+++ b/sktime/networks/ltsf/layers/enc_dec.py
@@ -1,6 +1,6 @@
 """Extra LTSF Model Layers."""
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch.nn as nn

--- a/sktime/networks/ltsf/models/linear.py
+++ b/sktime/networks/ltsf/models/linear.py
@@ -1,6 +1,6 @@
 """Deep Learning Forecasters using LTSF-Linear Models."""
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch.nn as nn

--- a/sktime/networks/ltsf/models/transformers.py
+++ b/sktime/networks/ltsf/models/transformers.py
@@ -1,6 +1,6 @@
 """Deep Learning Forecaster using LTSF-Transformer Model."""
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch.nn as nn

--- a/sktime/networks/ltsf/utils/extras.py
+++ b/sktime/networks/ltsf/utils/extras.py
@@ -1,6 +1,6 @@
 """Extra LTSF Model Layers."""
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch.nn as nn

--- a/sktime/networks/ltsf/utils/masking.py
+++ b/sktime/networks/ltsf/utils/masking.py
@@ -1,6 +1,6 @@
 """Extra LTSF Model Layers."""
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch

--- a/sktime/networks/mvts_transformer.py
+++ b/sktime/networks/mvts_transformer.py
@@ -16,7 +16,7 @@ In Proceedings of the 27th ACM SIGKDD Conference on Knowledge Discovery
 
 import math
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch

--- a/sktime/networks/rbf.py
+++ b/sktime/networks/rbf.py
@@ -1,6 +1,6 @@
 """RBF Neural Networks for Time Series Forecasting."""
 
-from sktime.utils.dependencies._dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch

--- a/sktime/networks/scinet.py
+++ b/sktime/networks/scinet.py
@@ -3,7 +3,6 @@
 import math
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):

--- a/sktime/networks/scinet.py
+++ b/sktime/networks/scinet.py
@@ -4,7 +4,7 @@ import math
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch

--- a/sktime/param_est/base.py
+++ b/sktime/param_est/base.py
@@ -31,7 +31,7 @@ from sktime.datatypes import (
 )
 from sktime.datatypes._dtypekind import DtypeKind
 from sktime.utils.adapters._safe_call import _safe_call
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.sklearn import is_sklearn_transformer
 from sktime.utils.warnings import warn
 

--- a/sktime/param_est/base.py
+++ b/sktime/param_est/base.py
@@ -21,6 +21,8 @@ __author__ = ["fkiraly", "satvshr"]
 
 __all__ = ["BaseParamFitter"]
 
+from skbase.utils.dependencies import _check_estimator_deps
+
 from sktime.base import BaseEstimator
 from sktime.datatypes import (
     VectorizedDF,
@@ -31,7 +33,6 @@ from sktime.datatypes import (
 )
 from sktime.datatypes._dtypekind import DtypeKind
 from sktime.utils.adapters._safe_call import _safe_call
-from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.sklearn import is_sklearn_transformer
 from sktime.utils.warnings import warn
 

--- a/sktime/param_est/compose/_pipeline.py
+++ b/sktime/param_est/compose/_pipeline.py
@@ -305,7 +305,7 @@ class ParamFitterPipeline(_HeterogenousMetaEstimator, BaseParamFitter):
         from sktime.param_est.fixed import FixedParams
         from sktime.param_est.seasonality import SeasonalityACF
         from sktime.transformations.exponent import ExponentTransformer
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         t1 = ExponentTransformer(power=2)
         t2 = ExponentTransformer(power=0.5)

--- a/sktime/param_est/compose/_pipeline.py
+++ b/sktime/param_est/compose/_pipeline.py
@@ -302,10 +302,11 @@ class ParamFitterPipeline(_HeterogenousMetaEstimator, BaseParamFitter):
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
         # imports
+        from skbase.utils.dependencies import _check_estimator_deps
+
         from sktime.param_est.fixed import FixedParams
         from sktime.param_est.seasonality import SeasonalityACF
         from sktime.transformations.exponent import ExponentTransformer
-        from skbase.utils.dependencies import _check_estimator_deps
 
         t1 = ExponentTransformer(power=2)
         t2 = ExponentTransformer(power=0.5)

--- a/sktime/param_est/impulse/_response.py
+++ b/sktime/param_est/impulse/_response.py
@@ -356,7 +356,7 @@ class ImpulseResponseFunction(BaseParamFitter):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         if _check_soft_dependencies("statsmodels", severity="none"):
             from sktime.datasets import load_airline

--- a/sktime/param_est/plugin/_forecaster.py
+++ b/sktime/param_est/plugin/_forecaster.py
@@ -288,7 +288,7 @@ class PluginParamsForecaster(_DelegatedForecaster):
         from sktime.forecasting.naive import NaiveForecaster
         from sktime.param_est.fixed import FixedParams
         from sktime.param_est.seasonality import SeasonalityACF
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         # use of dictionary to plug "foo" parameter into "sp", uses mock param_est
         params1 = {

--- a/sktime/param_est/plugin/_forecaster.py
+++ b/sktime/param_est/plugin/_forecaster.py
@@ -285,10 +285,11 @@ class PluginParamsForecaster(_DelegatedForecaster):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
+        from skbase.utils.dependencies import _check_estimator_deps
+
         from sktime.forecasting.naive import NaiveForecaster
         from sktime.param_est.fixed import FixedParams
         from sktime.param_est.seasonality import SeasonalityACF
-        from skbase.utils.dependencies import _check_estimator_deps
 
         # use of dictionary to plug "foo" parameter into "sp", uses mock param_est
         params1 = {

--- a/sktime/param_est/plugin/_transformer.py
+++ b/sktime/param_est/plugin/_transformer.py
@@ -215,11 +215,12 @@ class PluginParamsTransformer(_DelegatedTransformer):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
+        from skbase.utils.dependencies import _check_estimator_deps
+
         from sktime.param_est.fixed import FixedParams
         from sktime.param_est.seasonality import SeasonalityACF
         from sktime.transformations.detrend import Deseasonalizer
         from sktime.transformations.exponent import ExponentTransformer
-        from skbase.utils.dependencies import _check_estimator_deps
 
         # use of dictionary to plug "foo" parameter into "power", uses mock param_est
         params1 = {

--- a/sktime/param_est/plugin/_transformer.py
+++ b/sktime/param_est/plugin/_transformer.py
@@ -219,7 +219,7 @@ class PluginParamsTransformer(_DelegatedTransformer):
         from sktime.param_est.seasonality import SeasonalityACF
         from sktime.transformations.detrend import Deseasonalizer
         from sktime.transformations.exponent import ExponentTransformer
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         # use of dictionary to plug "foo" parameter into "power", uses mock param_est
         params1 = {

--- a/sktime/param_est/plugin/tests/test_plugin.py
+++ b/sktime/param_est/plugin/tests/test_plugin.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 from sktime.param_est.seasonality import SeasonalityACF
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/param_est/plugin/tests/test_plugin.py
+++ b/sktime/param_est/plugin/tests/test_plugin.py
@@ -3,9 +3,9 @@
 
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.param_est.seasonality import SeasonalityACF
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/param_est/tests/test_cointegration.py
+++ b/sktime/param_est/tests/test_cointegration.py
@@ -9,7 +9,7 @@ import pytest
 
 from sktime.datasets import load_airline
 from sktime.param_est.cointegration import JohansenCointegration
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/param_est/tests/test_cointegration.py
+++ b/sktime/param_est/tests/test_cointegration.py
@@ -6,10 +6,10 @@ __author__ = ["OldPatrick"]
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.datasets import load_airline
 from sktime.param_est.cointegration import JohansenCointegration
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/param_est/tests/test_lag.py
+++ b/sktime/param_est/tests/test_lag.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose
 
 from sktime.datasets import load_airline
 from sktime.param_est.lag import ARLagOrderSelector
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/param_est/tests/test_lag.py
+++ b/sktime/param_est/tests/test_lag.py
@@ -4,10 +4,10 @@ __author__ = ["satvshr"]
 
 import pytest
 from numpy.testing import assert_allclose
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.datasets import load_airline
 from sktime.param_est.lag import ARLagOrderSelector
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/param_est/tests/test_plugin.py
+++ b/sktime/param_est/tests/test_plugin.py
@@ -5,6 +5,7 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.datasets import load_airline, load_longley
 from sktime.forecasting.naive import NaiveForecaster
@@ -13,7 +14,6 @@ from sktime.param_est.plugin import PluginParamsForecaster
 from sktime.param_est.seasonality import SeasonalityACF
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.difference import Differencer
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/param_est/tests/test_plugin.py
+++ b/sktime/param_est/tests/test_plugin.py
@@ -13,7 +13,7 @@ from sktime.param_est.plugin import PluginParamsForecaster
 from sktime.param_est.seasonality import SeasonalityACF
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.difference import Differencer
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/param_est/tests/test_response.py
+++ b/sktime/param_est/tests/test_response.py
@@ -6,10 +6,10 @@ __author__ = ["OldPatrick"]
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.datasets import load_airline
 from sktime.param_est.impulse import ImpulseResponseFunction
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 # DynamicFactor tests

--- a/sktime/param_est/tests/test_response.py
+++ b/sktime/param_est/tests/test_response.py
@@ -9,7 +9,7 @@ import pytest
 
 from sktime.datasets import load_airline
 from sktime.param_est.impulse import ImpulseResponseFunction
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 # DynamicFactor tests

--- a/sktime/param_est/tests/test_seasonality.py
+++ b/sktime/param_est/tests/test_seasonality.py
@@ -5,10 +5,10 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.datasets import load_airline
 from sktime.param_est.seasonality import SeasonalityACF, SeasonalityACFqstat
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/param_est/tests/test_seasonality.py
+++ b/sktime/param_est/tests/test_seasonality.py
@@ -8,7 +8,7 @@ import pytest
 
 from sktime.datasets import load_airline
 from sktime.param_est.seasonality import SeasonalityACF, SeasonalityACFqstat
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/param_est/tests/test_stationarity.py
+++ b/sktime/param_est/tests/test_stationarity.py
@@ -7,7 +7,7 @@ import pytest
 
 from sktime.datasets import load_airline
 from sktime.param_est.stationarity import StationarityADF, StationarityKPSS
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/param_est/tests/test_stationarity.py
+++ b/sktime/param_est/tests/test_stationarity.py
@@ -4,10 +4,10 @@
 __author__ = ["fkiraly"]
 
 import pytest
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.datasets import load_airline
 from sktime.param_est.stationarity import StationarityADF, StationarityKPSS
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/performance_metrics/base/_base.py
+++ b/sktime/performance_metrics/base/_base.py
@@ -6,7 +6,7 @@ __author__ = ["rnkuhns", "fkiraly"]
 __all__ = ["BaseMetric"]
 
 from sktime.base import BaseObject
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 class BaseMetric(BaseObject):

--- a/sktime/performance_metrics/base/_base.py
+++ b/sktime/performance_metrics/base/_base.py
@@ -5,8 +5,9 @@
 __author__ = ["rnkuhns", "fkiraly"]
 __all__ = ["BaseMetric"]
 
-from sktime.base import BaseObject
 from skbase.utils.dependencies import _check_estimator_deps
+
+from sktime.base import BaseObject
 
 
 class BaseMetric(BaseObject):

--- a/sktime/pipeline/tests/regression_tests/test_pipeline_regression.py
+++ b/sktime/pipeline/tests/regression_tests/test_pipeline_regression.py
@@ -17,7 +17,7 @@ from sktime.transformations.difference import Differencer
 from sktime.transformations.exponent import ExponentTransformer
 from sktime.transformations.lag import Lag
 from sktime.utils._testing.hierarchical import _bottom_hier_datagen, _make_hierarchical
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/pipeline/tests/regression_tests/test_pipeline_regression.py
+++ b/sktime/pipeline/tests/regression_tests/test_pipeline_regression.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.linear_model import Ridge
 
 from sktime.classification.dummy import DummyClassifier
@@ -17,7 +18,6 @@ from sktime.transformations.difference import Differencer
 from sktime.transformations.exponent import ExponentTransformer
 from sktime.transformations.lag import Lag
 from sktime.utils._testing.hierarchical import _bottom_hier_datagen, _make_hierarchical
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -4,9 +4,9 @@
 __author__ = ["fkiraly"]
 
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.registry._craft import craft, deps, imports
-from skbase.utils.dependencies import _check_soft_dependencies
 
 simple_spec = "NaiveForecaster()"
 simple_spec_with_dep = "VAR(trend='ct')"

--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -6,7 +6,7 @@ __author__ = ["fkiraly"]
 import pytest
 
 from sktime.registry._craft import craft, deps, imports
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 simple_spec = "NaiveForecaster()"
 simple_spec_with_dep = "VAR(trend='ct')"

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from sktime.base import BasePanelMixin
 from sktime.datatypes import VectorizedDF
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.sklearn import is_sklearn_transformer
 
 

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -25,10 +25,10 @@ __author__ = ["mloning", "fkiraly", "ksharma6"]
 import time
 
 import numpy as np
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.base import BasePanelMixin
 from sktime.datatypes import VectorizedDF
-from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.sklearn import is_sklearn_transformer
 
 

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -293,9 +293,10 @@ class RegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
+        from skbase.utils.dependencies import _check_estimator_deps
+
         from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
         from sktime.transformations.exponent import ExponentTransformer
-        from skbase.utils.dependencies import _check_estimator_deps
 
         t1 = ExponentTransformer(power=2)
         t2 = ExponentTransformer(power=0.5)

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -295,7 +295,7 @@ class RegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
         """
         from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
         from sktime.transformations.exponent import ExponentTransformer
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         t1 = ExponentTransformer(power=2)
         t2 = ExponentTransformer(power=0.5)

--- a/sktime/regression/deep_learning/base/_base_tf.py
+++ b/sktime/regression/deep_learning/base/_base_tf.py
@@ -10,9 +10,9 @@ import os
 from abc import abstractmethod
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.regression.base import BaseRegressor
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class BaseDeepRegressor(BaseRegressor):

--- a/sktime/regression/deep_learning/base/_base_tf.py
+++ b/sktime/regression/deep_learning/base/_base_tf.py
@@ -12,7 +12,7 @@ from abc import abstractmethod
 import numpy as np
 
 from sktime.regression.base import BaseRegressor
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class BaseDeepRegressor(BaseRegressor):

--- a/sktime/regression/deep_learning/cnn/_cnn_tf.py
+++ b/sktime/regression/deep_learning/cnn/_cnn_tf.py
@@ -263,7 +263,7 @@ class CNNRegressor(BaseDeepRegressor):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 10,

--- a/sktime/regression/deep_learning/fcn.py
+++ b/sktime/regression/deep_learning/fcn.py
@@ -216,7 +216,7 @@ class FCNRegressor(BaseDeepRegressor):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 10,

--- a/sktime/regression/deep_learning/inceptiontime/_inceptiontime_tf.py
+++ b/sktime/regression/deep_learning/inceptiontime/_inceptiontime_tf.py
@@ -241,7 +241,7 @@ class InceptionTimeRegressor(BaseDeepRegressor):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 10,

--- a/sktime/regression/deep_learning/lstmfcn/_lstmfcn_tf.py
+++ b/sktime/regression/deep_learning/lstmfcn/_lstmfcn_tf.py
@@ -227,7 +227,7 @@ class LSTMFCNRegressor(BaseDeepRegressor):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 25,

--- a/sktime/regression/deep_learning/mlp/_mlp_tf.py
+++ b/sktime/regression/deep_learning/mlp/_mlp_tf.py
@@ -233,7 +233,7 @@ class MLPRegressor(BaseDeepRegressor):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 10,

--- a/sktime/regression/deep_learning/mlp/_mlp_tf.py
+++ b/sktime/regression/deep_learning/mlp/_mlp_tf.py
@@ -8,7 +8,6 @@ from sklearn.utils import check_random_state
 
 from sktime.networks.mlp import MLPNetwork
 from sktime.regression.deep_learning.base import BaseDeepRegressor
-from sktime.utils.dependencies import _check_dl_dependencies
 
 
 class MLPRegressor(BaseDeepRegressor):
@@ -104,8 +103,6 @@ class MLPRegressor(BaseDeepRegressor):
         n_layers=3,
         hidden_dim=500,
     ):
-        _check_dl_dependencies(severity="error")
-
         self.callbacks = callbacks
         self.n_epochs = n_epochs
         self.batch_size = batch_size

--- a/sktime/regression/deep_learning/mlp/_mlp_torch.py
+++ b/sktime/regression/deep_learning/mlp/_mlp_torch.py
@@ -260,7 +260,7 @@ class MLPRegressorTorch(BaseDeepRegressorTorch):
         }
         params = [params1, params2]
 
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         if _check_soft_dependencies("torchmetrics", severity="none"):
             params.append(

--- a/sktime/regression/deep_learning/resnet.py
+++ b/sktime/regression/deep_learning/resnet.py
@@ -222,7 +222,7 @@ class ResNetRegressor(BaseDeepRegressor):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 6,

--- a/sktime/regression/deep_learning/tapnet/_tapnet_tf.py
+++ b/sktime/regression/deep_learning/tapnet/_tapnet_tf.py
@@ -276,7 +276,7 @@ class TapNetRegressor(BaseDeepRegressor):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         param1 = {
             "n_epochs": 10,

--- a/sktime/regression/tests/test_base.py
+++ b/sktime/regression/tests/test_base.py
@@ -7,6 +7,7 @@ import pickle
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.regression.base import BaseRegressor
 from sktime.regression.deep_learning.base import BaseDeepRegressor
@@ -17,7 +18,6 @@ from sktime.utils._testing.panel import (
     _make_regression_y,
     make_regression_problem,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class _DummyRegressor(BaseRegressor):

--- a/sktime/regression/tests/test_base.py
+++ b/sktime/regression/tests/test_base.py
@@ -17,7 +17,7 @@ from sktime.utils._testing.panel import (
     _make_regression_y,
     make_regression_problem,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 class _DummyRegressor(BaseRegressor):

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -19,7 +19,7 @@ from sktime.split.base._common import (
     SPLIT_GENERATOR_TYPE,
     SPLIT_TYPE,
 )
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.validation import NON_FLOAT_WINDOW_LENGTH_TYPES
 from sktime.utils.validation.forecasting import check_fh
 

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.base import BaseObject
 from sktime.datatypes import check_is_scitype, convert
@@ -19,7 +20,6 @@ from sktime.split.base._common import (
     SPLIT_GENERATOR_TYPE,
     SPLIT_TYPE,
 )
-from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.validation import NON_FLOAT_WINDOW_LENGTH_TYPES
 from sktime.utils.validation.forecasting import check_fh
 

--- a/sktime/tests/_test_vm.py
+++ b/sktime/tests/_test_vm.py
@@ -29,9 +29,10 @@ def run_test_vm(cls_name):
     Exception
         if the ``check_estimator`` fails, or if the estimator is not found.
     """
+    from skbase.utils.dependencies import _check_estimator_deps
+
     from sktime.registry import craft
     from sktime.utils import check_estimator
-    from skbase.utils.dependencies import _check_estimator_deps
 
     cls = craft(cls_name)
     if not _check_estimator_deps(cls, severity="none"):

--- a/sktime/tests/_test_vm.py
+++ b/sktime/tests/_test_vm.py
@@ -31,7 +31,7 @@ def run_test_vm(cls_name):
     """
     from sktime.registry import craft
     from sktime.utils import check_estimator
-    from sktime.utils.dependencies import _check_estimator_deps
+    from skbase.utils.dependencies import _check_estimator_deps
 
     cls = craft(cls_name)
     if not _check_estimator_deps(cls, severity="none"):

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -16,6 +16,7 @@ from tempfile import TemporaryDirectory
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.base import BaseEstimator, BaseObject, load
 from sktime.classification.deep_learning.base import BaseDeepClassifier
@@ -48,7 +49,6 @@ from sktime.utils._testing.estimator_checks import (
 )
 from sktime.utils._testing.scenarios_getter import retrieve_scenarios
 from sktime.utils.deep_equals import deep_equals
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.random_state import set_random_state
 from sktime.utils.sampling import random_partition
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -48,7 +48,7 @@ from sktime.utils._testing.estimator_checks import (
 )
 from sktime.utils._testing.scenarios_getter import retrieve_scenarios
 from sktime.utils.deep_equals import deep_equals
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.random_state import set_random_state
 from sktime.utils.sampling import random_partition
 

--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -20,7 +20,7 @@ from sktime.registry import all_estimators
 from sktime.tests._config import EXCLUDE_ESTIMATORS
 from sktime.tests.test_switch import run_test_for_class
 from sktime.utils._testing.scenarios_getter import retrieve_scenarios
-from sktime.utils.dependencies import _check_python_version, _check_soft_dependencies
+from skbase.utils.dependencies import _check_python_version, _check_soft_dependencies
 
 # list of soft dependencies used
 # excludes estimators, only for soft dependencies used in non-estimator modules

--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -15,12 +15,12 @@ from importlib import import_module
 from unittest.mock import patch
 
 import pytest
+from skbase.utils.dependencies import _check_python_version, _check_soft_dependencies
 
 from sktime.registry import all_estimators
 from sktime.tests._config import EXCLUDE_ESTIMATORS
 from sktime.tests.test_switch import run_test_for_class
 from sktime.utils._testing.scenarios_getter import retrieve_scenarios
-from skbase.utils.dependencies import _check_python_version, _check_soft_dependencies
 
 # list of soft dependencies used
 # excludes estimators, only for soft dependencies used in non-estimator modules

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -213,7 +213,7 @@ def _run_test_for_class(
 
         If multiple reasons are present, the first one in the above list is returned.
     """
-    from sktime.utils.dependencies import _check_estimator_deps
+    from skbase.utils.dependencies import _check_estimator_deps
     from sktime.utils.git_diff import (
         get_packages_with_changed_specs,
         is_class_changed,

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -214,6 +214,7 @@ def _run_test_for_class(
         If multiple reasons are present, the first one in the above list is returned.
     """
     from skbase.utils.dependencies import _check_estimator_deps
+
     from sktime.utils.git_diff import (
         get_packages_with_changed_specs,
         is_class_changed,

--- a/sktime/tests/tests/test_test_utils.py
+++ b/sktime/tests/tests/test_test_utils.py
@@ -7,7 +7,7 @@ from sktime.tests._config import (
     EXCLUDED_TESTS_BY_TEST,
 )
 from sktime.tests.test_switch import run_test_for_class
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 def test_excluded_tests_by_test():

--- a/sktime/tests/tests/test_test_utils.py
+++ b/sktime/tests/tests/test_test_utils.py
@@ -1,5 +1,7 @@
 """Tests for the test utilities."""
 
+from skbase.utils.dependencies import _check_estimator_deps
+
 from sktime.registry import all_estimators
 from sktime.tests._config import (
     EXCLUDE_ESTIMATORS,
@@ -7,7 +9,6 @@ from sktime.tests._config import (
     EXCLUDED_TESTS_BY_TEST,
 )
 from sktime.tests.test_switch import run_test_for_class
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 def test_excluded_tests_by_test():

--- a/sktime/transformations/adapt.py
+++ b/sktime/transformations/adapt.py
@@ -418,10 +418,9 @@ class TabularToSeriesAdaptor(BaseTransformer):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
+        from skbase.utils.dependencies import _check_soft_dependencies
         from sklearn.feature_selection import VarianceThreshold
         from sklearn.preprocessing import LabelEncoder, StandardScaler
-
-        from skbase.utils.dependencies import _check_soft_dependencies
 
         params1 = {"transformer": StandardScaler(), "fit_in_transform": False}
         params2 = {

--- a/sktime/transformations/adapt.py
+++ b/sktime/transformations/adapt.py
@@ -421,7 +421,7 @@ class TabularToSeriesAdaptor(BaseTransformer):
         from sklearn.feature_selection import VarianceThreshold
         from sklearn.preprocessing import LabelEncoder, StandardScaler
 
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         params1 = {"transformer": StandardScaler(), "fit_in_transform": False}
         params2 = {

--- a/sktime/transformations/base/_base.py
+++ b/sktime/transformations/base/_base.py
@@ -59,7 +59,7 @@ from sktime.datatypes import (
 )
 from sktime.datatypes._dtypekind import DtypeKind
 from sktime.datatypes._series_as_panel import convert_to_scitype
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.sklearn import (
     is_sklearn_classifier,
     is_sklearn_clusterer,

--- a/sktime/transformations/base/_base.py
+++ b/sktime/transformations/base/_base.py
@@ -45,6 +45,7 @@ from itertools import product
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.base import BaseEstimator
 from sktime.datatypes import (
@@ -59,7 +60,6 @@ from sktime.datatypes import (
 )
 from sktime.datatypes._dtypekind import DtypeKind
 from sktime.datatypes._series_as_panel import convert_to_scitype
-from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.sklearn import (
     is_sklearn_classifier,
     is_sklearn_clusterer,

--- a/sktime/transformations/bootstrap/_tsbootstrap.py
+++ b/sktime/transformations/bootstrap/_tsbootstrap.py
@@ -143,7 +143,7 @@ class TSBootstrapAdapter(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         deps = cls.get_class_tag("python_dependencies")
 

--- a/sktime/transformations/boxcox.py
+++ b/sktime/transformations/boxcox.py
@@ -8,7 +8,7 @@ __all__ = ["BoxCoxTransformer", "LogTransformer"]
 import numpy as np
 
 from sktime.transformations.base import BaseTransformer
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation import is_int
 
 

--- a/sktime/transformations/boxcox.py
+++ b/sktime/transformations/boxcox.py
@@ -6,9 +6,9 @@ __author__ = ["mloning", "aiwalter", "fkiraly"]
 __all__ = ["BoxCoxTransformer", "LogTransformer"]
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.transformations.base import BaseTransformer
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation import is_int
 
 

--- a/sktime/transformations/dictionary_based/_sfa_fast_numba.py
+++ b/sktime/transformations/dictionary_based/_sfa_fast_numba.py
@@ -7,7 +7,7 @@ from warnings import simplefilter
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/dictionary_based/_sfa_fast_numba.py
+++ b/sktime/transformations/dictionary_based/_sfa_fast_numba.py
@@ -6,8 +6,8 @@ import math
 from warnings import simplefilter
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/hierarchical/tests/reconcile/test_full_hierarchy.py
+++ b/sktime/transformations/hierarchical/tests/reconcile/test_full_hierarchy.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
 from sktime.transformations.hierarchical.aggregate import Aggregator
@@ -10,7 +11,6 @@ from sktime.transformations.hierarchical.reconcile._optimal import (
     _create_summing_matrix_from_index,
 )
 from sktime.utils._testing.hierarchical import _make_hierarchical
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.fixture

--- a/sktime/transformations/hierarchical/tests/reconcile/test_full_hierarchy.py
+++ b/sktime/transformations/hierarchical/tests/reconcile/test_full_hierarchy.py
@@ -10,7 +10,7 @@ from sktime.transformations.hierarchical.reconcile._optimal import (
     _create_summing_matrix_from_index,
 )
 from sktime.utils._testing.hierarchical import _make_hierarchical
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.fixture

--- a/sktime/transformations/holiday/_holidayfeats.py
+++ b/sktime/transformations/holiday/_holidayfeats.py
@@ -11,9 +11,9 @@ from datetime import date
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.transformations.base import BaseTransformer
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
 

--- a/sktime/transformations/holiday/_holidayfeats.py
+++ b/sktime/transformations/holiday/_holidayfeats.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
 

--- a/sktime/transformations/hurst.py
+++ b/sktime/transformations/hurst.py
@@ -228,7 +228,7 @@ class HurstExponentTransformer(BaseTransformer):
 
     def plot_log_log(self, ts: pd.Series):
         """Plot the log-log graph used in Hurst exponent calculation."""
-        from sktime.utils.dependencies._dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         try:
             _check_soft_dependencies("matplotlib", severity="warning")

--- a/sktime/transformations/kalman_filter/_kalman_filter.py
+++ b/sktime/transformations/kalman_filter/_kalman_filter.py
@@ -15,7 +15,7 @@ __all__ = [
 import numpy as np
 
 from sktime.transformations.base import BaseTransformer
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
 from ._base import BaseKalmanFilter, _init_matrix, _validate_param_shape

--- a/sktime/transformations/kalman_filter/_kalman_filter.py
+++ b/sktime/transformations/kalman_filter/_kalman_filter.py
@@ -13,9 +13,9 @@ __all__ = [
 ]
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.transformations.base import BaseTransformer
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
 from ._base import BaseKalmanFilter, _init_matrix, _validate_param_shape

--- a/sktime/transformations/rocket/_minirocket_multi_numba.py
+++ b/sktime/transformations/rocket/_minirocket_multi_numba.py
@@ -4,7 +4,7 @@ __author__ = ["angus924"]
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/rocket/_minirocket_multi_numba.py
+++ b/sktime/transformations/rocket/_minirocket_multi_numba.py
@@ -3,8 +3,8 @@
 __author__ = ["angus924"]
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/rocket/_minirocket_multi_var_numba.py
+++ b/sktime/transformations/rocket/_minirocket_multi_var_numba.py
@@ -4,7 +4,7 @@ __author__ = ["angus924", "michaelfeil"]
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/rocket/_minirocket_multi_var_numba.py
+++ b/sktime/transformations/rocket/_minirocket_multi_var_numba.py
@@ -3,8 +3,8 @@
 __author__ = ["angus924", "michaelfeil"]
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/rocket/_minirocket_numba.py
+++ b/sktime/transformations/rocket/_minirocket_numba.py
@@ -4,7 +4,7 @@ __author__ = ["angus924"]
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/rocket/_minirocket_numba.py
+++ b/sktime/transformations/rocket/_minirocket_numba.py
@@ -3,8 +3,8 @@
 __author__ = ["angus924"]
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/rocket/_multirocket_multi_numba.py
+++ b/sktime/transformations/rocket/_multirocket_multi_numba.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/rocket/_multirocket_multi_numba.py
+++ b/sktime/transformations/rocket/_multirocket_multi_numba.py
@@ -1,8 +1,8 @@
 """Isolated numba imports for _multirocket_multivariate."""
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/rocket/_multirocket_numba.py
+++ b/sktime/transformations/rocket/_multirocket_numba.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/rocket/_multirocket_numba.py
+++ b/sktime/transformations/rocket/_multirocket_numba.py
@@ -1,8 +1,8 @@
 """Isolated numba imports for MultiRocket."""
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/rocket/_rocket_numba.py
+++ b/sktime/transformations/rocket/_rocket_numba.py
@@ -4,7 +4,7 @@ __author__ = ["angus924"]
 
 import numpy as np
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/rocket/_rocket_numba.py
+++ b/sktime/transformations/rocket/_rocket_numba.py
@@ -3,8 +3,8 @@
 __author__ = ["angus924"]
 
 import numpy as np
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.numba.njit import njit
 
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/transformations/summarize/_extract.py
+++ b/sktime/transformations/summarize/_extract.py
@@ -453,7 +453,7 @@ class FittedParamExtractor(BaseTransformer):
         """
         from sktime.forecasting.exp_smoothing import ExponentialSmoothing
         from sktime.forecasting.trend import TrendForecaster
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         # accessing a nested parameter
         params = [

--- a/sktime/transformations/summarize/_extract.py
+++ b/sktime/transformations/summarize/_extract.py
@@ -451,9 +451,10 @@ class FittedParamExtractor(BaseTransformer):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
+        from skbase.utils.dependencies import _check_estimator_deps
+
         from sktime.forecasting.exp_smoothing import ExponentialSmoothing
         from sktime.forecasting.trend import TrendForecaster
-        from skbase.utils.dependencies import _check_estimator_deps
 
         # accessing a nested parameter
         params = [

--- a/sktime/transformations/supervised_intervals.py
+++ b/sktime/transformations/supervised_intervals.py
@@ -522,7 +522,7 @@ class SupervisedIntervals(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         params0 = {}
 

--- a/sktime/transformations/tests/test_base.py
+++ b/sktime/transformations/tests/test_base.py
@@ -16,6 +16,7 @@ from inspect import isclass
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 
 from sktime.datatypes import check_is_scitype, get_examples, mtype_to_scitype
 from sktime.tests.test_switch import run_test_module_changed
@@ -38,7 +39,6 @@ from sktime.utils._testing.scenarios_transformers import (
     TransformerFitTransformSeriesUnivariate,
 )
 from sktime.utils._testing.series import _make_series
-from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.parallel import _get_parallel_test_fixtures
 
 # other scenarios that might be needed later in development:

--- a/sktime/transformations/tests/test_base.py
+++ b/sktime/transformations/tests/test_base.py
@@ -38,7 +38,7 @@ from sktime.utils._testing.scenarios_transformers import (
     TransformerFitTransformSeriesUnivariate,
 )
 from sktime.utils._testing.series import _make_series
-from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
+from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.parallel import _get_parallel_test_fixtures
 
 # other scenarios that might be needed later in development:

--- a/sktime/transformations/tests/test_categorical_in_composite.py
+++ b/sktime/transformations/tests/test_categorical_in_composite.py
@@ -2,6 +2,7 @@
 
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.preprocessing import LabelEncoder, OneHotEncoder
 
 from sktime.tests.test_switch import run_test_module_changed
@@ -9,7 +10,6 @@ from sktime.transformations.adapt import TabularToSeriesAdaptor
 from sktime.transformations.boxcox import BoxCoxTransformer
 from sktime.transformations.compose import ColumnEnsembleTransformer
 from sktime.transformations.subset import ColumnSelect
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/transformations/tests/test_categorical_in_composite.py
+++ b/sktime/transformations/tests/test_categorical_in_composite.py
@@ -9,7 +9,7 @@ from sktime.transformations.adapt import TabularToSeriesAdaptor
 from sktime.transformations.boxcox import BoxCoxTransformer
 from sktime.transformations.compose import ColumnEnsembleTransformer
 from sktime.transformations.subset import ColumnSelect
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -28,7 +28,7 @@ from sktime.transformations.summarize import SummaryTransformer
 from sktime.transformations.theta import ThetaLinesTransformer
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 from sktime.utils.deep_equals import deep_equals
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -6,6 +6,7 @@ __all__ = []
 
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_estimator_deps
 from sklearn.preprocessing import StandardScaler
 
 from sktime.datasets import load_airline, load_unit_test
@@ -28,7 +29,6 @@ from sktime.transformations.summarize import SummaryTransformer
 from sktime.transformations.theta import ThetaLinesTransformer
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 from sktime.utils.deep_equals import deep_equals
-from skbase.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(

--- a/sktime/transformations/tests/test_dummies.py
+++ b/sktime/transformations/tests/test_dummies.py
@@ -10,7 +10,7 @@ import pytest
 
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.dummies import SeasonalDummiesOneHot
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/transformations/tests/test_dummies.py
+++ b/sktime/transformations/tests/test_dummies.py
@@ -7,10 +7,10 @@ __all__ = []
 
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.dummies import SeasonalDummiesOneHot
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/transformations/tests/test_optionalpassthrough.py
+++ b/sktime/transformations/tests/test_optionalpassthrough.py
@@ -1,10 +1,10 @@
 """Tests for using OptionalPassthrough."""
 
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.compose import OptionalPassthrough
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/transformations/tests/test_optionalpassthrough.py
+++ b/sktime/transformations/tests/test_optionalpassthrough.py
@@ -4,7 +4,7 @@ import pytest
 
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.compose import OptionalPassthrough
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/transformations/tsfeatures.py
+++ b/sktime/transformations/tsfeatures.py
@@ -261,7 +261,7 @@ class TSFeaturesTransformer(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         params = [
             {

--- a/sktime/transformations/tsfresh.py
+++ b/sktime/transformations/tsfresh.py
@@ -5,8 +5,9 @@
 __author__ = ["AyushmaanSeth", "mloning", "alwinw", "MatthewMiddlehurst"]
 __all__ = ["TSFreshFeatureExtractor", "TSFreshRelevantFeatureExtractor"]
 
-from sktime.transformations.base import BaseTransformer
 from skbase.utils.dependencies import _check_estimator_deps
+
+from sktime.transformations.base import BaseTransformer
 from sktime.utils.validation import check_n_jobs
 
 

--- a/sktime/transformations/tsfresh.py
+++ b/sktime/transformations/tsfresh.py
@@ -6,7 +6,7 @@ __author__ = ["AyushmaanSeth", "mloning", "alwinw", "MatthewMiddlehurst"]
 __all__ = ["TSFreshFeatureExtractor", "TSFreshRelevantFeatureExtractor"]
 
 from sktime.transformations.base import BaseTransformer
-from sktime.utils.dependencies import _check_estimator_deps
+from skbase.utils.dependencies import _check_estimator_deps
 from sktime.utils.validation import check_n_jobs
 
 

--- a/sktime/utils/_maint/tests/test_show_versions.py
+++ b/sktime/utils/_maint/tests/test_show_versions.py
@@ -8,7 +8,7 @@ from sktime.utils._maint._show_versions import (
     _get_deps_info,
     show_versions,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def test_show_versions_runs():

--- a/sktime/utils/_maint/tests/test_show_versions.py
+++ b/sktime/utils/_maint/tests/test_show_versions.py
@@ -3,12 +3,13 @@
 import pathlib
 import uuid
 
+from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils._maint._show_versions import (
     DEFAULT_DEPS_TO_SHOW,
     _get_deps_info,
     show_versions,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def test_show_versions_runs():

--- a/sktime/utils/_testing/tests/test_check_imports.py
+++ b/sktime/utils/_testing/tests/test_check_imports.py
@@ -1,5 +1,4 @@
 import pytest
-
 from skbase.utils.dependencies import _check_soft_dependencies
 
 

--- a/sktime/utils/_testing/tests/test_check_imports.py
+++ b/sktime/utils/_testing/tests/test_check_imports.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def test_check_soft_dependencies_raises_error():

--- a/sktime/utils/deep_equals/_deep_equals.py
+++ b/sktime/utils/deep_equals/_deep_equals.py
@@ -176,7 +176,7 @@ def _dask_dataframe_equals_plugin(x, y, return_msg=False, deep_equals=None):
     if not hasattr(x, "compute"):
         return None
 
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     dask_available = _check_soft_dependencies("dask", severity="none")
 
@@ -225,7 +225,7 @@ def _gluonts_PandasDataset_equals_plugin(x, y, return_msg=False, deep_equals=Non
     if not hasattr(x, "_data_entries"):
         return None
 
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     gluonts_available = _check_soft_dependencies("gluonts", severity="none")
 
@@ -260,7 +260,7 @@ def _polars_equals_plugin(x, y, return_msg=False):
         if unequal, returns string
     returns None if this function does not apply, i.e., x is not polars
     """
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     polars_available = _check_soft_dependencies("polars", severity="none")
 
@@ -306,7 +306,7 @@ def _torchmetrics_metric_equals_plugin(x, y, return_msg=False, deep_equals=None)
     msg : str, optional
         reason for inequality if return_msg=True
     """
-    from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
+    from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
     if not _check_soft_dependencies("torchmetrics", severity="none"):
         return None

--- a/sktime/utils/deep_equals/tests/test_deep_equals.py
+++ b/sktime/utils/deep_equals/tests/test_deep_equals.py
@@ -6,10 +6,10 @@ import numpy as np
 import pandas as pd
 import pytest
 from scipy.sparse import csr_matrix
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.utils.deep_equals._deep_equals import deep_equals
-from skbase.utils.dependencies import _check_soft_dependencies
 
 # examples used for comparison below
 EXAMPLES = [

--- a/sktime/utils/deep_equals/tests/test_deep_equals.py
+++ b/sktime/utils/deep_equals/tests/test_deep_equals.py
@@ -9,7 +9,7 @@ from scipy.sparse import csr_matrix
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.utils.deep_equals._deep_equals import deep_equals
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # examples used for comparison below
 EXAMPLES = [

--- a/sktime/utils/dependencies/_placeholder.py
+++ b/sktime/utils/dependencies/_placeholder.py
@@ -38,7 +38,7 @@ def _placeholder_record(module_name, obj_name=None, dependencies=None, condition
     """
 
     def decorator(cls):
-        from sktime.utils.dependencies import _check_estimator_deps
+        from skbase.utils.dependencies import _check_estimator_deps
 
         # we need to write to a new var _obj_name
         # or obj_name will be considered local and lead to "not assigned" error

--- a/sktime/utils/dependencies/_placeholder.py
+++ b/sktime/utils/dependencies/_placeholder.py
@@ -53,7 +53,7 @@ def _placeholder_record(module_name, obj_name=None, dependencies=None, condition
         deps_satisfied = _check_estimator_deps(cls, severity="none")
 
         if dependencies is not None:
-            from sktime.utils.dependencies import _check_soft_dependencies
+            from skbase.utils.dependencies import _check_soft_dependencies
 
             added_deps_sat = _check_soft_dependencies(dependencies, severity="none")
             deps_satisfied = deps_satisfied and added_deps_sat

--- a/sktime/utils/numba/njit.py
+++ b/sktime/utils/numba/njit.py
@@ -1,6 +1,6 @@
 """Dispatch njit decorator used to isolate numba."""
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 # exports numba.njit if numba is present, otherwise an identity njit
 if _check_soft_dependencies("numba", severity="none"):

--- a/sktime/utils/numba/tests/test_general.py
+++ b/sktime/utils/numba/tests/test_general.py
@@ -7,7 +7,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 DATATYPES = ["int32", "int64", "float32", "float64"]
 

--- a/sktime/utils/numba/tests/test_general.py
+++ b/sktime/utils/numba/tests/test_general.py
@@ -5,9 +5,9 @@ __author__ = ["TonyBagnall"]
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 
 DATATYPES = ["int32", "int64", "float32", "float64"]
 

--- a/sktime/utils/parallel.py
+++ b/sktime/utils/parallel.py
@@ -252,7 +252,7 @@ def _get_parallel_test_fixtures(naming="estimator"):
         values are backend strings and backend parameter dicts
         only backends that are available in the environment are included
     """
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     fixtures = []
 

--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -510,8 +510,9 @@ def plot_folds_global_forecasting(cv, cv_global, cv_global_temporal, y):
     axes : np.ndarray
         matplotlib axes object with the figure
     """
-    from sktime.forecasting.model_evaluation._functions import gen_y_X_train_test_global
     from skbase.utils.dependencies import _check_soft_dependencies
+
+    from sktime.forecasting.model_evaluation._functions import gen_y_X_train_test_global
 
     _check_soft_dependencies("matplotlib")
 

--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -74,7 +74,7 @@ def plot_series(
     >>> y = load_airline()
     >>> fig, ax = plot_series(y)  # doctest: +SKIP
     """
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     _check_soft_dependencies("matplotlib", "seaborn")
     import matplotlib.pyplot as plt
@@ -231,7 +231,7 @@ def plot_interval(ax, interval_df):
     >>> ax.set_xlabel('Date')  # doctest: +SKIP
     >>> ax.set_ylabel('Passengers')  # doctest: +SKIP
     """
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     _check_soft_dependencies("seaborn")
 
@@ -290,7 +290,7 @@ def plot_lags(series, lags=1, suptitle=None):
     >>> fig, ax = plot_lags(y, lags=2) # plot of y(t) with y(t-2)  # doctest: +SKIP
     >>> fig, ax = plot_lags(y, lags=[1,2,3]) # y(t) & y(t-1), y(t-2).. # doctest: +SKIP
     """
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     _check_soft_dependencies("matplotlib")
     import matplotlib.pyplot as plt
@@ -406,7 +406,7 @@ def plot_correlations(
     >>> y = load_airline()
     >>> fig, ax = plot_correlations(y)  # doctest: +SKIP
     """
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     _check_soft_dependencies("matplotlib", "statsmodels")
     import matplotlib.pyplot as plt
@@ -511,7 +511,7 @@ def plot_folds_global_forecasting(cv, cv_global, cv_global_temporal, y):
         matplotlib axes object with the figure
     """
     from sktime.forecasting.model_evaluation._functions import gen_y_X_train_test_global
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     _check_soft_dependencies("matplotlib")
 
@@ -591,7 +591,7 @@ def plot_windows(cv, y, title="", ax=None):
     >>> y = load_airline()
     >>> plot_windows(cv, y.iloc[:50])  # doctest: +SKIP
     """
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     _check_soft_dependencies("matplotlib", "seaborn")
     import matplotlib.pyplot as plt
@@ -734,7 +734,7 @@ def plot_calibration(y_true, y_pred, ax=None):
     >>> pred_quantiles = forecaster.predict_quantiles(fh=fh, alpha=[0.1, 0.25, 0.5, 0.75, 0.9])  # doctest: +SKIP
     >>> plot_calibration(y_true=y_test.loc[pred_quantiles.index], y_pred=pred_quantiles)  # doctest: +SKIP
     """  # noqa: E501
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     _check_soft_dependencies("matplotlib", "statsmodels")
     import matplotlib.pyplot as plt

--- a/sktime/utils/seasonality.py
+++ b/sktime/utils/seasonality.py
@@ -10,8 +10,8 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
-
 from skbase.utils.dependencies import _check_soft_dependencies
+
 from sktime.utils.validation.forecasting import check_sp, check_y
 
 

--- a/sktime/utils/seasonality.py
+++ b/sktime/utils/seasonality.py
@@ -11,7 +11,7 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation.forecasting import check_sp, check_y
 
 

--- a/sktime/utils/sklearn/_metrics.py
+++ b/sktime/utils/sklearn/_metrics.py
@@ -10,7 +10,7 @@ of sktime across sklearn versions. This fork ensures upwards compatibility.
 __all__ = ["_check_reg_targets"]
 
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def _check_reg_targets(y_true, y_pred, multioutput, dtype="numeric", xp=None):

--- a/sktime/utils/sklearn/_tag_adapter.py
+++ b/sktime/utils/sklearn/_tag_adapter.py
@@ -27,7 +27,7 @@ def get_sklearn_tag(estimator, tagname):
     value : object
         Value of the specified tag.
     """
-    from sktime.utils.dependencies import _check_soft_dependencies
+    from skbase.utils.dependencies import _check_soft_dependencies
 
     if tagname == "capability:multioutput":
         if _check_soft_dependencies("scikit-learn<1.6", severity="none"):

--- a/sktime/utils/sklearn/_version_bridge.py
+++ b/sktime/utils/sklearn/_version_bridge.py
@@ -10,7 +10,7 @@ class _SklVersionBridgeMixin:
 
     def _sklearn_15_or_lower(self):
         """Check if the installed scikit-learn version is 1.5 or lower."""
-        from sktime.utils.dependencies import _check_soft_dependencies
+        from skbase.utils.dependencies import _check_soft_dependencies
 
         return _check_soft_dependencies("scikit-learn<1.6", severity="none")
 

--- a/sktime/utils/tests/test_datetime.py
+++ b/sktime/utils/tests/test_datetime.py
@@ -19,7 +19,7 @@ from sktime.utils.datetime import (
     infer_freq,
     set_hier_freq,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/utils/tests/test_datetime.py
+++ b/sktime/utils/tests/test_datetime.py
@@ -7,6 +7,7 @@ import datetime
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datasets import load_airline
 from sktime.datatypes import VectorizedDF
@@ -19,7 +20,6 @@ from sktime.utils.datetime import (
     infer_freq,
     set_hier_freq,
 )
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -16,7 +16,7 @@ from sktime.forecasting.arima import AutoARIMA
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.multiindex import flatten_multiindex
 
 if _check_soft_dependencies("mlflow", "boto3", "moto", "botocore", severity="none"):

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -10,13 +10,13 @@ from unittest import mock
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datasets import load_airline, load_arrow_head, load_longley
 from sktime.forecasting.arima import AutoARIMA
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.multiindex import flatten_multiindex
 
 if _check_soft_dependencies("mlflow", "boto3", "moto", "botocore", severity="none"):

--- a/sktime/utils/tests/test_parallel.py
+++ b/sktime/utils/tests/test_parallel.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.parallel import parallelize
 
 

--- a/sktime/utils/tests/test_parallel.py
+++ b/sktime/utils/tests/test_parallel.py
@@ -1,9 +1,9 @@
 import os
 
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.tests.test_switch import run_test_module_changed
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.parallel import parallelize
 
 

--- a/sktime/utils/tests/test_plotting.py
+++ b/sktime/utils/tests/test_plotting.py
@@ -9,7 +9,7 @@ import pytest
 
 from sktime.datasets import load_airline
 from sktime.tests.test_switch import run_test_for_class
-from sktime.utils.dependencies import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.plotting import plot_correlations, plot_lags, plot_series
 from sktime.utils.validation.series import VALID_DATA_TYPES
 

--- a/sktime/utils/tests/test_plotting.py
+++ b/sktime/utils/tests/test_plotting.py
@@ -6,10 +6,10 @@ import re
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.datasets import load_airline
 from sktime.tests.test_switch import run_test_for_class
-from skbase.utils.dependencies import _check_soft_dependencies
 from sktime.utils.plotting import plot_correlations, plot_lags, plot_series
 from sktime.utils.validation.series import VALID_DATA_TYPES
 


### PR DESCRIPTION
This PR points (hopefully) all `sktime.dependencies` imports to `scikit-base` utilities.

This deduplicates the dependencies management utilities.
The utilities are private to users, but are meant for reuse in the ecosystem.