### PR TITLE
[ENH] `GreyKiteForecaster` - clean up tags

### DIFF
--- a/sktime/forecasting/greykite.py
+++ b/sktime/forecasting/greykite.py
@@ -62,6 +62,11 @@ class GreykiteForecaster(BaseForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "python_dependencies": ["greykite>=1.0.0"],  # Required Python dependencies.
+        # estimator type
+        # --------------
         "capability:multivariate": False,  # Handles univariate targets here.
         "capability:exogenous": True,  # Can handle exogenous variables.
         "capability:missing_values": True,  # Handles missing data.
@@ -70,8 +75,6 @@ class GreykiteForecaster(BaseForecaster):
         "requires-fh-in-fit": True,  # Forecasting horizon is required in fit.
         "capability:pred_int": False,  # Can produce prediction intervals.
         "capability:unequal_length": False,
-        "python_dependencies": ["greykite>=1.0.0"],  # Required Python dependencies.
-        "tests:skip_all": True,  # skip all tests temporarily, issue tracked in #10083
         "capability:insample": False,
         # CI and test flags
         # -----------------

--- a/sktime/forecasting/greykite.py
+++ b/sktime/forecasting/greykite.py
@@ -113,7 +113,7 @@ class GreykiteForecaster(BaseForecaster):
         This method should be used for setting dynamic tags only.
         """
         if self.model_template == "PROPHET":
-            self.set_tags({"python_dependencies": ["greykite>=1.0.0", "prophet"]})
+            self.set_tags(**{"python_dependencies": ["greykite>=1.0.0", "prophet"]})
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.

--- a/sktime/forecasting/greykite.py
+++ b/sktime/forecasting/greykite.py
@@ -87,6 +87,7 @@ class GreykiteForecaster(BaseForecaster):
             "test_update_predict_predicted_index",
             "test_deepcopy_fitted_predict",
         ],
+        "tests:python_dependencies": ["prophet"],
     }
 
     def __init__(
@@ -102,6 +103,14 @@ class GreykiteForecaster(BaseForecaster):
         self.coverage = coverage
 
         super().__init__()
+
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        if self.model_template == "PROPHET":
+            self.set_tags({"python_dependencies": ["greykite>=1.0.0", "prophet"]})
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.

--- a/sktime/forecasting/greykite.py
+++ b/sktime/forecasting/greykite.py
@@ -64,7 +64,7 @@ class GreykiteForecaster(BaseForecaster):
     _tags = {
         # packaging info
         # --------------
-        "python_dependencies": ["greykite>=1.0.0"],  # Required Python dependencies.
+        "python_dependencies": ["greykite>=1.0.0"],
         # estimator type
         # --------------
         "capability:multivariate": False,  # Handles univariate targets here.
@@ -90,7 +90,7 @@ class GreykiteForecaster(BaseForecaster):
             "test_update_predict_predicted_index",
             "test_deepcopy_fitted_predict",
         ],
-        "tests:python_dependencies": ["prophet"],
+        "tests:python_dependencies": ["prophet", "setuptools<82"],
     }
 
     def __init__(

--- a/sktime/forecasting/greykite.py
+++ b/sktime/forecasting/greykite.py
@@ -80,6 +80,7 @@ class GreykiteForecaster(BaseForecaster):
         # -----------------
         "tests:vm": True,
         # greykite failures tracked in #10083
+        "tests:skip_all": True,
         # pickling is not supported for GreykiteForecaster.
         # The greykite package internally uses patsy, which does not support
         # pickling or deepcopy (see https://github.com/pydata/patsy/issues/26).

--- a/sktime/forecasting/greykite.py
+++ b/sktime/forecasting/greykite.py
@@ -76,6 +76,7 @@ class GreykiteForecaster(BaseForecaster):
         # CI and test flags
         # -----------------
         "tests:vm": True,
+        # greykite failures tracked in #10083
         # pickling is not supported for GreykiteForecaster.
         # The greykite package internally uses patsy, which does not support
         # pickling or deepcopy (see https://github.com/pydata/patsy/issues/26).

--- a/sktime/forecasting/greykite.py
+++ b/sktime/forecasting/greykite.py
@@ -75,7 +75,17 @@ class GreykiteForecaster(BaseForecaster):
         "capability:insample": False,
         # CI and test flags
         # -----------------
-        # "tests:vm": True, # skip all tests temporarily, issue tracked in #10083
+        "tests:vm": True,
+        # pickling is not supported for GreykiteForecaster.
+        # The greykite package internally uses patsy, which does not support
+        # pickling or deepcopy (see https://github.com/pydata/patsy/issues/26).
+        "tests:skip_by_name": [
+            "test_fit_idempotent",
+            "test_persistence_via_pickle",
+            "test_save_estimators_to_file",
+            "test_update_predict_predicted_index",
+            "test_deepcopy_fitted_predict",
+        ],
     }
 
     def __init__(


### PR DESCRIPTION
Cleans up `GreyKiteForecaster` tags. Tests are still skipped.

See #10083 for failure tracking.