### PR TITLE
[DOC] replace 'forecasters horizon' with 'forecasting horizon'

### DIFF
--- a/sktime/forecasting/arch/_uarch.py
+++ b/sktime/forecasting/arch/_uarch.py
@@ -504,7 +504,7 @@ class ARCH(BaseForecaster):
         Parameters
         ----------
         fh : array-like
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is
             one-step ahead forecast, i.e. np.array([1]).
         type : str, optional (default="mean")
@@ -539,7 +539,7 @@ class ARCH(BaseForecaster):
         Parameters
         ----------
         fh : array-like
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is
             one-step ahead forecast, i.e. np.array([1]).
         type : str, optional (default="mean")

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -68,7 +68,7 @@ class _ProphetAdapter(BaseForecaster):
         X : pd.DataFrame, optional (default=None)
             Exogenous variables.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
 
         Returns
         -------
@@ -179,7 +179,7 @@ class _ProphetAdapter(BaseForecaster):
         Parameters
         ----------
         fh : array-like
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is
             one-step ahead forecast, i.e. np.array([1]).
         X : pd.DataFrame, optional

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -51,7 +51,7 @@ class _PmdArimaAdapter(BaseForecaster):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list, np.array or ForecastingHorizon, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored
 
@@ -92,7 +92,7 @@ class _PmdArimaAdapter(BaseForecaster):
         Parameters
         ----------
         fh : array-like
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is
             one-step ahead forecast, i.e. np.array([1]).
 
@@ -142,7 +142,7 @@ class _PmdArimaAdapter(BaseForecaster):
         Parameters
         ----------
         fh : array-like
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is
             one-step ahead forecast, i.e. np.array([1]).
 
@@ -221,7 +221,7 @@ class _PmdArimaAdapter(BaseForecaster):
         Parameters
         ----------
         fh : array-like
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is
             one-step ahead forecast, i.e. np.array([1]).
 

--- a/sktime/forecasting/base/adapters/_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_statsforecast.py
@@ -134,7 +134,7 @@ class _StatsForecastAdapter(BaseForecaster):
         Parameters
         ----------
         fh : array-like
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is
             one-step ahead forecast, i.e. np.array([1]).
 
@@ -170,7 +170,7 @@ class _StatsForecastAdapter(BaseForecaster):
         Parameters
         ----------
         fh : array-like
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is
             one-step ahead forecast, i.e. np.array([1]).
 

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -50,7 +50,7 @@ class _StatsModelsAdapter(BaseForecaster):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored
 
@@ -109,7 +109,7 @@ class _StatsModelsAdapter(BaseForecaster):
         Parameters
         ----------
         fh : ForecastingHorizon
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is one-step ahead forecast,
             i.e. np.array([1])
         X : pd.DataFrame, optional (default=None)

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -95,7 +95,7 @@ class _TbatsAdapter(BaseForecaster):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables (ignored)
 

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -184,7 +184,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
         y : pd.DataFrame
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored.
 

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -146,7 +146,7 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional, default=None
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional, default=None
             Exogenous variables are ignored.
 
@@ -381,7 +381,7 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         y : pd.DataFrame - Series, Panel, or Hierarchical mtype format.
             Target time series to which to fit the forecaster.
         fh : ForecastingHorizon, optional, default=None
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional, default=None, must be of same mtype as y
             Exogenous data to which to fit the forecaster.
 

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -233,7 +233,7 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
         y : pd-multiindex
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored.
 
@@ -751,7 +751,7 @@ def _level_fit(params, meta):
         hier_dict: dict
             The level dictionary as created by the get_hier_dict function
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
     """
     _, forecaster, level = params
     z = meta["z"]
@@ -787,7 +787,7 @@ def _node_fit(params, meta):
         fcstr_dict: dict
             The forecaster dictionary as created by the get_node_dict function
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
     """
     key, node = params
     z = meta["z"]
