### PR TITLE
[DOC] update soft dependency management guide for developers to 1.0 patterns

### DIFF
--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -44,14 +44,15 @@ Estimators with a soft dependency need to ensure the following:
 
 *  imports of the soft dependency only happen inside the estimator,
    e.g., in ``_fit`` or ``__init__`` methods of the estimator.
-   In constructions, imports should happen only in ``__post_init__``, never in ``__init__``.
+   During constructor calls, imports should happen only in ``__post_init__``, never in ``__init__``.
 *  the packaging tags of the estimator are populated, i.e., ``python_dependencies``
    with PEP 440 compliant dependency specifier strings such as ``pandas>=2.0.1``, and optionally
    ``python_version`` and ``env_marker`` if specific markers are needed.
    Exceptions will automatically be raised when constructing the estimator
    in an environment where the requirements are not met.
    For further details, see the tag API reference, :ref:`packaging_tags`.
-*  the tag ``tests:vm`` is set to ``True``, to ensure that the estimator is tested in a virtual machine with all dependencies installed.
+*  the tag ``tests:vm`` of the estimator is set to ``True``. This automatically ensures
+   that the estimator is tested in a virtual machine with all dependencies installed.
    If the tag is not set, the estimator will automatically fail compliance.
 *  Decorate all ``pytest`` tests that import soft dependencies with a ``@pytest.mark.skipif(...)`` conditional on a soft dependency check.
    If the test is specific to a single estimator or object, use ``run_test_for_class`` from ``sktime.tests.test_switch``
@@ -72,7 +73,11 @@ as the base framework will automatically raise default exceptions, based on popu
 when the estimator is used in an environment where the requirements are not met.
 Adding additional warnings or error messages is not necessary, and will usually cause test failures.
 
-In case a step-out is needed, the ``_check_soft_dependencies`` utility
+To manage soft dependencies that are contingent on specific parameter settings of the estimator,
+use the ``__dynamic_tags__`` dunder of the estimator, as outlined in the extension templates.
+
+In case a step-out is needed from the above rules, it should be clearly justified
+in the pull request description. In such a case, the ``_check_soft_dependencies`` utility
 `here <https://github.com/sktime/sktime/blob/main/sktime/utils/dependencies/_dependencies.py>`__ can be used.
 
 Isolating soft dependencies at module level

--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -44,13 +44,15 @@ Estimators with a soft dependency need to ensure the following:
 
 *  imports of the soft dependency only happen inside the estimator,
    e.g., in ``_fit`` or ``__init__`` methods of the estimator.
-   In ``__init__``, imports should happen only after calls to ``super(cls).__init__``.
+   In constructions, imports should happen only in ``__post_init__``, never in ``__init__``.
 *  the packaging tags of the estimator are populated, i.e., ``python_dependencies``
    with PEP 440 compliant dependency specifier strings such as ``pandas>=2.0.1``, and optionally
    ``python_version`` and ``env_marker`` if specific markers are needed.
    Exceptions will automatically be raised when constructing the estimator
    in an environment where the requirements are not met.
    For further details, see the tag API reference, :ref:`packaging_tags`.
+*  the tag ``tests:vm`` is set to ``True``, to ensure that the estimator is tested in a virtual machine with all dependencies installed.
+   If the tag is not set, the estimator will automatically fail compliance.
 *  Decorate all ``pytest`` tests that import soft dependencies with a ``@pytest.mark.skipif(...)`` conditional on a soft dependency check.
    If the test is specific to a single estimator or object, use ``run_test_for_class`` from ``sktime.tests.test_switch``
    to mediate the condition through the class tags.
@@ -65,9 +67,10 @@ Estimators with a soft dependency need to ensure the following:
    ``run_test_for_class`` usage to decorate a test. See ``utils.tests.test_plotting``
    for an example of ``_check_soft_dependencies`` usage.
 
-Informative warnings or error messages for missing soft dependencies should be raised, in a situation where a user would need them.
-Usually, such warnings are automatically raised in ``__init__`` of the respective estimator by the base framework, via ``BaseObject``,
-and do not need to be added manually.
+For estimators, no additional warnings or error messages should be raised for missing soft dependencies,
+as the base framework will automatically raise default exceptions, based on populated tags (see above),
+when the estimator is used in an environment where the requirements are not met.
+Adding additional warnings or error messages is not necessary, and will usually cause test failures.
 
 In case a step-out is needed, the ``_check_soft_dependencies`` utility
 `here <https://github.com/sktime/sktime/blob/main/sktime/utils/dependencies/_dependencies.py>`__ can be used.


### PR DESCRIPTION
This PR updates de soft dependency management guide for developers to 1.0 patterns.

Overall, less boilerplate is required, e.g., tags replace manual placement of soft dependency checks, import logic in constructor is moved to `__post_init__`, etc.