### PR TITLE
fix(LinearTrendCost): handle zero-variance time column in _fit_linear…

### DIFF
--- a/sktime/detection/costs/_linear_trend_cost.py
+++ b/sktime/detection/costs/_linear_trend_cost.py
@@ -10,11 +10,19 @@ from sktime.detection.costs._base import BaseCost
 
 
 def _fit_linear_trend(time_steps, values):
-    """OLS fit of a linear trend: returns (slope, intercept)."""
+    """OLS fit of a linear trend: returns (slope, intercept).
+
+    When all time_steps are identical (zero variance), the denominator is zero
+    and no slope can be estimated. In that case we return slope=0 and
+    intercept=mean(values) so the cost equals the residual variance.
+    """
     mean_t = np.mean(time_steps)
     centered_t = time_steps - mean_t
     mean_v = np.mean(values)
     denominator = np.sum(np.square(centered_t))
+    if denominator == 0.0:
+        # All time steps are identical — cannot estimate a slope.
+        return 0.0, mean_v
     numerator = np.sum(centered_t * (values - mean_v))
     slope = numerator / denominator
     intercept = mean_v - slope * mean_t


### PR DESCRIPTION
### Reference Issues/PRs
Fixes #10394

### What does this implement/fix?

`_fit_linear_trend` computes OLS slope as `numerator / denominator` where `denominator = np.sum(np.square(time_steps - mean(time_steps)))`. When all time steps in a segment are identical (zero variance), `denominator` is `0`, causing a `ZeroDivisionError` or — with numpy — a silent `NaN` that propagates through the cost matrix.

**Fix:** add an early-return guard in `_fit_linear_trend`: if `denominator == 0`, we cannot estimate a slope, so return `(0.0, mean_v)`. This is mathematically correct — with no time variation, the best constant fit is just the mean of the values.

### Does your contribution introduce a new dependency?

No.