@@ -816,7 +816,7 @@ def _predict_one_forecaster(params, meta):
         X: pd.DataFrame, None
             The aggregated input data
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
     """
     X = meta["x"]
     fh = meta["fh"]

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -516,7 +516,7 @@ class ForecastingPipeline(_Pipeline):
         y : pd.Series, pd.DataFrame
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, required
             Exogenous variables are ignored
 
@@ -1067,7 +1067,7 @@ class TransformedTargetForecaster(_Pipeline):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored
 
@@ -1625,7 +1625,7 @@ class ForecastX(BaseForecaster):
         y : time series in sktime compatible format
             Target time series to which to fit the forecaster
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : time series in sktime compatible format, optional, default=None
             Exogenous time series to which to fit the forecaster
 

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -89,7 +89,7 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored
 

--- a/sktime/forecasting/croston.py
+++ b/sktime/forecasting/croston.py
@@ -98,7 +98,7 @@ class Croston(BaseForecaster):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored.
 
@@ -146,7 +146,7 @@ class Croston(BaseForecaster):
         Parameters
         ----------
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored.
 

--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -203,7 +203,7 @@ class DynamicFactor(_StatsModelsAdapter):
         Parameters
         ----------
         fh : ForecastingHorizon
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is one-step ahead forecast,
             i.e. np.array([1])
         X : pd.DataFrame, optional (default=None)

--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -453,7 +453,7 @@ class AutoETS(_StatsModelsAdapter):
         Parameters
         ----------
         fh : ForecastingHorizon
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is one-step ahead forecast,
             i.e. np.array([1])
         X : pd.DataFrame, optional (default=None)

--- a/sktime/forecasting/model_selection/_base.py
+++ b/sktime/forecasting/model_selection/_base.py
@@ -169,7 +169,7 @@ class BaseGridSearch(_DelegatedForecaster):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored
 

--- a/sktime/forecasting/online_learning/_online_ensemble.py
+++ b/sktime/forecasting/online_learning/_online_ensemble.py
@@ -58,7 +58,7 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored
 

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -144,7 +144,7 @@ class ThetaForecaster(ExponentialSmoothing):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored
 
@@ -195,7 +195,7 @@ class ThetaForecaster(ExponentialSmoothing):
         Parameters
         ----------
         fh : array-like
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is
             one-step ahead forecast, i.e. np.array([1]).
         X : pd.DataFrame, optional (default=None)

--- a/sktime/forecasting/trend/_polynomial_trend_forecaster.py
+++ b/sktime/forecasting/trend/_polynomial_trend_forecaster.py
@@ -125,7 +125,7 @@ class PolynomialTrendForecaster(BaseForecaster):
         X : pd.DataFrame, default=None
             Exogenous variables are ignored
         fh : int, list or np.array, default=None
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
 
         Returns
         -------

--- a/sktime/forecasting/trend/_stl_forecaster.py
+++ b/sktime/forecasting/trend/_stl_forecaster.py
@@ -208,7 +208,7 @@ class STLForecaster(BaseForecaster):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list, np.array or ForecastingHorizon, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
 
         Returns

--- a/sktime/forecasting/trend/_trend_forecaster.py
+++ b/sktime/forecasting/trend/_trend_forecaster.py
@@ -85,7 +85,7 @@ class TrendForecaster(BaseForecaster):
         X : pd.DataFrame, default=None
             Exogenous variables are ignored
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
 
         Returns
         -------

--- a/sktime/forecasting/tsb.py
+++ b/sktime/forecasting/tsb.py
@@ -76,7 +76,7 @@ class TSB(BaseForecaster):
         y : pd.Series
             Target time series to which to fit the forecaster.
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored.
 
@@ -125,7 +125,7 @@ class TSB(BaseForecaster):
         Parameters
         ----------
         fh : int, list or np.array, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
             Exogenous variables are ignored.
 

--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -138,7 +138,7 @@ class VAR(_StatsModelsAdapter):
         y : pd.DataFrame
             Target time series to which to fit the forecaster.
         fh : int, list, np.array or ForecastingHorizon, optional (default=None)
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
 
         Returns
@@ -173,7 +173,7 @@ class VAR(_StatsModelsAdapter):
         Parameters
         ----------
         fh : ForecastingHorizon
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is one-step ahead forecast,
             i.e. np.array([1])
         X : pd.DataFrame, optional (default=None)

--- a/sktime/forecasting/var_reduce.py
+++ b/sktime/forecasting/var_reduce.py
@@ -315,7 +315,7 @@ class VARReduce(BaseForecaster):
         Parameters
         ----------
         fh : ForecastingHorizon
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is one-step ahead forecast,
             i.e. np.array([1])
         X : pd.DataFrame, optional (default=None)

--- a/sktime/forecasting/varmax.py
+++ b/sktime/forecasting/varmax.py
@@ -371,7 +371,7 @@ class VARMAX(_StatsModelsAdapter):
         Parameters
         ----------
         fh : ForecastingHorizon
-            The forecasters horizon with the steps ahead to predict.
+            The forecasting horizon with the steps ahead to predict.
             Default is one-step ahead forecast,
             i.e. np.array([1])
         X : pd.DataFrame, optional (default=None)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10116

#### What does this implement/fix? Explain your changes.

This PR fixes a documentation typo in forecasting docstrings by replacing "forecasters horizon" with "forecasting horizon".

#### Does your contribution introduce a new dependency?

No.
