### PR TITLE
[ENH] Add second test parameter set for `PCATransformer`

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -186,7 +186,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "OptionalPassthrough",
         "PAA",
         "PAAlegacy",
-        "PCATransformer",
         "PaddingTransformer",
         "PlateauFinder",
         "Prophetverse",

--- a/sktime/transformations/pca.py
+++ b/sktime/transformations/pca.py
@@ -121,6 +121,18 @@ class PCATransformer(BaseTransformer):
 
         super().__init__()
 
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        # param sets to test with
+        return [
+            {},
+            {
+                "n_components": 1,
+                "whiten": True,
+                "svd_solver": "full",
+            },
+        ]
+
     def _fit(self, X, y=None):
         """Fit transformer to X and y.
 

--- a/sktime/transformations/pca.py
+++ b/sktime/transformations/pca.py
@@ -121,18 +121,6 @@ class PCATransformer(BaseTransformer):
 
         super().__init__()
 
-    @classmethod
-    def get_test_params(cls, parameter_set="default"):
-        # param sets to test with
-        return [
-            {},
-            {
-                "n_components": 1,
-                "whiten": True,
-                "svd_solver": "full",
-            },
-        ]
-
     def _fit(self, X, y=None):
         """Fit transformer to X and y.
 
@@ -183,3 +171,29 @@ class PCATransformer(BaseTransformer):
         Xt = Xt.reshape(N, num_var, num_time)
 
         return Xt
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"``
+            set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class.
+            Each dict constructs a valid test instance.
+        """
+        return [
+            {},
+            {
+                "n_components": 1,
+                "whiten": True,
+                "svd_solver": "full",
+            },
+        ]


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #3429

#### What does this implement/fix? Explain your changes.

This PR adds a second test parameter set for `PCATransformer`.

Changes made:
- Added `get_test_params()` with two parameter configurations.
- Added a second parameter set using `n_components=1`, `whiten=True`, and `svd_solver="full"`.
- Removed `PCATransformer` from the `test_get_test_params_coverage` exclusion list.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

The choice of the second test parameter set.

#### Did you add any tests for the change?

No additional tests were added. This PR extends existing estimator test parameter coverage.
