### PR TITLE
[MNT] Enable `HF_TOKEN` in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
 jobs:
   code-quality:
     name: code-quality
@@ -293,6 +296,7 @@ jobs:
     uses: ./.github/workflows/test_est.yml
     with:
       flags: ${{ toJson(matrix.chunk) }}
+    secrets: inherit
 
   test-est-r:
     needs: [detect-changed-classes, prepare-chunks, test-nosoftdeps]
@@ -306,6 +310,7 @@ jobs:
     uses: ./.github/workflows/test_est_r.yml
     with:
       flags: ${{ toJson(matrix.chunk) }}
+    secrets: inherit
 
   detect-package-change:
     needs: code-quality

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_READ_TOKEN }}
 
 jobs:
   code-quality:

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_READ_TOKEN }}
 
 jobs:
   code_quality:

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -4,6 +4,9 @@ on:
     - cron: 0 0 * * 0
   workflow_dispatch:
 
+env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
 jobs:
   code_quality:
     if: ${{ github.repository == 'sktime/sktime' }}

--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -5,6 +5,9 @@ on:
         required: true
         type: string
 
+env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
 jobs:
   test-est:
     strategy:

--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -6,7 +6,7 @@ on:
         type: string
 
 env:
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_READ_TOKEN }}
 
 jobs:
   test-est:

--- a/.github/workflows/test_est_r.yml
+++ b/.github/workflows/test_est_r.yml
@@ -6,7 +6,7 @@ on:
         type: string
 
 env:
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_READ_TOKEN }}
 
 jobs:
   test-est-r:

--- a/.github/workflows/test_est_r.yml
+++ b/.github/workflows/test_est_r.yml
@@ -5,6 +5,9 @@ on:
         required: true
         type: string
 
+env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
 jobs:
   test-est-r:
     strategy:

--- a/.github/workflows/test_module.yml
+++ b/.github/workflows/test_module.yml
@@ -1,6 +1,10 @@
 name: test module
 on:
   workflow_call:
+
+env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
 jobs:
   detect:
     name: detect

--- a/.github/workflows/test_module.yml
+++ b/.github/workflows/test_module.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 
 env:
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_READ_TOKEN }}
 
 jobs:
   detect:

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -16,6 +16,7 @@ __author__ = ["Harryx2019", "figolyd", "geetu040"]
 
 __all__ = ["FalconTSTForecaster"]
 
+import os
 from copy import deepcopy
 from warnings import warn
 
@@ -199,6 +200,15 @@ class FalconTSTForecaster(BaseForecaster):
         -------
         self : reference to self
         """
+        hf_token = os.environ.get("HF_TOKEN", "")
+        hf_token_status = (
+            "healthy (set and non-empty)" if hf_token.strip() else "missing or empty"
+        )
+        raise RuntimeError(
+            "Temporary CI validation: FalconTSTForecaster._fit sees "
+            f"HF_TOKEN status: {hf_token_status}."
+        )
+
         self.model_ = self._load_model()
         self.context_ = y
 

--- a/sktime/forecasting/falcon_tst.py
+++ b/sktime/forecasting/falcon_tst.py
@@ -16,7 +16,6 @@ __author__ = ["Harryx2019", "figolyd", "geetu040"]
 
 __all__ = ["FalconTSTForecaster"]
 
-import os
 from copy import deepcopy
 from warnings import warn
 
@@ -200,15 +199,6 @@ class FalconTSTForecaster(BaseForecaster):
         -------
         self : reference to self
         """
-        hf_token = os.environ.get("HF_TOKEN", "")
-        hf_token_status = (
-            "healthy (set and non-empty)" if hf_token.strip() else "missing or empty"
-        )
-        raise RuntimeError(
-            "Temporary CI validation: FalconTSTForecaster._fit sees "
-            f"HF_TOKEN status: {hf_token_status}."
-        )
-
         self.model_ = self._load_model()
         self.context_ = y
 


### PR DESCRIPTION
Closes #10336

This PR enables Hugging Face read-token access in CI by exposing the existing org-level secret `HF_READ_TOKEN` as `HF_TOKEN` in the relevant workflows.

The secret was added by @fkiraly as an org-wide secret restricted to the `sktime` repository, with read-only access to the Hugging Face API.

The token is only available to workflows running on `main` and to pull requests whose source branch is in the `sktime/sktime` repository. It is not exposed to pull requests from forks.

Using an authenticated Hugging Face token should reduce download failures by improving request handling, avoiding unauthenticated rate limits, and reducing the likelihood of blocked or deprioritized requests.

This does not fully resolve #10336: timeouts can still occur, especially for workflows where the token is unavailable. However, it should substantially reduce those failures for trusted CI runs.

This is also a necessary step toward future weekly CI runs for independent Hugging Face based estimators, as discussed in #10263.