### PR TITLE
[ENH] add pickle storage handler to benchmarking module

### DIFF
--- a/docs/source/api_reference/benchmarking.rst
+++ b/docs/source/api_reference/benchmarking.rst
@@ -45,6 +45,7 @@ Storage Backends
     JSONStorageHandler
     ParquetStorageHandler
     CSVStorageHandler
+    PickleStorageHandler
     NullStorageHandler
 
 

--- a/sktime/benchmarking/_storage_handlers.py
+++ b/sktime/benchmarking/_storage_handlers.py
@@ -3,6 +3,7 @@
 import abc
 import ast
 import json
+import pickle
 from pathlib import Path
 
 import pandas as pd
@@ -347,6 +348,66 @@ class CSVStorageHandler(BaseStorageHandler):
         return path.suffix == ".csv"
 
 
+class PickleStorageHandler(BaseStorageHandler):
+    """Storage handler for pickle files, with ending .pkl or .pickle.
+
+    Loads and saves results in Python's binary pickle format.
+
+    Unlike the JSON, Parquet and CSV handlers, this handler serializes the
+    ``ResultObject`` instances directly, without an intermediate conversion to a
+    tabular or record-oriented representation. As a consequence:
+
+    - The full result objects, including ``ground_truth``, ``predictions`` and
+      ``train_data`` (returned when ``return_data=True``), are stored and
+      restored losslessly, regardless of the index type of the underlying
+      ``pandas`` objects (e.g. ``PeriodIndex``, ``DatetimeIndex``,
+      ``MultiIndex``). This is the recommended backend when ``return_data=True``,
+      as the tabular backends can lose information or fail to serialize such
+      indices.
+    - The on-disk representation is a compact binary blob, which is typically
+      much smaller than the equivalent CSV or JSON file. This makes it a good
+      choice for benchmarking runs over many models and datasets with
+      ``return_data=True``.
+
+    Warning
+    -------
+    The pickle format is not secure. Only load result files that you have
+    generated yourself or that come from a trusted source, as loading a
+    maliciously crafted pickle file can execute arbitrary code.
+
+    Parameters
+    ----------
+    path : str, or Path coercible
+        The path to the file to save to or load
+    """
+
+    def save(self, results: list[ResultObject]):
+        """Save the results to a pickle file.
+
+        Parameters
+        ----------
+        results : ResultObject
+            The results to save.
+        """
+        with open(self.path, "wb") as f:
+            pickle.dump(results, f)
+
+    def _load(self) -> list[ResultObject]:
+        """Load the results from a pickle file.
+
+        Returns
+        -------
+        list[ResultObject]
+            The loaded results.
+        """
+        with open(self.path, "rb") as f:
+            return pickle.load(f)
+
+    @staticmethod
+    def is_applicable(path):
+        return path.suffix in (".pkl", ".pickle")
+
+
 class NullStorageHandler(BaseStorageHandler):
     """Storage handler for no file access.
 
@@ -392,6 +453,7 @@ STORAGE_HANDLERS = [
     JSONStorageHandler,
     ParquetStorageHandler,
     CSVStorageHandler,
+    PickleStorageHandler,
 ]
 
 

--- a/sktime/benchmarking/tests/test_storage_handlers.py
+++ b/sktime/benchmarking/tests/test_storage_handlers.py
@@ -5,6 +5,7 @@ from sktime.benchmarking._benchmarking_dataclasses import FoldResults, ResultObj
 from sktime.benchmarking._storage_handlers import (
     CSVStorageHandler,
     JSONStorageHandler,
+    PickleStorageHandler,
     # ParquetStorageHandler,
 )
 
@@ -48,6 +49,7 @@ RESULT_OBJECT_LISTS = [
     [
         (JSONStorageHandler, ".json"),
         (CSVStorageHandler, ".csv"),
+        (PickleStorageHandler, ".pkl"),
         # (ParquetStorageHandler, ".parquet"),
     ],
 )
@@ -92,6 +94,7 @@ def test_store_load_results(tmp_path, storage_handler, file_extension, sample_re
     [
         (JSONStorageHandler, ".json"),
         (CSVStorageHandler, ".csv"),
+        (PickleStorageHandler, ".pkl"),
         # (ParquetStorageHandler, ".parquet"),
     ],
 )
@@ -126,3 +129,43 @@ def test_store_load_results_empty_training(tmp_path, storage_handler, file_exten
     assert results[0].folds[0].ground_truth is None
     assert results[0].folds[0].predictions is None
     assert results[0].folds[0].train_data is None
+
+
+def test_pickle_preserves_non_default_index(tmp_path):
+    """Test the pickle handler round-trips returned data with a non-default index.
+
+    The tabular backends (parquet, csv) serialize the returned ``ground_truth``,
+    ``predictions`` and ``train_data`` frames via an intermediate dict
+    representation that does not handle ``pandas`` index types such as
+    ``PeriodIndex`` (the index used by ``load_airline`` and many other sktime
+    datasets). The pickle backend serializes the result objects directly and
+    therefore preserves the index losslessly.
+    """
+    index = pd.period_range("2000-01", periods=3, freq="M")
+    ground_truth = pd.DataFrame({"data": [1.0, 0.0, 1.0]}, index=index)
+    predictions = pd.DataFrame({"data": [1.0, 0.0, 1.0]}, index=index)
+    train_data = pd.DataFrame({"data": [0.0, 1.0, 0.0]}, index=index)
+
+    sample_results = [
+        ResultObject(
+            model_id="model_1",
+            task_id="val_1",
+            folds={
+                0: FoldResults(
+                    scores={"accuracy": 0.9},
+                    ground_truth=ground_truth,
+                    predictions=predictions,
+                    train_data=train_data,
+                )
+            },
+        )
+    ]
+
+    handler = PickleStorageHandler(tmp_path / "results.pkl")
+    handler.save(sample_results)
+    results = handler.load()
+
+    assert len(results) == 1
+    pd.testing.assert_frame_equal(results[0].folds[0].ground_truth, ground_truth)
+    pd.testing.assert_frame_equal(results[0].folds[0].predictions, predictions)
+    pd.testing.assert_frame_equal(results[0].folds[0].train_data, train_data)


### PR DESCRIPTION
<!-- LLM generated content, by Claude Opus 4.8 (drafted with Claude Code, reviewed and tested by the contributor) -->

#### Reference Issues/PRs

None yet. Happy to open a tracking issue if preferred.

#### What does this implement/fix? Explain your changes.

Adds a `PickleStorageHandler` to the benchmarking storage backends, registered for the `.pkl` and `.pickle` file extensions.

Previously, passing such a path to `Benchmark.run(output_file=...)` raised `ValueError: No storage handler found`, because only `NullStorageHandler`, `JSONStorageHandler`, `ParquetStorageHandler` and `CSVStorageHandler` were registered.

**Motivation.** When `return_data=True`, the JSON and CSV backends store the returned `ground_truth` / `predictions` / `train_data` frames in a text format, which becomes very large for benchmarks over many models and datasets. The Parquet backend is more compact but currently does not round-trip these frames reliably: it serializes them via an intermediate `to_dict(orient="tight")` representation whose `index` field holds raw `pandas` objects. For common sktime datasets the index is a `PeriodIndex` (e.g. `load_airline`), which `pyarrow` cannot serialize, so `run(output_file="...parquet")` raises `ArrowInvalid`. (Consistent with this, the `ParquetStorageHandler` tests are currently commented out.)

The pickle handler serializes the `ResultObject` instances **directly**, without the intermediate tabular/record conversion. As a result it is:

- **Lossless for returned data**, regardless of the underlying `pandas` index type (`PeriodIndex`, `DatetimeIndex`, `MultiIndex`, ...). This makes it the recommended backend for `return_data=True`.
- **Compact** — a binary blob, typically much smaller than the equivalent CSV/JSON file.
- **Dependency-free** — `pickle` is part of the standard library.

A security note is included in the docstring, since loading untrusted pickle files can execute arbitrary code.

The pre-existing Parquet index bug is intentionally left **out of scope** here to keep this change small and focused; I'm happy to follow up on it separately.

#### Does your contribution introduce a new dependency? If yes, which one?

No. `pickle` is in the Python standard library.

#### What should a reviewer concentrate their feedback on?

* Whether direct pickling of `ResultObject` is the preferred design, vs. reusing the dict/record normalization the other handlers use.
* The choice to register both `.pkl` and `.pickle` extensions.
* Whether the security note in the docstring is sufficient.

#### Did you add any tests for the change?

Yes:

* `PickleStorageHandler` is added to the parametrized `test_store_load_results` and `test_store_load_results_empty_training` round-trip tests.
* A new `test_pickle_preserves_non_default_index` verifies that returned data with a `PeriodIndex` round-trips losslessly — the exact case that breaks the tabular backends.

All `sktime/benchmarking/tests/test_storage_handlers.py` and `test_forecasting.py` tests pass locally, and `ruff` check/format are clean.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors.
- [x] The PR title starts with [ENH].

#### Reproducer

```python
from sktime.benchmarking.forecasting import ForecastingBenchmark
from sktime.datasets import load_airline
from sktime.forecasting.naive import NaiveForecaster
from sktime.performance_metrics.forecasting import MeanSquaredPercentageError
from sktime.split import ExpandingWindowSplitter

benchmark = ForecastingBenchmark(return_data=True)
benchmark.add_estimator(NaiveForecaster(strategy="mean", sp=12), estimator_id="m-mean")
benchmark.add_task(
    load_airline,
    ExpandingWindowSplitter(initial_window=24, step_length=12, fh=12),
    [MeanSquaredPercentageError()],
)

# Before: ValueError: No storage handler found for results.pkl
# After:  saves losslessly, PeriodIndex preserved on reload
results = benchmark.run(output_file="results.pkl")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
