### PR TITLE
[BUG] Fix ExponentialSmoothing with DatetimeIndex start/end-of-period offset aliases (MS, QS, YS, ME, QE, YE)

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -1015,6 +1015,32 @@ def _check_cutoff(cutoff, index):
         assert isinstance(cutoff, (pd.Timestamp, pd.DatetimeIndex))
 
 
+def _normalize_period_freq(freq):
+    """Map start/end-of-period offset aliases to their period-compatible equivalent.
+
+    pandas DatetimeIndex offsets such as MonthBegin ("MS") and QuarterBegin
+    ("QS-JAN") have no direct ``to_period()`` mapping.  This function returns
+    the nearest period frequency alias ("M", "Q", "Y") so callers can convert
+    without a ValueError.
+    """
+    try:
+        from pandas.tseries import offsets as _offsets
+
+        _offset_map = {
+            _offsets.MonthBegin: "M",
+            _offsets.MonthEnd: "M",
+            _offsets.QuarterBegin: "Q",
+            _offsets.QuarterEnd: "Q",
+            _offsets.YearBegin: "Y",
+            _offsets.YearEnd: "Y",
+        }
+        if type(freq) in _offset_map:
+            return _offset_map[type(freq)]
+    except ImportError:
+        pass
+    return freq
+
+
 def _coerce_to_period(x, freq=None):
     """Coerce pandas time index to a alternative pandas time index.
 
@@ -1038,6 +1064,10 @@ def _coerce_to_period(x, freq=None):
         raise ValueError(
             "_coerce_to_period requires freq argument to be passed if x is pd.Timestamp"
         )
+    # Start-of-period and end-of-period offsets (e.g. MonthBegin/"MS",
+    # QuarterBegin/"QS-JAN") have no direct to_period() mapping; normalise
+    # them to the nearest period-compatible alias before converting.
+    freq = _normalize_period_freq(freq)
     return x.to_period(freq)
 
 

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -179,9 +179,20 @@ class ExponentialSmoothing(_StatsModelsAdapter):
         super().__init__(random_state=random_state)
 
     def _fit_forecaster(self, y, X=None):
+        import pandas as pd
         from statsmodels.tsa.holtwinters import (
             ExponentialSmoothing as _ExponentialSmoothing,
         )
+
+        from sktime.forecasting.base._fh import _normalize_period_freq
+
+        # statsmodels cannot handle DatetimeIndex with start/end-of-period
+        # offsets (e.g. MonthBegin/"MS"); convert to PeriodIndex first.
+        if isinstance(y.index, pd.DatetimeIndex) and y.index.freq is not None:
+            normalized = _normalize_period_freq(y.index.freq)
+            if normalized is not y.index.freq:
+                y = y.copy()
+                y.index = y.index.to_period(normalized)
 
         self._forecaster = _ExponentialSmoothing(
             y,

--- a/sktime/forecasting/tests/test_exp_smoothing.py
+++ b/sktime/forecasting/tests/test_exp_smoothing.py
@@ -1,6 +1,6 @@
 """Test exponential smoothing forecasters."""
 
-__author__ = ["mloning", "big-o", "ciaran-g"]
+__author__ = ["mloning", "big-o", "ciaran-g", "mahesh-sadupalli"]
 __all__ = ["test_set_params"]
 
 import pandas as pd
@@ -88,3 +88,38 @@ def check_panel_with_freq():
     y_pred = forecaster.predict(fh=fh)
 
     assert y_pred.equals(y_pred_update), "Expected same predictions after update"
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ExponentialSmoothing),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize(
+    "datetime_freq, expected_period_freq",
+    [
+        ("MS", "M"),
+        ("ME", "M"),
+        ("QS", "Q"),
+        ("QE", "Q"),
+        ("YS", "Y"),
+        ("YE", "Y"),
+    ],
+)
+def test_exponential_smoothing_datetime_start_of_period_freqs(
+    datetime_freq, expected_period_freq
+):
+    """Regression test for DatetimeIndex with start/end-of-period offset aliases.
+
+    statsmodels cannot infer a PeriodIndex from offsets such as MonthBegin ("MS");
+    sktime should convert transparently before fitting.
+    See https://github.com/sktime/sktime/issues/10480
+    """
+    n = 24
+    index = pd.date_range("2020-01", periods=n, freq=datetime_freq)
+    y = pd.Series(range(n), index=index, dtype=float, name="y")
+
+    forecaster = ExponentialSmoothing(trend="add")
+    forecaster.fit(y)
+    preds = forecaster.predict(fh=[1, 2, 3])
+
+    assert len(preds) == 3


### PR DESCRIPTION
## Summary

Fixes #10480.

`ExponentialSmoothing` (and any `_StatsModelsAdapter`-based forecaster) raises a
`ValueError` when fitted on a `pd.Series` with a `DatetimeIndex` whose frequency
is a start- or end-of-period alias such as `MS` (MonthBegin), `QS` (QuarterBegin),
`YS` (YearBegin), and their end-of-period counterparts `ME`, `QE`, `YE`.

Root cause: `statsmodels.ExponentialSmoothing` cannot infer a `PeriodIndex` from
`MonthBegin`/`QuarterBegin` offsets; it raises
`ValueError: <MonthBegin> is not supported as period frequency`.
The same failure re-appeared during `predict()` because `_coerce_to_period` in
`_fh.py` had no mapping for those offset types.

## Changes

**`sktime/forecasting/base/_fh.py`**
- Add `_normalize_period_freq(freq)` helper that maps pandas offset *types*
  (`MonthBegin`/`MonthEnd` → `"M"`, `QuarterBegin`/`QuarterEnd` → `"Q"`,
  `YearBegin`/`YearEnd` → `"Y"`) using `pandas.tseries.offsets` class checks
  (avoids fragile `freqstr` string matching like `"QS-JAN"`).
- Call it in `_coerce_to_period` before `x.to_period(freq)`.

**`sktime/forecasting/exp_smoothing.py`**
- In `_fit_forecaster`, use `_normalize_period_freq` to detect start/end-of-period
  offsets and convert the `DatetimeIndex` to `PeriodIndex` before passing to
  `statsmodels`, transparently and without changing the public API.

**`sktime/forecasting/tests/test_exp_smoothing.py`**
- Add regression test `test_exponential_smoothing_datetime_start_of_period_freqs`
  parametrized over all six aliases: `MS`, `ME`, `QS`, `QE`, `YS`, `YE`.

## Testing

```
python -c "
import pandas as pd
from sktime.forecasting.exp_smoothing import ExponentialSmoothing
for freq in ['MS','ME','QS','QE','YS','YE']:
    n = 24
    y = pd.Series(range(n), index=pd.date_range('2020-01', periods=n, freq=freq), dtype=float)
    f = ExponentialSmoothing(trend='add')
    f.fit(y)
    p = f.predict(fh=[1, 2, 3])
    print(f'PASS {freq}: {p.values.round(1)}')
"
```

All 6 pass after this fix (all 6 failed before).

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Added tests to cover the fix
- [x] Unit tests pass locally