### PR TITLE
[DOC] fix docstrings of `__post_init__`

### DIFF
--- a/extension_templates/metric_forecasting.py
+++ b/extension_templates/metric_forecasting.py
@@ -194,7 +194,6 @@ class MyForecastingMetric(BaseForecastingErrorMetric):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here

--- a/extension_templates/metric_forecasting_hierarchical.py
+++ b/extension_templates/metric_forecasting_hierarchical.py
@@ -213,7 +213,6 @@ class MyForecastingMetricHierarchical(BaseForecastingErrorMetric):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -219,7 +219,6 @@ class MyTransformer(BaseTransformer):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here

--- a/extension_templates/transformer_supersimple.py
+++ b/extension_templates/transformer_supersimple.py
@@ -129,7 +129,6 @@ class MyTransformer(BaseTransformer):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here

--- a/extension_templates/transformer_supersimple_features.py
+++ b/extension_templates/transformer_supersimple_features.py
@@ -129,7 +129,6 @@ class MyTransformer(BaseTransformer):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # todo: optional, parameter checking or coercion should happen here

--- a/sktime/alignment/base.py
+++ b/sktime/alignment/base.py
@@ -67,7 +67,6 @@ class BaseAligner(BaseEstimator):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         pass

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -117,7 +117,6 @@ class BaseClassifier(BasePanelMixin):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         pass

