### PR TITLE
[MNT] isolate `torch` in `huggingface-hub` `PyTorchModelHubMixin` imports

### DIFF
--- a/sktime/forecasting/moirai.py
+++ b/sktime/forecasting/moirai.py
@@ -117,6 +117,7 @@ class MOIRAIForecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
         # CI and test flags
         # -----------------
         "tests:vm": True,
+        "tests:libs": ["sktime.libs.uni2ts"],
     }
 
     def __init__(

--- a/sktime/libs/uni2ts/moirai2_module.py
+++ b/sktime/libs/uni2ts/moirai2_module.py
@@ -37,7 +37,7 @@ else:
             pass
 
 
-if _check_soft_dependencies("huggingface_hub", severity="none"):
+if _check_soft_dependencies(["torch", "huggingface_hub"], severity="none"):
     from huggingface_hub import PyTorchModelHubMixin
 else:
 

--- a/sktime/libs/uni2ts/moirai_module.py
+++ b/sktime/libs/uni2ts/moirai_module.py
@@ -26,7 +26,7 @@ else:
         pass
 
 
-if _check_soft_dependencies("huggingface_hub", severity="none"):
+if _check_soft_dependencies(["torch", "huggingface_hub"], severity="none"):
     from huggingface_hub import PyTorchModelHubMixin
 else:
     # Create Dummy class


### PR DESCRIPTION
`huggingface-hub` does not imply `torch`, but its `PyTorchModelHubMixin` does.

Therefore, for proper soft dependency isolation when `torch` is not present but `huggingface-hub` is, we need to isolate `PyTorchModelHubMixin` behind an additional `torch` check.