### PR TITLE
[ENH] Add capability tag for pretraining updates

### DIFF
--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -98,6 +98,7 @@ These tags are used to describe capabilities, properties, and behavior of foreca
     capability__pred_int
     capability__pred_int__insample
     capability__pretrain
+    capability__pretrain_update
     capability__missing_values
     capability__categorical_in_X
     capability__random_state

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -157,6 +157,10 @@ class MyForecaster(BaseForecaster):
         # valid values: boolean True (yes), False (no)
         # if True, implement _pretrain and optionally _pretrain_update below
         # enables the pretrain -> fit -> predict workflow for global learning
+        "capability:pretrain_update": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, repeated pretrain calls continue from the existing pretrained state
+        # requires capability:pretrain=True and an implementation of _pretrain_update
         #
         # ----------------------------------------------------------------------------
         # packaging info - only required for sktime contribution or 3rd party packages
@@ -420,12 +424,14 @@ class MyForecaster(BaseForecaster):
         #   self.n_pretrain_instances_ = len(y.index.droplevel(-1).unique())
 
     # todo: consider implementing this, optional
-    # if not implementing, delete this method (default calls _pretrain)
+    # if implementing, set capability:pretrain_update to True
+    # otherwise, delete this method (default calls _pretrain)
     def _pretrain_update(self, y, X=None, fh=None):
         """Update pretrained forecaster with additional panel data.
 
         private _pretrain_update, called from pretrain when already pretrained.
-        Default implementation calls _pretrain. Override for incremental logic.
+        Must continue from the existing pretrained state. Restarting from the
+        initial state or recomputing from only the new data is not an update.
 
         Parameters
         ----------

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -120,6 +120,7 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
         "capability:categorical_in_X": True,
         # does the forecaster natively support categorical in exogenous X?
         "capability:unequal_length": True,  # can forecaster handle unequal length TS?
+        "capability:pretrain_update": False,  # can repeated pretrain update state?
     }
 
     # configs and default config values
@@ -1071,8 +1072,9 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
         ``pretrain`` is a no-op that still transitions the state.
 
         If called when the forecaster is already in the ``"pretrained"`` or
-        ``"fitted"`` state, the internal ``_pretrain_update`` method is called
-        instead, enabling incremental pretraining on additional data batches.
+        ``"fitted"`` state, the internal ``_pretrain_update`` method is called.
+        The ``capability:pretrain_update`` tag indicates whether this operation
+        is guaranteed to continue from the existing pretrained state.
 
         State change:
             Changes ``state`` from ``"new"`` to ``"pretrained"``.
@@ -2461,6 +2463,11 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
 
     def _pretrain_update(self, y, X=None, fh=None):
         """Pretrain forecaster on training data, if already pretrained.
+
+        The default calls ``_pretrain`` and does not guarantee continuation
+        from the existing pretrained state. Forecasters should set the
+        ``capability:pretrain_update`` tag to ``True`` only when overriding
+        this method with continuation semantics.
 
         Returns
         -------

--- a/sktime/forecasting/cinn.py
+++ b/sktime/forecasting/cinn.py
@@ -124,6 +124,7 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
         "capability:missing_values": False,
         "capability:pred_int": False,
         "capability:pretrain": True,
+        "capability:pretrain_update": True,
         # CI and test flags
         # -----------------
         "tests:vm": True,  # run tests on vm in GHA

--- a/sktime/forecasting/convtimenet.py
+++ b/sktime/forecasting/convtimenet.py
@@ -156,6 +156,7 @@ class ConvTimeNetForecaster(_pytorch.BaseDeepNetworkPyTorch):
         # --------------
         "capability:random_state": True,
         "capability:pretrain": True,
+        "capability:pretrain_update": True,
         "property:randomness": "derandomized",
         # CI and testing
         # --------------

--- a/sktime/forecasting/es_rnn.py
+++ b/sktime/forecasting/es_rnn.py
@@ -141,6 +141,7 @@ class ESRNNForecaster(BaseDeepNetworkPyTorch):
         # -----------------
         "tests:vm": True,
         "capability:pretrain": True,
+        "capability:pretrain_update": True,
     }
 
     def __init__(

--- a/sktime/forecasting/ltsf.py
+++ b/sktime/forecasting/ltsf.py
@@ -77,6 +77,7 @@ class LTSFLinearForecaster(BaseDeepNetworkPyTorch):
         # "python_dependencies": "pytorch" - inherited from BaseDeepNetworkPyTorch
         # estimator type vars inherited from BaseDeepNetworkPyTorch
         "capability:pretrain": True,
+        "capability:pretrain_update": True,
     }
 
     def __init__(
@@ -427,6 +428,7 @@ class LTSFDLinearForecaster(BaseDeepNetworkPyTorch):
         # "python_dependencies": "pytorch" - inherited from BaseDeepNetworkPyTorch
         # estimator type vars inherited from BaseDeepNetworkPyTorch
         "capability:pretrain": True,
+        "capability:pretrain_update": True,
     }
 
     def __init__(
@@ -620,6 +622,7 @@ class LTSFNLinearForecaster(BaseDeepNetworkPyTorch):
         # "python_dependencies": "pytorch" - inherited from BaseDeepNetworkPyTorch
         # estimator type vars inherited from BaseDeepNetworkPyTorch
         "capability:pretrain": True,
+        "capability:pretrain_update": True,
     }
 
     def __init__(
@@ -994,6 +997,7 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
         # "python_dependencies": "pytorch" - inherited from BaseDeepNetworkPyTorch
         # estimator type vars inherited from BaseDeepNetworkPyTorch
         "capability:pretrain": True,
+        "capability:pretrain_update": True,
     }
 
     def __init__(

--- a/sktime/forecasting/rbf.py
+++ b/sktime/forecasting/rbf.py
@@ -107,6 +107,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         "capability:missing_values": False,
         "capability:pred_int": False,
         "capability:pretrain": True,
+        "capability:pretrain_update": True,
     }
 
     def __init__(

--- a/sktime/forecasting/scinet.py
+++ b/sktime/forecasting/scinet.py
@@ -132,6 +132,7 @@ class SCINetForecaster(BaseDeepNetworkPyTorch):
         # "python_dependencies": "pytorch" - inherited from BaseDeepNetworkPyTorch
         # estimator type vars inherited from BaseDeepNetworkPyTorch
         "capability:pretrain": True,
+        "capability:pretrain_update": True,
     }
 
     def __init__(

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -1012,6 +1012,35 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
                 f"capability:pretrain=True but does not override _pretrain method"
             )
 
+    def test_pretrain_update_capability_tag(self, estimator_instance):
+        """Test that pretrain update capability matches its implementation."""
+        from sktime.forecasting.base import BaseForecaster
+
+        has_custom_pretrain_update = (
+            estimator_instance.__class__._pretrain_update
+            != BaseForecaster._pretrain_update
+        )
+        can_pretrain = estimator_instance.get_tag(
+            "capability:pretrain", tag_value_default=False, raise_error=False
+        )
+        can_pretrain_update = estimator_instance.get_tag(
+            "capability:pretrain_update",
+            tag_value_default=False,
+            raise_error=False,
+        )
+
+        if can_pretrain_update:
+            assert can_pretrain, (
+                f"{estimator_instance.__class__.__name__} sets "
+                "capability:pretrain_update=True but does not set "
+                "capability:pretrain=True"
+            )
+            assert has_custom_pretrain_update, (
+                f"{estimator_instance.__class__.__name__} sets "
+                "capability:pretrain_update=True but does not override "
+                "_pretrain_update"
+            )
+
     def test_pretrain_state_transitions(self, estimator_instance, n_columns):
         """Test that pretrain() correctly transitions state.
 

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -1105,6 +1105,37 @@ class capability__pretrain(_BaseTag):
     }
 
 
+class capability__pretrain_update(_BaseTag):
+    """Capability: the forecaster can update an existing pretrained state.
+
+    - String name: ``"capability:pretrain_update"``
+    - Public capability tag
+    - Values: boolean, ``True`` / ``False``
+    - Example: ``True``
+    - Default: ``False``
+
+    The ``capability:pretrain_update`` tag indicates whether a subsequent call
+    to ``pretrain`` can continue from the estimator's existing pretrained state.
+    The update consumes the newly passed panel or hierarchical data without
+    restarting from the estimator's initial state or an external checkpoint.
+
+    If the tag is ``True``, ``capability:pretrain`` must also be ``True`` and
+    the forecaster implements ``_pretrain_update`` with continuation semantics.
+
+    If the tag is ``False``, the forecaster does not guarantee that repeated
+    pretraining builds on its existing pretrained state. A full retrain or a
+    recomputation from only the new data does not qualify as a pretrain update.
+    """
+
+    _tags = {
+        "tag_name": "capability:pretrain_update",
+        "parent_type": "forecaster",
+        "tag_type": "bool",
+        "short_descr": "can repeated pretrain update existing pretrained state",
+        "user_facing": True,
+    }
+
+
 class pretrain__fitted_params(_BaseTag):
     """Property: named attributes that carry pretrained state.
 


### PR DESCRIPTION
This PR introduces the `capability:pretrain_update` forecaster tag. The tag distinguishes forecasters that support an initial `pretrain` call from forecasters that can continue pretraining from an existing pretrained state when `pretrain` is called again.

This is a necessary next step for the pretraining API unification tracked in #10151. Foundation models and regular global forecasters do not all have the same update semantics: some can incrementally continue training with additional data, while others must restart training, reload an external checkpoint, or cannot support an update at all. These cases need to be represented explicitly before repeated `pretrain` calls can be handled consistently by the common API.

See also #10154
## Why this requires a separate capability

Support for initial pretraining does not imply support for a pretraining update. For example, a global reduction forecaster can train its inner estimator once on panel data, but cannot continue from that fitted state when the inner estimator is a batch-only learner without an incremental `update` or `partial_fit` operation. Calling `fit` again would construct a new model rather than update the pretrained one. Concrete examples include reductions backed by estimators such as `LinearRegression` or `RandomForestRegressor`: they can learn a global model in one training pass, but do not expose the incremental-learning contract required for a genuine pretraining update.

`LagLlamaForecaster` demonstrates the same distinction for a different reason. It supports initial pretraining and currently defines `_pretrain_update`, but that method only calls `_pretrain` again. `_pretrain` reloads the original checkpoint and trains on the newly supplied data, so it does not continue from the existing pretrained weights. This is an implementation gap in Lag-Llama rather than an inherent model limitation, but it still shows why `capability:pretrain=True` must not automatically imply `capability:pretrain_update=True`.

## Changes

- Adds the public boolean tag `capability:pretrain_update`, with a default value of `False`.
- Defines an update as a repeated `pretrain` call that continues from the existing pretrained state. Restarting from the initial state or recomputing a model from only the new data does not qualify.
- Documents the tag in the registry, `BaseForecaster`, and the forecasting extension template.
- Adds a generic forecaster test requiring every estimator with `capability:pretrain_update=True` to also declare `capability:pretrain=True` and provide its own `_pretrain_update` implementation.
- Enables the tag explicitly on the concrete forecasters that currently implement continuation semantics: `CINNForecaster`, `ConvTimeNetForecaster`, `ESRNNForecaster`, `RBFForecaster`, `SCINetForecaster`, and the LTSF forecasters.
- Leaves the tag disabled for `LagLlamaForecaster`, because its current `_pretrain_update` implementation restarts from the original checkpoint instead of continuing from the existing pretrained state.

## Design decision

The tag remains `False` on `BaseForecaster` and is not enabled on `BaseDeepNetworkPyTorch`. Inheriting from a shared PyTorch base class does not by itself guarantee that a forecaster can safely continue pretraining. Requiring each concrete forecaster to opt in prevents subclasses from advertising unsupported behavior accidentally and makes the capability an explicit part of each estimator's contract.

## Scope

This PR adds the metadata and validation needed to identify pretraining-update support. It does not yet change what the public `pretrain` method does when it is called repeatedly on a forecaster with `capability:pretrain_update=False`; that runtime behavior can be implemented separately against the explicit capability introduced here.
