### PR TITLE
[DOC] Document `cov` parameter of `BaseForecaster.predict_var`

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -915,19 +915,29 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
             If ``self.get_tag("X-y-must-have-same-index")``,
             ``X.index`` must contain ``fh`` index reference.
 
+        cov : bool, optional (default=False)
+            If True, computes covariance matrix forecast.
+            If False, computes marginal variance forecasts.
+
         Returns
         -------
         pred_var : pd.DataFrame, format dependent on ``cov`` variable
-            Variance forecasts, with columns and rows as follows:
-
-            * Column names are exactly those of ``y`` passed in ``fit``/``update``.
-              For nameless formats, column index will be a RangeIndex.
-            * Row index is fh, with additional levels equal to instance levels,
-              from y seen in fit, if y seen in fit was Panel or Hierarchical.
-            * Entries are variance forecasts, for var in col index.
-
-            A variance forecast for given variable and fh index is a predicted
-            marginal variance for that variable and index, given observed data.
+            If cov=False:
+                Column names are exactly those of ``y`` passed in ``fit``/``update``.
+                For nameless formats, column index will be a RangeIndex.
+                Row index is fh, with additional levels equal to instance levels,
+                from y seen in fit, if y seen in fit was Panel or Hierarchical.
+                Entries are variance forecasts, for var in col index.
+                A variance forecast for given variable and fh index is a predicted
+                marginal variance for that variable and index, given observed data.
+            If cov=True:
+                Column index is a multiindex: 1st level is variable names (as above)
+                2nd level is fh.
+                Row index is fh, with additional levels equal to instance levels,
+                from y seen in fit, if y seen in fit was Panel or Hierarchical.
+                Entries are (co-)variance forecasts, for var in col index, and
+                covariance between time index in row and col.
+                No covariance forecasts are returned between different variables.
         """
         if not self.get_tag("capability:pred_int"):
             raise NotImplementedError(


### PR DESCRIPTION
LLM generated content, by Claude Sonnet 5

## What does this implement/fix? Explain your changes.

Closes #10586. The issue title says the undocumented parameter is called `covariate`, but `BaseForecaster.predict_var`'s actual signature is `predict_var(self, fh=None, X=None, cov=False)` — there's no `covariate` parameter. The real gap is the undocumented `cov` boolean flag, which I've documented instead of a nonexistent one.

- Added a `Parameters` entry for `cov`, matching the style of the sibling `marginal` bool parameter in `predict_proba`'s docstring in the same file.
- Expanded the `Returns` section to actually describe the output shape for both `cov=False` and `cov=True` (previously only the `cov=False` case was described, despite the docstring claiming the format depends on `cov`). Wording adapted from the authoritative `_predict_var` extension-point docstring in `extension_templates/forecasting.py`, converted to this file's numpydoc house style.

## Does your contribution introduce a new dependency? If yes, which one?

No.

## What should a reviewer concentrate their attention on?

Just the docstring accuracy — no code/behavior changes.

## Any other comments?

Verified:
- `help(BaseForecaster.predict_var)` renders the docstring cleanly in a minimal venv.
- Ran `pydocstyle` (convention=numpy, rule `D417` = missing arg description) before/after via `git stash`: the `predict_var: cov` violation is gone after this change; no new violations introduced.

## PR checklist

- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc). **Note: this step is optional.**
- [x] The PR title starts with either `[ENH]`, `[MNT]`, `[DOC]`, `[BUG]`, `[REF]`, `[DEP]`, or `[GOV]`. Add `[BUG-r]` if the bug is a bugfix regression, or `[DOC-nb]` if you're changing an ipynb file. `[MNT]` can be added if the PR only makes small, technical changes to the code.