### PR TITLE
[ENH] shared LRU registry to bound multiton cache growth (prototype for #10581)

### DIFF
--- a/sktime/utils/singleton.py
+++ b/sktime/utils/singleton.py
@@ -2,6 +2,9 @@
 
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
+import threading
+from collections import OrderedDict
+
 
 def _singleton(cls):
     """Turn a class into a singleton."""
@@ -16,13 +19,97 @@ def _singleton(cls):
     return get_instance
 
 
+class _MultitonRegistry:
+    """Tracks multiton instances across all ``_multiton``-decorated classes.
+
+    A single instance of this registry is shared by every class created with
+    the ``_multiton`` decorator. It records, for each cached instance, which
+    per-class cache dict it lives in and under which key, ordered by recency
+    of use. When ``maxsize`` is set and the number of tracked instances
+    exceeds it, the least recently used instance is evicted (removed from its
+    owning cache dict), so it becomes eligible for garbage collection.
+
+    By default ``maxsize`` is ``None``, which preserves the previous
+    unbounded caching behaviour.
+    """
+
+    def __init__(self, maxsize=None):
+        self.maxsize = maxsize
+        self._entries = OrderedDict()  # token -> (owning instances dict, key)
+        self._lock = threading.Lock()
+
+    def touch_or_register(self, token, instances, key):
+        """Record use of ``instances[key]``, registering it if new."""
+        with self._lock:
+            if token in self._entries:
+                self._entries.move_to_end(token)
+            else:
+                self._entries[token] = (instances, key)
+                self._evict_if_needed()
+
+    def _evict_if_needed(self):
+        # caller already holds self._lock
+        if self.maxsize is None:
+            return
+        while len(self._entries) > self.maxsize:
+            _, (instances, key) = self._entries.popitem(last=False)
+            instances.pop(key, None)
+
+    def set_maxsize(self, maxsize):
+        """Set the global cache size limit, evicting if now over it."""
+        with self._lock:
+            self.maxsize = maxsize
+            self._evict_if_needed()
+
+    def clear(self):
+        """Evict every tracked multiton instance from its owning cache."""
+        with self._lock:
+            for instances, key in self._entries.values():
+                instances.pop(key, None)
+            self._entries.clear()
+
+    def __len__(self):
+        return len(self._entries)
+
+
+_registry = _MultitonRegistry()
+
+
+def set_global_multiton_limit(maxsize):
+    """Bound the total number of multiton instances kept alive at once.
+
+    Applies across every class created with the ``_multiton`` decorator, not
+    just one of them. When the limit is exceeded, the least recently used
+    instance is evicted first. Pass ``None`` to remove the limit again.
+
+    Parameters
+    ----------
+    maxsize : int or None
+        Maximum number of multiton instances to keep cached across all
+        multiton classes. ``None`` means unbounded (the default).
+    """
+    _registry.set_maxsize(maxsize)
+
+
+def clear_all_multitons():
+    """Evict every currently cached multiton instance, regardless of class."""
+    _registry.clear()
+
+
 def _multiton(cls):
-    """Turn a class into a multiton."""
+    """Turn a class into a multiton.
+
+    Instances are cached per ``key`` and registered with a shared global
+    registry (see ``set_global_multiton_limit`` and ``clear_all_multitons``)
+    so callers can bound or clear the combined cache across all multiton
+    classes, not just this one.
+    """
     instances = {}
 
     def get_instance(key, *args, **kwargs):
         if key not in instances:
             instances[key] = cls(key, *args, **kwargs)
+        _registry.touch_or_register((cls, key), instances, key)
         return instances[key]
 
     return get_instance

--- a/sktime/utils/tests/test_singleton.py
+++ b/sktime/utils/tests/test_singleton.py
@@ -4,7 +4,13 @@
 import pytest
 
 from sktime.tests.test_switch import run_test_for_class
-from sktime.utils.singleton import _multiton, _singleton
+from sktime.utils.singleton import (
+    _multiton,
+    _registry,
+    _singleton,
+    clear_all_multitons,
+    set_global_multiton_limit,
+)
 
 
 @_singleton
@@ -24,6 +30,15 @@ class _TestMultiton:
 
     def set_b(self, b):
         self.b = b
+
+
+@_multiton
+class _TestMultitonOther:
+    """A second, independent multiton class, for cross-class eviction tests."""
+
+    def __init__(self, key, a=0):
+        self.key = key
+        self.a = a
 
 
 @pytest.mark.skipif(
@@ -69,3 +84,99 @@ def test_multiton():
     assert instance2.a == 0
     assert instance1b.b == 43
     assert instance2.b == 44
+
+
+@pytest.fixture
+def _clean_multiton_registry():
+    """Ensure the global multiton registry is unbounded and empty around a test."""
+    clear_all_multitons()
+    set_global_multiton_limit(None)
+    yield
+    clear_all_multitons()
+    set_global_multiton_limit(None)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(_multiton),
+    reason="run test incrementally (if requested)",
+)
+def test_multiton_default_is_unbounded(_clean_multiton_registry):
+    """Without a limit set, multiton caching behaves as before (no eviction)."""
+    keys = [f"k{i}" for i in range(5)]
+    instances = [_TestMultiton(k) for k in keys]
+
+    assert len(_registry) == 5
+    for k, inst in zip(keys, instances):
+        assert _TestMultiton(k) is inst
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(_multiton),
+    reason="run test incrementally (if requested)",
+)
+def test_multiton_global_limit_evicts_least_recently_used(_clean_multiton_registry):
+    """Exceeding the global limit evicts the least recently used instance."""
+    set_global_multiton_limit(2)
+
+    a = _TestMultiton("a")
+    _TestMultiton("b")
+    assert len(_registry) == 2
+
+    # adding a third distinct key evicts "a" (never re-accessed since creation)
+    _TestMultiton("c")
+    assert len(_registry) == 2
+
+    # "a" was evicted, so requesting it again builds a genuinely new instance
+    a_new = _TestMultiton("a")
+    assert a_new is not a
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(_multiton),
+    reason="run test incrementally (if requested)",
+)
+def test_multiton_reaccess_protects_from_eviction(_clean_multiton_registry):
+    """Re-accessing an instance marks it recently used, protecting it from eviction."""
+    set_global_multiton_limit(2)
+
+    x = _TestMultiton("x")
+    y = _TestMultiton("y")
+    _TestMultiton("x")  # touch x again -> x is now more recently used than y
+
+    _TestMultiton("z")  # forces an eviction: y should go, not x
+
+    assert _TestMultiton("x") is x
+    assert _TestMultiton("y") is not y
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(_multiton),
+    reason="run test incrementally (if requested)",
+)
+def test_multiton_global_limit_shared_across_classes(_clean_multiton_registry):
+    """The global limit is shared across different multiton-decorated classes."""
+    set_global_multiton_limit(2)
+
+    _TestMultiton("p")
+    _TestMultitonOther("q")
+    assert len(_registry) == 2
+
+    # a new instance of either class can evict an instance of the other class
+    _TestMultiton("r")
+    assert len(_registry) == 2
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(_multiton),
+    reason="run test incrementally (if requested)",
+)
+def test_clear_all_multitons_removes_every_instance(_clean_multiton_registry):
+    """clear_all_multitons empties the registry and the owning per-class caches."""
+    a = _TestMultiton("a")
+    _TestMultitonOther("b")
+    assert len(_registry) == 2
+
+    clear_all_multitons()
+    assert len(_registry) == 0
+
+    assert _TestMultiton("a") is not a


