### PR TITLE
[DOC] fix broken contributors hall of fame badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ There are many ways to join the sktime community. We follow the [all-contributor
 Thanks to all our community for all your wonderful contributions, PRs, issues, ideas.
 
 <a href="https://github.com/sktime/sktime/graphs/contributors">
-<img src="https://opencollective.com/sktime/contributors.svg?width=600&button=false" />
+<img src="https://contrib.rocks/image?repo=sktime/sktime" />
 </a>
 <br>
 


### PR DESCRIPTION
## Reference Issues/PRs
Fixes the broken "Hall of fame" badge flagged in #core-dev Discord (opencollective link no longer works).

## What does this implement/fix?
`opencollective.com/sktime/contributors.svg` now returns HTTP 400 - OpenCollective removed the classic contributor-avatar embed endpoint (verified directly; the org page itself still exists, just no longer serves this widget).

Replaced with `contrib.rocks/image?repo=sktime/sktime`, a maintained drop-in equivalent that renders a live avatar grid from GitHub's contributor list. No custom infra, GitHub API polling, or cron job needed - verified it renders correctly for this repo.

## Does your contribution introduce a new dependency?
No, it's a static image URL in the README, same as before.

## Did you add any tests for the change?
No, README markup change, nothing to test.