### PR TITLE
[ENH] rename `timesfm2_forecaster` module to `timesfm2`

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -750,7 +750,7 @@ Domain agnostic foundation models
 
     TimesFMForecaster
 
-.. currentmodule:: sktime.forecasting.timesfm2_forecaster
+.. currentmodule:: sktime.forecasting.timesfm2
 
 .. autosummary::
     :toctree: auto_generated/

--- a/sktime/forecasting/__init__.py
+++ b/sktime/forecasting/__init__.py
@@ -17,6 +17,7 @@ _MODULE_ALIASES = {
     "pykan_forecaster": "pykan",
     "rbf_forecaster": "rbf",
     "timesfm_forecaster": "timesfm",
+    "timesfm2_forecaster": "timesfm2",
 }
 # TODO 2.0.0: remove deprecation and aliasing logic in 2.0 release
 # imports do not need to be updated in the codebase

--- a/sktime/forecasting/timesfm2.py
+++ b/sktime/forecasting/timesfm2.py
@@ -135,7 +135,7 @@ class TimesFM2Forecaster(BaseForecaster):
     Simple zero-shot forecasting with TimesFM-2.5:
 
     >>> from sktime.datasets import load_airline
-    >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
+    >>> from sktime.forecasting.timesfm2 import TimesFM2Forecaster
     >>> y = load_airline()
     >>> # By default, loads google/timesfm-2.5-200m-transformers.
     >>> forecaster = TimesFM2Forecaster()  # doctest: +SKIP
@@ -146,7 +146,7 @@ class TimesFM2Forecaster(BaseForecaster):
     Simple zero-shot forecasting with TimesFM-2.0:
 
     >>> from sktime.datasets import load_airline
-    >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
+    >>> from sktime.forecasting.timesfm2 import TimesFM2Forecaster
     >>> y = load_airline()
     >>> # Loads google/timesfm-2.0-500m-pytorch.
     >>> forecaster = TimesFM2Forecaster(  # doctest: +SKIP
@@ -159,7 +159,7 @@ class TimesFM2Forecaster(BaseForecaster):
     Quantile prediction:
 
     >>> from sktime.datasets import load_airline
-    >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
+    >>> from sktime.forecasting.timesfm2 import TimesFM2Forecaster
     >>> y = load_airline()
     >>> forecaster = TimesFM2Forecaster()  # doctest: +SKIP
     >>> forecaster.fit(y)  # doctest: +SKIP
@@ -173,7 +173,7 @@ class TimesFM2Forecaster(BaseForecaster):
 
     >>> import torch  # doctest: +SKIP
     >>> from sktime.datasets import load_airline
-    >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
+    >>> from sktime.forecasting.timesfm2 import TimesFM2Forecaster
     >>> from transformers import QuantoConfig  # doctest: +SKIP
     >>> y = load_airline()
     >>> forecaster = TimesFM2Forecaster(  # doctest: +SKIP
@@ -189,7 +189,7 @@ class TimesFM2Forecaster(BaseForecaster):
 
     >>> from peft import LoraConfig  # doctest: +SKIP
     >>> from sktime.datasets import load_airline
-    >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
+    >>> from sktime.forecasting.timesfm2 import TimesFM2Forecaster
     >>> from sktime.utils._testing.hierarchical import _make_hierarchical
     >>> y_panel = _make_hierarchical(  # doctest: +SKIP
     ...     hierarchy_levels=(3,),
@@ -217,7 +217,7 @@ class TimesFM2Forecaster(BaseForecaster):
     ``model_path`` and are ignored when ``model_path=None``.
 
     >>> from sktime.datasets import load_airline
-    >>> from sktime.forecasting.timesfm2_forecaster import TimesFM2Forecaster
+    >>> from sktime.forecasting.timesfm2 import TimesFM2Forecaster
     >>> from sktime.utils._testing.hierarchical import _make_hierarchical
     >>> y_panel = _make_hierarchical(  # doctest: +SKIP
     ...     hierarchy_levels=(3,),


### PR DESCRIPTION
renames the `timesfm2_forecaster` module to `timesfm2` to adhere to the convention to not multiply "forecasting" in the module names and imports, i.e., `sktime.forecasting.timesfm2_forecaster`.

The old path still works silently, but is no longer advertised, hence no breaking change.