### PR DESCRIPTION
#### Reference Issues/PRs

Prototype for #10581, following the discussion there with @fkiraly on a shared eviction registry.

#### What does this implement/fix? Explain your changes.

Adds a global registry that every `_multiton`-decorated class registers with, instead of each class only ever growing its own private cache dict forever. This means:

- `set_global_multiton_limit(n)` bounds the total number of cached instances kept alive *across all* multiton classes (Chronos, TSPulse, MomentFM, TTM, and the rest of the ~25 wrapper classes that use `_multiton`), not per-class. Exceeding the limit evicts the least recently used instance.
- `clear_all_multitons()` evicts everything, giving callers an explicit way to release cached models that didn't exist before.
- Default behaviour with no limit set is unchanged (unbounded), so this is non-breaking for existing usage.

Eviction is by last *access*, not insertion order (LRU, not FIFO): a grid search cycling through a small set of configs across CV folds (e.g. `freeze_backbone=[True, False]`) keeps reusing the same couple of entries, so evicting by recency of use avoids reloading a model that's about to be reused, which insertion-order eviction would not.

This is posted as a prototype to explore the API shape per @fkiraly's comment on #10581, not a finished/final design. Open questions I'd want input on:

- Should the limit be entry-count based (what's here) or byte-size based? Byte-size is the more accurate fix for the actual GPU/RAM problem, but requires each wrapped class to report its own size, which is a bigger ask across ~25 call sites.
- Naming/location of `set_global_multiton_limit` / `clear_all_multitons` — should these be more discoverable/public than `sktime.utils.singleton`, given the real-world trigger (grid search over foundation model configs) is end-user facing?

#### Did you add any tests for the change?

Yes. `sktime/utils/tests/test_singleton.py` adds:
- default (no limit) behaviour is unchanged from before
- exceeding the limit evicts the least recently used instance
- re-accessing an instance protects it from a later eviction
- the limit is shared across two independent multiton classes, not per-class
- `clear_all_multitons` empties the registry and the owning per-class caches

All existing tests in that file still pass unmodified.

#### Did you run the existing tests to see if they pass?

Yes, `sktime/utils/tests/test_singleton.py` (7 passed), plus `ruff check` and `ruff format --check` on both changed files.
