### PR TITLE
[ENH] Implement efficient MdRAE by-index evaluation

### DIFF
--- a/sktime/performance_metrics/forecasting/_medrelae.py
+++ b/sktime/performance_metrics/forecasting/_medrelae.py
@@ -7,6 +7,8 @@ Classes named as ``*Error`` or ``*Loss`` return a value to minimize:
 the lower the better.
 """
 
+import numpy as np
+
 from sktime.performance_metrics.forecasting._base import BaseForecastingErrorMetricFunc
 from sktime.performance_metrics.forecasting._functions import (
     median_relative_absolute_error,
@@ -95,3 +97,22 @@ class MedianRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
     }
 
     func = median_relative_absolute_error
+
+    def _evaluate_by_index(self, y_true, y_pred, **kwargs):
+        """Return the metric evaluated at each time point."""
+        multioutput = self.multioutput
+        y_pred_benchmark = kwargs["y_pred_benchmark"]
+
+        eps = np.finfo(np.float64).eps
+        denominator = (y_true - y_pred_benchmark).abs().clip(lower=eps)
+        raw_values = (y_true - y_pred).abs() / denominator
+        raw_values = self._get_weighted_df(raw_values, **kwargs)
+
+        if isinstance(multioutput, str):
+            if multioutput == "raw_values":
+                return raw_values
+
+            if multioutput == "uniform_average":
+                return raw_values.median(axis=1)
+
+        return raw_values.dot(multioutput)

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -139,6 +139,41 @@ def test_linex_function():
     not run_test_module_changed(["sktime.performance_metrics"]),
     reason="Run if performance_metrics module has changed.",
 )
+def test_median_relative_absolute_error_by_index():
+    """Test per-index values for MedianRelativeAbsoluteError."""
+    from sktime.performance_metrics.forecasting import MedianRelativeAbsoluteError
+
+    y_true = pd.DataFrame({"a": [3.0, -0.5, 2.0], "b": [1.0, 1.0, 7.0]})
+    y_pred = pd.DataFrame({"a": [2.5, 0.0, 2.5], "b": [2.0, 2.0, 8.0]})
+    y_pred_benchmark = pd.DataFrame(
+        {"a": [2.0, -0.25, 3.0], "b": [0.5, 2.5, 6.5]}
+    )
+
+    expected = (y_true - y_pred).abs() / (y_true - y_pred_benchmark).abs()
+
+    metric = MedianRelativeAbsoluteError(multioutput="raw_values")
+    result = metric.evaluate_by_index(
+        y_true, y_pred, y_pred_benchmark=y_pred_benchmark
+    )
+    pd.testing.assert_frame_equal(result, expected)
+
+    metric = MedianRelativeAbsoluteError()
+    result = metric.evaluate_by_index(
+        y_true, y_pred, y_pred_benchmark=y_pred_benchmark
+    )
+    pd.testing.assert_series_equal(result, expected.median(axis=1))
+
+    metric = MedianRelativeAbsoluteError(multioutput=[0.3, 0.7])
+    result = metric.evaluate_by_index(
+        y_true, y_pred, y_pred_benchmark=y_pred_benchmark
+    )
+    pd.testing.assert_series_equal(result, expected.dot([0.3, 0.7]))
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.performance_metrics"]),
+    reason="Run if performance_metrics module has changed.",
+)
 def test_make_scorer():
     """Test make_forecasting_scorer and the failure case in #4827."""
     import functools


### PR DESCRIPTION
#### Reference Issues/PRs

Refs #4304

#### What does this implement/fix? Explain your changes.

Adds a direct `_evaluate_by_index` implementation for `MedianRelativeAbsoluteError`.

The new path computes the absolute relative error at each time index and then applies the existing multioutput aggregation behavior, avoiding the generic jackknife fallback for this median-based metric.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Whether the by-index aggregation for `uniform_average`, `raw_values`, and weighted multioutput matches the intended MdRAE behavior.

#### Did you add any tests for the change?

Yes. Added a focused test for raw, default, and weighted `evaluate_by_index` output.

#### Any other comments?

Validation:
- `git diff --check`
- `PYTHONPATH=. python -m pytest -o addopts="" sktime/performance_metrics/forecasting/tests/test_metrics.py -k median_relative_absolute_error_by_index`
