### PR TITLE
[BUG] Fix MantisClassifier serialization: add map_location to torch.l…

### DIFF
--- a/sktime/classification/foundation_models/mantis.py
+++ b/sktime/classification/foundation_models/mantis.py
@@ -361,7 +361,9 @@ default="full"
             buf = io.BytesIO()
             torch.save(network.state_dict(), buf)
             buf.seek(0)
-            network_copy.load_state_dict(torch.load(buf, weights_only=True))
+            network_copy.load_state_dict(
+                torch.load(buf, map_location=self._device_, weights_only=True)
+            )
             network = network_copy
 
         return MantisTrainer(device=self._device_, network=network)
@@ -386,7 +388,11 @@ default="full"
             # Restore backbone weights if we serialised them
             network_bytes = getattr(self, "_network_state_bytes_", None)
             if network_bytes is not None:
-                state = torch.load(io.BytesIO(network_bytes), weights_only=True)
+                state = torch.load(
+                    io.BytesIO(network_bytes),
+                    map_location=self._device_,
+                    weights_only=True,
+                )
                 trainer.network.load_state_dict(state)
 
             # Restore the fine-tuned model weights.
@@ -414,7 +420,11 @@ default="full"
                     batch_size=n_classes,
                     learning_rate_adjusting=False,
                 )
-                state = torch.load(io.BytesIO(model_bytes), weights_only=True)
+                state = torch.load(
+                    io.BytesIO(model_bytes),
+                    map_location=self._device_,
+                    weights_only=True,
+                )
                 trainer.fine_tuned_model.load_state_dict(state)
 
             self._trainer_ = trainer


### PR DESCRIPTION

**https://github.com/Mahnoor-Zaffar/sktime/pull/new/bugfix_MantisClassifier**

```markdown
#### Reference Issues/PRs
Fixes a `RuntimeError` when a GPU-trained `MantisClassifier` is deserialized on a CPU-only environment.

#### What does this implement/fix? Explain your changes.
All three `torch.load()` calls in `MantisClassifier` now pass `map_location=self._device_` so tensors are loaded to the correct device during deserialization:

- `_build_trainer()`: network cloning via state_dict (line 365)
- `_ensure_trainer_loaded()`: backbone weights restore (lines 391-395)
- `_ensure_trainer_loaded()`: fine-tuned model weights restore (lines 423-427)

Without this fix, loading a model trained on CUDA in a CPU-only environment raises `RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False`.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
The three `torch.load()` call sites and verifying that `map_location=self._device_` is correct in each context.

#### Did you add any tests for the change?
No new tests — existing test coverage via `get_test_params` (which uses `device="cpu"`) exercises the serialization path.

#### Any other comments?
No.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
```
