### PR TITLE
[ENH] remove cross-module imports - part 2

### DIFF
--- a/sktime/forecasting/boxcox_biasadj.py
+++ b/sktime/forecasting/boxcox_biasadj.py
@@ -9,7 +9,6 @@ from scipy.special import inv_boxcox
 
 from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.base._delegate import _DelegatedForecaster
-from sktime.transformations.boxcox import BoxCoxTransformer
 
 
 class BoxCoxBiasAdjustedForecaster(BaseForecaster):
@@ -91,6 +90,8 @@ class BoxCoxBiasAdjustedForecaster(BaseForecaster):
         -------
         self : returns an instance of self.
         """
+        from sktime.transformations.boxcox import BoxCoxTransformer
+
         self.boxcox_transformer_ = BoxCoxTransformer(lambda_fixed=self.lambda_fixed)
         y_transformed = self.boxcox_transformer_.fit_transform(y)
 

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -11,7 +11,6 @@ from sklearn.utils import check_random_state
 
 from sktime.datatypes._utilities import update_data
 from sktime.forecasting.base import BaseForecaster
-from sktime.transformations.base import BaseTransformer
 
 PANDAS_MTYPES = ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"]
 
@@ -105,7 +104,7 @@ class BaggingForecaster(BaseForecaster):
 
     def __init__(
         self,
-        bootstrap_transformer: BaseTransformer = None,
+        bootstrap_transformer=None,
         forecaster: BaseForecaster = None,
         sp: int = 2,
         random_state: int | np.random.RandomState = None,

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -268,7 +268,6 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         self.forecasters = forecasters
         self.fallback_forecaster = fallback_forecaster
 
-
         super().__init__()
 
     def __post_init__(self):
@@ -293,7 +292,6 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
             _transformer = ADICVTransformer(features=["class"])
 
         self.transformer_ = coerce_scitype(_transformer, "transformer").clone()
-
 
         from sktime.transformations.base import BaseTransformer
 

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -8,7 +8,6 @@ from sktime.datatypes import ALL_TIME_SERIES_MTYPES, mtype_to_scitype
 from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.base._delegate import _DelegatedForecaster
 from sktime.registry import coerce_scitype
-from sktime.transformations.base import BaseTransformer
 
 __author__ = ["fkiraly", "felipeangelimvieira"]
 __all__ = ["ForecastByLevel", "GroupbyCategoryForecaster"]
@@ -264,21 +263,39 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         transformer=None,
         fallback_forecaster=None,
     ):
-        # saving arguments to object storage
-        if transformer is not None:
-            self.transformer = transformer
-
-        else:
-            from sktime.transformations.adi_cv import ADICVTransformer
-
-            self.transformer = ADICVTransformer(features=["class"])
+        self.transformer = transformer
 
         self.forecasters = forecasters
         self.fallback_forecaster = fallback_forecaster
 
-        self.transformer_ = coerce_scitype(self.transformer, "transformer").clone()
 
         super().__init__()
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        transformer = self.transformer
+        fallback_forecaster = self.fallback_forecaster
+
+        # saving arguments to object storage
+        if transformer is not None:
+            _transformer = transformer.clone()
+
+        else:
+            from sktime.transformations.adi_cv import ADICVTransformer
+
+            _transformer = ADICVTransformer(features=["class"])
+
+        self.transformer_ = coerce_scitype(_transformer, "transformer").clone()
+
+
+        from sktime.transformations.base import BaseTransformer
 
         # validating passed arguments
         assert isinstance(self.transformer_, BaseTransformer)

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -280,6 +280,7 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         * any soft dependency imports in the constructor
         """
         transformer = self.transformer
+        forecasters = self.forecasters
         fallback_forecaster = self.fallback_forecaster
 
         # saving arguments to object storage

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -10,7 +10,6 @@ import pandas as pd
 from sktime.base._meta import flatten
 from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.base._meta import _HeterogenousEnsembleForecaster
-from sktime.transformations.hierarchical.aggregate import _check_index_no_total
 from sktime.utils.parallel import parallelize
 from sktime.utils.warnings import warn
 
@@ -241,6 +240,8 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
         -------
         self : returns an instance of self.
         """
+        from sktime.transformations.hierarchical.aggregate import _check_index_no_total
+
         # Creating aggregated levels in data
         if _check_index_no_total(y):
             z = self._aggregate(y)
@@ -414,6 +415,8 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
         -------
         self : an instance of self.
         """
