### PR TITLE
[ENH] Fill values with `NaN` upon experiment failures, instead of empty df

### DIFF
--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from sktime.base import BaseEstimator
 from sktime.benchmarking._benchmarking_dataclasses import (
+    FoldResults,
     ResultObject,
     TaskObject,
 )
@@ -123,6 +124,15 @@ class FailedExperimentRecord:
     exception_message: str
 
 
+def _is_failed_result(result: ResultObject) -> bool:
+    """Return whether a result is a placeholder for a failed validation run."""
+    if not result.folds:
+        return True
+    first_fold = next(iter(result.folds.values()))
+    fit_time = first_fold.scores.get("fit_time")
+    return fit_time is not None and pd.isna(fit_time)
+
+
 @dataclass
 class _BenchmarkingResults:
     """In-memory container for benchmark results.
@@ -206,7 +216,9 @@ class _BenchmarkingResults:
             exists in the in-memory result list.
         """
         return any(
-            result.task_id == task_id and result.model_id == model_id
+            result.task_id == task_id
+            and result.model_id == model_id
+            and not _is_failed_result(result)
             for result in self.results
         )
 
@@ -638,6 +650,7 @@ class BaseBenchmark:
                     failure.exception_type,
                     failure.exception_message,
                 )
+                results.update(self._make_failed_result(task_id, estimator_id, task))
                 continue
 
             results.update(
@@ -720,6 +733,32 @@ class BaseBenchmark:
             Summary of benchmark run for all completed experiments.
         """
         return self._run(output_file, force_rerun)
+
+    def _task_type_for_data(self) -> str:
+        """Return the task type string passed to ``TaskObject.get_y_X``."""
+        # We can infer the type automatically from the tag for dataloader classes,
+        # but earlier data loaders were functions, and people still use them.
+        raise NotImplementedError("This method must be implemented by a subclass.")
+
+    def _failed_result_score_keys(self, task: TaskObject) -> list[str]:
+        """Return score keys used in fold results for the given task."""
+        raise NotImplementedError("This method must be implemented by a subclass.")
+
+    def _make_failed_result(
+        self, task_id: str, model_id: str, task: TaskObject
+    ) -> ResultObject:
+        """Build a placeholder result with NaN scores for a failed validation run."""
+        score_keys = self._failed_result_score_keys(task)
+        xy = task.get_y_X(self._task_type_for_data())
+        split_data = xy["X"] if xy.get("X") is not None else xy["y"]
+        n_folds = task.cv_splitter.get_n_splits(split_data)
+
+        nan = float("nan")
+        folds = {
+            fold_idx: FoldResults(scores=dict.fromkeys(score_keys, nan))
+            for fold_idx in range(n_folds)
+        }
+        return ResultObject(task_id=task_id, model_id=model_id, folds=folds)
 
     def _run_validation(self, task: TaskObject, estimator: BaseEstimator):
         """Run validation for a single task and estimator."""

--- a/sktime/benchmarking/classification.py
+++ b/sktime/benchmarking/classification.py
@@ -138,6 +138,15 @@ class ClassificationBenchmark(BaseBenchmark):
             TaskObject(**task_kwargs),
         )
 
+    # We need this because older dataloaders were functions without tags
+    def _task_type_for_data(self) -> str:
+        return "classification"
+
+    def _failed_result_score_keys(self, task: TaskObject) -> list[str]:
+        keys = [scorer.__name__ for scorer in task.scorers]
+        keys.extend(["fit_time", "pred_time"])
+        return keys
+
     def _run_validation(self, task: TaskObject, estimator: BaseClassifier):
         cv_splitter = task.cv_splitter
         scorers = task.scorers

--- a/sktime/benchmarking/forecasting.py
+++ b/sktime/benchmarking/forecasting.py
@@ -189,6 +189,15 @@ class ForecastingBenchmark(BaseBenchmark):
             TaskObject(**task_kwargs),
         )
 
+    # We need this because older dataloaders were functions without tags
+    def _task_type_for_data(self) -> str:
+        return "forecasting"
+
+    def _failed_result_score_keys(self, task: TaskObject) -> list[str]:
+        keys = [scorer.name for scorer in task.scorers]
+        keys.extend(["fit_time", "pred_time"])
+        return keys
+
     def _run_validation(self, task: TaskObject, estimator: BaseForecaster):
         cv_splitter = task.cv_splitter
         scorers = task.scorers

--- a/sktime/benchmarking/tests/test_fault_tolerance.py
+++ b/sktime/benchmarking/tests/test_fault_tolerance.py
@@ -48,7 +48,7 @@ def cv_splitter_classification():
 def test_classification_continues_after_failure(
     tmp_path, cv_splitter_classification, caplog
 ):
-    """Failed classification pair is skipped; remaining pairs still run."""
+    """Failed classification pair is recorded with NaN; remaining pairs still run."""
     benchmark = ClassificationBenchmark()
     benchmark.add_estimator(_FailingClassifier())
     benchmark.add_estimator(DummyClassifier())
@@ -59,9 +59,15 @@ def test_classification_continues_after_failure(
     with caplog.at_level(logging.WARNING):
         results_df = benchmark.run(tmp_path / "results.csv")
 
-    assert len(results_df) == 1
-    assert results_df["model_id"].iloc[0] == "DummyClassifier"
-    assert "FailingClassifier" not in results_df["model_id"].values
+    assert len(results_df) == 2
+    assert set(results_df["model_id"]) == {"DummyClassifier", "_FailingClassifier"}
+
+    failing_row = results_df.loc[results_df["model_id"] == "_FailingClassifier"].iloc[0]
+    assert pd.isna(failing_row["accuracy_score_mean"])
+    assert pd.isna(failing_row["fit_time_mean"])
+
+    success_row = results_df.loc[results_df["model_id"] == "DummyClassifier"].iloc[0]
+    assert not pd.isna(success_row["accuracy_score_mean"])
 
     failures = benchmark.failed_experiments
     assert len(failures) == 1
@@ -77,7 +83,7 @@ def test_classification_continues_after_failure(
 
 
 def test_forecasting_continues_after_failure(tmp_path, cv_splitter_forecasting, caplog):
-    """Failed forecasting pair is skipped; remaining pairs still run."""
+    """Failed forecasting pair is recorded with NaN; remaining pairs still run."""
     benchmark = ForecastingBenchmark()
     benchmark.add_estimator(_FailingForecaster())
     benchmark.add_estimator(NaiveForecaster(strategy="last"))
@@ -88,9 +94,12 @@ def test_forecasting_continues_after_failure(tmp_path, cv_splitter_forecasting, 
     with caplog.at_level(logging.WARNING):
         results_df = benchmark.run(tmp_path / "results.csv")
 
-    assert len(results_df) == 1
-    assert results_df["model_id"].iloc[0] == "NaiveForecaster"
-    assert "_FailingForecaster" not in results_df["model_id"].values
+    assert len(results_df) == 2
+    assert set(results_df["model_id"]) == {"NaiveForecaster", "_FailingForecaster"}
+
+    failing_row = results_df.loc[results_df["model_id"] == "_FailingForecaster"].iloc[0]
+    assert pd.isna(failing_row["MeanAbsoluteError_mean"])
+    assert pd.isna(failing_row["fit_time_mean"])
 
     failures = benchmark.failed_experiments
     assert len(failures) == 1
@@ -118,8 +127,13 @@ def test_multiple_failures_all_reported(tmp_path, cv_splitter_classification, ca
     with caplog.at_level(logging.WARNING):
         results_df = benchmark.run(tmp_path / "results.csv")
 
-    assert len(results_df) == 2
-    assert set(results_df["model_id"]) == {"DummyClassifier"}
+    assert len(results_df) == 4
+    assert set(results_df["model_id"]) == {"DummyClassifier", "_FailingClassifier"}
+
+    failing_rows = results_df.loc[results_df["model_id"] == "_FailingClassifier"]
+    assert len(failing_rows) == 2
+    assert failing_rows["accuracy_score_mean"].isna().all()
+
     assert len(benchmark.failed_experiments) == 2
     assert {f.model_id for f in benchmark.failed_experiments} == {"_FailingClassifier"}
     assert {f.task_id for f in benchmark.failed_experiments} == {
@@ -129,8 +143,8 @@ def test_multiple_failures_all_reported(tmp_path, cv_splitter_classification, ca
     assert "Benchmark completed with 2 failed task-estimator pair(s)" in caplog.text
 
 
-def test_failed_pair_not_saved_to_checkpoint(tmp_path, cv_splitter_classification):
-    """Failed pairs are absent from saved results; successful pairs are persisted."""
+def test_failed_pair_saved_to_checkpoint_with_nan(tmp_path, cv_splitter_classification):
+    """Failed pairs are persisted with NaN scores; successful pairs are persisted."""
     results_file = tmp_path / "results.csv"
 
     benchmark = ClassificationBenchmark()
@@ -142,8 +156,11 @@ def test_failed_pair_not_saved_to_checkpoint(tmp_path, cv_splitter_classificatio
     benchmark.run(results_file)
 
     saved_df = pd.read_csv(results_file)
-    assert len(saved_df) == 1
-    assert saved_df["model_id"].iloc[0] == "DummyClassifier"
+    assert len(saved_df) == 2
+    assert set(saved_df["model_id"]) == {"DummyClassifier", "_FailingClassifier"}
+
+    failing_row = saved_df.loc[saved_df["model_id"] == "_FailingClassifier"].iloc[0]
+    assert pd.isna(failing_row["means.accuracy_score"])
 
 
 def test_rerun_retries_failed_pair_after_partial_success(
@@ -171,14 +188,14 @@ def test_rerun_retries_failed_pair_after_partial_success(
 
     results_df = benchmark2.run(results_file)
 
-    assert len(results_df) == 1
+    assert len(results_df) == 2
     assert len(benchmark2.failed_experiments) == 1
 
 
-def test_all_pairs_fail_returns_empty_results(
+def test_all_pairs_fail_returns_nan_results(
     tmp_path, cv_splitter_classification, caplog
 ):
-    """When every pair fails, results are empty and failures are reported."""
+    """When every pair fails, results contain NaN rows with expected columns."""
     benchmark = ClassificationBenchmark()
     benchmark.add_estimator(_FailingClassifier())
     benchmark.add_task(
@@ -188,7 +205,12 @@ def test_all_pairs_fail_returns_empty_results(
     with caplog.at_level(logging.WARNING):
         results_df = benchmark.run(tmp_path / "results.csv")
 
-    assert results_df.empty
+    assert len(results_df) == 1
+    assert results_df["model_id"].iloc[0] == "_FailingClassifier"
+    assert pd.isna(results_df["accuracy_score_mean"].iloc[0])
+    assert pd.isna(results_df["fit_time_mean"].iloc[0])
+    assert "validation_id" in results_df.columns
+    assert "model_id" in results_df.columns
     assert len(benchmark.failed_experiments) == 1
     assert "Benchmark completed with 1 failed task-estimator pair(s)" in caplog.text
 

--- a/sktime/benchmarking/tests/test_incremental_store.py
+++ b/sktime/benchmarking/tests/test_incremental_store.py
@@ -15,7 +15,7 @@ from sktime.benchmarking._storage_handlers import (
     CSVStorageHandler,
     JSONStorageHandler,
 )
-from sktime.benchmarking.benchmarks import _BenchmarkingResults
+from sktime.benchmarking.benchmarks import _BenchmarkingResults, _is_failed_result
 from sktime.benchmarking.forecasting import ForecastingBenchmark
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.performance_metrics.forecasting import MeanSquaredPercentageError
@@ -302,7 +302,8 @@ def test_benchmark_resumes_after_crash(tmp_path, monkeypatch, output_suffix):
             raise RuntimeError("Simulated benchmark failure")
         return original_save(self)
 
-    # Validation failures are caught; simulate a crash during final save instead.
+    # Failed validation runs are checkpointed with NaN; simulate a crash during
+    # final save instead.
     monkeypatch.setattr(_BenchmarkingResults, "save", crashing_save_once)
 
     with pytest.raises(RuntimeError, match="Simulated benchmark failure"):
@@ -313,8 +314,13 @@ def test_benchmark_resumes_after_crash(tmp_path, monkeypatch, output_suffix):
 
     assert not results_path.exists()
     assert store.parts_dir.exists()
-    assert len(partial_results) == 1
-    assert partial_results[0].model_id == "naive_last"
+    assert len(partial_results) == 2
+    successful = [r for r in partial_results if not _is_failed_result(r)]
+    failed = [r for r in partial_results if _is_failed_result(r)]
+    assert len(successful) == 1
+    assert successful[0].model_id == "naive_last"
+    assert len(failed) == 1
+    assert failed[0].model_id == "naive_mean"
 
     resumed_benchmark = _setup_benchmark()
     results_df = resumed_benchmark.run(str(results_path))


### PR DESCRIPTION
Currently if one or more task-estimator pair fails in the benchmarking experiment, the failure gets raised as warnings instead of exceptions to not break the entire experiment, and in the case where the entire experiment fails, an empty result file gets written, the on-memory dataframe is empty too as a result with two dummy columns. This PR allows a valid result file write and dataframe creation in the case of failures as well, with the missing values filled with `NaN`. In the case of rerun, the benchmark then detects the columns with `NaN` values and considers those estimator-task pairs as unsuccessful. 