### PR TITLE
[ENH] Add estimator checks for deepcopy support

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2880,6 +2880,16 @@
         "code",
         "bug"
       ]
+    },
+    {
+      "login": "areychana",
+      "name": "Archana K.",
+      "avatar_url": "https://avatars.githubusercontent.com/u/93970069?v=4",
+      "profile": "https://github.com/areychana",
+      "contributions": [
+        "code",
+        "maintenance"
+      ]
     }
   ]
 }

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -1149,6 +1149,12 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         if hasattr(est_clone, "is_fitted"):
             assert not est_clone.is_fitted
 
+    def test_deepcopy(self, estimator_instance):
+        """Check that an unfitted estimator instance can be deepcopied."""
+        est_copy = deepcopy(estimator_instance)
+        assert isinstance(est_copy, type(estimator_instance))
+        assert est_copy is not estimator_instance
+
     def test_repr(self, estimator_instance):
         """Check that __repr__ call to instance does not raise exceptions."""
         estimator = estimator_instance
@@ -1690,6 +1696,36 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
                 decimal=6,
                 err_msg=msg,
             )
+
+    def test_deepcopy_fitted(self, estimator_instance, scenario):
+        """Check that a fitted estimator instance can be deepcopied."""
+        estimator = estimator_instance
+        set_random_state(estimator)
+        scenario.run(estimator, method_sequence=["fit"])
+
+        est_copy = deepcopy(estimator)
+        assert isinstance(est_copy, type(estimator))
+        assert est_copy is not estimator
+
+    def test_deepcopy_fitted_predict(
+        self, estimator_instance, scenario, method_nsc_arraylike
+    ):
+        """Check that a fitted estimator can still predict after deepcopy."""
+        estimator = estimator_instance
+        set_random_state(estimator)
+        scenario.run(estimator, method_sequence=["fit"])
+
+        est_copy = deepcopy(estimator)
+
+        # skip test if vectorization would be necessary and method predict_proba
+        # this is since vectorization is not implemented for predict_proba
+        if method_nsc_arraylike in ["predict_proba", "predict_var"]:
+            with ValidProbaErrors() as handler:
+                scenario.run(est_copy, method_sequence=[method_nsc_arraylike])
+            if handler.skipped:
+                return None
+        else:
+            scenario.run(est_copy, method_sequence=[method_nsc_arraylike])
 
     def test_multiprocessing_idempotent(
         self, estimator_instance, scenario, method_nsc_arraylike


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10491

#### What does this implement/fix? Explain your changes.

Adds dedicated estimator checks for deepcopy support, so failures caused by
non-deepcopyable fitted attributes are caught directly instead of surfacing
indirectly through unrelated tests like `test_update_predict_predicted_index`
(which exercises `deepcopy` transitively via `BaseForecaster.update_predict(...,
reset_forecaster=True)`).

Three new checks in `sktime/tests/test_all_estimators.py`:

- `test_deepcopy` (`TestAllObjects`): an unfitted estimator instance can be deepcopied.
- `test_deepcopy_fitted` (`TestAllEstimators`): a fitted estimator instance can be deepcopied.
- `test_deepcopy_fitted_predict` (`TestAllEstimators`): the deepcopied fitted estimator
can still run its relevant predict-like method. Reuses the existing
`method_nsc_arraylike` fixture (already scitype/capability-aware via
`NON_STATE_CHANGING_METHODS_ARRAYLIKE` and `_has_capability`), so no new
scitype-branching logic was needed.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether `test_deepcopy_fitted_predict` should assert output equality between
  the original and the deepcopy (like `test_persistence_via_pickle` does), or
  whether "runs without raising" is the right bar for this check.
- Placement: unfitted check on `TestAllObjects`, fitted checks on `TestAllEstimators`.

#### Did you add any tests for the change?

Yes. this PR is entirely new tests (the checks described above). No
`EXCLUDED_TESTS` entries were needed based on local verification.

#### Any other comments?

Verified locally: 1754 passed, 0 failed across all estimators installable in
a core-only environment (no torch/tensorflow/statsmodels etc.). Soft-dependency-gated
estimators weren't exercised locally due to missing optional deps, but should be
covered by CI's full dependency matrix.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].