### PR TITLE
[BUG] in `ARCH`, fix constructor tag setting: move `set_tags` to after super call and add tests

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2937,6 +2937,16 @@
         "maintenance",
         "test"
       ]
+    },
+    {
+      "login": "joshdunnlime",
+      "name": "Josh Dunn",
+      "avatar_url": "https://avatars.githubusercontent.com/u/89857735?v=4",
+      "profile": "https://github.com/joshdunnlime",
+      "contributions": [
+        "bug",
+        "test"
+      ]
     }
   ]
 }

--- a/sktime/forecasting/arch/_uarch.py
+++ b/sktime/forecasting/arch/_uarch.py
@@ -175,6 +175,9 @@ class ARCH(BaseForecaster):
         "capability:non_contiguous_X": False,
         "capability:random_state": True,
         "property:randomness": "derandomized",
+        # CI and test flags
+        # -----------------
+        "tests:vm": True,
     }
 
     def __init__(

--- a/sktime/forecasting/arch/_uarch.py
+++ b/sktime/forecasting/arch/_uarch.py
@@ -23,9 +23,13 @@ class ARCH(BaseForecaster):
     frequency time series data..
 
     A complete ARCH model is divided into three components:
-        a mean model, e.g., a constant mean or an ARX;
-        a volatility process, e.g., a GARCH or an EGARCH process; and
-        a distribution for the standardized residuals.
+
+    * a mean model, e.g., a constant mean or an ARX;
+    * a volatility process, e.g., a GARCH or an EGARCH process; and
+    *a distribution for the standardized residuals.
+
+    Includes but is not limited to the following commonly used models:
+    ARCH, GARCH, EGARCH, HARCH, FIARCH, ARX, HARX.
 
     Parameters
     ----------

--- a/sktime/forecasting/arch/_uarch.py
+++ b/sktime/forecasting/arch/_uarch.py
@@ -26,7 +26,7 @@ class ARCH(BaseForecaster):
 
     * a mean model, e.g., a constant mean or an ARX;
     * a volatility process, e.g., a GARCH or an EGARCH process; and
-    *a distribution for the standardized residuals.
+    * a distribution for the standardized residuals.
 
     Includes but is not limited to the following commonly used models:
     ARCH, GARCH, EGARCH, HARCH, FIARCH, ARX, HARX.

--- a/sktime/forecasting/arch/_uarch.py
+++ b/sktime/forecasting/arch/_uarch.py
@@ -230,10 +230,10 @@ class ARCH(BaseForecaster):
         self.random_state = random_state
         self.reindex = reindex
 
+        super().__init__()
+
         if self.mean in ["ARX", "HARX"]:
             self.set_tags(**{"capability:exogenous": True})
-
-        super().__init__()
 
     def _fit(self, y, X=None, fh=None):
         """Fit the training data to the estimator.

--- a/sktime/forecasting/arch/_uarch.py
+++ b/sktime/forecasting/arch/_uarch.py
@@ -166,6 +166,7 @@ class ARCH(BaseForecaster):
         "capability:missing_values": False,
         "capability:pred_int": True,
         "capability:exogenous": False,
+        "capability:non_contiguous_X": False,
         "capability:random_state": True,
         "property:randomness": "derandomized",
     }

--- a/sktime/forecasting/arch/_uarch.py
+++ b/sktime/forecasting/arch/_uarch.py
@@ -16,7 +16,7 @@ from sktime.forecasting.base import BaseForecaster
 
 
 class ARCH(BaseForecaster):
-    r"""Directly interfaces ARCH models from python package arch.
+    r"""ARCH models from arch package, including (E)(G/H)AR(X)CH, FIAR(X)CH.
 
     ARCH models are a popular class of volatility models that use observed values of
     returns or residuals as volatility shocks to forecast the volatility in high
@@ -48,10 +48,12 @@ class ARCH(BaseForecaster):
         Power to use with GARCH and related models
     dist : int, optional
         Name of the error distribution.  Currently supported options are:
-            * Normal: 'normal', 'gaussian' (default)
-            * Students's t: 't', 'studentst'
-            * Skewed Student's t: 'skewstudent', 'skewt'
-            * Generalized Error Distribution: 'ged', 'generalized error"
+
+        * Normal: 'normal', 'gaussian' (default)
+        * Students's t: 't', 'studentst'
+        * Skewed Student's t: 'skewstudent', 'skewt'
+        * Generalized Error Distribution: 'ged', 'generalized error"
+
     hold_back : int
         Number of observations at the start of the sample to exclude when
         estimating model parameters.  Used when comparing models with different

--- a/sktime/forecasting/arch/_uarch.py
+++ b/sktime/forecasting/arch/_uarch.py
@@ -165,7 +165,7 @@ class ARCH(BaseForecaster):
         "requires-fh-in-fit": False,
         "capability:missing_values": False,
         "capability:pred_int": True,
-        "capability:exogenous": False,
+        "capability:exogenous": True,
         "capability:non_contiguous_X": False,
         "capability:random_state": True,
         "property:randomness": "derandomized",
@@ -233,8 +233,13 @@ class ARCH(BaseForecaster):
 
         super().__init__()
 
-        if self.mean in ["ARX", "HARX"]:
-            self.set_tags(**{"capability:exogenous": True})
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        if self.mean not in ["ARX", "HARX"]:
+            self.set_tags(**{"capability:exogenous": False})
 
     def _fit(self, y, X=None, fh=None):
         """Fit the training data to the estimator.

--- a/sktime/forecasting/tests/test_arch.py
+++ b/sktime/forecasting/tests/test_arch.py
@@ -128,8 +128,9 @@ def test_ARCH_with_exogenous():
     np.random.seed(42)
     n_train = 100
     n_forecast = 3
+    n_periods = n_train + n_forecast
     
-    date_range = pd.date_range(start="2020-01-03", periods=n_train + n_forecast, freq="B")
+    date_range = pd.date_range(start="2020-01-03", periods=n_periods, freq="B")
     y = pd.Series(
         np.random.normal(loc=0, scale=0.02, size=n_train),
         index=pd.PeriodIndex(date_range[:n_train], freq="D"),

--- a/sktime/forecasting/tests/test_arch.py
+++ b/sktime/forecasting/tests/test_arch.py
@@ -155,12 +155,12 @@ def test_ARCH_with_exogenous():
         rescale=False,
     )
     sktime_model.fit(y, X=X_train)
-    
+
     # Verify that exogenous capability is enabled
     assert sktime_model.get_tag("capability:exogenous") is True
-    
+
     # Predict with exogenous variables (X_forecast must match horizon exactly)
-    sktime_pred = sktime_model.predict(fh=[1, 2, 3], X=X_forecast)
+    skt_pred = sktime_model.predict(fh=[1, 2, 3], X=X_forecast)
 
     # Fit arch package model directly for comparison
     arch_model_direct = arch_model(
@@ -175,12 +175,10 @@ def test_ARCH_with_exogenous():
         rescale=False,
     )
     arch_fitted = arch_model_direct.fit(disp="off")
-    
+
     # Forecast with arch package
     x_forecast_dict = {col: X_forecast[col].values for col in X_forecast.columns}
-    arch_pred = arch_fitted.forecast(
-        horizon=3, x=x_forecast_dict, method="analytic"
-    )
+    arch_pred = arch_fitted.forecast(horizon=3, x=x_forecast_dict, method="analytic")
 
     # Compare predictions - should be very close
-    assert np.allclose(sktime_pred.values, arch_pred.mean.iloc[-1, :3].values, rtol=1e-5)
+    assert np.allclose(skt_pred.values, arch_pred.mean.iloc[-1, :3].values, rtol=1e-5)

--- a/sktime/forecasting/tests/test_arch.py
+++ b/sktime/forecasting/tests/test_arch.py
@@ -129,7 +129,7 @@ def test_ARCH_with_exogenous():
     n_train = 100
     n_forecast = 3
     n_periods = n_train + n_forecast
-    
+
     date_range = pd.date_range(start="2020-01-03", periods=n_periods, freq="B")
     y = pd.Series(
         np.random.normal(loc=0, scale=0.02, size=n_train),

--- a/sktime/forecasting/tests/test_arch.py
+++ b/sktime/forecasting/tests/test_arch.py
@@ -109,3 +109,78 @@ def test_ARCH_insample():
     assert np.allclose(
         sktime_pred_mean.values, arch_model_arch_pred_mean.values
     ) and np.allclose(sktime_pred_var.values, arch_model_arch_pred_var.values)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ARCH),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_ARCH_with_exogenous():
+    """Test ARX-GARCH with exogenous variables against arch package.
+
+    This test verifies that exogenous variables are correctly passed through
+    to the underlying arch package when using ARX or HARX mean models.
+    Regression test for bug where super().__init__() reset dynamic tags.
+    """
+    from arch import arch_model
+
+    # Generate returns data and exogenous variable
+    np.random.seed(42)
+    n_train = 100
+    n_forecast = 3
+    
+    date_range = pd.date_range(start="2020-01-03", periods=n_train + n_forecast, freq="B")
+    y = pd.Series(
+        np.random.normal(loc=0, scale=0.02, size=n_train),
+        index=pd.PeriodIndex(date_range[:n_train], freq="D"),
+    )
+    # Create exogenous variable for full period
+    X_full = pd.DataFrame(
+        {"exog": np.random.normal(loc=0, scale=0.01, size=n_train + n_forecast)},
+        index=pd.PeriodIndex(date_range, freq="D"),
+    )
+    X_train = X_full.iloc[:n_train]
+    X_forecast = X_full.iloc[n_train : n_train + n_forecast]
+
+    # Fit sktime ARX-GARCH model
+    sktime_model = ARCH(
+        mean="ARX",
+        lags=1,
+        vol="GARCH",
+        p=1,
+        q=1,
+        dist="Normal",
+        method="analytic",
+        random_state=42,
+        rescale=False,
+    )
+    sktime_model.fit(y, X=X_train)
+    
+    # Verify that exogenous capability is enabled
+    assert sktime_model.get_tag("capability:exogenous") is True
+    
+    # Predict with exogenous variables (X_forecast must match horizon exactly)
+    sktime_pred = sktime_model.predict(fh=[1, 2, 3], X=X_forecast)
+
+    # Fit arch package model directly for comparison
+    arch_model_direct = arch_model(
+        y,
+        x=X_train,
+        mean="ARX",
+        lags=1,
+        vol="GARCH",
+        p=1,
+        q=1,
+        dist="Normal",
+        rescale=False,
+    )
+    arch_fitted = arch_model_direct.fit(disp="off")
+    
+    # Forecast with arch package
+    x_forecast_dict = {col: X_forecast[col].values for col in X_forecast.columns}
+    arch_pred = arch_fitted.forecast(
+        horizon=3, x=x_forecast_dict, method="analytic"
+    )
+
+    # Compare predictions - should be very close
+    assert np.allclose(sktime_pred.values, arch_pred.mean.iloc[-1, :3].values, rtol=1e-5)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10610

#### What does this implement/fix? Explain your changes.

This PR fixes a critical bug in the `ARCH` forecaster where exogenous variables were silently dropped when using ARX or HARX mean models.

**The Problem:**
When instantiating an ARCH forecaster with `mean="ARX"` or `mean="HARX"`, the forecaster should accept and use exogenous regressors (the X variables). However, due to a tag initialization ordering bug, the `capability:exogenous` tag was being reset to False, causing sktime to null out exogenous variables before they reached the underlying arch package. This effectively degraded ARX-GARCH models to plain AR-GARCH.

**Root Cause:**
In the `__init__` method, `set_tags(capability:exogenous=True)` was called *before* `super().__init__()`. The parent class initialization resets `_tags_dynamic` to an empty dict, wiping out any tags set beforehand.

**The Fix:**
Reordered the initialization sequence in `ARCH.__init__()`:
- Call `super().__init__()` first
- Then conditionally set `capability:exogenous=True` for ARX/HARX models

This ensures the tag persists and exogenous variables are correctly forwarded to the arch package.

**Testing:**
Added a new test `test_ARCH_with_exogenous()` that:
- Verifies the `capability:exogenous` tag is properly set for ARX models
- Compares ARX-GARCH predictions against the underlying arch package directly
- Serves as a regression test to prevent reintroduction of this bug

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- [ ] Verify the initialization order fix in `ARCH.__init__()` is correct
- [ ] Review the new test case for completeness and clarity
- [ ] Confirm that the fix doesn't break any existing functionality (all tests pass)

#### Did you add any tests for the change?

Yes, added `test_ARCH_with_exogenous()` in `sktime/forecasting/tests/test_arch.py` that:
- Tests ARX-GARCH with exogenous variables
- Compares predictions against the arch package to ensure correctness
- Explicitly checks that the `capability:exogenous` tag is set correctly
- Provides a regression test for this specific bug

#### Any other comments?

This was a subtle bug that could easily go unnoticed since the code appeared to work (it just silently ignored the exogenous variables). The fix is minimal but important for anyone using ARX or HARX models for volatility forecasting with exogenous regressors.

#### PR checklist

##### For all contributions
- [x] I've added myself to the list of contributors with any new badges I've earned
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. **[BUG]** - bugfix for ARX/HARX exogenous variable handling

##### For new estimators
N/A - This is a bugfix to an existing estimator