### PR TITLE
[ENH] warn when loading estimators saved with another sktime version

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -263,6 +263,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         * ``_metadata`` - contains class of self, i.e., ``type(self)``
         * ``_obj`` - serialized self. This class uses the default serialization
           (pickle).
+        * ``_sktime_version`` - contains the sktime version used for serialization.
 
         Parameters
         ----------
@@ -328,6 +329,9 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
                 pickle.dump(type(self), file)
             with open(path / "_obj", "wb") as file:
                 pickle.dump(self, file)
+
+        with open(path / "_sktime_version", "w") as file:
+            file.write(SKTIME_VERSION)
 
         shutil.make_archive(base_name=path, format="zip", root_dir=path)
         shutil.rmtree(path)

--- a/sktime/base/_serialize.py
+++ b/sktime/base/_serialize.py
@@ -32,6 +32,13 @@ def load(serial):
     -------
     Deserialized self resulting in output `serial`, of `cls.save`
 
+    Warns
+    -----
+    UserWarning
+        If a file-based serialization includes a different sktime version than the
+        current environment. Serialized estimators are not guaranteed to be
+        compatible across sktime versions.
+
     Examples
     --------
     Example 1: saving an estimator in-memory and loading it back
@@ -105,8 +112,11 @@ def load(serial):
     >>> loaded_pred = loaded_est.predict(X_test)  # doctest: +SKIP
     """
     import pickle
+    import warnings
     from pathlib import Path
     from zipfile import ZipFile
+
+    from sktime import __version__ as SKTIME_VERSION
 
     if isinstance(serial, tuple):
         if len(serial) != 2:
@@ -123,6 +133,19 @@ def load(serial):
             raise FileNotFoundError(f"The given save location: {serial}\nwas not found")
         with ZipFile(path) as file:
             cls = pickle.loads(file.open("_metadata", "r").read())
+            try:
+                saved_version = file.read("_sktime_version").decode()
+            except KeyError:
+                saved_version = None
+
+        if saved_version is not None and saved_version != SKTIME_VERSION:
+            warnings.warn(
+                "The serialized estimator was created with sktime version "
+                f"{saved_version}, but the current version is {SKTIME_VERSION}. "
+                "Loading across sktime versions may be incompatible.",
+                UserWarning,
+                stacklevel=2,
+            )
         return cls.load_from_path(path)
     else:
         raise TypeError(

--- a/sktime/base/tests/test_base_sktime.py
+++ b/sktime/base/tests/test_base_sktime.py
@@ -64,3 +64,34 @@ def test_clone_nested_sklearn():
 
     # failure condition, see issue #4704: the setting of the copy also sets the orig
     assert original_model.get_params()["estimator__random_state"] == 5
+
+
+def test_load_warns_for_different_sktime_version(tmp_path, monkeypatch):
+    """Test loading an estimator saved with a different sktime version warns."""
+    import pytest
+
+    import sktime.base._base
+    from sktime.base import BaseObject, load
+
+    monkeypatch.setattr(sktime.base._base, "SKTIME_VERSION", "0.0.0")
+    save_path = tmp_path / "estimator"
+    BaseObject().save(save_path)
+
+    with pytest.warns(UserWarning, match="created with sktime version 0.0.0"):
+        load(save_path.with_suffix(".zip"))
+
+
+def test_load_does_not_warn_for_same_sktime_version(tmp_path):
+    """Test loading an estimator saved with the current sktime version does not warn."""
+    import warnings
+
+    from sktime.base import BaseObject, load
+
+    save_path = tmp_path / "estimator"
+    BaseObject().save(save_path)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        loaded = load(save_path.with_suffix(".zip"))
+
+    assert isinstance(loaded, BaseObject)


### PR DESCRIPTION
Fixes #10579

## Summary
- record the sktime version in file-based estimator serializations
- warn when loading an estimator saved with a different sktime version
- document the compatibility limitation and cover matching and mismatched versions

## Rationale
Pickle-based estimator state is not guaranteed to be compatible across sktime releases. The warning makes this limitation visible before an incompatible loaded estimator fails later.

## Validation
- `python -m pre_commit run --files sktime/base/_base.py sktime/base/_serialize.py sktime/base/tests/test_base_sktime.py`
- `python -m pytest sktime/base/tests/test_base.py sktime/base/tests/test_base_sktime.py -q --disable-warnings --maxfail=1`