### PR TITLE
[MNT] add `numba` dependency to `notebooks` test depset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,7 @@ notebooks = [
   "lightning>=2.0,<2.7",
   "skpro",
   "statsforecast",
+  "numba",
 ]
 numpy1 = [
   "numpy<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,7 +252,7 @@ notebooks = [
   "lightning>=2.0,<2.7",
   "skpro",
   "statsforecast",
-  "numba",
+  'numba<0.63; python_version < "3.14"',
 ]
 numpy1 = [
   "numpy<2.0.0",


### PR DESCRIPTION
adds the `numba` dependency to `notebooks` test depset to fix the failure in the old benchmarking notebook.