### PR TITLE
[ENH] Move MLPRegressor test skip config from tests._config to estimator tags

### DIFF
--- a/sktime/regression/deep_learning/mlp/_mlp_tf.py
+++ b/sktime/regression/deep_learning/mlp/_mlp_tf.py
@@ -84,6 +84,7 @@ class MLPRegressor(BaseDeepRegressor):
         "authors": ["hfawaz", "James-Large", "AurumnPegasus", "nilesh05apr", "noxthot"],
         "maintainers": ["James-Large", "AurumnPegasus", "nilesh05apr"],
         # estimator type handled by parent class
+        "tests:skip_all": True,  # DL suspected hangs/memouts, see #4610
     }
 
     def __init__(

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -41,7 +41,6 @@ EXCLUDE_ESTIMATORS = [
     "EditDist",
     "LSTMFCNClassifier",
     "MLPClassifier",
-    "MLPRegressor",
     "ResNetRegressor",
     "LSTMFCNRegressor",
     # splitters excluded with undiagnosed failures, see #6194


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #8515 (single estimator, per maintainer's request to handle one estimator at a time).

#### What does this implement/fix? Explain your changes.
Moves the test skip configuration for `MLPRegressor` from the global `EXCLUDE_ESTIMATORS` list in `sktime/tests/_config.py` to a class-level tag on the estimator itself, following the recipe described in #8515.

Changes:
- Removed `"MLPRegressor"` from `EXCLUDE_ESTIMATORS` in `sktime/tests/_config.py`
- Added `"tests:skip_all": True` to the `_tags` dict in `MLPRegressor` (`sktime/regression/deep_learning/mlp/_mlp_tf.py`)

Before making the change, I confirmed `MLPRegressor` does not inherit `"tests:skip_all": True` from any parent class (`BaseDeepRegressor`, `BaseRegressor`, `BaseObject` all default to `False`), so the local override is necessary and not redundant.

Skip reason is unchanged from the original: DL suspected hangs/memouts, see #4610.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Confirming the tag placement/formatting matches the convention used in similar merged PRs for this issue (e.g. MLPClassifier in #9409)
- Confirming no other estimators in `_config.py` were inadvertently affected

#### Did you add any tests for the change?
No new tests added — this is a metadata migration with no behavior change. Verified locally that `MLPRegressor.get_class_tags()["tests:skip_all"]` returns `True`, and that `pytest sktime/tests/test_all_estimators.py -k "MLPRegressor"` collects no tests as a result.

#### Any other comments?
First-time contributor to sktime — happy to adjust formatting/placement if it doesn't match conventions I might have missed.