### PR TITLE
[ENH] `ForecastingHorizon` refactor - `pandas` decoupling

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -122,6 +122,7 @@ def _check_values(values) -> pd.Index:
     # return sorted values
     return values.sort_values(), np.sort(values_np)
 
+
 def _check_freq(obj):
     """Coerce obj to a pandas frequency offset for the ForecastingHorizon.
 

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -95,9 +95,8 @@ def _check_values(values):
             values_pd = norm._normalize_pd_index_legacy(values)
             values_np = norm._normalize(values)
             normalizer_found = True
+            values = values_pd
             break
-
-    values = values_pd
 
     # otherwise, raise type error
     if not normalizer_found:

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -305,17 +305,17 @@ class ForecastingHorizon:
         # types inherit from each other, hence we check for type equality
         error_msg = f"`values` type is not compatible with `is_relative={is_relative}`."
         if is_relative is None:
-            if is_in_valid_relative_index_types(values):
+            if is_in_valid_relative_index_types(values_pd):
                 is_relative = True
-            elif is_in_valid_absolute_index_types(values):
+            elif is_in_valid_absolute_index_types(values_pd):
                 is_relative = False
             else:
-                raise TypeError(f"{type(values)} is not a supported fh index type")
+                raise TypeError(f"{type(values_pd)} is not a supported fh index type")
         if is_relative:
-            if not is_in_valid_relative_index_types(values):
+            if not is_in_valid_relative_index_types(values_pd):
                 raise TypeError(error_msg)
         else:
-            if not is_in_valid_absolute_index_types(values):
+            if not is_in_valid_absolute_index_types(values_pd):
                 raise TypeError(error_msg)
         self._is_relative = is_relative
 

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -65,7 +65,7 @@ def _delegator(method):
     return delegated
 
 
-def _check_values(values) -> pd.Index:
+def _check_values(values):
     """Validate forecasting horizon values.
 
     Validation checks validity and also converts forecasting horizon values
@@ -89,11 +89,13 @@ def _check_values(values) -> pd.Index:
         Normalized forecasting horizon values as a 1D numpy array of integers or floats.
     """
     normalizer_found = False
-    for norm in ALL_NORMALIZERS:
+    for norm_cls in ALL_NORMALIZERS:
+        norm = norm_cls()
         if norm._is_applicable(values):
             values_pd = norm._normalize_pd_index_legacy(values)
             values_np = norm._normalize(values)
             normalizer_found = True
+            break
 
     values = values_pd
 

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -13,18 +13,11 @@ from pandas import Timedelta
 from pandas.tseries.frequencies import to_offset
 from skbase.utils.dependencies import _check_soft_dependencies
 
+from sktime.forecasting.base._fh_types import ALL_NORMALIZERS
 from sktime.utils.datetime import _coerce_duration_to_int
-from sktime.utils.validation import (
-    array_is_int,
-    array_is_timedelta_or_date_offset,
-    is_array,
-    is_int,
-    is_timedelta_or_date_offset,
-)
 from sktime.utils.validation.series import (
     VALID_INDEX_TYPES,
     is_in_valid_absolute_index_types,
-    is_in_valid_index_types,
     is_in_valid_relative_index_types,
     is_integer_index,
 )
@@ -92,43 +85,20 @@ def _check_values(values) -> pd.Index:
     -------
     values : pd.Index
         Sorted and validated forecasting horizon values.
+    np_values : np.ndarray, 1D array of integers or floats
+        Normalized forecasting horizon values as a 1D numpy array of integers or floats.
     """
-    # if values are one of the supported pandas index types, we don't have
-    # to do
-    # anything as the forecasting horizon directly wraps the index, note that
-    # isinstance() does not work here, because index types inherit from each
-    # other,
-    # hence we check for type equality here
-    if is_in_valid_index_types(values):
-        pass
+    normalizer_found = False
+    for norm in ALL_NORMALIZERS:
+        if norm._is_applicable(values):
+            values_pd = norm._normalize_pd_index_legacy(values)
+            values_np = norm._normalize(values)
+            normalizer_found = True
 
