### PR TITLE
[ENH] Fault-tolerant benchmark runs

### DIFF
--- a/sktime/benchmarking/_storage_handlers.py
+++ b/sktime/benchmarking/_storage_handlers.py
@@ -234,6 +234,12 @@ class ParquetStorageHandler(BaseStorageHandler):
         results : ResultObject
             The results to save.
         """
+        if not results:
+            pd.DataFrame(columns=["validation_id", "model_id"]).to_parquet(
+                self.path, index=False
+            )
+            return
+
         results_df = pd.json_normalize(
             list(map(lambda x: asdict(x, pd_orient="tight"), results))
         )
@@ -312,6 +318,12 @@ class CSVStorageHandler(BaseStorageHandler):
         results : ResultObject
             The results to save.
         """
+        if not results:
+            pd.DataFrame(columns=["validation_id", "model_id"]).to_csv(
+                self.path, index=False
+            )
+            return
+
         results_df = pd.json_normalize(
             list(map(lambda x: asdict(x, pd_orient="tight"), results))
         )

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -30,6 +30,8 @@ _SCTYPE_TO_COLLECTION = {
     **dict.fromkeys(_SPLITTER_SCITYPES, "_cv_splitters"),
 }
 
+logger = logging.getLogger(__name__)
+
 
 def _is_initialised_estimator(estimator: BaseEstimator) -> bool:
     """Check if estimator is initialised BaseEstimator object."""
@@ -85,6 +87,28 @@ def _coerce_estimator_and_id(estimators, estimator_id=None):
             "estimator must be of a type a dict, list or an initialised "
             f"BaseEstimator object but received {type(estimators)} type."
         )
+
+
+@dataclass
+class FailedExperimentRecord:
+    """Record of a failed task-estimator pair during benchmark execution.
+
+    Parameters
+    ----------
+    task_id : str
+        Identifier of the task that failed.
+    model_id : str
+        Identifier of the estimator that failed.
+    exception_type : str
+        Name of the exception type raised.
+    exception_message : str
+        Message of the exception raised.
+    """
+
+    task_id: str
+    model_id: str
+    exception_type: str
+    exception_message: str
 
 
 @dataclass
@@ -260,6 +284,8 @@ class BaseBenchmark:
         self._datasets = []
         self._cv_splitters = []
         self._metrics = []
