### PR TITLE
[BUG] Correct `benchmark.add()`'s inconsistent API

### DIFF
--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -57,6 +57,18 @@ def _check_estimators_type(objs: dict | list | BaseEstimator) -> None:
         )
 
 
+def _get_dataset_name(dataset_loader):
+    """Derive dataset name from a dataset loader or instance."""
+    if callable(dataset_loader) and hasattr(dataset_loader, "__name__"):
+        return dataset_loader.__name__
+    elif isinstance(dataset_loader, type):
+        return dataset_loader().get_tags().get("name")
+    elif hasattr(dataset_loader, "get_tags"):
+        return dataset_loader.get_tags().get("name")
+    else:
+        return "_"
+
+
 def _coerce_estimator_and_id(estimators, estimator_id=None):
     """Coerce estimators to a dict with estimator_id as key and estimator as value.
 
@@ -470,35 +482,35 @@ class BaseBenchmark:
     def _add_unique(self, collection, item):
         if item not in collection:
             collection.append(item)
+            self.register_stored_tasks()
+
+    def _make_task_id(self, dataset_loader, cv_splitter):
+        """Generate a task ID from a dataset and CV splitter."""
+        dataset_name = _get_dataset_name(dataset_loader)
+        return (
+            f"[dataset={dataset_name}]_[cv_splitter={cv_splitter.__class__.__name__}]"
+        )
 
     def register_stored_tasks(self):
-        """Register stored tasks from global DATASETS, METRICS, CV_SPLITTERS."""
-        if self._datasets and self._metrics and self._cv_splitters:
-            for dataset_loader in self._datasets:
-                if callable(dataset_loader) and hasattr(dataset_loader, "__name__"):
-                    dataset_name = dataset_loader.__name__
-                elif isinstance(dataset_loader, type):
-                    dataset_name = dataset_loader().get_tags().get("name")
-                elif hasattr(dataset_loader, "get_tags"):
-                    dataset_name = dataset_loader.get_tags().get("name")
-                else:
-                    dataset_name = "_"
+        """Register stored tasks from datasets, metrics, and CV splitters."""
+        if not (self._datasets and self._metrics and self._cv_splitters):
+            return
 
-                for splitter in self._cv_splitters:
-                    task_id = (
-                        f"[dataset={dataset_name}]"
-                        f"_[cv_splitter={splitter.__class__.__name__}]"
-                    )
+        for dataset_loader in self._datasets:
+            for splitter in self._cv_splitters:
+                task_id = self._make_task_id(dataset_loader, splitter)
+                if task_id in self.tasks.entities:
+                    continue
 
-                    task_kwargs = {
-                        "data": dataset_loader,
-                        "cv_splitter": splitter,
-                        "scorers": self._metrics,
-                    }
-                    self._add_task(
-                        task_id,
-                        TaskObject(**task_kwargs),
-                    )
+                task_kwargs = {
+                    "data": dataset_loader,
+                    "cv_splitter": splitter,
+                    "scorers": self._metrics,
+                }
+                self._add_task(
+                    task_id,
+                    TaskObject(**task_kwargs),
+                )
 
     def _run(self, results_path: str, force_rerun: str | list[str] = "none"):
         """

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -528,8 +528,6 @@ class BaseBenchmark:
             * If "all", will run validation for all tasks and models.
             * If list of str, will run validation for tasks and models in list.
         """
-        self.register_stored_tasks()
-
         results = _BenchmarkingResults(path=results_path)
 
         for task_id, estimator_id, task, estimator in self._generate_experiments():

--- a/sktime/benchmarking/tests/test_add_methods.py
+++ b/sktime/benchmarking/tests/test_add_methods.py
@@ -212,3 +212,42 @@ class TestBenchmarkAddMethods:
 
         with pytest.raises(TypeError, match="Unsupported tuple format of length 2"):
             benchmark.add((clf, "should_fail"))
+
+    def test_add_registers_estimators_before_run(self):
+        """Test add() registers estimators before run() is called."""
+        benchmark = ClassificationBenchmark()
+        benchmark.add(DummyClassifier())
+
+        assert len(benchmark.estimators.entities) == 1
+        assert "DummyClassifier" in benchmark.estimators.entities
+
+    def test_add_registers_tasks_before_run_tuple(self):
+        """Test add() registers tasks before run() when using task tuple."""
+        benchmark = ClassificationBenchmark()
+        benchmark.add(DummyClassifier())
+        benchmark.add((ArrowHead(), accuracy_score, KFold(n_splits=3)))
+
+        assert len(benchmark.tasks.entities) == 1
+
+    def test_add_registers_tasks_before_run_individually(self):
+        """Test add() registers tasks before run() when adding components."""
+        benchmark = ClassificationBenchmark()
+        benchmark.add(DummyClassifier())
+        benchmark.add(ArrowHead())
+        benchmark.add(accuracy_score)
+        benchmark.add(KFold(n_splits=3))
+
+        assert len(benchmark.tasks.entities) == 1
+
+    def test_add_registers_tasks_incrementally(self):
+        """Test tasks are registered as soon as all components are available."""
+        benchmark = ClassificationBenchmark()
+
+        benchmark.add(ArrowHead())
+        assert len(benchmark.tasks.entities) == 0
+
+        benchmark.add(accuracy_score)
+        assert len(benchmark.tasks.entities) == 0
+
+        benchmark.add(KFold(n_splits=3))
+        assert len(benchmark.tasks.entities) == 1


### PR DESCRIPTION
`benchmark.add()`'s behaviour is currently inconsistent with `benchmark.add_task()`. `add_estimator()` and `add_task()` immediately registers the entities to their respective registry, but the general `add()` method only register the tasks when the benchmark is run. This is problematic for cases when there is a need to inspect tasks for any development purpose, as it ties the task registry to benchmark execution. 

This PR fixes the inconsistent behaviour, refactors some part of the method for readability, and adds a few tests to test the change.