### PR TITLE
Disable FlowState predict_proba Normal fallback

### DIFF
--- a/sktime/forecasting/flowstate.py
+++ b/sktime/forecasting/flowstate.py
@@ -223,6 +223,36 @@ class FlowStateForecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
         pred_q.index.names = self._context.index.names
         return pred_q
 
+    def _predict_var(self, fh, X=None, cov=False):
+        """Compute marginal variance from the FlowState inter-quartile range."""
+        from scipy.stats import norm
+
+        if cov:
+            raise NotImplementedError(
+                "FlowStateForecaster does not support covariance forecasts."
+            )
+
+        pred_int = self._predict_interval(fh=fh, X=X, coverage=[0.5])
+        var_name = pred_int.columns.get_level_values(0)[0]
+        iqr = pred_int[(var_name, 0.5, "upper")] - pred_int[(var_name, 0.5, "lower")]
+        var = (iqr / (2 * norm.ppf(0.75))) ** 2
+
+        return pd.DataFrame({var_name: var}, index=pred_int.index)
+
+    def _predict_proba(self, fh, X=None, marginal=True):
+        """Return FlowState predictive distribution.
+
+        FlowState provides fixed quantile knots, but sktime currently has no
+        matching linear-interpolation distribution object until skpro provides
+        HistogramQPD. Avoid the base class Normal fallback because it disagrees
+        with FlowState quantile predictions.
+        """
+        raise NotImplementedError(
+            "FlowStateForecaster.predict_proba requires a linear-interpolation "
+            "quantile-knot distribution such as skpro HistogramQPD. Until that "
+            "is available, use predict_quantiles or predict_interval instead."
+        )
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.

--- a/sktime/forecasting/tests/test_flowstate.py
+++ b/sktime/forecasting/tests/test_flowstate.py
@@ -1,0 +1,48 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for FlowStateForecaster."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sktime.forecasting.flowstate import FlowStateForecaster
+
+
+class _FlowStateWithoutModel(FlowStateForecaster):
+    """FlowState test double that avoids loading the external model."""
+
+    _tags = {**FlowStateForecaster._tags, "python_dependencies": []}
+
+    def _fit(self, y, X=None, fh=None):
+        self._context = y
+        return self
+
+    def _predict(self, fh, X=None):
+        index = fh.to_absolute(self.cutoff)._values
+        return pd.DataFrame(0.0, index=index, columns=self._context.columns)
+
+    def _predict_quantiles(self, fh, X, alpha):
+        index = fh.to_absolute(self.cutoff)._values
+        cols = pd.MultiIndex.from_product([self._context.columns, alpha])
+        return pd.DataFrame(np.tile(alpha, (len(index), 1)), index=index, columns=cols)
+
+
+def test_flowstate_predict_proba_does_not_use_normal_fallback():
+    """FlowState predict_proba should not expose the base Normal fallback."""
+    y = pd.DataFrame({"y": np.arange(10.0)})
+    forecaster = _FlowStateWithoutModel().fit(y, fh=[1, 2])
+
+    with pytest.raises(NotImplementedError, match="HistogramQPD"):
+        forecaster.predict_proba()
+
+
+def test_flowstate_predict_var_still_uses_quantiles():
+    """FlowState variance should remain available from quantile forecasts."""
+    y = pd.DataFrame({"y": np.arange(10.0)})
+    forecaster = _FlowStateWithoutModel().fit(y, fh=[1, 2])
+
+    pred_var = forecaster.predict_var()
+
+    assert list(pred_var.columns) == ["y"]
+    assert pred_var.index.equals(pd.Index([10, 11]))
+    assert (pred_var["y"] > 0).all()


### PR DESCRIPTION
# Disable FlowState predict_proba Normal fallback

## Summary

- Add an explicit `FlowStateForecaster._predict_proba` that raises `NotImplementedError` instead of using the base Normal fallback.
- Preserve `predict_var` by computing marginal variance from FlowState quantile intervals.
- Add model-free tests covering the disabled `predict_proba` path and the retained quantile-based variance path.

## Test evidence

- `python -m pytest -o addopts='' sktime/forecasting/tests/test_flowstate.py -q` passed: `2 passed in 0.22s`.
- `python -m py_compile sktime/forecasting/flowstate.py sktime/forecasting/tests/test_flowstate.py` passed.
- `git diff --check` passed.

## Risks or notes for maintainers

- This intentionally makes `FlowStateForecaster.predict_proba` unavailable until skpro provides a linear-interpolation quantile-knot distribution such as `HistogramQPD`.
- `predict_quantiles`, `predict_interval`, and marginal `predict_var` remain available.
- The implementation should be revisited once sktime/skpro#1076 is resolved.

Fixes #10474
