### PR TITLE
[BUG] support duplicate time indices in NaiveForecaster

### DIFF
--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -414,7 +414,7 @@ class NaiveForecaster(_BaseWindowForecaster):
         strategy = self.strategy
         NEW_PREDICT = ["last"]
 
-        if strategy in NEW_PREDICT:
+        if strategy in NEW_PREDICT and self._y.index.is_unique:
             return self._predict_naive(fh=fh, X=X)
 
         y_pred = super()._predict(fh=fh, X=X)

--- a/sktime/forecasting/tests/test_naive.py
+++ b/sktime/forecasting/tests/test_naive.py
@@ -45,6 +45,22 @@ def test_strategy_last(fh):
     not run_test_for_class(NaiveForecaster),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
+@pytest.mark.parametrize("sp, expected", [(1, 19), (2, 18)])
+def test_strategy_last_with_duplicate_time_index(sp, expected):
+    """Test last strategy with a duplicate time index."""
+    index = pd.period_range("2000-01", periods=19, freq="M")
+    y = pd.Series(range(20), index=index.append(pd.PeriodIndex([index[-1]], freq="M")))
+
+    y_pred = NaiveForecaster(strategy="last", sp=sp).fit(y, fh=[1]).predict()
+
+    assert y_pred.iloc[0] == expected
+    assert y_pred.index.equals(pd.PeriodIndex(["2001-08"], freq="M"))
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(NaiveForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
 def test_strategy_mean(fh, window_length):

--- a/sktime/utils/_testing/scenarios_forecasting.py
+++ b/sktime/utils/_testing/scenarios_forecasting.py
@@ -150,6 +150,21 @@ class ForecasterFitPredictUnivariateNoXLateFh(ForecasterTestScenario):
     default_method_sequence = ["fit", "predict"]
 
 
+class ForecasterFitPredictUnivariateNoXDuplicateIndex(ForecasterTestScenario):
+    """Fit/predict with a duplicate time index and no exogenous data."""
+
+    _tags = {"univariate_y": True, "fh_passed_in_fit": True, "is_enabled": False}
+
+    @property
+    def args(self):
+        y = _make_series(n_timepoints=20, random_state=RAND_SEED)
+        index = pd.period_range("2000-01", periods=19, freq="M")
+        y.index = index.append(pd.PeriodIndex([index[-1]], freq="M"))
+        return {"fit": {"y": y, "fh": 1}, "predict": {}}
+
+    default_method_sequence = ["fit", "predict"]
+
+
 class ForecasterFitPredictUnivariateNoXLongFh(ForecasterTestScenario):
     """Fit/predict only, univariate y, no X, longer fh, passed early in fit."""
 
@@ -299,6 +314,7 @@ forecasting_scenarios_extended = [
     ForecasterFitPredictUnivariateNoX,
     ForecasterFitPredictUnivariateNoXEarlyFh,
     ForecasterFitPredictUnivariateNoXLateFh,
+    ForecasterFitPredictUnivariateNoXDuplicateIndex,
     ForecasterFitPredictUnivariateWithX,
     ForecasterFitPredictUnivariateWithXLongFh,
     ForecasterFitPredictMultivariateNoX,


### PR DESCRIPTION
## Summary

- add a reusable forecasting scenario with a duplicate PeriodIndex
- use the established base-window prediction path when NaiveForecaster receives duplicate time labels
- add regression coverage for non-seasonal and seasonal last-value forecasts

## Motivation

Duplicate time indices are supported by sktime data conventions. The optimized last-value path delegated to Lag, whose reindexing step rejects duplicate labels. The base-window path handles out-of-sample forecasts without that restriction.

## Validation

- ruff check on the changed files
- ruff format --check on the changed files
- pytest sktime/forecasting/tests/test_naive.py sktime/utils/_testing/tests/test_testscenario_getter.py -q --disable-warnings --maxfail=1
- git diff --check