### PR TITLE
[ENH] remove cross-module imports - part 1

### DIFF
--- a/sktime/classification/compose/_pipeline.py
+++ b/sktime/classification/compose/_pipeline.py
@@ -6,8 +6,6 @@ import numpy as np
 from sktime.base import _HeterogenousMetaEstimator
 from sktime.classification.base import BaseClassifier
 from sktime.datatypes import convert_to
-from sktime.transformations.compose._pipeline import TransformerPipeline
-from sktime.transformations.compose._pipeline import TransformerPipeline
 from sktime.utils.sklearn import is_sklearn_classifier
 
 __author__ = ["fkiraly"]

--- a/sktime/classification/compose/_pipeline.py
+++ b/sktime/classification/compose/_pipeline.py
@@ -6,8 +6,6 @@ import numpy as np
 from sktime.base import _HeterogenousMetaEstimator
 from sktime.classification.base import BaseClassifier
 from sktime.datatypes import convert_to
-from sktime.transformations.base import BaseTransformer
-from sktime.transformations.compose import TransformerPipeline
 from sktime.utils.sklearn import is_sklearn_classifier
 
 __author__ = ["fkiraly"]
@@ -193,6 +191,8 @@ class ClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
         ClassifierPipeline object, concatenation of ``other`` (first) with ``self``
         (last).
         """
+        from sktime.transformations.base import BaseTransformer
+
         if isinstance(other, BaseTransformer):
             # use the transformers dunder to get a TransformerPipeline
             trafo_pipeline = other * self.transformers_
@@ -458,9 +458,12 @@ class SklearnClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
         self.classifier = classifier
         self.classifier_ = clone(classifier)
         self.transformers = transformers
-        self.transformers_ = TransformerPipeline(transformers)
 
         super().__init__()
+
+        from sktime.transformations.compose import TransformerPipeline
+
+        self.transformers_ = TransformerPipeline(transformers)
 
         # all sktime and sklearn transformers always support multivariate
         multivariate = True
@@ -519,6 +522,8 @@ class SklearnClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
         ClassifierPipeline object, concatenation of ``other`` (first) with ``self``
         (last).
         """
+        from sktime.transformations.base import BaseTransformer
+
         if isinstance(other, BaseTransformer):
             # use the transformers dunder to get a TransformerPipeline
             trafo_pipeline = other * self.transformers_

--- a/sktime/classification/compose/_pipeline.py
+++ b/sktime/classification/compose/_pipeline.py
@@ -6,6 +6,8 @@ import numpy as np
 from sktime.base import _HeterogenousMetaEstimator
 from sktime.classification.base import BaseClassifier
 from sktime.datatypes import convert_to
+from sktime.transformations.compose._pipeline import TransformerPipeline
+from sktime.transformations.compose._pipeline import TransformerPipeline
 from sktime.utils.sklearn import is_sklearn_classifier
 
 __author__ = ["fkiraly"]
@@ -114,11 +116,27 @@ class ClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
 
     def __init__(self, classifier, transformers):
         self.classifier = classifier
-        self.classifier_ = classifier.clone()
         self.transformers = transformers
-        self.transformers_ = TransformerPipeline(transformers)
 
         super().__init__()
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        transformers = self.transformers
+        classifier = self.classifier
+
+        self.classifier_ = classifier.clone()
+
+        from sktime.transformations.compose import TransformerPipeline
+
+        self.transformers_ = TransformerPipeline(transformers)
 
         # can handle multivariate iff: both classifier and all transformers can
         multivariate = classifier.get_tag("capability:multivariate", False)
@@ -453,13 +471,26 @@ class SklearnClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
     # no default tag values - these are set dynamically below
 
     def __init__(self, classifier, transformers):
-        from sklearn.base import clone
-
         self.classifier = classifier
-        self.classifier_ = clone(classifier)
         self.transformers = transformers
 
         super().__init__()
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        transformers = self.transformers
+        classifier = self.classifier
+
+        from sklearn.base import clone
+
+        self.classifier_ = clone(classifier)
 
         from sktime.transformations.compose import TransformerPipeline
 

