### PR TITLE
[BUG] preliminary fix for incorrect setting of `_pretrained_attrs` in case `__init__` already sets fitted attrs

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1148,12 +1148,12 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
         orig_y_mtypes = _coerce_to_list(self.get_tag("y_inner_mtype"))
         pretrain_y_mtypes = list(set(orig_y_mtypes + _PRETRAIN_MTYPES))
 
-        prior_attrs = [
+        prior_attrs = {
             a
             for a in dir(self)
             if a.endswith("_")
             and not a.startswith("_")
-        ]
+        }
 
         # pretrain accepts multivariate panel data even for univariate forecasters,
         # because _pretrain can split columns into separate univariate series.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1149,10 +1149,7 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
         pretrain_y_mtypes = list(set(orig_y_mtypes + _PRETRAIN_MTYPES))
 
         prior_attrs = {
-            a
-            for a in dir(self)
-            if a.endswith("_")
-            and not a.startswith("_")
+            a for a in dir(self) if a.endswith("_") and not a.startswith("_")
         }
 
         # pretrain accepts multivariate panel data even for univariate forecasters,

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1148,6 +1148,13 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
         orig_y_mtypes = _coerce_to_list(self.get_tag("y_inner_mtype"))
         pretrain_y_mtypes = list(set(orig_y_mtypes + _PRETRAIN_MTYPES))
 
+        prior_attrs = [
+            a
+            for a in dir(self)
+            if a.endswith("_")
+            and not a.startswith("_")
+        ]
+
         # pretrain accepts multivariate panel data even for univariate forecasters,
         # because _pretrain can split columns into separate univariate series.
         # Pass multivariate=True to prevent column vectorization.
@@ -1184,6 +1191,7 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
             if a.endswith("_")
             and not a.startswith("_")
             and a not in self._pretrained_attrs
+            and a not in prior_attrs
         ]
         self._pretrained_attrs.extend(new_attrs)
 

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -560,7 +560,7 @@ def _get_exog_proba_fcst():
 
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.forecasting.base"]),
-    reason="run only if base module has changed or datatypes module has changed",
+    reason="run only if forecasting base module has changed",
 )
 def test_pretrain_respects_preexisting_attrs():
     """Test that pretrain does not misclassify preexisting attrs as set by pretrain.

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -556,3 +556,31 @@ def _get_exog_proba_fcst():
     reg_proba = ResidualDouble(lin_reg, lin_reg)
 
     return YfromX(reg_proba)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
+def test_pretrain_respects_preexisting_attrs():
+    """Test that pretrain does not misclassify preexisting attrs as set by pretrain.
+
+    Regression test for bug #10531, but also a general API contract test.
+    """
+
+    from sktime.forecasting.naive import NaiveForecaster
+    from sktime.utils._testing.hierarchical import _make_hierarchical
+
+    y_panel = _make_hierarchical(
+        hierarchy_levels=(2,),
+        min_timepoints=5,
+        max_timepoints=5,
+    )
+
+    forecaster = NaiveForecaster()
+
+    forecaster.pretrain(y_panel)
+
+    msg = "pretrain should not misclassify preexisting attrs as set by pretrain"
+    assert len(forecaster._pretrained_attrs) == 0, msg
+    assert len(forecaster.get_pretrained_params()) == 0, msg


### PR DESCRIPTION
Bug #10531 is triggered in case `__init__` already sets fitted attrs, e.g., for initialization (the diagnosis in the issue is incorrect, see discussion below).

This PR adds a preliminary fix: only those attrs are added to `self._pretrained_attrs` that do not already exist once `pretrain` is entered.

A test for regression is also added.

For a final fix, an API design discussion needs to be reopened first.