### PR TITLE
Update classification_examples.py

### DIFF
--- a/_contrib/classification_examples.py
+++ b/_contrib/classification_examples.py
@@ -1,16 +1,54 @@
 """Classifier Examples: some use case examples for building and assessing classifiers.
 
-This will become a note book once complete.
+This will become a notebook once complete.
 """
-
 __author__ = ["TonyBagnall"]
 
 import numpy as np
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
-
 from sktime.classification.dictionary_based import ContractableBOSS
+from sktime.classification.kernel_based import RocketClassifier
+from sktime.classification.hybrid import HIVECOTEV2
 from sktime.datasets import load_unit_test
+
+
+def make_toy_problem(n_dims=1, n_instances_per_class=20, n_timepoints=100):
+    """Make a toy binary classification problem out of numpy arrays.
+
+    Parameters
+    ----------
+    n_dims : int
+        Number of dimensions/channels. 1 returns a 2D array (n_instances,
+        n_timepoints); >1 returns a 3D array (n_instances, n_dims,
+        n_timepoints).
+    n_instances_per_class : int
+        Number of instances to generate for each of the two classes.
+    n_timepoints : int
+        Series length.
+
+    Returns
+    -------
+    X_train, y_train, X_test, y_test
+    """
+
+    def _make_split():
+        shape1 = (
+            (n_instances_per_class, n_timepoints)
+            if n_dims == 1
+            else (n_instances_per_class, n_dims, n_timepoints)
+        )
+        X_class1 = np.random.uniform(-1, 1, size=shape1)
+        y_class1 = np.zeros(n_instances_per_class)
+        X_class2 = np.random.uniform(-0.9, 1.1, size=shape1)
+        y_class2 = np.ones(n_instances_per_class)
+        X = np.concatenate((X_class1, X_class2), axis=0)
+        y = np.concatenate((y_class1, y_class2))
+        return X, y
+
+    X_train, y_train = _make_split()
+    X_test, y_test = _make_split()
+    return X_train, y_train, X_test, y_test
 
 
 def build_classifiers():
@@ -22,85 +60,121 @@ def build_classifiers():
     4. From a baked in dataset.
     5. From any UCR/UEA dataset downloaded from timeseriesclassification.com.
     """
-    # Create an array
-    # Random forest, rocket and HC2.
+    X_train, y_train, X_test, y_test = make_toy_problem(n_dims=1)
+    y_train = pd.Series(y_train)
+    y_test = pd.Series(y_test)
+
+    # Random forest on 2D data (sklearn expects (n_instances, n_features))
     randf = RandomForestClassifier()
-    trainX, train_y, testX, test_y = make_toy_2d_problem()
-    X = trainX.reshape(trainX.shape[0], 1, trainX.shape[1])
-    train_y = pd.Series(train_y)
-    test_y = pd.Series(test_y)
-    # randf.fit(trainX, train_y)
-    cls1 = ContractableBOSS(time_limit_in_minutes=1)
-    # cls2 = BOSSEnsemble()
-    cls1.fit(trainX, train_y)
-    print(" CBOSS acc = ", cls1.score(testX, test_y))
-    # preds = cls1.predict(testX)
+    randf.fit(X_train, y_train)
+    print("Random Forest acc = ", randf.score(X_test, y_test))
+
+    # ContractableBOSS, an sktime time series classifier
+    cboss = ContractableBOSS(time_limit_in_minutes=1)
+    cboss.fit(X_train, y_train)
+    print("CBOSS acc = ", cboss.score(X_test, y_test))
+
+    # RocketClassifier, works on 2D or 3D input
+    rocket = RocketClassifier(num_kernels=500)
+    rocket.fit(X_train, y_train)
+    print("Rocket acc = ", rocket.score(X_test, y_test))
+
+    # 3D (multivariate) toy problem, needed for HIVE-COTE style classifiers
+    X_train_3d, y_train_3d, X_test_3d, y_test_3d = make_toy_problem(n_dims=3)
+    y_train_3d = pd.Series(y_train_3d)
+    y_test_3d = pd.Series(y_test_3d)
+
+    hc2 = HIVECOTEV2(time_limit_in_minutes=1)
+    hc2.fit(X_train_3d, y_train_3d)
+    print("HC2 acc = ", hc2.score(X_test_3d, y_test_3d))
 
 
-def make_toy_2d_problem():
-    """Make a toy classification problem out of numpy arrays."""
-    X_train_class1 = np.random.uniform(-1, 1, size=(20, 100))
-    y_train_class1 = np.zeros(
-        20,
-    )
-    X_train_class2 = np.random.uniform(-0.9, 1.1, size=(20, 100))
-    y_train_class2 = np.ones(
-        20,
-    )
-    X_train = np.concatenate((X_train_class1, X_train_class2), axis=0)
-    y_train = np.concatenate((y_train_class1, y_train_class2))
+def compare_classifiers(datasets=None):
+    """Build pipeline classifiers, compare accuracies and draw a CD diagram.
 
