### PR TITLE
[ENH] remove cross-module imports - part 3

### DIFF
--- a/sktime/detection/wclust.py
+++ b/sktime/detection/wclust.py
@@ -10,7 +10,6 @@ import numpy as np
 import pandas as pd
 from sklearn.base import clone
 
-from sktime.clustering.dbscan import TimeSeriesDBSCAN
 from sktime.detection.base import BaseDetector
 from sktime.dists_kernels import DtwDist
 from sktime.utils.sklearn import is_sklearn_clusterer
@@ -191,6 +190,8 @@ class WindowSegmenter(BaseDetector):
         self.step_size = step_size
         self.return_segments = return_segments
         if self.clusterer is None:
+            from sktime.clustering.dbscan import TimeSeriesDBSCAN
+
             self._clusterer = TimeSeriesDBSCAN(distance=DtwDist())
         else:
             self._clusterer = self.clusterer
@@ -290,6 +291,8 @@ class WindowSegmenter(BaseDetector):
         -------
         params : dict or list of dict, default = {}
         """
+        from sktime.clustering.dbscan import TimeSeriesDBSCAN
+
         params1 = {"clusterer": TimeSeriesDBSCAN(distance=DtwDist()), "window_size": 2}
         params2 = {}
         return [params1, params2]

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -175,7 +175,6 @@ KNOWN_EXCEPTIONS = frozenset(
         ("detection/compose/_as_transform.py", "detection", "transformations"),
         ("detection/eagglo.py", "detection", "transformations"),
         ("detection/stray.py", "detection", "transformations"),
-        ("detection/wclust.py", "detection", "clustering"),
         (
             "forecasting/base/tests/test_base_bugs.py",
             "forecasting",


### PR DESCRIPTION
#### Reference Issues/PRs
Part 3 of removing cross module imports.
Fixes #10523 
See also #10479 and #10512.

#### What does this implement/fix? Explain your changes.
This PR defers cross-module imports in the `detection` and `forecasting` modules, following the exact same pattern used by @fkiraly in #10512 (Part 1).

Specifically, it defers the following imports into local scopes or `_post_init_` methods:
* `detection/wclust.py`: Defers `TimeSeriesDBSCAN` import from `clustering`.
* `forecasting/boxcox_biasadj.py`: Defers `BoxCoxTransformer` import from `transformations`.
* `forecasting/enbpi.py`: Defers `MovingBlockBootstrapTransformer` and `TSBootstrapAdapter` imports from `transformations`.
* `forecasting/theta.py`: Defers `Deseasonalizer` and `ThetaLinesTransformer` imports from `transformations`.
* `tests/test_cross_module_imports.py`: Removes the 4 resolved entries from `KNOWN_EXCEPTIONS`.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
* Ensure the deferred imports inside `_post_init_` (e.g., in `enbpi.py` and `theta.py`) are correctly implemented and don't introduce any side effects.

#### Did you add any tests for the change?
The changes are validated by the existing `sktime/tests/test_cross_module_imports.py` architecture test, which now passes cleanly without the exceptions for these files.

#### Any other comments?
All estimators touched by this PR were also successfully instantiated manually.

#### PR checklist
- [x] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] I've added the estimator to the API reference
- [ ] I've added one or more illustrative usage examples to the docstring
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag
