### PR TITLE
[ENH] temporarily skip `test_forecastingbenchmark_global_mode` until fixed

### DIFF
--- a/sktime/benchmarking/tests/test_forecasting.py
+++ b/sktime/benchmarking/tests/test_forecasting.py
@@ -177,7 +177,7 @@ def test_forecastingbenchmark(tmp_path, expected_results_df, scorers):
     )
 
 
-@pytest.mark.skip(reason="currently unfixed failure, see #10555")
+@pytest.mark.xfail(reason="currently unfixed failure, see #10555")
 @pytest.mark.skipif(
     not run_test_module_changed("sktime.benchmarking")
     and not run_test_module_changed("sktime.forecasting.base")

--- a/sktime/benchmarking/tests/test_forecasting.py
+++ b/sktime/benchmarking/tests/test_forecasting.py
@@ -177,6 +177,7 @@ def test_forecastingbenchmark(tmp_path, expected_results_df, scorers):
     )
 
 
+@pytest.mark.skip(reason="currently unfixed failure, see #10555")
 @pytest.mark.skipif(
     not run_test_module_changed("sktime.benchmarking")
     and not run_test_module_changed("sktime.forecasting.base")


### PR DESCRIPTION
temporarily skips `test_forecastingbenchmark_global_mode` until fixed, see #10555 for the bug report.