### PR TITLE
[BUG] fix SCINetForecaster pretrain test failures via smaller test params

### DIFF
--- a/sktime/forecasting/scinet.py
+++ b/sktime/forecasting/scinet.py
@@ -260,22 +260,27 @@ class SCINetForecaster(BaseDeepNetworkPyTorch):
         -------
         params : dict or list of dict
         """
+        # seq_len + pred_len must not exceed the shortest series used by the
+        # generic forecaster/pretrain test suite (10 timepoints), otherwise
+        # the training dataloader ends up with zero samples, see #10493, #10279
         params = [
             {
-                "seq_len": 8,
-                "pred_len": 3,
+                "seq_len": 4,
+                "pred_len": 2,
+                "num_levels": 1,
                 "lr": 0.005,
                 "optimizer": "Adam",
                 "batch_size": 1,
                 "num_epochs": 1,
             },
             {
-                "seq_len": 16,
-                "pred_len": 4,
+                "seq_len": 4,
+                "pred_len": 3,
+                "num_levels": 1,
                 "lr": 0.001,
                 "optimizer": "Adam",
-                "batch_size": 4,
-                "num_epochs": 2,
+                "batch_size": 1,
+                "num_epochs": 1,
             },
         ]
 


### PR DESCRIPTION
## Reference Issues/PRs
Fixes #10493
Fixes #10279

## What does this implement/fix?
`get_test_params()` used `seq_len=8/16` with `num_levels=3`, exceeding the timepoint count of the fixed-size fixtures in the pretrain/forecaster test suite (10-15 timepoints). `PyTorchTrainDataset` ended up with zero samples, so `DataLoader` raised `num_samples=0`.

Shrunk params to `seq_len=4, num_levels=1, pred_len=2/3` stays within the smallest fixture (10) and respects `seq_len % 2**num_levels == 0`. Also speeds up the tests, per the issue's second complaint.

Verified: `check_estimator(SCINetForecaster)`, 668/668 pass, 0 failures.

#10289 is a separate open PR adding input validation for the same root cause, but doesn't touch `get_test_params()`, complementary, no conflict.

## Does your contribution introduce a new dependency?
No.

## Did you add any tests for the change?
No, existing `test_pretrain_*` / `test_predict_series_name_preserved` now pass and serve as regression coverage.