### PR TITLE
[DOC] fix stale `no-update_params` description in add_task and evaluate

### DIFF
--- a/sktime/benchmarking/forecasting.py
+++ b/sktime/benchmarking/forecasting.py
@@ -138,8 +138,8 @@ class ForecastingBenchmark(BaseBenchmark):
             * "refit" = forecaster is refitted to each training window
             * "update" = forecaster is updated with training window data,
               in sequence provided
-            * "no-update_params" = fit to first training window,
-              re-used without fit or update
+            * "no-update_params" = forecaster is updated via ``update``, with
+              ``update_params=False``, to the cutoff of each new training window
 
         cv_global_temporal:  SingleWindowSplitter, default=None
             ignored if cv_global is None. If passed, it splits the Panel temporally

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -527,8 +527,8 @@ def evaluate(
         * "refit" = forecaster is refitted to each training window
         * "update" = forecaster is updated with training window data,
           in sequence provided
-        * "no-update_params" = fit to first training window,
-          re-used without fit or update
+        * "no-update_params" = forecaster is updated via ``update``, with
+          ``update_params=False``, to the cutoff of each new training window
 
     scoring : subclass of sktime.performance_metrics.BaseMetric or list of same,
         default=None. Used to get a score function that takes y_pred and y_test


### PR DESCRIPTION
## Reference Issues/PRs
Fixes #10590

## What does this implement/fix?
The `strategy` parameter's `"no-update_params"` bullet said "fit to first training window, re-used without fit or update" inaccurate under the current pretrain API, where `.update(..., update_params=False)` is always called on each new window (as correctly described in `evaluate`'s own step-by-step algorithm docs a few lines above the same stale bullet).

The stale wording was duplicated verbatim in two places: `add_task`'s docstring (the one reported) and `evaluate`'s own Parameters section same root cause, so both are fixed to match the accurate description.

## Does your contribution introduce a new dependency?
No.

## Did you add any tests for the change?
No, docstring-only change.