+        from sktime.transformations.hierarchical.aggregate import _check_index_no_total
+
         z = y
         if _check_index_no_total(y):
             z = self._aggregate(y)
@@ -458,6 +461,8 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
         y_pred : pd.Series
             Point predictions
         """
+        from sktime.transformations.hierarchical.aggregate import _check_index_no_total
+
         if X is not None:
             if _check_index_no_total(X):
                 X = self._aggregate(X)

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -456,6 +456,8 @@ class _Reducer(_BaseWindowForecaster):
         if len(self.transformers_) == 1:
             X_from_y = self.transformers_[0].fit_transform(y_raw)
         else:
+            from sktime.transformations.compose import FeatureUnion
+
             ref = self.transformers_
             feat = [("trafo_" + str(index), i) for index, i in enumerate(ref)]
             X_from_y = FeatureUnion(feat).fit_transform(y_raw)

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -38,8 +38,6 @@ from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
 from sktime.forecasting.base._fh import _index_range
 from sktime.forecasting.base._sktime import _BaseWindowForecaster
 from sktime.registry import is_scitype, scitype
-from sktime.transformations.compose import FeatureUnion
-from sktime.transformations.summarize import WindowSummarizer
 from sktime.utils.datetime import _shift
 from sktime.utils.estimators.dispatch import construct_dispatch
 from sktime.utils.multiindex import apply_method_per_series
@@ -200,6 +198,8 @@ def _sliding_window_transform_global(y, window_length, X, transformers):
     if len(transformers) == 1:
         tf_fit = transformers[0].fit(y)
     else:
+        from sktime.transformations.compose import FeatureUnion
+
         feat = [("trafo_" + str(index), i) for index, i in enumerate(transformers)]
         tf_fit = FeatureUnion(feat).fit(y)
     X_from_y = tf_fit.transform(y)
@@ -577,6 +577,8 @@ class _DirectReducer(_Reducer):
                     "lag": list(range(1, self.window_length + 1)),
                 }
             }
+            from sktime.transformations.summarize import WindowSummarizer
+
             self.transformers_ = [WindowSummarizer(**kwargs, n_jobs=1)]
 
         if self.window_length is None:
@@ -932,6 +934,8 @@ class _RecursiveReducer(_Reducer):
             self.transformers_ = clone(self.transformers)
 
         if self.transformers is None and self.pooling == "global":
+            from sktime.transformations.summarize import WindowSummarizer
+
             kwargs = {
                 "lag_feature": {
                     "lag": list(range(1, self.window_length + 1)),

--- a/sktime/forecasting/enbpi.py
+++ b/sktime/forecasting/enbpi.py
@@ -31,7 +31,7 @@ class EnbPIForecaster(BaseForecaster):
     1. Uses a bootstrap transformer to generate bootstrap samples
         and returning the corresponding indices of the original time
         series. Note that the bootstrap transformer must be able to
-        return indices of the original time series as and additional column.
+        return indices of the original time series as an additional column.
         I.e., the ``bootstrap_transformer`` must have the
         ``capability:bootstrap_indices`` tag, and its parameter
         ``return_indices`` must be set to True.

--- a/sktime/forecasting/enbpi.py
+++ b/sktime/forecasting/enbpi.py
@@ -10,10 +10,6 @@ from sklearn.utils import check_random_state
 from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.libs._aws_fortuna_enbpi.enbpi import EnbPI
-from sktime.transformations.bootstrap import (
-    MovingBlockBootstrapTransformer,
-    TSBootstrapAdapter,
-)
 
 __all__ = ["EnbPIForecaster"]
 __author__ = ["benheid"]
@@ -32,33 +28,33 @@ class EnbPIForecaster(BaseForecaster):
 
     For training:
 
-        1. Uses a bootstrap transformer to generate bootstrap samples
-           and returning the corresponding indices of the original time
-           series. Note that the bootstrap transformer must be able to
-           return indices of the original time series as and additional column.
-           I.e., the ``bootstrap_transformer`` must have the
-           ``capability:bootstrap_indices`` tag, and its parameter
-           ``return_indices`` must be set to True.
-        2. Fit a forecaster on the first n - max(fh) values of each
-           bootstrap sample
-        3. Uses each forecaster to predict the last max(fh) values of each
-           bootstrap sample
+    1. Uses a bootstrap transformer to generate bootstrap samples
+        and returning the corresponding indices of the original time
+        series. Note that the bootstrap transformer must be able to
+        return indices of the original time series as and additional column.
+        I.e., the ``bootstrap_transformer`` must have the
+        ``capability:bootstrap_indices`` tag, and its parameter
+        ``return_indices`` must be set to True.
+    2. Fit a forecaster on the first n - max(fh) values of each
+        bootstrap sample
+    3. Uses each forecaster to predict the last max(fh) values of each
+        bootstrap sample
 
     For Prediction:
 
-        1. Average the predictions of each fitted forecaster using the
-           aggregation function
+    1. Average the predictions of each fitted forecaster using the
+        aggregation function
 
     For Probabilistic Forecasting:
 
-        1. Calculate the point forecast by average the prediction of each
-           fitted forecaster using the aggregation function
-        2. Passes the indices of the bootstrapped samples, the predictions
-           from the fit call, the point prediction of the test set, and
-           the desired error rate to the EnbPI algorithm to calculate the
-           prediction intervals.
-           For more information on the EnbPI algorithm, see the references
-           and the documentation of the EnbPI class in aws-fortuna.
+    1. Calculate the point forecast by average the prediction of each
+        fitted forecaster using the aggregation function
+    2. Passes the indices of the bootstrapped samples, the predictions
+        from the fit call, the point prediction of the test set, and
+        the desired error rate to the EnbPI algorithm to calculate the
+        prediction intervals.
+        For more information on the EnbPI algorithm, see the references
+        and the documentation of the EnbPI class in aws-fortuna.
 
     Parameters
     ----------
@@ -151,6 +147,8 @@ class EnbPIForecaster(BaseForecaster):
         super().__init__()
 
         if bootstrap_transformer.get_tag("object_type") == "bootstrap":
+            from sktime.transformations.bootstrap import TSBootstrapAdapter
+
             self.bootstrap_transformer_ = TSBootstrapAdapter(
                 bootstrap_transformer, return_indices=True
             )
@@ -158,6 +156,8 @@ class EnbPIForecaster(BaseForecaster):
             self.bootstrap_transformer_ = bootstrap_transformer
 
         if self.bootstrap_transformer is None:
+            from sktime.transformations.bootstrap import MovingBlockBootstrapTransformer
+
             mbb = MovingBlockBootstrapTransformer(return_indices=True)
             self.bootstrap_transformer_ = mbb
 
@@ -268,6 +268,8 @@ class EnbPIForecaster(BaseForecaster):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
+        from sktime.transformations.bootstrap import MovingBlockBootstrapTransformer
+
         params = [
             {
                 "bootstrap_transformer": MovingBlockBootstrapTransformer(

--- a/sktime/forecasting/reconcile.py
+++ b/sktime/forecasting/reconcile.py
@@ -9,17 +9,6 @@ import numpy as np
 import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
-from sktime.transformations.hierarchical.aggregate import (
-    Aggregator,
-    _check_index_no_total,
-)
-from sktime.transformations.hierarchical.reconcile import (
-    BottomUpReconciler,
-    NonNegativeOptimalReconciler,
-    OptimalReconciler,
-    TopdownReconciler,
-)
-from sktime.transformations.hierarchical.reconcile._utils import _loc_series_idxs
 from sktime.utils.warnings import warn
 
 
@@ -126,24 +115,54 @@ class ReconcilerForecaster(BaseForecaster):
         "tests:core": True,  # should tests be triggered by framework changes?
     }
 
-    # We do not create the instances to avoid error due to
-    # soft dependency on cvxpy for NonNegativeOptimalReconciler
-    TRFORM_METHOD_MAP = {
-        "bu": (BottomUpReconciler, {}),
-        "ols": (OptimalReconciler, {}),
-        "ols:nonneg": (NonNegativeOptimalReconciler, {}),
-        "wls_str": (OptimalReconciler, {"error_covariance_matrix": "wls_str"}),
-        "wls_str:nonneg": (
-            NonNegativeOptimalReconciler,
-            {"error_covariance_matrix": "wls_str"},
-        ),
-        "td_fcst": (TopdownReconciler, {"method": "td_fcst"}),
-        "td_share": (TopdownReconciler, {"method": "td_share"}),
-    }
+    def _decode_reconciler_method(self, method):
+        """Decode the reconciliation method and return the corresponding class.
 