--- a/sktime/classification/compose/tests/test_pipeline.py
+++ b/sktime/classification/compose/tests/test_pipeline.py
@@ -9,9 +9,6 @@ from sklearn.preprocessing import StandardScaler
 from sktime.classification.compose import ClassifierPipeline
 from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.transformations.exponent import ExponentTransformer
-from sktime.transformations.impute import Imputer
-from sktime.transformations.padder import PaddingTransformer
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 from sktime.utils._testing.panel import _make_classification_y, _make_panel_X
 
@@ -26,6 +23,8 @@ def test_dunder_mul():
     y = _make_classification_y(n_instances=10, random_state=RAND_SEED)
     X = _make_panel_X(n_instances=10, n_timepoints=20, random_state=RAND_SEED, y=y)
     X_test = _make_panel_X(n_instances=5, n_timepoints=20, random_state=RAND_SEED)
+
+    from sktime.transformations.exponent import ExponentTransformer
 
     t1 = ExponentTransformer(power=4)
     t2 = ExponentTransformer(power=0.25)
@@ -57,6 +56,8 @@ def test_mul_sklearn_autoadapt():
     X = _make_panel_X(n_instances=10, n_timepoints=20, random_state=RAND_SEED, y=y)
     X_test = _make_panel_X(n_instances=10, n_timepoints=20, random_state=RAND_SEED)
 
+    from sktime.transformations.exponent import ExponentTransformer
+
     t1 = ExponentTransformer(power=2)
     t2 = StandardScaler()
     c = KNeighborsTimeSeriesClassifier()
@@ -81,6 +82,10 @@ def test_mul_sklearn_autoadapt():
 )
 def test_missing_unequal_tag_inference():
     """Test that ClassifierPipeline infers missing/unequal tags correctly."""
+    from sktime.transformations.exponent import ExponentTransformer
+    from sktime.transformations.impute import Imputer
+    from sktime.transformations.padder import PaddingTransformer
+
     c = KNeighborsTimeSeriesClassifier()
     c1 = ExponentTransformer() * PaddingTransformer() * ExponentTransformer() * c
     c2 = ExponentTransformer() * ExponentTransformer() * c

--- a/sktime/detection/clasp.py
+++ b/sktime/detection/clasp.py
@@ -21,7 +21,6 @@ from queue import PriorityQueue
 import numpy as np
 import pandas as pd
 
-from sktime.transformations.clasp import ClaSPTransformer
 from sktime.utils.validation.series import check_series
 
 
@@ -327,6 +326,8 @@ class ClaSPSegmentation(BaseDetector):
 
         if isinstance(X, pd.Series):
             X = X.to_numpy()
