### PR TITLE
[DOC] add missing `TiRexForeaster` to API reference

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -744,6 +744,14 @@ Pre-trained and foundation models - domain agnostic
 
     TinyTimeMixerForecaster
 
+.. currentmodule:: sktime.forecasting.tirex
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    TirexForecaster
+
 .. currentmodule:: sktime.forecasting.toto
 
 .. autosummary::

--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -750,7 +750,7 @@ Pre-trained and foundation models - domain agnostic
     :toctree: auto_generated/
     :template: class.rst
 
-    TirexForecaster
+    TiRexForecaster
 
 .. currentmodule:: sktime.forecasting.toto
 


### PR DESCRIPTION
adds missing `TiRexForeaster` to API reference