### PR TITLE
[DOC] clarify make_forecasting_scorer signature

### DIFF
--- a/sktime/performance_metrics/forecasting/_base.py
+++ b/sktime/performance_metrics/forecasting/_base.py
@@ -990,7 +990,9 @@ def make_forecasting_scorer(
     ----------
     func : callable
         Callable to convert to a forecasting scorer class.
-        Score function (or loss function) with signature ``func(y, y_pred, **kwargs)``.
+        Score function (or loss function) with signature
+        ``func(y_true, y_pred, **kwargs)``.
+        The arguments ``y_true`` and ``y_pred`` are passed as keyword arguments.
 
     name : str, default=None
         Name to use for the forecasting scorer loss class.


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #9374.

#### What does this implement/fix? Explain your changes.

This updates the `make_forecasting_scorer` docstring so the documented callable signature uses `y_true` instead of `y`. The implementation calls custom metric functions with `y_true` and `y_pred` as keyword arguments, so the previous wording could lead to custom metrics that work positionally but fail when used through benchmarking.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Whether the wording is clear and matches the current scorer call path.

#### Did you add any tests for the change?

Not added; this is a docstring-only clarification.

Local validation:

- `python -m compileall -q sktime\performance_metrics\forecasting\_base.py`
- `git diff --check`

I also tried the focused scorer tests, but this local environment is missing `skbase`, so pytest did not start.