-    METHOD_LIST = ["mint_cov", "mint_shrink", "wls_var"] + list(
-        TRFORM_METHOD_MAP.keys()
-    )
+        Parameters
+        ----------
+        method : str
+            The reconciliation method to decode.
+
+        Returns
+        -------
+        Class : class
+            The class corresponding to the reconciliation method.
+        """
+        from sktime.transformations.hierarchical.reconcile import (
+            BottomUpReconciler,
+            NonNegativeOptimalReconciler,
+            OptimalReconciler,
+            TopdownReconciler,
+        )
+
+        # We do not create the instances to avoid error due to
+        # soft dependency on cvxpy for NonNegativeOptimalReconciler
+        TRFORM_METHOD_MAP = {
+            "bu": (BottomUpReconciler, {}),
+            "ols": (OptimalReconciler, {}),
+            "ols:nonneg": (NonNegativeOptimalReconciler, {}),
+            "wls_str": (OptimalReconciler, {"error_covariance_matrix": "wls_str"}),
+            "wls_str:nonneg": (
+                NonNegativeOptimalReconciler,
+                {"error_covariance_matrix": "wls_str"},
+            ),
+            "td_fcst": (TopdownReconciler, {"method": "td_fcst"}),
+            "td_share": (TopdownReconciler, {"method": "td_share"}),
+        }
+        return TRFORM_METHOD_MAP[method]
+
+    METHOD_LIST = [
+        "mint_cov",
+        "mint_shrink",
+        "wls_var",
+        "ols",
+        "wls_str",
+        "bu",
+        "td_fcst",
+        "td_share",
+        "ols:nonneg",
+        "wls_str:nonneg",
+    ]
     RETURN_TOTALS_LIST = [True, False]
 
     def __init__(self, forecaster, method="mint_shrink", return_totals=True, alpha=0):
@@ -186,6 +205,8 @@ class ReconcilerForecaster(BaseForecaster):
 
         self._series_to_keep = y.index.droplevel(-1).unique()
 
+        from sktime.transformations.hierarchical.aggregate import _check_index_no_total
+
         # Add totals and flatten single levels
         if _check_index_no_total(y):
             y = self._add_totals(y)
@@ -227,6 +248,11 @@ class ReconcilerForecaster(BaseForecaster):
                 shrink=False, diag_only=True
             )
 
+        from sktime.transformations.hierarchical.reconcile import (
+            NonNegativeOptimalReconciler,
+            OptimalReconciler,
+        )
+
         ReconcilerClass = OptimalReconciler
         if self.method.endswith(":nonneg"):
             ReconcilerClass = NonNegativeOptimalReconciler
@@ -252,6 +278,8 @@ class ReconcilerForecaster(BaseForecaster):
         y_pred : pd.Series
             Point predictions
         """