-    # convert single positive integer to range index 1 ... integer,
-    # no further checks needed
-    elif is_int(values) and values > 0:
-        values = pd.Index(range(1, values + 1), dtype=int)
-
-    # convert single non-positive integer to index with one value,
-    # no further checks needed
-    elif is_int(values) and values <= 0:
-        values = pd.Index([values], dtype=int)
-
-    # convert range object to pandas.RangeIndex
-    # range has to be for integers, no need to separate check
-    elif isinstance(values, range):
-        values = pd.Index(values)
-
-    elif is_timedelta_or_date_offset(values):
-        values = pd.Index([values])
-
-    # convert np.array or list to pandas index
-    elif is_array(values) and array_is_int(values):
-        values = pd.Index(values, dtype=int)
-
-    elif is_array(values) and array_is_timedelta_or_date_offset(values):
-        values = pd.Index(values)
+    values = values_pd
 
     # otherwise, raise type error
-    else:
+    if not normalizer_found:
         valid_types = (
             "int",
             "range",
@@ -150,8 +120,7 @@ def _check_values(values) -> pd.Index:
         )
 
     # return sorted values
-    return values.sort_values()
-
+    return values.sort_values(), np.sort(values_np)
 
 def _check_freq(obj):
     """Coerce obj to a pandas frequency offset for the ForecastingHorizon.
@@ -311,8 +280,9 @@ class ForecastingHorizon:
         # coercing inputs
 
         # values to pd.Index self._values
-        values = _check_values(values)
-        self._values = values
+        values_pd, values_np = _check_values(values)
+        self._values = values_pd
+        self._values_np = values_np
 
         # infer freq from values, if available
         # if not, infer from freq argument, if available

--- a/sktime/forecasting/base/_fh_types.py
+++ b/sktime/forecasting/base/_fh_types.py
@@ -178,6 +178,7 @@ class FhDateTypeNumpyOrPandas:
 
         return is_timedelta(x=x) or is_date_offset(x=x)
 
+    @staticmethod
     def _to_int64(x):
         """Convert datetime-like or timedelta-like x to int64 representation."""
         import pandas as pd

--- a/sktime/forecasting/base/_fh_types.py
+++ b/sktime/forecasting/base/_fh_types.py
@@ -1,5 +1,3 @@
-
-
 from datetime import timedelta
 
 import numpy as np

--- a/sktime/forecasting/base/_fh_types.py
+++ b/sktime/forecasting/base/_fh_types.py
@@ -71,6 +71,7 @@ class FhIntTypeNonPandas:
 
         return pd.Index(self._normalize(fh))
 
+
 class FhPandasIntType:
     """Normalizer for integer-like forecasting horizons, pandas only."""
 

--- a/sktime/forecasting/base/_fh_types.py
+++ b/sktime/forecasting/base/_fh_types.py
@@ -49,7 +49,10 @@ class FhIntTypeNonPandas:
             Normalized forecasting horizon as a 1D numpy array of integers or floats.
         """
         if self._is_int(fh) and fh > 0:
+            return np.arange(1, fh + 1, dtype=int)
+        elif self._is_int(fh):
             return np.array([fh])
+
         if isinstance(fh, range):
             return np.array(fh)
         else:

--- a/sktime/forecasting/base/_fh_types.py
+++ b/sktime/forecasting/base/_fh_types.py
@@ -73,6 +73,7 @@ class FhIntTypeNonPandas:
         import pandas as pd
 
         vals = self._normalize(fh)
+        # downwards compatible, tests expect length zero values to be RangeIndex
         if len(vals) == 0:
             return pd.RangeIndex(0)
 