-    X_test_class1 = np.random.uniform(-1, 1, size=(20, 100))
-    y_test_class1 = np.zeros(
-        20,
-    )
-    X_test_class2 = np.random.uniform(-0.9, 1.1, size=(20, 100))
-    y_test_class2 = np.ones(
-        20,
-    )
-    X_test = np.concatenate((X_test_class1, X_test_class2), axis=0)
-    y_test = np.concatenate((y_test_class1, y_test_class2))
-    return X_train, y_train, X_test, y_test
+    Parameters
+    ----------
+    datasets : list of str, optional
+        Names of datasets to load via sktime's dataset loaders. Defaults to
+        just the small "UnitTest" dataset bundled with sktime, so this runs
+        quickly out of the box. Swap in real UCR/UEA dataset names to run a
+        proper comparison, e.g. ["Chinatown", "ItalyPowerDemand", "Coffee"].
+    """
+    if datasets is None:
+        datasets = ["UnitTest"]
+
+    classifiers = {
+        "CBOSS": ContractableBOSS(time_limit_in_minutes=1),
+        "Rocket": RocketClassifier(num_kernels=500),
+    }
+
+    results = pd.DataFrame(index=datasets, columns=list(classifiers.keys()), dtype=float)
+
+    for dataset_name in datasets:
+        # load_unit_test is a stand-in loader for the bundled toy dataset;
+        # swap for sktime.datasets.load_UCR_UEA_dataset(name=dataset_name)
+        # to pull real datasets from timeseriesclassification.com
+        if dataset_name == "UnitTest":
+            X_train, y_train = load_unit_test(split="train", return_X_y=True)
+            X_test, y_test = load_unit_test(split="test", return_X_y=True)
+        else:
+            from sktime.datasets import load_UCR_UEA_dataset
+
+            X_train, y_train = load_UCR_UEA_dataset(
+                name=dataset_name, split="train", return_X_y=True
+            )
+            X_test, y_test = load_UCR_UEA_dataset(
+                name=dataset_name, split="test", return_X_y=True
+            )
+
+        for clf_name, clf in classifiers.items():
+            clf.fit(X_train, y_train)
+            acc = clf.score(X_test, y_test)
+            results.loc[dataset_name, clf_name] = acc
+            print(f"{dataset_name} / {clf_name} acc = {acc:.4f}")
+
+    print("\nResults summary:")
+    print(results)
+
+    _draw_cd_diagram(results)
+    return results
 
 
-def make_toy_3d_problem():
-    """Make a toy 3D classification problem out of numpy arrays."""
-    X_train_class1 = np.random.uniform(-1, 1, size=(20, 3, 100))
-    y_train_class1 = np.zeros(
-        20,
-    )
-    X_train_class2 = np.random.uniform(-0.9, 1.1, size=(20, 3, 100))
-    y_train_class2 = np.ones(
-        20,
-    )
-    X_train = np.concatenate((X_train_class1, X_train_class2), axis=0)
-    y_train = np.concatenate((y_train_class1, y_train_class2))
+def _draw_cd_diagram(results):
+    """Draw a critical difference diagram comparing classifiers.
 
-    X_test_class1 = np.random.uniform(-1, 1, size=(20, 3, 100))
-    y_test_class1 = np.zeros(
-        20,
-    )
-    X_test_class2 = np.random.uniform(-0.9, 1.1, size=(20, 3, 100))
-    y_test_class2 = np.ones(
-        20,
-    )
-    X_test = np.concatenate((X_test_class1, X_test_class2), axis=0)
-    y_test = np.concatenate((y_test_class1, y_test_class2))
-    return X_train, y_train, X_test, y_test
+    Requires at least 3 datasets to be meaningful; with only one dataset
+    (the default quick-run case) this just prints a note instead.
+    """
+    if results.shape[0] < 3:
+        print(
+            "\nSkipping CD diagram: need results on >= 3 datasets for a "
+            "meaningful critical difference comparison. Pass more dataset "
+            "names to compare_classifiers()."
+        )
+        return
+
+    try:
+        from sktime.benchmarking.evaluation import Evaluator
+        from sktime.benchmarking.results import RAMResults
+
+        # sktime's benchmarking API expects results logged per-dataset via a
+        # Results object; wiring this up fully requires running fit/predict
+        # through sktime.benchmarking.tasks/strategies rather than the plain
+        # sklearn-style calls above. Left as a pointer for a full pipeline.
+        print(
+            "\nTo draw a proper CD diagram, log per-fold results through "
+            "sktime.benchmarking (RAMResults + Evaluator) or use the "
+            "critical-difference plotting utility in "
+            "sktime.benchmarking.evaluation."
+        )
+    except ImportError:
+        print("\nsktime.benchmarking not available; skipping CD diagram.")
 
 
-def compare_classifiers():
-    """Build pipeline classifiers and compare to published results."""
-    # Data set list
-    X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    X_test, y_test = load_unit_test(split="test", return_X_y=True)
-    # Define Transformer pipeline
-    print(y_train)
-    print(type(y_train))
-    print(type(y_train[0]))
+if __name__ == "__main__":
+    print("=== build_classifiers ===")
+    build_classifiers()
 
-    # fit and score for each dataset
-
-    # Pull down accuracies
-
-    # Draw CD diagram
+    print("\n=== compare_classifiers ===")
+    compare_classifiers()


### PR DESCRIPTION
Fix dead code and implement classifier comparison examples

- Remove unused reshape/Series conversions in build_classifiers()
  that were never passed to any classifier call
- Actually fit and score RandomForest, Rocket, and HIVECOTEV2 as
  promised in the docstring (previously only ContractableBOSS ran)
- Merge make_toy_2d_problem() and make_toy_3d_problem() into a
  single make_toy_problem(n_dims=...) helper to remove duplication
- Implement compare_classifiers() to actually loop over datasets,
  fit/score multiple classifiers, and collect results into a
  DataFrame (previously only printed debug info)
- Add CD diagram stub pointing at sktime.benchmarking utilities,
  with a note that full wiring requires sktime's Results/Evaluator
  objects
- Add __main__ block so the script runs end-to-end
- Remove stale commented-out code