+
+        from sktime.transformations.clasp import ClaSPTransformer
 
         clasp_transformer = ClaSPTransformer(
             window_length=self.period_length, exclusion_radius=self.exclusion_radius

--- a/sktime/forecasting/cinn.py
+++ b/sktime/forecasting/cinn.py
@@ -16,9 +16,6 @@ from sktime.forecasting.base.adapters._pytorch import (
 )
 from sktime.forecasting.trend import CurveFitForecaster
 from sktime.networks.cinn import CINNNetwork
-from sktime.transformations.fourier import FourierFeatures
-from sktime.transformations.merger import Merger
-from sktime.transformations.summarize import WindowSummarizer
 from sktime.utils.dependencies import _safe_import
 
 torch = _safe_import("torch")
@@ -217,6 +214,9 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
         -------
         self : reference to self
         """
+        from sktime.transformations.fourier import FourierFeatures
+        from sktime.transformations.summarize import WindowSummarizer
+
         if self.window_size > len(y):
             raise ValueError(
                 f"Invalid window_size: {self.window_size}. "
@@ -328,6 +328,9 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
             (dataset, n_cond_features) on success, None if the series is too
             short or curve fitting fails.
         """
+        from sktime.transformations.fourier import FourierFeatures
+        from sktime.transformations.summarize import WindowSummarizer
+
         if len(series) < self.window_size:
             warnings.warn(
                 f"Skipping series (length {len(series)}) shorter than "
@@ -554,6 +557,8 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
             should be of the same type as seen in _fit, as in "y_inner_mtype" tag
             Point predictions
         """
+        from sktime.transformations.merger import Merger
+
         if fh is None:
             fh = self._fh
         if len(fh) < self.sample_dim:

--- a/sktime/regression/compose/_ensemble.py
+++ b/sktime/regression/compose/_ensemble.py
@@ -19,7 +19,6 @@ from sklearn.tree import DecisionTreeRegressor
 
 from sktime.base._panel.forest._composable import BaseTimeSeriesForest
 from sktime.regression.base import BaseRegressor
-from sktime.transformations.summarize import RandomIntervalFeatureExtractor
 from sktime.utils.slope_and_trend import _slope
 from sktime.utils.validation.panel import check_X, check_X_y
 from sktime.utils.warnings import warn
@@ -276,6 +275,8 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
 
         # Set base estimator
         if self.estimator is None:
+            from sktime.transformations.summarize import RandomIntervalFeatureExtractor
+
             # Set default time series forest
             features = [np.mean, np.std, _slope]
             steps = [

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -106,11 +106,27 @@ class RegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
 
     def __init__(self, regressor, transformers):
         self.regressor = regressor
-        self.regressor_ = regressor.clone()
         self.transformers = transformers
-        self.transformers_ = TransformerPipeline(transformers)
 
         super().__init__()
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        transformers = self.transformers
+        regressor = self.regressor
+        
+        self.regressor_ = regressor.clone()
+
+        from sktime.transformations.compose import TransformerPipeline
+
+        self.transformers_ = TransformerPipeline(transformers)
 
         # can handle multivariate iff: both regressor and all transformers can
         multivariate = regressor.get_tag("capability:multivariate", False)
@@ -410,10 +426,7 @@ class SklearnRegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
     # no default tag values - these are set dynamically below
 
     def __init__(self, regressor, transformers):
-        from sklearn.base import clone
-
         self.regressor = regressor
-        self.regressor_ = clone(regressor)
         self.transformers = transformers
 
         super().__init__()
@@ -428,6 +441,11 @@ class SklearnRegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
         * any soft dependency imports in the constructor
         """
         transformers = self.transformers
+        regressor = self.regressor
+
+        from sklearn.base import clone
+
+        self.regressor_ = clone(regressor)
 
         from sktime.transformations.compose import TransformerPipeline
 

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -6,8 +6,6 @@ import numpy as np
 from sktime.base import _HeterogenousMetaEstimator
 from sktime.datatypes import convert_to
 from sktime.regression.base import BaseRegressor
-from sktime.transformations.base import BaseTransformer
-from sktime.transformations.compose import TransformerPipeline
 from sktime.utils.sklearn import is_sklearn_regressor
 
 __author__ = ["fkiraly"]
@@ -180,6 +178,8 @@ class RegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
         -------
         RegressorPipeline object, concatenation of `other` (first) with `self` (last).
         """
+        from sktime.transformations.base import BaseTransformer
+
         if isinstance(other, BaseTransformer):
             # use the transformers dunder to get a TransformerPipeline
             trafo_pipeline = other * self.transformers_
@@ -415,9 +415,23 @@ class SklearnRegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
         self.regressor = regressor
         self.regressor_ = clone(regressor)
         self.transformers = transformers
-        self.transformers_ = TransformerPipeline(transformers)
 
         super().__init__()
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        transformers = self.transformers
+
+        from sktime.transformations.compose import TransformerPipeline
+
+        self.transformers_ = TransformerPipeline(transformers)
 
         # can handle multivariate iff all transformers can
         # sklearn transformers always support multivariate
@@ -475,6 +489,8 @@ class SklearnRegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
         -------
         RegressorPipeline object, concatenation of `other` (first) with `self` (last).
         """
+        from sktime.transformations.base import BaseTransformer
+
         if isinstance(other, BaseTransformer):
             # use the transformers dunder to get a TransformerPipeline
             trafo_pipeline = other * self.transformers_

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -121,7 +121,7 @@ class RegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
         """
         transformers = self.transformers
         regressor = self.regressor
-        
+
         self.regressor_ = regressor.clone()
 
         from sktime.transformations.compose import TransformerPipeline

--- a/sktime/regression/kernel_based/_rocket_regressor.py
+++ b/sktime/regression/kernel_based/_rocket_regressor.py
@@ -187,12 +187,14 @@ class RocketRegressor(_DelegatedRegressor, BaseRegressor):
 
         elif rocket_transform == "minirocket":
             from sktime.transformations.rocket import MiniRocket, MiniRocketMultivariate
+
             multivar_rocket = MiniRocketMultivariate(**common_params)
             univar_rocket = MiniRocket(**common_params)
 
         elif self.rocket_transform == "multirocket":
             from sktime.transformations.rocket import (
-                MultiRocket, MultiRocketMultivariate
+                MultiRocket,
+                MultiRocketMultivariate,
             )
             common_params["n_features_per_kernel"] = self.n_features_per_kernel
             multivar_rocket = MultiRocketMultivariate(**common_params)

--- a/sktime/regression/kernel_based/_rocket_regressor.py
+++ b/sktime/regression/kernel_based/_rocket_regressor.py
@@ -196,6 +196,7 @@ class RocketRegressor(_DelegatedRegressor, BaseRegressor):
                 MultiRocket,
                 MultiRocketMultivariate,
             )
+
             common_params["n_features_per_kernel"] = self.n_features_per_kernel
             multivar_rocket = MultiRocketMultivariate(**common_params)
             univar_rocket = MultiRocket(**common_params)

--- a/sktime/regression/kernel_based/_rocket_regressor.py
+++ b/sktime/regression/kernel_based/_rocket_regressor.py
@@ -13,13 +13,6 @@ from sklearn.preprocessing import StandardScaler
 from sktime.pipeline import make_pipeline
 from sktime.regression._delegate import _DelegatedRegressor
 from sktime.regression.base import BaseRegressor
-from sktime.transformations.rocket import (
-    MiniRocket,
-    MiniRocketMultivariate,
-    MultiRocket,
-    MultiRocketMultivariate,
-    Rocket,
-)
 
 
 class RocketRegressor(_DelegatedRegressor, BaseRegressor):
@@ -136,15 +129,6 @@ class RocketRegressor(_DelegatedRegressor, BaseRegressor):
         self.num_kernels = num_kernels
         self.rocket_transform = rocket_transform
 
-        if rocket_transform in ["multirocket", "minirocket"]:
-            if self.num_kernels < 84:
-                self.num_kernels_ = 84
-            else:
-                self.num_kernels_ = (self.num_kernels // 84) * 84
-
-        else:
-            self.num_kernels_ = num_kernels
-
         self.max_dilations_per_kernel = max_dilations_per_kernel
         self.n_features_per_kernel = n_features_per_kernel
         self.use_multivariate = use_multivariate
@@ -153,6 +137,29 @@ class RocketRegressor(_DelegatedRegressor, BaseRegressor):
         self.random_state = random_state
 
         super().__init__()
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        n_jobs = self.n_jobs
+        use_multivariate = self.use_multivariate
+        num_kernels = self.num_kernels
+        rocket_transform = self.rocket_transform
+
+        if rocket_transform in ["multirocket", "minirocket"]:
+            if self.num_kernels < 84:
+                self.num_kernels_ = 84
+            else:
+                self.num_kernels_ = (self.num_kernels // 84) * 84
+
+        else:
+            self.num_kernels_ = num_kernels
 
         from sktime.utils.validation import check_n_jobs
 
@@ -172,15 +179,21 @@ class RocketRegressor(_DelegatedRegressor, BaseRegressor):
         }
 
         if rocket_transform == "rocket":
+            from sktime.transformations.rocket import Rocket
+
             del common_params["max_dilations_per_kernel"]
             univar_rocket = Rocket(**common_params)
             multivar_rocket = univar_rocket
 
         elif rocket_transform == "minirocket":
+            from sktime.transformations.rocket import MiniRocket, MiniRocketMultivariate
             multivar_rocket = MiniRocketMultivariate(**common_params)
             univar_rocket = MiniRocket(**common_params)
 
         elif self.rocket_transform == "multirocket":
+            from sktime.transformations.rocket import (
+                MultiRocket, MultiRocketMultivariate
+            )
             common_params["n_features_per_kernel"] = self.n_features_per_kernel
             multivar_rocket = MultiRocketMultivariate(**common_params)
             univar_rocket = MultiRocket(**common_params)

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -245,7 +245,6 @@ KNOWN_EXCEPTIONS = frozenset(
         ("param_est/plugin/_transformer.py", "param_est", "transformations"),
         ("param_est/tests/test_plugin.py", "param_est", "forecasting"),
         ("param_est/tests/test_plugin.py", "param_est", "transformations"),
-        ("regression/compose/_ensemble.py", "regression", "transformations"),
         ("regression/compose/_pipeline.py", "regression", "transformations"),
         (
             "regression/tests/test_categorical_in_composite.py",

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -262,7 +262,6 @@ KNOWN_EXCEPTIONS = frozenset(
             "transformations",
             "forecasting",
         ),
-        ("transformations/impute.py", "transformations", "forecasting"),
         (
             "transformations/summarize/tests/test_FittedParamExtractor.py",
             "transformations",

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -284,7 +284,6 @@ KNOWN_EXCEPTIONS = frozenset(
             "transformations",
             "param_est",
         ),
-        ("transformations/tests/test_vmd.py", "transformations", "forecasting"),
     }
 )
 

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -172,7 +172,6 @@ KNOWN_EXCEPTIONS = frozenset(
             "clustering",
             "transformations",
         ),
-        ("detection/clasp.py", "detection", "transformations"),
         ("detection/compose/_as_transform.py", "detection", "transformations"),
         ("detection/eagglo.py", "detection", "transformations"),
         ("detection/stray.py", "detection", "transformations"),

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -248,11 +248,6 @@ KNOWN_EXCEPTIONS = frozenset(
         ("regression/compose/_ensemble.py", "regression", "transformations"),
         ("regression/compose/_pipeline.py", "regression", "transformations"),
         (
-            "regression/kernel_based/_rocket_regressor.py",
-            "regression",
-            "transformations",
-        ),
-        (
             "regression/tests/test_categorical_in_composite.py",
             "regression",
             "transformations",

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -44,12 +44,6 @@ _CHECKED_SOURCES = TYPE_MODULES | {_NETWORKS}
 # These are pre-existing and should be fixed in follow-up PRs, not in this one.
 KNOWN_EXCEPTIONS = frozenset(
     {
-        ("classification/compose/_pipeline.py", "classification", "transformations"),
-        (
-            "classification/compose/tests/test_pipeline.py",
-            "classification",
-            "transformations",
-        ),
         (
             "classification/dictionary_based/_boss.py",
             "classification",

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -258,11 +258,6 @@ KNOWN_EXCEPTIONS = frozenset(
             "transformations",
         ),
         (
-            "transformations/detrend/tests/test_deseasonalise.py",
-            "transformations",
-            "forecasting",
-        ),
-        (
             "transformations/detrend/tests/test_detrend.py",
             "transformations",
             "forecasting",

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -245,7 +245,6 @@ KNOWN_EXCEPTIONS = frozenset(
         ("param_est/plugin/_transformer.py", "param_est", "transformations"),
         ("param_est/tests/test_plugin.py", "param_est", "forecasting"),
         ("param_est/tests/test_plugin.py", "param_est", "transformations"),
-        ("regression/compose/_pipeline.py", "regression", "transformations"),
         (
             "regression/tests/test_categorical_in_composite.py",
             "regression",

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -182,7 +182,6 @@ KNOWN_EXCEPTIONS = frozenset(
             "transformations",
         ),
         ("forecasting/boxcox_biasadj.py", "forecasting", "transformations"),
-        ("forecasting/cinn.py", "forecasting", "transformations"),
         ("forecasting/compose/_bagging.py", "forecasting", "transformations"),
         ("forecasting/compose/_grouped.py", "forecasting", "transformations"),
         (

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -257,7 +257,6 @@ KNOWN_EXCEPTIONS = frozenset(
             "regression",
             "transformations",
         ),
-        ("transformations/detrend/_detrend.py", "transformations", "forecasting"),
         (
             "transformations/detrend/tests/test_deseasonalise.py",
             "transformations",

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -285,7 +285,6 @@ KNOWN_EXCEPTIONS = frozenset(
             "param_est",
         ),
         ("transformations/tests/test_vmd.py", "transformations", "forecasting"),
-        ("transformations/theta.py", "transformations", "forecasting"),
     }
 )
 

--- a/sktime/transformations/detrend/_detrend.py
+++ b/sktime/transformations/detrend/_detrend.py
@@ -8,8 +8,6 @@ __author__ = ["mloning", "SveaMeyer13", "KishManani", "fkiraly"]
 import pandas as pd
 
 from sktime.datatypes import update_data
-from sktime.forecasting.base._fh import ForecastingHorizon
-from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.transformations.base import BaseTransformer
 
 
@@ -99,15 +97,28 @@ class Detrender(BaseTransformer):
 
         super().__init__()
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
         # default for forecaster - written to forecaster_ to not overwrite param
         if self.forecaster is None:
+            from sktime.forecasting.trend import PolynomialTrendForecaster
+
             self.forecaster_ = PolynomialTrendForecaster(degree=1)
         else:
-            self.forecaster_ = forecaster.clone()
+            self.forecaster_ = self.forecaster.clone()
 
         allowed_models = ("additive", "multiplicative")
-        if model not in allowed_models:
-            raise ValueError("`model` must be 'additive' or 'multiplicative'")
+        if self.model not in allowed_models:
+            raise ValueError(
+                "Error in Detrender: `model` must be 'additive' or 'multiplicative'"
+            )
 
     def _fit(self, X, y=None):
         """Fit transformer to X and y.
@@ -138,6 +149,9 @@ class Detrender(BaseTransformer):
             time_index = X.index
         else:
             time_index = X.index.get_level_values(-1).unique()
+
+        from sktime.forecasting.base._fh import ForecastingHorizon
+
         return ForecastingHorizon(time_index, is_relative=False)
 
     def _get_fitted_forecaster(self, X, y, fh):

--- a/sktime/transformations/detrend/tests/test_deseasonalise.py
+++ b/sktime/transformations/detrend/tests/test_deseasonalise.py
@@ -8,13 +8,12 @@ __all__ = []
 import numpy as np
 import pytest
 
-from sktime.forecasting.tests._config import TEST_SPS
-from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.detrend import Deseasonalizer
 from sktime.utils._testing.forecasting import make_forecasting_problem
 
 MODELS = ["additive", "multiplicative"]
+TEST_SPS = [3, 12]
 
 
 @pytest.mark.skipif(
@@ -24,6 +23,8 @@ MODELS = ["additive", "multiplicative"]
 @pytest.mark.parametrize("sp", TEST_SPS)
 def test_deseasonalised_values(sp):
     from statsmodels.tsa.seasonal import seasonal_decompose
+
+    from sktime.split import temporal_train_test_split
 
     y = make_forecasting_problem()
     y_train, _ = temporal_train_test_split(y, train_size=0.75)
@@ -44,6 +45,8 @@ def test_deseasonalised_values(sp):
 @pytest.mark.parametrize("sp", TEST_SPS)
 @pytest.mark.parametrize("model", MODELS)
 def test_transform_time_index(sp, model):
+    from sktime.split import temporal_train_test_split
+
     y = make_forecasting_problem()
     y_train, y_test = temporal_train_test_split(y, train_size=0.75)
 
@@ -60,6 +63,8 @@ def test_transform_time_index(sp, model):
 @pytest.mark.parametrize("sp", TEST_SPS)
 @pytest.mark.parametrize("model", MODELS)
 def test_inverse_transform_time_index(sp, model):
+    from sktime.split import temporal_train_test_split
+
     y = make_forecasting_problem()
     y_train, y_test = temporal_train_test_split(y, train_size=0.75)
 
@@ -76,8 +81,10 @@ def test_inverse_transform_time_index(sp, model):
 @pytest.mark.parametrize("sp", TEST_SPS)
 @pytest.mark.parametrize("model", MODELS)
 def test_transform_inverse_transform_equivalence(sp, model):
+    from sktime.split import temporal_train_test_split
+
     y = make_forecasting_problem()
-    y_train, y_test = temporal_train_test_split(y, train_size=0.75)
+    y_train, _ = temporal_train_test_split(y, train_size=0.75)
 
     transformer = Deseasonalizer(sp=sp, model=model)
     transformer.fit(y_train)

--- a/sktime/transformations/impute.py
+++ b/sktime/transformations/impute.py
@@ -9,8 +9,6 @@ import numpy as np
 import pandas as pd
 from sklearn.utils import check_random_state
 
-from sktime.forecasting.base import ForecastingHorizon
-from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.transformations.base import BaseTransformer
 
 
@@ -196,6 +194,8 @@ class Imputer(BaseTransformer):
             if self.method in ["drift", "forecaster"]:
                 self._y = y.copy() if y is not None else None
                 if self.method == "drift":
+                    from sktime.forecasting.trend import PolynomialTrendForecaster
+
                     self._forecaster = PolynomialTrendForecaster(degree=1)
                 elif self.method == "forecaster":
                     self._forecaster = self.forecaster.clone()
@@ -354,6 +354,8 @@ class Imputer(BaseTransformer):
         Xt : pd.DataFrame
             Series with imputed values.
         """
+        from sktime.forecasting.base import ForecastingHorizon
+
         for col in X.columns:
             if _has_missing_values(X[col]):
                 # define fh based on index of missing values

--- a/sktime/transformations/tests/test_vmd.py
+++ b/sktime/transformations/tests/test_vmd.py
@@ -8,8 +8,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from sktime.forecasting.compose import TransformedTargetForecaster
-from sktime.forecasting.trend import TrendForecaster
 from sktime.libs.vmdpy import VMD
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.vmd import VmdTransformer
@@ -52,6 +50,9 @@ def _generate_vmd_testdata(T=1000, f_1=2, f_2=24, f_3=288, noise=0.1):
 def test_vmd_in_pipeline():
     """Test vmd as part of a TransformedTargetForecaster pipeline."""
     y = _generate_vmd_testdata()
+
+    from sktime.forecasting.compose import TransformedTargetForecaster
+    from sktime.forecasting.trend import TrendForecaster
 
     pipe = TransformedTargetForecaster(
         steps=[

--- a/sktime/transformations/theta.py
+++ b/sktime/transformations/theta.py
@@ -8,8 +8,6 @@ __all__ = ["ThetaLinesTransformer"]
 import numpy as np
 import pandas as pd
 
-from sktime.forecasting.base import ForecastingHorizon
-from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.transformations.base import BaseTransformer
 
 
@@ -103,6 +101,9 @@ class ThetaLinesTransformer(BaseTransformer):
             pd.DataFrame of shape: [len(X), len(self.theta)], if self.theta is tuple
         """
         theta = _check_theta(self.theta)
+
+        from sktime.forecasting.base import ForecastingHorizon
+        from sktime.forecasting.trend import PolynomialTrendForecaster
 
         forecaster = PolynomialTrendForecaster()
         forecaster.fit(y=X)


### PR DESCRIPTION
Removes some of the cross-module imports detected in https://github.com/sktime/sktime/pull/10479.

Focuses on non-test modules which are walked during registry imports.