### PR TITLE
[DOC] Fix docstrings and typos in benchmarking module

### DIFF
--- a/sktime/benchmarking/_benchmarking_dataclasses.py
+++ b/sktime/benchmarking/_benchmarking_dataclasses.py
@@ -13,14 +13,14 @@ from sktime.split.singlewindow import SingleWindowSplitter
 
 
 def _coerce_data_for_evaluate(dataset_loader, task_type=None):
-    """Coerce data input object to a dict to pass to forecasting evaluate.
+    """Coerce data input object to a dict to pass to evaluate.
 
     Parameters
     ----------
     dataset_loader : Callable or tuple
 
         - a function which returns a dataset, like from `sktime.datasets`.
-        - a tuple containing two data container that are sktime comptaible.
+        - a tuple containing two data containers that are sktime compatible.
         - single data container that is sktime compatible (only first argument).
 
     task_type : str, optional (default=None)
@@ -81,7 +81,7 @@ class TaskObject:
         Can be
 
         - a function which returns a dataset, like from `sktime.datasets`.
-        - a tuple containing two data container that are sktime comptaible.
+        - a tuple containing two data containers that are sktime compatible.
         - single data container that is sktime compatible (only endogenous data).
 
     cv_splitter: BaseSplitter object

--- a/sktime/benchmarking/_utils.py
+++ b/sktime/benchmarking/_utils.py
@@ -7,7 +7,7 @@ def _check_id_format(id_format: str, id: str) -> None:
     """Check if given input ID follows regex specified in id_format."""
     if id_format is not None:
         if not isinstance(id_format, str):
-            raise TypeError(f"id_format must be str but receive {type(id_format)}")
+            raise TypeError(f"id_format must be str but received {type(id_format)}")
         entity_id_re = re.compile(id_format)
         match = entity_id_re.search(id)
         if not match:

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -243,22 +243,12 @@ class _SktimeRegistry:
 
         Parameters
         ----------
-        entity_id: str
-            A unique entity ID.
-        entry_point: Callable or str
-            The python entrypoint of the entity class. Should be one of:
-
-            - the string path to the python object (e.g.module.name:factory_func, or
-                module.name:Class)
-            - the python object (class or factory) itself
-
-        deprecated: Bool, optional (default=False)
-            Flag to denote whether this entity should be skipped in validation runs
-            and considered deprecated and replaced by a more recent/better model
-        nondeterministic: Bool, optional (default=False)
-            Whether this entity is non-deterministic even after seeding
-        kwargs: Dict, optional (default=None)
-            kwargs to pass to the entity entry point when instantiating the entity.
+        entity_id : str
+            A unique entity ID. If an entity with the same ID is already
+            registered, a unique suffix (e.g., ``"_2"``) is appended and
+            a ``UserWarning`` is issued.
+        entity : BaseEstimator or TaskObject
+            The entity to register.
         """
         entity_id_unique = _make_strings_unique(list(self.entities.keys()), entity_id)
         _check_id_format(self.entity_id_format, entity_id_unique)
@@ -386,12 +376,8 @@ class BaseBenchmark:
 
         Parameters
         ----------
-        estimator : Dict, List or BaseEstimator object
-            Estimator to add to the benchmark.
-            If Dict, keys are estimator_ids used to customise identifier ID
-            and values are estimators.
-            If List, each element is an estimator. estimator_ids are generated
-            automatically using the estimator's class name.
+        estimator : BaseEstimator
+            A single initialised estimator to add to the benchmark.
 
         estimator_id : str, optional (default=None)
             Identifier for estimator. If none given then uses estimator's class name.

--- a/sktime/benchmarking/classification.py
+++ b/sktime/benchmarking/classification.py
@@ -89,10 +89,10 @@ class ClassificationBenchmark(BaseBenchmark):
 
         Parameters
         ----------
-        data : Union[Callable, tuple]
+        dataset_loader : Union[Callable, tuple]
             Can be
             - a function which returns a dataset, like from `sktime.datasets`.
-            - a tuple contianing two data container that are sktime comptaible.
+            - a tuple containing two data containers that are sktime compatible.
             - single data container that is sktime compatible (only endogenous data).
         cv_splitter : BaseSplitter object
             Splitter used for generating validation folds.

--- a/sktime/benchmarking/forecasting.py
+++ b/sktime/benchmarking/forecasting.py
@@ -91,11 +91,11 @@ class ForecastingBenchmark(BaseBenchmark):
 
         Parameters
         ----------
-        data : Union[Callable, tuple]
+        dataset_loader : Union[Callable, tuple]
             Can be
 
             - a function which returns a dataset, like from `sktime.datasets`.
-            - a tuple containing two data container that are sktime comptaible.
+            - a tuple containing two data containers that are sktime compatible.
             - single data container that is sktime compatible (only endogenous data).
 
         cv_splitter : BaseSplitter object


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10500.

#### What does this implement/fix? Explain your changes.
This PR systematically cleans up docstrings and fixes typos across the `sktime/benchmarking` module, as described in #10500. Specifically:
- Fixes typos ("comptaible", "contianing", "receive") in `classification.py`, `forecasting.py`, `_benchmarking_dataclasses.py`, and `_utils.py`.
- Corrects parameter mismatches where `add_task` incorrectly documented `data` instead of the actual `dataset_loader` parameter.
- Updates the outdated docstring for `_SktimeRegistry.register` in `benchmarks.py` by removing legacy parameters that no longer exist.
- Fixes the copy-pasted docstring for `_add_estimator` in `benchmarks.py` to accurately state that it accepts a single `BaseEstimator`.
- Generalizes the docstring for `_coerce_data_for_evaluate` in `_benchmarking_dataclasses.py` to accurately reflect its use across all task types, not just forecasting.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
A quick sanity check to ensure the updated docstrings accurately reflect the method signatures.

#### Did you add any tests for the change?
No tests were added as this is strictly a documentation/docstring cleanup. However, all existing benchmarking tests and lint checks pass locally.

#### Any other comments?
N/A

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