+
+        self._failed_experiments: list[FailedExperimentRecord] = []
 
     def add_estimator(
         self,
@@ -471,6 +497,11 @@ class BaseBenchmark:
         if item not in collection:
             collection.append(item)
 
+    @property
+    def failed_experiments(self) -> list[FailedExperimentRecord]:
+        """Failed task-estimator pairs from the most recent benchmark run."""
+        return list(self._failed_experiments)
+
     def register_stored_tasks(self):
         """Register stored tasks from global DATASETS, METRICS, CV_SPLITTERS."""
         if self._datasets and self._metrics and self._cv_splitters:
@@ -519,21 +550,40 @@ class BaseBenchmark:
         self.register_stored_tasks()
 
         results = _BenchmarkingResults(path=results_path)
+        self._failed_experiments = []
 
         for task_id, estimator_id, task, estimator in self._generate_experiments():
             if results.contains(task_id, estimator_id) and (
                 force_rerun == "none"
                 or (isinstance(force_rerun, list) and estimator_id not in force_rerun)
             ):
-                logging.info(
+                logger.info(
                     f"Skipping validation - model: "
                     f"{task_id} - {estimator_id}"
                     ", as found prior result in results."
                 )
                 continue
 
-            logging.info(f"Running validation - model: {task_id} - {estimator_id}")
-            folds = self._run_validation(task, estimator)
+            logger.info(f"Running validation - model: {task_id} - {estimator_id}")
+            try:
+                folds = self._run_validation(task, estimator)
+            except Exception as exc:
+                failure = FailedExperimentRecord(
+                    task_id=task_id,
+                    model_id=estimator_id,
+                    exception_type=type(exc).__name__,
+                    exception_message=str(exc),
+                )
+                self._failed_experiments.append(failure)
+                logger.error(
+                    "Validation failed: %s - %s: %s: %s",
+                    task_id,
+                    estimator_id,
+                    failure.exception_type,
+                    failure.exception_message,
+                )
+                continue
+
             results.update(
                 ResultObject(
                     task_id=task_id,
@@ -542,9 +592,29 @@ class BaseBenchmark:
                 )
             )
 
+        self._report_failed_experiments()
+
         if results_path is not None:
             results.save()
         return results.to_dataframe()
+
+    def _report_failed_experiments(self):
+        """Log a summary of failed task-estimator pairs from the current run."""
+        if not self._failed_experiments:
+            return
+
+        logger.warning(
+            "Benchmark completed with %d failed task-estimator pair(s):",
+            len(self._failed_experiments),
+        )
+        for failure in self._failed_experiments:
+            logger.warning(
+                "  - task=%s, model=%s: %s: %s",
+                failure.task_id,
+                failure.model_id,
+                failure.exception_type,
+                failure.exception_message,
+            )
 
     def _generate_experiments(self):
         """Generate experiments for the benchmark.

--- a/sktime/benchmarking/tests/test_fault_tolerance.py
+++ b/sktime/benchmarking/tests/test_fault_tolerance.py
@@ -1,0 +1,222 @@
+"""Tests for fault-tolerant benchmark execution."""
+
+import logging
+
+import pandas as pd
+import pytest
+from sklearn.metrics import accuracy_score
+from sklearn.model_selection import KFold
+
+from sktime.benchmarking.benchmarks import FailedExperimentRecord
+from sktime.benchmarking.classification import ClassificationBenchmark
+from sktime.benchmarking.forecasting import ForecastingBenchmark
+from sktime.classification.dummy import DummyClassifier
+from sktime.forecasting.naive import NaiveForecaster
+from sktime.performance_metrics.forecasting import MeanAbsoluteError
+from sktime.split import ExpandingWindowSplitter
+from sktime.utils._testing.panel import make_classification_problem
+
+
+class _FailingClassifier(DummyClassifier):
+    """Classifier that always raises on fit."""
+
+    def _fit(self, X, y):
+        raise RuntimeError("classifier fit failed")
+
+
+class _FailingForecaster(NaiveForecaster):
+    """Forecaster that always raises on fit."""
+
+    def _fit(self, y, X, fh):
+        raise ValueError("forecaster fit failed")
+
+
+def _data_loader_simple() -> pd.DataFrame:
+    return pd.DataFrame([2, 2, 3])
+
+
+@pytest.fixture
+def cv_splitter_forecasting():
+    return ExpandingWindowSplitter(initial_window=1, step_length=1, fh=1)
+
+
+@pytest.fixture
+def cv_splitter_classification():
+    return KFold(n_splits=3)
+
+
+def test_classification_continues_after_failure(
+    tmp_path, cv_splitter_classification, caplog
+):
+    """Failed classification pair is skipped; remaining pairs still run."""
+    benchmark = ClassificationBenchmark()
+    benchmark.add_estimator(_FailingClassifier())
+    benchmark.add_estimator(DummyClassifier())
+    benchmark.add_task(
+        make_classification_problem, cv_splitter_classification, [accuracy_score]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        results_df = benchmark.run(tmp_path / "results.csv")
+
+    assert len(results_df) == 1
+    assert results_df["model_id"].iloc[0] == "DummyClassifier"
+    assert "FailingClassifier" not in results_df["model_id"].values
+
+    failures = benchmark.failed_experiments
+    assert len(failures) == 1
+    assert failures[0] == FailedExperimentRecord(
+        task_id="[dataset=make_classification_problem]_[cv_splitter=KFold]",
+        model_id="_FailingClassifier",
+        exception_type="RuntimeError",
+        exception_message="classifier fit failed",
+    )
+
+    assert "Benchmark completed with 1 failed task-estimator pair(s)" in caplog.text
+    assert "RuntimeError: classifier fit failed" in caplog.text
+
+
+def test_forecasting_continues_after_failure(tmp_path, cv_splitter_forecasting, caplog):
+    """Failed forecasting pair is skipped; remaining pairs still run."""
+    benchmark = ForecastingBenchmark()
+    benchmark.add_estimator(_FailingForecaster())
+    benchmark.add_estimator(NaiveForecaster(strategy="last"))
+    benchmark.add_task(
+        _data_loader_simple, cv_splitter_forecasting, [MeanAbsoluteError()]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        results_df = benchmark.run(tmp_path / "results.csv")
+
+    assert len(results_df) == 1
+    assert results_df["model_id"].iloc[0] == "NaiveForecaster"
+    assert "_FailingForecaster" not in results_df["model_id"].values
+
+    failures = benchmark.failed_experiments
+    assert len(failures) == 1
+    assert failures[0].exception_type == "ValueError"
+    assert failures[0].exception_message == "forecaster fit failed"
+
+    assert "Benchmark completed with 1 failed task-estimator pair(s)" in caplog.text
+
+
+def test_multiple_failures_all_reported(tmp_path, cv_splitter_classification, caplog):
+    """Multiple failing pairs are all recorded and reported."""
+    benchmark = ClassificationBenchmark()
+    benchmark.add_estimator(_FailingClassifier())
+    benchmark.add_estimator(DummyClassifier())
+    benchmark.add_task(
+        make_classification_problem, cv_splitter_classification, [accuracy_score]
+    )
+    benchmark.add_task(
+        make_classification_problem,
+        KFold(n_splits=2),
+        [accuracy_score],
+        task_id="task-2",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        results_df = benchmark.run(tmp_path / "results.csv")
+
+    assert len(results_df) == 2
+    assert set(results_df["model_id"]) == {"DummyClassifier"}
+    assert len(benchmark.failed_experiments) == 2
+    assert {f.model_id for f in benchmark.failed_experiments} == {"_FailingClassifier"}
+    assert {f.task_id for f in benchmark.failed_experiments} == {
+        "[dataset=make_classification_problem]_[cv_splitter=KFold]",
+        "task-2",
+    }
+    assert "Benchmark completed with 2 failed task-estimator pair(s)" in caplog.text
+
+
+def test_failed_pair_not_saved_to_checkpoint(tmp_path, cv_splitter_classification):
+    """Failed pairs are absent from saved results; successful pairs are persisted."""
+    results_file = tmp_path / "results.csv"
+
+    benchmark = ClassificationBenchmark()
+    benchmark.add_estimator(_FailingClassifier())
+    benchmark.add_estimator(DummyClassifier())
+    benchmark.add_task(
+        make_classification_problem, cv_splitter_classification, [accuracy_score]
+    )
+    benchmark.run(results_file)
+
+    saved_df = pd.read_csv(results_file)
+    assert len(saved_df) == 1
+    assert saved_df["model_id"].iloc[0] == "DummyClassifier"
+
+
+def test_rerun_retries_failed_pair_after_partial_success(
+    tmp_path, cv_splitter_classification
+):
+    """Checkpoint skips successful pairs but retries pairs that previously failed."""
+    results_file = tmp_path / "results.csv"
+
+    benchmark = ClassificationBenchmark()
+    benchmark.add_estimator(_FailingClassifier())
+    benchmark.add_estimator(DummyClassifier())
+    benchmark.add_task(
+        make_classification_problem, cv_splitter_classification, [accuracy_score]
+    )
+
+    benchmark.run(results_file)
+    assert len(benchmark.failed_experiments) == 1
+
+    benchmark2 = ClassificationBenchmark()
+    benchmark2.add_estimator(_FailingClassifier())
+    benchmark2.add_estimator(DummyClassifier())
+    benchmark2.add_task(
+        make_classification_problem, cv_splitter_classification, [accuracy_score]
+    )
+
+    results_df = benchmark2.run(results_file)
+
+    assert len(results_df) == 1
+    assert len(benchmark2.failed_experiments) == 1
+
+
+def test_all_pairs_fail_returns_empty_results(
+    tmp_path, cv_splitter_classification, caplog
+):
+    """When every pair fails, results are empty and failures are reported."""
+    benchmark = ClassificationBenchmark()
+    benchmark.add_estimator(_FailingClassifier())
+    benchmark.add_task(
+        make_classification_problem, cv_splitter_classification, [accuracy_score]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        results_df = benchmark.run(tmp_path / "results.csv")
+
+    assert results_df.empty
+    assert len(benchmark.failed_experiments) == 1
+    assert "Benchmark completed with 1 failed task-estimator pair(s)" in caplog.text
+
+
+def test_failure_logged_at_error_level(tmp_path, cv_splitter_classification, caplog):
+    """Each failure is logged immediately at error level."""
+    benchmark = ClassificationBenchmark()
+    benchmark.add_estimator(_FailingClassifier())
+    benchmark.add_task(
+        make_classification_problem, cv_splitter_classification, [accuracy_score]
+    )
+
+    with caplog.at_level(logging.ERROR):
+        benchmark.run(tmp_path / "results.csv")
+
+    assert "Validation failed:" in caplog.text
+    assert "RuntimeError: classifier fit failed" in caplog.text
+
+
+def test_no_failures_no_summary_logged(tmp_path, caplog):
+    """When all pairs succeed, no failure summary is logged."""
+    benchmark = ClassificationBenchmark()
+    benchmark.add_estimator(DummyClassifier())
+    benchmark.add_task(make_classification_problem, KFold(n_splits=3), [accuracy_score])
+
+    with caplog.at_level(logging.WARNING):
+        results_df = benchmark.run(tmp_path / "results.csv")
+
+    assert len(results_df) == 1
+    assert benchmark.failed_experiments == []
+    assert "Benchmark completed with" not in caplog.text


### PR DESCRIPTION
Currently if a task-estimator pair fails in a benchmarking experiment, the entire experiment comes to a halt and further task-estimator pairs are not evaluated. This is problematic when running large experiments on a cluster. This PR adds the capability for benchmark runs to continue even if a task-estimator pair fails and log the failed pairs.

This also fixes a related bug in the tabular storage handlers (CSV, Parquet), currently if a result file is passed in `benchmark.run()` and all task-estimator pair fails leading to in-memory results being empty, then the storage handlers raise an error because the `_run` still calls `.save()`, this PR creates an empty dataframe if results is empty.