--- a/sktime/forecasting/base/_fh_types.py
+++ b/sktime/forecasting/base/_fh_types.py
@@ -72,7 +72,11 @@ class FhIntTypeNonPandas:
         """Legacy normalizer for pandas index types, for downwards compatibility."""
         import pandas as pd
 
-        return pd.Index(self._normalize(fh))
+        vals = self._normalize(fh)
+        if len(vals) == 0:
+            return pd.RangeIndex(0)
+
+        return pd.Index(vals)
 
 
 class FhPandasIntType:

--- a/sktime/forecasting/base/_fh_types.py
+++ b/sktime/forecasting/base/_fh_types.py
@@ -3,9 +3,6 @@
 from datetime import timedelta
 
 import numpy as np
-
-from sktime.utils.validation import is_int
-
 from skbase.utils.dependencies import _check_soft_dependencies
 
 
@@ -234,7 +231,7 @@ class FhDateTypeNumpyOrPandas:
                 return np.array([self._to_int64(value) for value in fh]).flatten()
 
         raise RuntimeError("Please only pass fh that pass _is_applicable.")
-    
+
     def _normalize_pd_index_legacy(self, fh):
         """Legacy normalizer for pandas index types, for downwards compatibility."""
         import pandas as pd

--- a/sktime/forecasting/base/_fh_types.py
+++ b/sktime/forecasting/base/_fh_types.py
@@ -154,7 +154,7 @@ class FhDateTypeNumpyOrPandas:
         if self._is_timedelta_or_date_offset(fh):
             return True
 
-        if isinstance(fh, list | np.ndarray):
+        if isinstance(fh, (list, np.ndarray)):
             if all([self._is_timedelta_or_date_offset(value) for value in fh]):
                 return True
 
@@ -228,7 +228,7 @@ class FhDateTypeNumpyOrPandas:
         if self._is_timedelta_or_date_offset(fh):
             return np.array([self._to_int64(fh)])
 
-        if isinstance(fh, list | np.ndarray):
+        if isinstance(fh, (list, np.ndarray)):
             if all([self._is_timedelta_or_date_offset(value) for value in fh]):
                 return np.array([self._to_int64(value) for value in fh]).flatten()
 
@@ -246,7 +246,7 @@ class FhDateTypeNumpyOrPandas:
         if self._is_timedelta_or_date_offset(fh):
             return pd.Index([fh])
 
-        if isinstance(fh, list | np.ndarray):
+        if isinstance(fh, (list, np.ndarray)):
             if all([self._is_timedelta_or_date_offset(value) for value in fh]):
                 return pd.Index(fh)
 

--- a/sktime/forecasting/base/_fh_types.py
+++ b/sktime/forecasting/base/_fh_types.py
@@ -252,3 +252,6 @@ class FhDateTypeNumpyOrPandas:
                 return pd.Index(fh)
 
         raise RuntimeError("Please only pass fh that pass _is_applicable.")
+
+
+ALL_NORMALIZERS = [FhIntTypeNonPandas, FhPandasIntType, FhDateTypeNumpyOrPandas]

