### PR TITLE
[MNT] lint deprecated `_contrib` module

### DIFF
--- a/_contrib/classification_experiments.py
+++ b/_contrib/classification_experiments.py
@@ -13,8 +13,9 @@ os.environ["MKL_NUM_THREADS"] = "1"  # must be done before numpy import!!
 os.environ["NUMEXPR_NUM_THREADS"] = "1"  # must be done before numpy import!!
 os.environ["OMP_NUM_THREADS"] = "1"  # must be done before numpy import!!
 
-import sktime.datasets.tsc_dataset_names as dataset_lists
 from sktime._contrib.set_classifier import set_classifier
+
+import sktime.datasets.tsc_dataset_names as dataset_lists
 from sktime.benchmarking.experiments import load_and_run_classification_experiment
 from sktime.classification.feature_based import FreshPRINCE
 from sktime.datasets import load_from_tsfile_to_dataframe as load_ts

--- a/_contrib/clustering_experiments.py
+++ b/_contrib/clustering_experiments.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     else:  # Local run
         print(" Local Run")
         dataset = "ElectricDevices"
-        data_dir = f"../datasets/data/"
+        data_dir = "../datasets/data/"
         results_dir = "./temp"
         resample = 0
         tf = True


### PR DESCRIPTION
Applies linting to the `_contrib` module that was removed in 1.0.

This is a simple measure to prevent accidental linter failures showing up from those files.