### PR TITLE
[ENH] Add tests for dilation mapping transformer

### DIFF
--- a/sktime/transformations/tests/test_dilation_mapping.py
+++ b/sktime/transformations/tests/test_dilation_mapping.py
@@ -1,0 +1,65 @@
+"""DilationMapping transformer test code."""
+
+import pandas as pd
+import pytest
+
+from sktime.tests.test_switch import run_test_for_class
+from sktime.transformations.dilation_mapping import DilationMappingTransformer
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DilationMappingTransformer),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_dilation_mapping_reorders_values():
+    """Test that dilation mapping reorders values by dilation groups."""
+    X = pd.Series([1, 2, 3, 4, 5], name="y")
+
+    result = DilationMappingTransformer(dilation=2).fit_transform(X)
+    expected = pd.Series([1, 3, 5, 2, 4], name="y")
+
+    pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DilationMappingTransformer),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_dilation_mapping_preserves_missing_values():
+    """Test that missing values are preserved during dilation mapping."""
+    X = pd.Series([1.0, None, 3.0, 4.0, 5.0], name="z")
+
+    result = DilationMappingTransformer(dilation=2).fit_transform(X)
+    expected = pd.Series([1.0, 3.0, 5.0, None, 4.0], name="z")
+
+    pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DilationMappingTransformer),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("dilation", [1, 10])
+def test_dilation_mapping_boundary_dilations(dilation):
+    """Test boundary dilation values preserve values and reset the index."""
+    X = pd.Series(
+        [10, 20, 30],
+        index=pd.date_range("2020-01-01", periods=3),
+        name="short",
+    )
+
+    result = DilationMappingTransformer(dilation=dilation).fit_transform(X)
+    expected = pd.Series([10, 20, 30], name="short")
+
+    pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DilationMappingTransformer),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("dilation", [0, -1])
+def test_dilation_mapping_invalid_dilation(dilation):
+    """Test that non-positive dilation values raise an error."""
+    with pytest.raises(ValueError, match="Dilation must be greater than 0"):
+        DilationMappingTransformer(dilation=dilation)


### PR DESCRIPTION
#### Reference Issues/PRs

No existing issue. This is a small test coverage improvement.

#### What does this implement/fix? Explain your changes.

Adds dedicated low-level tests for `DilationMappingTransformer`.

The generic transformer contract tests cover interface compliance, but they do not assert the transformer-specific dilation semantics. This PR adds focused tests for:

- exact value reordering by dilation groups
- preservation of missing values during dilation mapping
- boundary dilation values, including `dilation=1` and `dilation > len(series)`
- validation of non-positive `dilation` values

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the tested edge cases are appropriate for `DilationMappingTransformer`
- Whether the assertions are specific enough without duplicating generic transformer contract tests

#### Did you add any tests for the change?

Yes. Added:

`sktime/transformations/tests/test_dilation_mapping.py`

Local checks run:

```bash
pre-commit run --files sktime/transformations/tests/test_dilation_mapping.py
pytest sktime/transformations/tests/test_dilation_mapping.py -q --only_changed_modules False
```

Results:

- `pre-commit`: passed
- `pytest`: 6 passed

Also checked `DilationMappingTransformer` with `check_estimator`; the only reported failure was the pre-existing `test_get_test_params_coverage[DilationMappingTransformer]`, which is already listed in the repo skip configuration.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [ ✔️] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

<!--
Thanks for contributing!
-->