### PR TITLE
[BUG] Preserve pretrained state across repeated `fit` calls

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -482,9 +482,10 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
         # check y is not None
         assert y is not None, "y cannot be None, but found None"
 
-        # if fit is called, estimator is reset, including fitted state
+        # skip reset on the first fit after pretrain; on refit, discard
+        # task-specific fitted state while retaining pretrained state
         if not self._state == "pretrained":
-            self.reset()
+            self._reset_at("pretrained")
 
         # check and convert X/y
         X_inner, y_inner = self._check_X_y(X=X, y=y)

--- a/sktime/forecasting/tests/test_dummy_global.py
+++ b/sktime/forecasting/tests/test_dummy_global.py
@@ -215,6 +215,34 @@ class TestDummyGlobalForecaster:
         np.testing.assert_almost_equal(forecaster.global_mean_, pretrained_mean)
         np.testing.assert_almost_equal(forecaster.global_std_, pretrained_std)
 
+    def test_preserves_pretrained_params_across_refits(self):
+        """Repeated fit calls preserve values learned during pretraining."""
+        forecaster = DummyGlobalForecaster(strategy="last")
+        y_panel = _make_hierarchical(
+            hierarchy_levels=(3,), min_timepoints=10, max_timepoints=10
+        )
+        forecaster.pretrain(y_panel)
+
+        pretrained_mean = forecaster.global_mean_
+        pretrained_std = forecaster.global_std_
+
+        y_first = pd.Series([10.0, 20.0, 30.0])
+        forecaster.fit(y_first, fh=[1, 2, 3])
+
+        assert forecaster.state == "fitted"
+        assert forecaster.last_value_ == y_first.iloc[-1]
+        np.testing.assert_almost_equal(forecaster.global_mean_, pretrained_mean)
+        np.testing.assert_almost_equal(forecaster.global_std_, pretrained_std)
+
+        y_second = pd.Series([100.0, 200.0, 300.0, 400.0])
+        forecaster.fit(y_second, fh=[1, 2, 3])
+
+        assert forecaster.state == "fitted"
+        assert forecaster.last_value_ == y_second.iloc[-1]
+        np.testing.assert_almost_equal(forecaster.global_mean_, pretrained_mean)
+        np.testing.assert_almost_equal(forecaster.global_std_, pretrained_std)
+        assert forecaster.get_pretrained_params(deep=False)
+
     def test_pretrain_rejects_single_series(self):
         """Test that pretrain() raises TypeError when passed a single Series."""
         forecaster = DummyGlobalForecaster()


### PR DESCRIPTION
This PR fixes a state-management bug in `BaseForecaster.fit` for forecasters that support pretraining. The first `fit` after `pretrain` preserves the pretrained state as intended. However, that call changes the estimator state to `"fitted"`. A subsequent `fit` then called the public `reset()` method, which removed the complete pretrained state.

As a result, a forecaster could silently behave as if it had never been pretrained after being refit on another task. For example, `DummyGlobalForecaster(strategy="mean")` recomputed its `global_mean_` from the second task series instead of retaining the value learned during pretraining.

This closes #10397.

## Changes

`BaseForecaster.fit` now uses `_reset_at("pretrained")` (introduced in #10410) instead of a full `reset()` when starting a new fit outside the initial pretrained state. This clears task-specific fitted attributes while preserving attributes registered as pretrained state. Forecasters without pretrained state retain the previous full-reset behavior.

The first `fit` directly after `pretrain` remains unchanged. Repeated calls to `fit` now preserve the pretrained parameters and refresh only the task-specific fitted state.

## Regression test

A regression test covers the following sequence:

```text
pretrain -> fit on task A -> fit on task B
```

It verifies that the task-fitted value is updated for task B while the pretrained statistics remain unchanged and available through `get_pretrained_params()`.

## Compatibility

This does not change the public API. It restores the intended lifecycle for pretrain-capable forecasters: pretrain once, then fit or refit on one or more downstream task series without discarding the pretrained state.
