### PR TITLE
[ENH] Deprecate global forecasting in `flowstate` forecaster

### DIFF
--- a/sktime/forecasting/flowstate.py
+++ b/sktime/forecasting/flowstate.py
@@ -8,14 +8,18 @@ import numpy as np
 import pandas as pd
 from skbase.utils.dependencies import _check_soft_dependencies
 
-from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
+from sktime.forecasting.base import (
+    BaseForecaster,
+    ForecastingHorizon,
+    _GlobalForecastingDeprecationMixin,
+)
 from sktime.utils.dependencies import _safe_import
 from sktime.utils.singleton import _multiton
 
 torch = _safe_import("torch")
 
 
-class FlowStateForecaster(BaseForecaster):
+class FlowStateForecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
     """Zero-shot forecaster wrapping IBM FlowState via granite-tsfm.
 
     FlowState, developed by IBM Research, is an encoder-decoder architecture,
@@ -160,57 +164,6 @@ class FlowStateForecaster(BaseForecaster):
         self.model.eval()
         self._context = y
         return self
-
-    def predict(self, fh=None, X=None, y=None):
-        """Forecast time series at future horizon.
-
-        State required:
-            Requires state to be "fitted", i.e., ``self.is_fitted=True``.
-
-        Accesses in self:
-
-            * Fitted model attributes ending in "_".
-            * ``self.cutoff``, ``self.is_fitted``
-
-        Writes to self:
-            Stores ``fh`` to ``self.fh`` if ``fh`` is passed and has not been passed
-            previously.
-
-        Parameters
-        ----------
-        fh : int, list, pd.Index coercible, or ``ForecastingHorizon``, default=None
-            The forecasting horizon encoding the time stamps to forecast at.
-            Should not be passed if has already been passed in ``fit``.
-            If has not been passed in fit, must be passed, not optional
-
-        X : time series in ``sktime`` compatible format, optional (default=None)
-            Exogenous time series. Ignored; ``capability:exogenous`` is ``False``.
-
-        y : time series in ``sktime`` compatible format, optional (default=None)
-            Historical values of the time series that should be predicted.
-            If not None, global forecasting will be performed via ``fit_predict``,
-            reloading context from ``y`` before forecasting.
-            Only pass the historical values, not the time points to be predicted.
-
-        Returns
-        -------
-        y_pred : time series in sktime compatible data container format
-            Point forecasts at ``fh``, with same index as ``fh``.
-            ``y_pred`` has same type as the ``y`` that has been passed most recently:
-            ``Series``, ``Panel``, ``Hierarchical`` scitype, same format (see above)
-
-        Notes
-        -----
-        If ``y`` is not None, global forecast will be performed: the estimator refits
-        on the extended history in ``y``, then predicts at ``fh``.
-
-        If ``y`` is None, non-global forecast will be performed using the series seen
-        in ``fit``.
-        """
-        if y is not None:
-            _fh = fh if self._fh is None and fh is not None else self._fh
-            return self.fit_predict(fh=_fh, X=X, y=y)
-        return super().predict(fh=fh, X=X)
 
     def _run(self, pred_len):
         if self.model is None:


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs

Flowstate PR: #10329
Refs https://github.com/sktime/sktime/pull/10398#discussion_r3425968987

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
- removes overriding of predict in estimator
- inherits `_GlobalForecastingDeprecationMixin`


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [x] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
