### PR TITLE
[BUG] fix: convert start-aligned frequency offsets to period alias in _coerce_to_period

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -1038,6 +1038,17 @@ def _coerce_to_period(x, freq=None):
         raise ValueError(
             "_coerce_to_period requires freq argument to be passed if x is pd.Timestamp"
         )
+    # Some offset aliases (e.g. "MS", "QS", "YS") are not valid period frequencies;
+    # convert to their period equivalents before calling to_period
+    if hasattr(freq, "name"):
+        try:
+            from pandas.tseries.frequencies import get_period_alias
+
+            period_alias = get_period_alias(freq.name)
+            if period_alias:
+                freq = period_alias
+        except Exception:
+            pass
     return x.to_period(freq)
 
 


### PR DESCRIPTION
## Summary

Closes #10480.

`ExponentialSmoothing.predict()` (and any other forecaster using `to_absolute_int`) raises `ValueError: <MonthBegin> is not supported as period frequency` when the training data uses a start-aligned `DatetimeIndex` frequency such as `freq="MS"` (MonthBegin), `freq="QS"` (QuarterBegin), or `freq="YS"` (YearBegin).

## Root Cause

`_coerce_to_period` in `sktime/forecasting/base/_fh.py` calls `x.to_period(freq)` where `freq` is a pandas `DateOffset` object (e.g. `MonthBegin()`). Pandas' `to_period()` requires a period frequency string (`"M"`), not a start-aligned offset — the two representations are different objects even though they represent the same calendar unit.

## Fix

Before calling `to_period`, use `pandas.tseries.frequencies.get_period_alias()` to map the offset's string name to its period equivalent:

| DatetimeIndex freq | Offset name | Period alias |
|----|----|----|
| `"MS"` | `"MS"` | `"M"` |
| `"QS"` | `"QS"` | `"Q"` |
| `"YS"` | `"YS"` | `"Y"` |

The conversion is wrapped in a `try/except` so unknown or custom offsets fall through to the original `to_period` call unchanged.

## Tests

- All 385 tests in `sktime/forecasting/base/tests/` pass.
- End-to-end verification:
```python
import pandas as pd
from sktime.forecasting.exp_smoothing import ExponentialSmoothing

data = pd.Series(
    [112, 118, 132, 129, 121, 135, 148, 148, 136, 119, 104, 118,
     115, 126, 141, 135, 125, 149, 170, 170, 158, 133, 114, 140],
    index=pd.date_range("1949-01", periods=24, freq="MS"),
)
ExponentialSmoothing(trend="add", seasonal="add", sp=12).fit(data).predict(fh=[1, 2, 3])
# Before: ValueError: <MonthBegin> is not supported as period frequency
# After:  works correctly
```