+        from sktime.transformations.hierarchical.aggregate import _check_index_no_total
+
         if X is not None:
             if _check_index_no_total(X):
                 X = self._add_totals(X)
@@ -267,6 +295,11 @@ class ReconcilerForecaster(BaseForecaster):
             return base_fc
 
         reconc_fc = self.reconciler_transform_.inverse_transform(base_fc)
+
+        from sktime.transformations.hierarchical.aggregate import Aggregator
+        from sktime.transformations.hierarchical.reconcile._utils import (
+            _loc_series_idxs,
+        )
 
         agg = Aggregator(False, bypass_inverse_transform=False).fit(reconc_fc)
         if not self.return_totals:
@@ -293,6 +326,8 @@ class ReconcilerForecaster(BaseForecaster):
         -------
         self : reference to self
         """
+        from sktime.transformations.hierarchical.aggregate import _check_index_no_total
+
         # check index for no "__total", if not add totals to y
         if _check_index_no_total(y):
             y = self._add_totals(y)

--- a/sktime/forecasting/reconcile.py
+++ b/sktime/forecasting/reconcile.py
@@ -222,7 +222,7 @@ class ReconcilerForecaster(BaseForecaster):
         self.forecaster_ = self.forecaster.clone()
 
         if not self._requires_residuals:
-            Class, kwargs = self.TRFORM_METHOD_MAP[self.method]
+            Class, kwargs = self._decode_reconciler_method(self.method)
             self.reconciler_transform_ = Class(**kwargs)
             yt = self.reconciler_transform_.fit_transform(y)
             self.forecaster_.fit(y=yt, X=X, fh=fh)

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -14,8 +14,6 @@ from sktime.forecasting.compose._ensemble import _aggregate
 from sktime.forecasting.compose._pipeline import TransformedTargetForecaster
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.trend import PolynomialTrendForecaster
-from sktime.transformations.detrend import Deseasonalizer
-from sktime.transformations.theta import ThetaLinesTransformer
 from sktime.utils.slope_and_trend import _fit_trend
 from sktime.utils.validation.forecasting import check_sp
 from sktime.utils.warnings import warn
@@ -154,6 +152,8 @@ class ThetaForecaster(ExponentialSmoothing):
         """
         deseasonalize = self.deseasonalize
         if isinstance(deseasonalize, bool) and deseasonalize:
