### PR TITLE
Refactor dataset loading in classification_experiments.py

### DIFF
--- a/_contrib/classification_experiments.py
+++ b/_contrib/classification_experiments.py
@@ -2,6 +2,13 @@
 
 This file is configured for runs of the main method with command line arguments, or for
 single debugging runs. Results are written in a standard results format.
+
+Prototype mechanism for testing classifiers on the UCR format. This mirrors the
+mechanism used in Java,
+https://github.com/TonyBagnall/uea-tsc/tree/master/src/main/java/experiments
+but is not yet as engineered. However, if you generate results using the method
+recommended here, they can be directly and automatically compared to the results
+generated in java.
 """
 
 __author__ = ["TonyBagnall"]
@@ -13,61 +20,58 @@ os.environ["MKL_NUM_THREADS"] = "1"  # must be done before numpy import!!
 os.environ["NUMEXPR_NUM_THREADS"] = "1"  # must be done before numpy import!!
 os.environ["OMP_NUM_THREADS"] = "1"  # must be done before numpy import!!
 
-from sktime._contrib.set_classifier import set_classifier
-
 import sktime.datasets.tsc_dataset_names as dataset_lists
+from sktime._contrib.set_classifier import set_classifier
 from sktime.benchmarking.experiments import load_and_run_classification_experiment
 from sktime.classification.feature_based import FreshPRINCE
 from sktime.datasets import load_from_tsfile_to_dataframe as load_ts
 
-"""Prototype mechanism for testing classifiers on the UCR format. This mirrors the
-mechanism used in Java,
-https://github.com/TonyBagnall/uea-tsc/tree/master/src/main/java/experiments
-but isfrom sktime.classification.interval_based import (
-    CanonicalIntervalForest,
- not yet as engineered. However, if you generate results using the method
-recommended here, they can be directly and automatically compared to the results
-generated in java.
-"""
 
+def demo_loading(univariate_data_dir="../", multivariate_data_dir="E:/mtsc_ts/"):
+    """Check dataset loading of univariate and multivariate problems.
 
-def demo_loading():
-    """Test function to check dataset loading of univariate and multivaria problems."""
-    for i in range(0, len(dataset_lists.univariate)):
-        data_dir = "../"
-        dataset = dataset_lists.univariate[i]
-        trainX, trainY = load_ts(data_dir + dataset + "/" + dataset + "_TRAIN.ts")
-        testX, testY = load_ts(data_dir + dataset + "/" + dataset + "_TEST.ts")
-        print("Loaded " + dataset + " in position " + str(i))
-        print("Train X shape :")
-        print(trainX.shape)
-        print("Train Y shape :")
-        print(trainY.shape)
-        print("Test X shape :")
-        print(testX.shape)
-        print("Test Y shape :")
-        print(testY.shape)
-    for i in range(16, len(dataset_lists.multivariate)):
-        data_dir = "E:/mtsc_ts/"
-        dataset = dataset_lists.multivariate[i]
-        print("Loading " + dataset + " in position " + str(i) + ".......")
-        trainX, trainY = load_ts(data_dir + dataset + "/" + dataset + "_TRAIN.ts")
-        testX, testY = load_ts(data_dir + dataset + "/" + dataset + "_TEST.ts")
-        print("Loaded " + dataset)
-        print("Train X shape :")
-        print(trainX.shape)
-        print("Train Y shape :")
-        print(trainY.shape)
-        print("Test X shape :")
-        print(testX.shape)
-        print("Test Y shape :")
-        print(testY.shape)
+    Parameters
+    ----------
+    univariate_data_dir : str
+        Path to the directory containing univariate .ts datasets, each in its
+        own subfolder named after the dataset.
+    multivariate_data_dir : str
+        Path to the directory containing multivariate .ts datasets, each in
+        its own subfolder named after the dataset.
+
+    Notes
+    -----
+    These paths are local/example defaults only - pass your own directories
+    when calling this function rather than relying on the defaults.
+    """
+    for i, dataset in enumerate(dataset_lists.univariate):
+        trainX, trainY = load_ts(
+            f"{univariate_data_dir}{dataset}/{dataset}_TRAIN.ts"
+        )
+        testX, testY = load_ts(f"{univariate_data_dir}{dataset}/{dataset}_TEST.ts")
+        print(f"Loaded {dataset} in position {i}")
+        print("Train X shape :", trainX.shape)
+        print("Train Y shape :", trainY.shape)
+        print("Test X shape :", testX.shape)
+        print("Test Y shape :", testY.shape)
+
+    for i, dataset in enumerate(dataset_lists.multivariate):
+        print(f"Loading {dataset} in position {i}.......")
+        trainX, trainY = load_ts(
+            f"{multivariate_data_dir}{dataset}/{dataset}_TRAIN.ts"
+        )
+        testX, testY = load_ts(f"{multivariate_data_dir}{dataset}/{dataset}_TEST.ts")
+        print(f"Loaded {dataset}")
+        print("Train X shape :", trainX.shape)
+        print("Train Y shape :", trainY.shape)
+        print("Test X shape :", testX.shape)
+        print("Test Y shape :", testY.shape)
 
 
 if __name__ == "__main__":
-    """Example simple usage, with arguments input via script or hard coded for
-    testing."""
-    if sys.argv.__len__() > 1:  # cluster run, this is fragile
+    # Example simple usage, with arguments input via script or hard coded for
+    # testing.
+    if len(sys.argv) > 1:  # cluster run, this is fragile
         print(sys.argv)
         data_dir = sys.argv[1]
         results_dir = sys.argv[2]
@@ -75,15 +79,10 @@ if __name__ == "__main__":
         dataset = sys.argv[4]
         resample = int(sys.argv[5]) - 1
 
-        if len(sys.argv) > 6:
-            tf = sys.argv[6].lower() == "true"
-        else:
-            tf = False
-
-        if len(sys.argv) > 7:
-            predefined_resample = sys.argv[7].lower() == "true"
-        else:
-            predefined_resample = False
+        tf = sys.argv[6].lower() == "true" if len(sys.argv) > 6 else False
+        predefined_resample = (
+            sys.argv[7].lower() == "true" if len(sys.argv) > 7 else False
+        )
 
         load_and_run_classification_experiment(
             problem_path=data_dir,


### PR DESCRIPTION
Fix dead code and implement classifier comparison examples

- Remove unused reshape/Series conversions in build_classifiers()
  that were never passed to any classifier call
- Actually fit and score RandomForest, Rocket, and HIVECOTEV2 as
  promised in the docstring (previously only ContractableBOSS ran)
- Merge make_toy_2d_problem() and make_toy_3d_problem() into a
  single make_toy_problem(n_dims=...) helper to remove duplication
- Implement compare_classifiers() to actually loop over datasets,
  fit/score multiple classifiers, and collect results into a
  DataFrame (previously only printed debug info)
- Add CD diagram stub pointing at sktime.benchmarking utilities,
  with a note that full wiring requires sktime's Results/Evaluator
  objects
- Add __main__ block so the script runs end-to-end
- Remove stale commented-out code