### PR TITLE
[MNT] add `skpro` to VM test depsets, remove `skchange` from `binder` depset

### DIFF
--- a/.github/workflows/test_est.yml
+++ b/.github/workflows/test_est.yml
@@ -41,8 +41,8 @@ jobs:
         shell: pwsh
         run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
 
-      - name: Install sktime with dev dependencies
-        run: uv pip install .[dev]
+      - name: Install sktime with dev dependencies and skpro
+        run: uv pip install .[dev,skpro]
         env:
           UV_SYSTEM_PYTHON: 1
 

--- a/.github/workflows/test_est_r.yml
+++ b/.github/workflows/test_est_r.yml
@@ -42,8 +42,8 @@ jobs:
         shell: pwsh
         run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
 
-      - name: Install sktime with dev dependencies
-        run: uv pip install .[dev]
+      - name: Install sktime with dev dependencies and skpro
+        run: uv pip install .[dev,skpro]
         env:
           UV_SYSTEM_PYTHON: 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,7 +197,6 @@ tests = [
 # these are for special uses and may be changed or removed at any time
 binder = [
   "jupyter",
-  "skchange",
 ]
 cython_extras = [
   "mrseql < 0.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ dev = [
   "pytest-randomly",
   "pytest-timeout",
   "pytest-xdist",
+  "skpro",
   "wheel",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,6 @@ dev = [
   "pytest-randomly",
   "pytest-timeout",
   "pytest-xdist",
-  "skpro",
   "wheel",
 ]
 
@@ -259,6 +258,9 @@ numpy1 = [
 ]
 pandas1 = [
   "pandas<2.0.0",
+]
+skpro = [
+  "skpro",
 ]
 compatibility_tests = [
   'catboost; python_version < "3.13"',


### PR DESCRIPTION
Small update to non-user depsets:

* adds `skpro` to the VM dependencies to ensure it is installed in VM tests and for developers, to test `predict_proba`
* removes `skchange` from the `binder` depset, where it is no longer needed after `skchange` has been merged into `sktime`