### PR TITLE
[DOC] fix a number of broken links in API reference

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -501,15 +501,21 @@ Deep learning based forecasters
     LTSFNLinearForecaster
     LTSFTransformerForecaster
 
-.. currentmodule:: sktime.forecasting.neuralprophet
 .. currentmodule:: sktime.forecasting.xlstm
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    NeuralProphet
     XLSTMForecaster
+
+.. currentmodule:: sktime.forecasting.neuralprophet
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    NeuralProphet
 
 .. currentmodule:: sktime.forecasting.scinet
 

--- a/docs/source/api_reference/regression.rst
+++ b/docs/source/api_reference/regression.rst
@@ -71,7 +71,7 @@ Deep learning
     lstmfcn.LSTMFCNRegressor
     lstmfcn.LSTMFCNRegressorTorch
     macnn.MACNNRegressor
-    macnn.MACCNNRegressorTorch
+    macnn.MACNNRegressorTorch
     mcdcnn.MCDCNNRegressor
     mcdcnn.MCDCNNRegressorTorch
     mlp.MLPRegressor

--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -93,7 +93,7 @@ These tags are used to describe capabilities, properties, and behavior of foreca
     :template: function.rst
     :nosignatures:
 
-    capability__exogeneous
+    capability__exogenous
     capability__insample
     capability__pred_int
     capability__pred_int__insample

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -261,7 +261,14 @@ Dictionary-based features
     SFAFast
     PAAlegacy
     SAXlegacy
-    fABBA
+
+.. currentmodule:: sktime.transformations.fabba
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    FABBA
 
 Auto-correlation-based features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -314,7 +321,6 @@ These transformers extract larger collections of features.
     :template: class.rst
 
     TSFeaturesTransformer
-    TSFeaturesWideTransformer
 
 .. currentmodule:: sktime.transformations.catch22
 
@@ -750,7 +756,7 @@ Multivariate-to-univariate
 
 These transformers convert multivariate series to univariate.
 
-.. currentmodule:: sktime.transformations.compose
+.. currentmodule:: sktime.transformations.colconcat
 
 .. autosummary::
     :toctree: auto_generated/
@@ -967,6 +973,8 @@ They compute features that are related to a domain of application.
 
 Energy, weather and climate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.transformations.clear_sky
 
 .. autosummary::
     :toctree: auto_generated/


### PR DESCRIPTION
This PR fixes a number of broken links in API reference that were mostly due to typos.