--- a/sktime/forecasting/base/_fh_types.py
+++ b/sktime/forecasting/base/_fh_types.py
@@ -1,0 +1,254 @@
+
+
+from datetime import timedelta
+
+import numpy as np
+
+from sktime.utils.validation import is_int
+
+from skbase.utils.dependencies import _check_soft_dependencies
+
+
+class FhIntTypeNonPandas:
+    """Normalizer for integer-like forecasting horizons, numpy and python native."""
+
+    def _is_applicable(self, fh):
+        """Check if this normalizer class is applicable to the input fh.
+
+        Parameters
+        ----------
+        fh : input object
+            The input forecasting horizon to check for applicability.
+
+        Returns
+        -------
+        bool
+             True if this normalizer class can be used to normalize the input fh.
+        """
+        if self._is_int(fh):
+            return True
+
+        # range object
+        if isinstance(fh, range):
+            return True
+        # numpy array
+        if isinstance(fh, np.ndarray) and np.issubdtype(fh.dtype, np.integer):
+            return True
+        # list of integer
+        if isinstance(fh, list) and all([self._is_int(value) for value in fh]):
+            return True
+
+        return False
+
+    def _normalize(self, fh):
+        """Coerce fh to 1D np.array of integers (periods) or floats (if fractional).
+
+        Parameters
+        ----------
+        fh : input object
+            The input object to normalize.
+
+        Returns
+        -------
+        np.array, 1D array of integers or floats
+            Normalized forecasting horizon as a 1D numpy array of integers or floats.
+        """
+        if self._is_int(fh) and fh > 0:
+            return np.array([fh])
+        if isinstance(fh, range):
+            return np.array(fh)
+        else:
+            return np.asarray(fh).flatten()
+
+    @staticmethod
+    def _is_int(x) -> bool:
+        """Check if x is of integer type, but not boolean."""
+        # boolean are subclasses of integers in Python, so explicitly exclude them
+        return (
+            isinstance(x, (int, np.integer))
+            and not isinstance(x, bool)
+            and not isinstance(x, np.timedelta64)
+        )
+
+    def _normalize_pd_index_legacy(self, fh):
+        """Legacy normalizer for pandas index types, for downwards compatibility."""
+        import pandas as pd
+
+        return pd.Index(self._normalize(fh))
+
+class FhPandasIntType:
+    """Normalizer for integer-like forecasting horizons, pandas only."""
+
+    def _is_applicable(self, fh):
+        """Check if this normalizer class is applicable to the input fh.
+
+        Parameters
+        ----------
+        fh : input object
+            The input forecasting horizon to check for applicability.
+
+        Returns
+        -------
+        bool
+             True if this normalizer class can be used to normalize the input fh.
+        """
+        if not _check_soft_dependencies("pandas", severity="none"):
+            return False
+
+        import pandas as pd
+
+        if isinstance(fh, pd.RangeIndex):
+            return True
+
+        if isinstance(fh, pd.Index) and pd.api.types.is_integer_dtype(fh):
+            return True
+
+        return False
+
+    def _normalize(self, fh):
+        """Coerce fh to 1D np.array of integers (periods) or floats (if fractional).
+
+        Parameters
+        ----------
+        fh : input object
+            The input object to normalize.
+
+        Returns
+        -------
+        np.array, 1D array of integers or floats
+            Normalized forecasting horizon as a 1D numpy array of integers or floats.
+        """
+        return fh.to_numpy().flatten()
+
+    def _normalize_pd_index_legacy(self, fh):
+        """Legacy normalizer for pandas index types, for downwards compatibility."""
+        # already a pd.Index, so return as is
+        return fh
+
+
+class FhDateTypeNumpyOrPandas:
+    """Normalizer for date-like forecasting horizons, numpy and pandas."""
+
+    def _is_applicable(self, fh):
+        """Check if this normalizer class is applicable to the input fh.
+
+        Parameters
+        ----------
+        fh : input object
+            The input forecasting horizon to check for applicability.
+
+        Returns
+        -------
+        bool
+             True if this normalizer class can be used to normalize the input fh.
+        """
+        if not _check_soft_dependencies("pandas", severity="none"):
+            return False
+
+        import pandas as pd
+
+        VALID_INDEX_TYPES = (pd.PeriodIndex, pd.DatetimeIndex, pd.TimedeltaIndex)
+
+        if isinstance(fh, VALID_INDEX_TYPES):
+            return True
+
+        if self._is_timedelta_or_date_offset(fh):
+            return True
+
+        if isinstance(fh, list | np.ndarray):
+            if all([self._is_timedelta_or_date_offset(value) for value in fh]):
+                return True
+
+        return False
+
+    def _is_timedelta_or_date_offset(self, x) -> bool:
+        """Check if x is of timedelta or pd.DateOffset type."""
+        import pandas as pd
+
+        # ACCEPTED_DATETIME_TYPES = np.datetime64, pd.Timestamp
+        ACCEPTED_TIMEDELTA_TYPES = pd.Timedelta, timedelta, np.timedelta64
+        ACCEPTED_DATEOFFSET_TYPES = pd.DateOffset
+
+        def is_timedelta(x) -> bool:
+            """Check if x is of timedelta type."""
+            return isinstance(x, ACCEPTED_TIMEDELTA_TYPES)
+
+        def is_date_offset(x) -> bool:
+            """Check if x is of pd.DateOffset type."""
+            return isinstance(x, ACCEPTED_DATEOFFSET_TYPES)
+
+        return is_timedelta(x=x) or is_date_offset(x=x)
+
+    def _to_int64(x):
+        """Convert datetime-like or timedelta-like x to int64 representation."""
+        import pandas as pd
+
+        # Timestamp-like: ns since Unix epoch
+        if isinstance(x, pd.Timestamp):
+            return x.value
+
+        if isinstance(x, np.datetime64):
+            return x.astype("datetime64[ns]").astype(np.int64)
+
+        # Timedelta-like: ns duration
+        if isinstance(x, pd.Timedelta):
+            return x.value
+
+        if isinstance(x, timedelta):
+            return pd.Timedelta(x).value
+
+        if isinstance(x, np.timedelta64):
+            return x.astype("timedelta64[ns]").astype(np.int64)
+
+        raise TypeError(f"Unsupported type: {type(x)}")
+
+    def _normalize(self, fh):
+        """Coerce fh to 1D np.array of integers (periods) or floats (if fractional).
+
+        Parameters
+        ----------
+        fh : input object
+            The input object to normalize.
+
+        Returns
+        -------
+        np.array, 1D array of integers or floats
+            Normalized forecasting horizon as a 1D numpy array of integers or floats.
+        """
+        import pandas as pd
+
+        # number of periods
+        if isinstance(fh, pd.PeriodIndex):
+            return fh.astype("int64")
+
+        # nanoseconds since 1970-01-01 00:00:00 UTC, as integer
+        # this is the usual convention representing datetimes internally
+        if isinstance(fh, (pd.DatetimeIndex, pd.TimedeltaIndex)):
+            return fh.asi8.flatten()
+
+        if self._is_timedelta_or_date_offset(fh):
+            return np.array([self._to_int64(fh)])
+
+        if isinstance(fh, list | np.ndarray):
+            if all([self._is_timedelta_or_date_offset(value) for value in fh]):
+                return np.array([self._to_int64(value) for value in fh]).flatten()
+
+        raise RuntimeError("Please only pass fh that pass _is_applicable.")
+    
+    def _normalize_pd_index_legacy(self, fh):
+        """Legacy normalizer for pandas index types, for downwards compatibility."""
+        import pandas as pd
+
+        VALID_INDEX_TYPES = (pd.PeriodIndex, pd.DatetimeIndex, pd.TimedeltaIndex)
+
+        if isinstance(fh, VALID_INDEX_TYPES):
+            return fh
+
+        if self._is_timedelta_or_date_offset(fh):
+            return pd.Index([fh])
+
+        if isinstance(fh, list | np.ndarray):
+            if all([self._is_timedelta_or_date_offset(value) for value in fh]):
+                return pd.Index(fh)
+
+        raise RuntimeError("Please only pass fh that pass _is_applicable.")


### PR DESCRIPTION
Experimental refactor of `ForecastingHorizon`.

The aim of this refactor is to:

* decouple `pandas` from the `ForecastingHorizon` entirely
* mediate the coupling through a strategy pattern of normalizers. The normalizers map datatype-adjacent objects to an internal encoding based entirely on integers.
    * this allows to move logic related to `pandas` entirely into the normalizers

Hopefully, this will help with the remaining `pandas 3` compatibility issues.