### PR TITLE
[MNT] Add missing `__all__` and `__author__` to benchmarking module files

### DIFF
--- a/sktime/benchmarking/_benchmarking_dataclasses.py
+++ b/sktime/benchmarking/_benchmarking_dataclasses.py
@@ -1,5 +1,13 @@
 """Dataclasses for benchmarking."""
 
+__author__ = ["benHeid"]
+__all__ = [
+    "_coerce_data_for_evaluate",
+    "TaskObject",
+    "FoldResults",
+    "ResultObject",
+]
+
 import copy
 from collections.abc import Callable
 from dataclasses import dataclass, field, fields

--- a/sktime/benchmarking/_utils.py
+++ b/sktime/benchmarking/_utils.py
@@ -1,5 +1,8 @@
 """utility functions for benchmarking module."""
 
+__author__ = ["benHeid"]
+__all__ = ["_check_id_format"]
+
 import re
 
 

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -1,5 +1,8 @@
 """Benchmarking interface for use with sktime objects."""
 
+__author__ = ["alex-hh"]
+__all__ = ["BaseBenchmark"]
+
 import logging
 import warnings
 from dataclasses import dataclass, field

--- a/sktime/benchmarking/forecasting.py
+++ b/sktime/benchmarking/forecasting.py
@@ -1,5 +1,8 @@
 """Benchmarking for forecasting estimators."""
 
+__author__ = ["alex-hh"]
+__all__ = ["ForecastingBenchmark"]
+
 from collections.abc import Callable
 
 from sktime.benchmarking._benchmarking_dataclasses import (


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10503 

#### What does this implement/fix? Explain your changes.
This PR adds missing `__author__` and `__all__` tags to files in the `sktime/benchmarking` module to align with codebase conventions. 

Specifically, this adds tags to:
- `benchmarks.py` (author: alex-hh)
- `forecasting.py` (author: alex-hh)
- `_benchmarking_dataclasses.py` (author: benHeid)
- `_utils.py` (author: benHeid)

Authorship was determined by running `git blame` on each file and finding the initial creator of the code. The `__all__` tags define the expected public exports from each module (e.g. `BaseBenchmark`, `ForecastingBenchmark`, and the exported dataclasses).

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
Verify the authors and public exports are correct.

#### Did you add any tests for the change?
No. Existing lint (`ruff`) and tests in `sktime/benchmarking/tests/` passed locally.