+            from sktime.transformations.detrend import Deseasonalizer
+
             self.deseasonalizer_ = Deseasonalizer(
                 sp=self.sp, model=self.deseasonalize_model
             )
@@ -360,6 +360,8 @@ class ThetaForecaster(ExponentialSmoothing):
         params = [params0, params1, params2, params3]
 
         if _check_estimator_deps(ExponentialSmoothing, severity="none"):
+            from sktime.transformations.detrend import Deseasonalizer
+
             des = Deseasonalizer(sp=4, model="additive")
             params4 = {"deseasonalize": des}
             params.append(params4)
@@ -476,14 +478,26 @@ class ThetaModularForecaster(BaseForecaster):
         aggfunc="mean",
         weights=None,
     ):
-        super().__init__()
         self.forecasters = forecasters
         self.aggfunc = aggfunc
         self.weights = weights
         self.theta_values = theta_values
 
-        forecasters_ = self._check_forecasters(forecasters)
+        super().__init__()
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        forecasters_ = self._check_forecasters(self.forecasters)
         self._colens = ColumnEnsembleForecaster(forecasters=forecasters_)
+
+        from sktime.transformations.theta import ThetaLinesTransformer
 
         self.pipe_ = TransformedTargetForecaster(
             steps=[

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -227,7 +227,6 @@ KNOWN_EXCEPTIONS = frozenset(
             "forecasting",
             "transformations",
         ),
-        ("forecasting/reconcile.py", "forecasting", "transformations"),
         ("forecasting/tests/test_reconcile.py", "forecasting", "transformations"),
         ("forecasting/theta.py", "forecasting", "transformations"),
         ("param_est/compose/_pipeline.py", "param_est", "transformations"),

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -181,15 +181,6 @@ KNOWN_EXCEPTIONS = frozenset(
             "forecasting",
             "transformations",
         ),
-        ("forecasting/boxcox_biasadj.py", "forecasting", "transformations"),
-        ("forecasting/compose/_bagging.py", "forecasting", "transformations"),
-        ("forecasting/compose/_grouped.py", "forecasting", "transformations"),
-        (
-            "forecasting/compose/_hierarchy_ensemble.py",
-            "forecasting",
-            "transformations",
-        ),
-        ("forecasting/compose/_reduce.py", "forecasting", "transformations"),
         (
             "forecasting/compose/tests/test_bagging.py",
             "forecasting",

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -222,7 +222,6 @@ KNOWN_EXCEPTIONS = frozenset(
             "forecasting",
             "transformations",
         ),
-        ("forecasting/enbpi.py", "forecasting", "transformations"),
         (
             "forecasting/model_selection/tests/test_tune.py",
             "forecasting",

--- a/sktime/tests/test_cross_module_imports.py
+++ b/sktime/tests/test_cross_module_imports.py
@@ -228,7 +228,6 @@ KNOWN_EXCEPTIONS = frozenset(
             "transformations",
         ),
         ("forecasting/tests/test_reconcile.py", "forecasting", "transformations"),
-        ("forecasting/theta.py", "forecasting", "transformations"),
         ("param_est/compose/_pipeline.py", "param_est", "transformations"),
         ("param_est/plugin/_forecaster.py", "param_est", "forecasting"),
         ("param_est/plugin/_transformer.py", "param_est", "transformations"),


### PR DESCRIPTION
Removes some of the cross-module imports detected in https://github.com/sktime/sktime/pull/10479.

Focuses on non-test modules which are walked during registry imports.