--- a/sktime/classification/deep_learning/_pytorch.py
+++ b/sktime/classification/deep_learning/_pytorch.py
@@ -61,7 +61,6 @@ class BaseDeepClassifierPytorch(BaseClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         import torch

--- a/sktime/classification/deep_learning/base/_base_torch.py
+++ b/sktime/classification/deep_learning/base/_base_torch.py
@@ -183,7 +183,6 @@ class BaseDeepClassifierPytorch(BaseClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # set random seed for torch

--- a/sktime/classification/deep_learning/cnn/_cnn_tf.py
+++ b/sktime/classification/deep_learning/cnn/_cnn_tf.py
@@ -147,7 +147,6 @@ class CNNClassifier(BaseDeepClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # TODO (release 0.42.0)

--- a/sktime/classification/deep_learning/cntc.py
+++ b/sktime/classification/deep_learning/cntc.py
@@ -159,7 +159,6 @@ class CNTCClassifier(BaseDeepClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self._network = CNTCNetwork(

--- a/sktime/classification/deep_learning/convtimenet.py
+++ b/sktime/classification/deep_learning/convtimenet.py
@@ -160,7 +160,6 @@ class ConvTimeNetClassifier(BaseDeepClassifierPytorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # Ensure dw_ks is a list

--- a/sktime/classification/deep_learning/fcn.py
+++ b/sktime/classification/deep_learning/fcn.py
@@ -119,7 +119,6 @@ class FCNClassifier(BaseDeepClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self._network = FCNNetwork(

--- a/sktime/classification/deep_learning/inceptiontime/_inceptiontime_tf.py
+++ b/sktime/classification/deep_learning/inceptiontime/_inceptiontime_tf.py
@@ -165,7 +165,6 @@ class InceptionTimeClassifier(BaseDeepClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         network_params = {

--- a/sktime/classification/deep_learning/inceptiontime/_inceptiontime_torch.py
+++ b/sktime/classification/deep_learning/inceptiontime/_inceptiontime_torch.py
@@ -261,7 +261,6 @@ class InceptionTimeClassifierTorch(BaseDeepClassifierPytorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # input_size and num_classes to be inferred from the data

--- a/sktime/classification/deep_learning/macnn/_macnn_tf.py
+++ b/sktime/classification/deep_learning/macnn/_macnn_tf.py
@@ -140,7 +140,6 @@ class MACNNClassifier(BaseDeepClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.history = None

--- a/sktime/classification/deep_learning/mcdcnn/_mcdcnn_tf.py
+++ b/sktime/classification/deep_learning/mcdcnn/_mcdcnn_tf.py
@@ -141,7 +141,6 @@ class MCDCNNClassifier(BaseDeepClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.history = None

--- a/sktime/classification/deep_learning/mvts_transformer.py
+++ b/sktime/classification/deep_learning/mvts_transformer.py
@@ -153,7 +153,6 @@ class MVTSTransformerClassifier(BaseDeepClassifierPytorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         import torch

--- a/sktime/classification/deep_learning/resnet.py
+++ b/sktime/classification/deep_learning/resnet.py
@@ -113,7 +113,6 @@ class ResNetClassifier(BaseDeepClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.history = None

--- a/sktime/classification/deep_learning/rnn/_rnn_tf.py
+++ b/sktime/classification/deep_learning/rnn/_rnn_tf.py
@@ -120,7 +120,6 @@ class SimpleRNNClassifier(BaseDeepClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.history = None

--- a/sktime/classification/deep_learning/rnn/_rnn_torch.py
+++ b/sktime/classification/deep_learning/rnn/_rnn_torch.py
@@ -208,7 +208,6 @@ class SimpleRNNClassifierTorch(BaseDeepClassifierPytorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # Note: we do not validate activation_hidden here.

--- a/sktime/classification/deep_learning/tapnet/_tapnet_tf.py
+++ b/sktime/classification/deep_learning/tapnet/_tapnet_tf.py
@@ -171,7 +171,6 @@ class TapNetClassifier(BaseDeepClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self._network = TapNetNetwork(

--- a/sktime/classification/deep_learning/tapnet/_tapnet_torch.py
+++ b/sktime/classification/deep_learning/tapnet/_tapnet_torch.py
@@ -239,7 +239,6 @@ class TapNetClassifierTorch(BaseDeepClassifierPytorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # input_size and num_classes inferred from the data and will be

--- a/sktime/classification/dictionary_based/_weasel.py
+++ b/sktime/classification/dictionary_based/_weasel.py
@@ -169,7 +169,6 @@ class WEASEL(BaseClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.norm_options = [False]

--- a/sktime/classification/feature_based/_signature_classifier.py
+++ b/sktime/classification/feature_based/_signature_classifier.py
@@ -148,7 +148,6 @@ class SignatureClassifier(BaseClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.signature_method = SignatureTransformer(

--- a/sktime/classification/shapelet_based/_mrseql.py
+++ b/sktime/classification/shapelet_based/_mrseql.py
@@ -80,7 +80,6 @@ class MrSEQL(_DelegatedClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self._symrep = self._coerce_to_list(self.symrep)

--- a/sktime/classification/shapelet_based/_mrsqm.py
+++ b/sktime/classification/shapelet_based/_mrsqm.py
@@ -91,7 +91,6 @@ class MrSQM(_DelegatedClassifier):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # construct the delegate - direct delegation to MrSQMClassifier

--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -64,7 +64,6 @@ class BaseClusterer(BaseEstimator):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         pass

--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -103,7 +103,6 @@ class BaseDetector(BaseEstimator):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         pass

--- a/sktime/forecasting/autots.py
+++ b/sktime/forecasting/autots.py
@@ -309,7 +309,6 @@ class AutoTS(BaseForecaster):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         from autots import AutoTS as _autots

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -174,7 +174,6 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         pass

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -374,7 +374,6 @@ class ChronosForecaster(BaseForecaster):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self._seed = np.random.randint(0, 2**31) if self.seed is None else self.seed

--- a/sktime/forecasting/chronos2.py
+++ b/sktime/forecasting/chronos2.py
@@ -130,7 +130,6 @@ class Chronos2Forecaster(BaseForecaster):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self._seed = np.random.randint(0, 2**31) if self.seed is None else self.seed

--- a/sktime/forecasting/fbprophet.py
+++ b/sktime/forecasting/fbprophet.py
@@ -204,7 +204,6 @@ class Prophet(_ProphetAdapter):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         from prophet.forecaster import Prophet as _Prophet

--- a/sktime/forecasting/lagllama.py
+++ b/sktime/forecasting/lagllama.py
@@ -296,7 +296,6 @@ class LagLlamaForecaster(BaseForecaster):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         import torch

--- a/sktime/forecasting/ltsf.py
+++ b/sktime/forecasting/ltsf.py
@@ -128,7 +128,6 @@ class LTSFLinearForecaster(BaseDeepNetworkPyTorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         import torch
@@ -479,7 +478,6 @@ class LTSFDLinearForecaster(BaseDeepNetworkPyTorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         import torch
@@ -673,7 +671,6 @@ class LTSFNLinearForecaster(BaseDeepNetworkPyTorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         import torch
@@ -1078,7 +1075,6 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         import torch

--- a/sktime/forecasting/model_selection/_base.py
+++ b/sktime/forecasting/model_selection/_base.py
@@ -65,7 +65,6 @@ class BaseGridSearch(_DelegatedForecaster):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self._set_delegated_tags(self.forecaster)

--- a/sktime/forecasting/prophetverse.py
+++ b/sktime/forecasting/prophetverse.py
@@ -152,7 +152,6 @@ class Prophetverse(_DelegatedForecaster):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # delegation, only for prophetverse 0.2.X
@@ -337,7 +336,6 @@ class HierarchicalProphet(_DelegatedForecaster):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # delegation, only for prophetverse 0.2.X

--- a/sktime/forecasting/rbf.py
+++ b/sktime/forecasting/rbf.py
@@ -160,7 +160,6 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self._fh_length = None

--- a/sktime/forecasting/timemoe.py
+++ b/sktime/forecasting/timemoe.py
@@ -173,7 +173,6 @@ class TimeMoEForecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self._seed = np.random.randint(0, 2**31) if self.seed is None else self.seed

--- a/sktime/forecasting/trend/_pwl_trend_forecaster.py
+++ b/sktime/forecasting/trend/_pwl_trend_forecaster.py
@@ -124,7 +124,6 @@ class ProphetPiecewiseLinearTrendForecaster(_ProphetAdapter):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.freq = None

--- a/sktime/networks/base.py
+++ b/sktime/networks/base.py
@@ -32,7 +32,6 @@ class BaseDeepNetwork(BaseObject):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         pass

--- a/sktime/networks/cnn/_cnn_tf.py
+++ b/sktime/networks/cnn/_cnn_tf.py
@@ -70,7 +70,6 @@ class CNNNetwork(BaseDeepNetwork):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         if self.filter_sizes is None:

--- a/sktime/networks/fcn.py
+++ b/sktime/networks/fcn.py
@@ -66,7 +66,6 @@ class FCNNetwork(BaseDeepNetwork):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # type check for filter_sizes

--- a/sktime/networks/mlp/_mlp_tf.py
+++ b/sktime/networks/mlp/_mlp_tf.py
@@ -73,7 +73,6 @@ class MLPNetwork(BaseDeepNetwork):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         dropout = self.dropout

--- a/sktime/param_est/base.py
+++ b/sktime/param_est/base.py
@@ -103,7 +103,6 @@ class BaseParamFitter(BaseEstimator):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         pass

--- a/sktime/performance_metrics/base/_base.py
+++ b/sktime/performance_metrics/base/_base.py
@@ -38,7 +38,6 @@ class BaseMetric(BaseObject):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         pass

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -108,7 +108,6 @@ class BaseRegressor(BasePanelMixin):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         pass

--- a/sktime/regression/deep_learning/base/_base_torch.py
+++ b/sktime/regression/deep_learning/base/_base_torch.py
@@ -162,7 +162,6 @@ class BaseDeepRegressorTorch(BaseRegressor):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # set random seed for torch

--- a/sktime/regression/deep_learning/cnn/_cnn_tf.py
+++ b/sktime/regression/deep_learning/cnn/_cnn_tf.py
@@ -141,7 +141,6 @@ class CNNRegressor(BaseDeepRegressor):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.history = None

--- a/sktime/regression/deep_learning/cntc.py
+++ b/sktime/regression/deep_learning/cntc.py
@@ -139,7 +139,6 @@ class CNTCRegressor(BaseDeepRegressor):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self._network = CNTCNetwork(

--- a/sktime/regression/deep_learning/fcn.py
+++ b/sktime/regression/deep_learning/fcn.py
@@ -105,7 +105,6 @@ class FCNRegressor(BaseDeepRegressor):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self._network = FCNNetwork(

--- a/sktime/regression/deep_learning/inceptiontime/_inceptiontime_tf.py
+++ b/sktime/regression/deep_learning/inceptiontime/_inceptiontime_tf.py
@@ -110,7 +110,6 @@ class InceptionTimeRegressor(BaseDeepRegressor):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         network_params = {

--- a/sktime/regression/deep_learning/inceptiontime/_inceptiontime_torch.py
+++ b/sktime/regression/deep_learning/inceptiontime/_inceptiontime_torch.py
@@ -231,7 +231,6 @@ class InceptionTimeRegressorTorch(BaseDeepRegressorTorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # input_size to be inferred from the data

--- a/sktime/regression/deep_learning/macnn/_macnn_tf.py
+++ b/sktime/regression/deep_learning/macnn/_macnn_tf.py
@@ -130,7 +130,6 @@ class MACNNRegressor(BaseDeepRegressor):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.history = None

--- a/sktime/regression/deep_learning/mcdcnn/_mcdcnn_tf.py
+++ b/sktime/regression/deep_learning/mcdcnn/_mcdcnn_tf.py
@@ -133,7 +133,6 @@ class MCDCNNRegressor(BaseDeepRegressor):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.history = None

--- a/sktime/regression/deep_learning/mcdcnn/_mcdcnn_torch.py
+++ b/sktime/regression/deep_learning/mcdcnn/_mcdcnn_torch.py
@@ -205,7 +205,6 @@ class MCDCNNRegressorTorch(BaseDeepRegressorTorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         if len(self.filter_sizes) != len(self.kernel_sizes):

--- a/sktime/regression/deep_learning/resnet.py
+++ b/sktime/regression/deep_learning/resnet.py
@@ -104,7 +104,6 @@ class ResNetRegressor(BaseDeepRegressor):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.history = None

--- a/sktime/regression/deep_learning/rnn/_rnn_tf.py
+++ b/sktime/regression/deep_learning/rnn/_rnn_tf.py
@@ -115,7 +115,6 @@ class SimpleRNNRegressor(BaseDeepRegressor):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.history = None

--- a/sktime/regression/deep_learning/rnn/_rnn_torch.py
+++ b/sktime/regression/deep_learning/rnn/_rnn_torch.py
@@ -204,7 +204,6 @@ class SimpleRNNRegressorTorch(BaseDeepRegressorTorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # Note: we do not validate activation_hidden here.

--- a/sktime/regression/deep_learning/tapnet/_tapnet_tf.py
+++ b/sktime/regression/deep_learning/tapnet/_tapnet_tf.py
@@ -152,7 +152,6 @@ class TapNetRegressor(BaseDeepRegressor):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self._network = TapNetNetwork(

--- a/sktime/regression/deep_learning/tapnet/_tapnet_torch.py
+++ b/sktime/regression/deep_learning/tapnet/_tapnet_torch.py
@@ -233,7 +233,6 @@ class TapNetRegressorTorch(BaseDeepRegressorTorch):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.input_size = None

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -126,7 +126,6 @@ class BaseSplitter(BaseObject):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         pass

--- a/sktime/transformations/base/_base.py
+++ b/sktime/transformations/base/_base.py
@@ -221,7 +221,6 @@ class BaseTransformer(BaseEstimator):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         pass

--- a/sktime/transformations/dictionary_based/_sfa_fast.py
+++ b/sktime/transformations/dictionary_based/_sfa_fast.py
@@ -195,7 +195,6 @@ class SFAFast(BaseTransformer):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.words = []

--- a/sktime/transformations/signature_based/_signature_method.py
+++ b/sktime/transformations/signature_based/_signature_method.py
@@ -118,7 +118,6 @@ class SignatureTransformer(BaseTransformer):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         if self.backend not in ["esig", "iisignature"]:

--- a/sktime/transformations/tsfel/_tsfel.py
+++ b/sktime/transformations/tsfel/_tsfel.py
@@ -133,7 +133,6 @@ class TSFELTransformer(BaseTransformer):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.domain_strings = ["statistical", "temporal", "spectral", "fractal"]

--- a/sktime/transformations/tsfresh.py
+++ b/sktime/transformations/tsfresh.py
@@ -68,7 +68,6 @@ class _TSFreshFeatureExtractor(BaseTransformer):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         # _get_extraction_params should be after the init because this imports tsfresh
@@ -531,7 +530,6 @@ class TSFreshRelevantFeatureExtractor(_TSFreshFeatureExtractor):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
         """
         self.default_fc_parameters_ = self._get_extraction_params()


### PR DESCRIPTION
Many docstrings of `__post_init__` were still referring to dynamic tag setting - this is now moved to `__dynamic_tags__`.

This PR removes the reference to dynamic tags in those `__post_init__` docstrings.