### PR TITLE
[DOC] document the cov parameter in BaseForecaster.predict_var

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -916,9 +916,7 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
             ``X.index`` must contain ``fh`` index reference.
 
         cov : bool, optional (default=False)
-            if False, returns marginal variance forecasts.
-            if True, returns covariance matrix forecasts, i.e., covariances
-            between time points as well as variances, see ``Returns`` below.
+            currently unused, present for downwards compatibility and future extension
 
         Returns
         -------

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -915,6 +915,11 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
             If ``self.get_tag("X-y-must-have-same-index")``,
             ``X.index`` must contain ``fh`` index reference.
 
+        cov : bool, optional (default=False)
+            if False, returns marginal variance forecasts.
+            if True, returns covariance matrix forecasts, i.e., covariances
+            between time points as well as variances, see ``Returns`` below.
+
         Returns
         -------
         pred_var : pd.DataFrame, format dependent on ``cov`` variable


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10586.

#### What does this implement/fix? Explain your changes.

The `cov` parameter of `BaseForecaster.predict_var` was missing from the docstring's Parameters section, so it did not show up in the rendered API reference. The issue calls it `covariate`, but the actual argument is `cov` (a bool that switches between marginal variance and full covariance-matrix forecasts). This adds a Parameters entry for `cov` matching the description already used in the private `_predict_var` docstrings.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

* Whether the wording for `cov` reads consistently with the existing `Returns` description, which already says the format is "dependent on ``cov``".

#### Did you add any tests for the change?

No, this is a docstring-only change.

#### Any other comments?

No.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
