### PR TITLE
[DOC] fix incorrect data type in PanelGluontsPandas docstring

### DIFF
--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -1415,7 +1415,7 @@ class PanelGluontsList(ScitypePanel):
 
 
 class PanelGluontsPandas(ScitypePanel):
-    """Data type: polars.DataFrame based specification of panel of time series.
+    """Data type: gluonts PandasDataset based specification of panel of time series.
 
     Parameters
     ----------


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #7386 (documentation of in-memory data formats).

#### What does this implement/fix? Explain your changes.

The class docstring of `PanelGluontsPandas` (in `sktime/datatypes/_panel/_check.py`) incorrectly opened with:

> Data type: polars.DataFrame based specification of panel of time series.

This appears to be a copy-paste error from `PanelPolarsEager`. The class actually describes the **gluonts `PandasDataset`** panel format, as confirmed by its own tags (`name="gluonts_PandasDataset_panel"`, `python_type="gluonts.PandasDataset"`, `python_dependencies="gluonts"`).

The first docstring line is corrected to:

> Data type: gluonts PandasDataset based specification of panel of time series.

This matches the wording of the sibling `SeriesGluontsPandas` and the class's own tags. Documentation-only change; no code or behaviour changes.

#### Does your contribution introduce a new dependency? If yes, which one?

No.
