### PR TITLE
[BUG] fix context_length lookup for use_source_package Chronos-Bolt

### DIFF
--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -596,10 +596,19 @@ class ChronosForecaster(BaseForecaster):
         index_names = _y.index.names
         _y = _y.values.reshape(1, -1, 1)
 
+        model_config = self.model_pipeline.model.config
+        # the ``context_length`` shortcut is only set on sktime's vendored
+        # models; the source ``chronos`` package only exposes it nested
+        # under ``chronos_config`` on the underlying HF model config
+        context_length = (
+            getattr(model_config, "context_length", None)
+            or model_config.chronos_config["context_length"]
+        )
+
         results = []
         for i in range(_y.shape[0]):
             _y_i = _y[i, :, 0]
-            _y_i = _y_i[-self.model_pipeline.model.config.context_length :]
+            _y_i = _y_i[-context_length:]
 
             values = self.model_strategy.predict(
                 self.model_pipeline, torch.Tensor(_y_i), prediction_length, self._config


### PR DESCRIPTION
## Reference Issues/PRs
Fixes #10592

## What does this implement/fix?
`ChronosForecaster._predict` read `self.model_pipeline.model.config.context_length`, which only exists because sktime's vendored `ChronosBoltModelForForecasting` patches this attribute onto its HF config at construction (`sktime/libs/chronos/chronos_bolt.py:268`). The upstream `chronos-forecasting`package's model class does not do this patch `context_length` there is only available nested under `config.chronos_config["context_length"]` (confirmed present in both sktime's vendored copy, used internally at `chronos_bolt.py:661,710`, and in the upstream package's own `ChronosBoltPipeline.embed()` on GitHub). This broke `predict()` whenever `use_source_package=True`, with `AttributeError: 'T5Config' object has no attribute 'context_length'`.

Fix tries the direct attribute first (covers plain Chronos and sktime's vendored Bolt, both currently working) and falls back to the nested dict only when the shortcut isn't present (covers `use_source_package=True` Chronos-Bolt).

Note: `chronos-forecasting` and model weights aren't available in my environment, so this is verified by reading sktime's vendored source plus the upstream source on GitHub, not by running the reporter's exact repro. Would appreciate a sanity check from anyone with the package installed.

## Does your contribution introduce a new dependency?
No.

## Did you add any tests for the change?
No, the model/weights dependency makes this hard to unit test cheaply; flagging for maintainer input on the best way to cover it.