### PR TITLE
DO NOT MERGE - diagnostic to test estimator specific tests in #10628

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -95,6 +95,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         "tests:core": False,  # core objects have wider trigger conditions in testing
         "tests:vm": False,  # whether the object should be tested in its own VM
         "tests:libs": None,  # required libraries, for change conditional testing
+        "tests:specific": None,  # modules with estimator specific tests
         "tests:skip_all": False,  # whether all tests for the object should be skipped
         "tests:skip_by_name": None,  # list of test names to skip for this object
     }

--- a/sktime/forecasting/arima/_pmdarima.py
+++ b/sktime/forecasting/arima/_pmdarima.py
@@ -294,6 +294,7 @@ class AutoARIMA(_PmdArimaAdapter):
         # CI and test flags
         # -----------------
         "tests:skip_by_name": ["test_predict_time_index_with_X"],  # bug report #9081
+        "tests:specific": ["sktime.forecasting.tests.test_pmdarima"],
     }
 
     SARIMAX_KWARGS_KEYS = [
@@ -713,6 +714,7 @@ class ARIMA(_PmdArimaAdapter):
         "tests:skip_by_name": [
             "test_predict_time_index_with_X",  # bug report #9081
         ],
+        "tests:specific": ["sktime.forecasting.tests.test_pmdarima"],
     }
 
     SARIMAX_KWARGS_KEYS = [

--- a/sktime/forecasting/croston.py
+++ b/sktime/forecasting/croston.py
@@ -82,6 +82,7 @@ class Croston(BaseForecaster):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
+        "tests:specific": ["sktime.forecasting.tests.test_croston"],
     }
 
     def __init__(self, smoothing=0.1):

--- a/sktime/forecasting/croston.py
+++ b/sktime/forecasting/croston.py
@@ -82,7 +82,6 @@ class Croston(BaseForecaster):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
-        "tests:specific": ["sktime.forecasting.tests.test_croston"],
     }
 
     def __init__(self, smoothing=0.1):

--- a/sktime/forecasting/dummy_global.py
+++ b/sktime/forecasting/dummy_global.py
@@ -88,6 +88,7 @@ class DummyGlobalForecaster(BaseForecaster):
         ],
         "y_inner_mtype": ["pd.Series", "pd.DataFrame"],
         "requires-fh-in-fit": False,
+        "tests:specific": ["sktime.forecasting.tests.test_dummy_global"],
     }
 
     def __init__(self, strategy="mean"):

--- a/sktime/forecasting/tests/test_pmdarima.py
+++ b/sktime/forecasting/tests/test_pmdarima.py
@@ -20,3 +20,5 @@ def test_ARIMA_pred_quantiles_insample():
     forecaster = ARIMA(order=(1, 1, 0), seasonal_order=(0, 1, 0, 12))
     forecaster.fit(y)
     forecaster.predict_quantiles(fh=y.index, X=None, alpha=[0.05, 0.95])
+
+    raise ValueError("FAIL! FAIL! FAIL!")

--- a/sktime/forecasting/timesfm.py
+++ b/sktime/forecasting/timesfm.py
@@ -190,6 +190,7 @@ class TimesFMForecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
         # ---------------------
         "tests:vm": True,
         "tests:libs": ["sktime.libs.timesfm"],
+        "tests:specific": ["sktime.forecasting.tests.test_timesfm"],
     }
 
     def __init__(

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -523,6 +523,43 @@ class tests__libs(_BaseTag):
     }
 
 
+class tests__specific(_BaseTag):
+    """Modules containing estimator specific tests, for test triggers and execution.
+
+    Part of packaging metadata for the object, used only in ``sktime`` CI.
+
+    - String name: ``"tests:specific"``
+    - Private tag, developer and framework facing
+    - Values: list of str, or None
+    - Example: ``["sktime.forecasting.tests.test_croston"]``
+    - Default: ``None``
+
+    ``sktime``'s CI framework regularly tests estimators in pull request,
+    usually only estimators that have changed.
+
+    The ``tests:specific`` tag of an object is a list of strings,
+    it specifies modules that contain estimator specific pytest tests.
+
+    Setting this tag has two effects:
+
+    * testing the estimator is triggered whenever any listed module has changed,
+      in addition to the other test trigger conditions
+    * ``TestAllObjects.test_run_specific_tests`` runs the listed pytest test modules
+      for that estimator
+
+    The ``tests:specific`` tag is not used in user facing checks, error messages,
+    or recommended build processes otherwise.
+    """
+
+    _tags = {
+        "tag_name": "tests:specific",
+        "parent_type": "object",
+        "tag_type": "list",
+        "short_descr": "Estimator specific pytest modules for trigger and execution.",
+        "user_facing": False,
+    }
+
+
 class tests__skip_all(_BaseTag):
     """Whether all tests for this estimator should be skipped.
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -799,7 +799,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
     def test_run_specific_tests(self, estimator_class):
         """Run estimator specific pytest modules defined in ``tests:specific``."""
         modules = estimator_class.get_class_tag("tests:specific", None)
-        if modules is None or modules == []:
+        if not modules:
             pytest.skip(f"{estimator_class.__name__} does not define tests:specific")
 
         msg = (

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -8,6 +8,8 @@ __author__ = ["mloning", "fkiraly", "achieveordie"]
 
 import numbers
 import os
+import subprocess
+import sys
 import types
 from copy import deepcopy
 from inspect import getfullargspec, isclass, signature
@@ -795,6 +797,34 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         from skbase.utils.doctest_run import run_doctest
 
         run_doctest(estimator_class, name=f"class {estimator_class.__name__}")
+
+    def test_run_specific_tests(self, estimator_class):
+        """Run estimator specific pytest modules defined in ``tests:specific``."""
+        modules = estimator_class.get_class_tag("tests:specific", None)
+        if modules is None:
+            return None
+        if isinstance(modules, str):
+            modules = [modules]
+
+        msg = (
+            f"{estimator_class.__name__}.tests:specific must be a list of strings, "
+            f"found: {modules}"
+        )
+        assert isinstance(modules, list), msg
+        assert all(isinstance(module, str) for module in modules), msg
+
+        for module in modules:
+            cmd = [sys.executable, "-m", "pytest", "--pyargs", module]
+            proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+            if proc.returncode != 0:
+                stderr = proc.stderr.strip()
+                stdout = proc.stdout.strip()
+                err_msg = (
+                    f"running specific tests failed for {estimator_class.__name__}, "
+                    f"module {module}, return code {proc.returncode}\n"
+                    f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
+                )
+                raise RuntimeError(err_msg)
 
     def test_create_test_instance(self, estimator_class):
         """Check create_test_instance logic and basic constructor functionality.

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -6,6 +6,7 @@ adapted from scikit-learn's estimator_checks
 
 __author__ = ["mloning", "fkiraly", "achieveordie"]
 
+import io
 import numbers
 import os
 import re
@@ -793,7 +794,6 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
     """Package level tests for all sktime objects."""
 
     estimator_type_filter = "object"
-    _ran_specific_test_modules = set()
 
     def test_doctest_examples(self, estimator_class):
         """Runs doctests for estimator class."""
@@ -818,7 +818,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         assert isinstance(modules, list), msg
         assert all(isinstance(module, str) for module in modules), msg
         if len(modules) == 0:
-            pytest.skip(f"{estimator_class.__name__} has empty tests:specific")
+            return
 
         module_pat = re.compile(r"^sktime(?:\.[a-z_][a-z0-9_]*)*$")
         bad_modules = [module for module in modules if not module_pat.fullmatch(module)]
@@ -832,26 +832,24 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             f"{missing_modules}"
         )
 
-        modules_to_run = [
-            module
-            for module in modules
-            if module not in self._ran_specific_test_modules
-        ]
+        modules_to_run = modules.copy()
         if len(modules_to_run) == 0:
             return
 
-        cmd = [sys.executable, "-m", "pytest", "--pyargs"] + modules_to_run
-        proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
-        if proc.returncode != 0:
-            stderr = proc.stderr.strip()
-            stdout = proc.stdout.strip()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            returncode = pytest.main(["--pyargs", *modules_to_run])
+
+        if returncode != pytest.ExitCode.OK:
             err_msg = (
                 f"running specific tests failed for {estimator_class.__name__}, "
-                f"modules {modules_to_run}, return code {proc.returncode}\n"
-                f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
+                f"modules {modules_to_run}, return code {returncode}\n"
+                f"stdout:\n{stdout.getvalue().strip()}\n\n"
+                f"stderr:\n{stderr.getvalue().strip()}"
             )
             raise RuntimeError(err_msg)
-        self._ran_specific_test_modules.update(modules_to_run)
 
     def test_create_test_instance(self, estimator_class):
         """Check create_test_instance logic and basic constructor functionality.

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -801,8 +801,6 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         modules = estimator_class.get_class_tag("tests:specific", None)
         if modules is None or modules == []:
             pytest.skip(f"{estimator_class.__name__} does not define tests:specific")
-        if isinstance(modules, str):
-            modules = [modules]
 
         msg = (
             f"{estimator_class.__name__}.tests:specific must be a list of strings, "

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -805,6 +805,9 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         ``tests:specific`` must be a list of importable module paths, e.g.,
         ``["sktime.forecasting.tests.test_dummy_global"]``.
         """
+        from skbase.utils.stderr_mute import StderrMute
+        from skbase.utils.stdout_mute import StdoutMute
+
         modules = estimator_class.get_class_tag("tests:specific", None)
         if modules is None:
             pytest.skip(f"{estimator_class.__name__} does not define tests:specific")
@@ -834,10 +837,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         if len(modules_to_run) == 0:
             return
 
-        stdout = io.StringIO()
-        stderr = io.StringIO()
-
-        with redirect_stdout(stdout), redirect_stderr(stderr):
+        with StderrMute(), StdoutMute():
             returncode = pytest.main(["--pyargs", *modules_to_run])
 
         if returncode != pytest.ExitCode.OK:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -8,6 +8,8 @@ __author__ = ["mloning", "fkiraly", "achieveordie"]
 
 import numbers
 import os
+import subprocess
+import sys
 import types
 from copy import deepcopy
 from inspect import getfullargspec, isclass, signature
@@ -812,11 +814,15 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             pytest.skip(f"{estimator_class.__name__} has empty tests:specific")
 
         for module in modules:
-            ret = pytest.main(["--pyargs", module])
-            if ret != pytest.ExitCode.OK:
+            cmd = [sys.executable, "-m", "pytest", "--pyargs", module]
+            proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+            if proc.returncode != 0:
+                stderr = proc.stderr.strip()
+                stdout = proc.stdout.strip()
                 err_msg = (
                     f"running specific tests failed for {estimator_class.__name__}, "
-                    f"module {module}, return code {ret}"
+                    f"module {module}, return code {proc.returncode}\n"
+                    f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
                 )
                 raise RuntimeError(err_msg)
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -799,7 +799,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
     def test_run_specific_tests(self, estimator_class):
         """Run estimator specific pytest modules defined in ``tests:specific``."""
         modules = estimator_class.get_class_tag("tests:specific", None)
-        if not modules:
+        if modules is None:
             pytest.skip(f"{estimator_class.__name__} does not define tests:specific")
 
         msg = (
@@ -808,6 +808,8 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         )
         assert isinstance(modules, list), msg
         assert all(isinstance(module, str) for module in modules), msg
+        if len(modules) == 0:
+            pytest.skip(f"{estimator_class.__name__} has empty tests:specific")
 
         for module in modules:
             ret = pytest.main(["--pyargs", module])

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -11,6 +11,7 @@ import os
 import re
 import subprocess
 import sys
+from importlib.util import find_spec
 import types
 from copy import deepcopy
 from inspect import getfullargspec, isclass, signature
@@ -819,11 +820,16 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         if len(modules) == 0:
             pytest.skip(f"{estimator_class.__name__} has empty tests:specific")
 
-        module_pat = re.compile(r"^sktime(?:\.[A-Za-z_][A-Za-z0-9_]*)*$")
+        module_pat = re.compile(r"^sktime(?:\.[a-z_][a-z0-9_]*)*$")
         bad_modules = [module for module in modules if not module_pat.fullmatch(module)]
         assert len(bad_modules) == 0, (
             f"{estimator_class.__name__}.tests:specific contains invalid module paths: "
             f"{bad_modules}"
+        )
+        missing_modules = [module for module in modules if find_spec(module) is None]
+        assert len(missing_modules) == 0, (
+            f"{estimator_class.__name__}.tests:specific contains missing modules: "
+            f"{missing_modules}"
         )
 
         modules_to_run = [
@@ -832,7 +838,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             if module not in self._ran_specific_test_modules
         ]
         if len(modules_to_run) == 0:
-            return None
+            return
 
         cmd = [sys.executable, "-m", "pytest", "--pyargs"] + modules_to_run
         proc = subprocess.run(cmd, check=False, capture_output=True, text=True)

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -8,6 +8,7 @@ __author__ = ["mloning", "fkiraly", "achieveordie"]
 
 import numbers
 import os
+import re
 import subprocess
 import sys
 import types
@@ -799,7 +800,11 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         run_doctest(estimator_class, name=f"class {estimator_class.__name__}")
 
     def test_run_specific_tests(self, estimator_class):
-        """Run estimator specific pytest modules defined in ``tests:specific``."""
+        """Run pytest modules from ``tests:specific`` for the estimator.
+
+        ``tests:specific`` must be a list of importable module paths, e.g.,
+        ``["sktime.forecasting.tests.test_dummy_global"]``.
+        """
         modules = estimator_class.get_class_tag("tests:specific", None)
         if modules is None:
             pytest.skip(f"{estimator_class.__name__} does not define tests:specific")
@@ -813,18 +818,24 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         if len(modules) == 0:
             pytest.skip(f"{estimator_class.__name__} has empty tests:specific")
 
-        for module in modules:
-            cmd = [sys.executable, "-m", "pytest", "--pyargs", module]
-            proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
-            if proc.returncode != 0:
-                stderr = proc.stderr.strip()
-                stdout = proc.stdout.strip()
-                err_msg = (
-                    f"running specific tests failed for {estimator_class.__name__}, "
-                    f"module {module}, return code {proc.returncode}\n"
-                    f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
-                )
-                raise RuntimeError(err_msg)
+        module_pat = re.compile(r"^sktime(?:\.[A-Za-z_][A-Za-z0-9_]*)+$")
+        bad_modules = [module for module in modules if not module_pat.fullmatch(module)]
+        assert len(bad_modules) == 0, (
+            f"{estimator_class.__name__}.tests:specific contains invalid module paths: "
+            f"{bad_modules}"
+        )
+
+        cmd = [sys.executable, "-m", "pytest", "--pyargs"] + modules
+        proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+        if proc.returncode != 0:
+            stderr = proc.stderr.strip()
+            stdout = proc.stdout.strip()
+            err_msg = (
+                f"running specific tests failed for {estimator_class.__name__}, "
+                f"modules {modules}, return code {proc.returncode}\n"
+                f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
+            )
+            raise RuntimeError(err_msg)
 
     def test_create_test_instance(self, estimator_class):
         """Check create_test_instance logic and basic constructor functionality.

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -792,6 +792,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
     """Package level tests for all sktime objects."""
 
     estimator_type_filter = "object"
+    _ran_specific_test_modules = set()
 
     def test_doctest_examples(self, estimator_class):
         """Runs doctests for estimator class."""
@@ -818,24 +819,33 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         if len(modules) == 0:
             pytest.skip(f"{estimator_class.__name__} has empty tests:specific")
 
-        module_pat = re.compile(r"^sktime(?:\.[A-Za-z_][A-Za-z0-9_]*)+$")
+        module_pat = re.compile(r"^sktime(?:\.[A-Za-z_][A-Za-z0-9_]*)*$")
         bad_modules = [module for module in modules if not module_pat.fullmatch(module)]
         assert len(bad_modules) == 0, (
             f"{estimator_class.__name__}.tests:specific contains invalid module paths: "
             f"{bad_modules}"
         )
 
-        cmd = [sys.executable, "-m", "pytest", "--pyargs"] + modules
+        modules_to_run = [
+            module
+            for module in modules
+            if module not in self._ran_specific_test_modules
+        ]
+        if len(modules_to_run) == 0:
+            return None
+
+        cmd = [sys.executable, "-m", "pytest", "--pyargs"] + modules_to_run
         proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
         if proc.returncode != 0:
             stderr = proc.stderr.strip()
             stdout = proc.stdout.strip()
             err_msg = (
                 f"running specific tests failed for {estimator_class.__name__}, "
-                f"modules {modules}, return code {proc.returncode}\n"
+                f"modules {modules_to_run}, return code {proc.returncode}\n"
                 f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
             )
             raise RuntimeError(err_msg)
+        self._ran_specific_test_modules.update(modules_to_run)
 
     def test_create_test_instance(self, estimator_class):
         """Check create_test_instance logic and basic constructor functionality.

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -8,8 +8,6 @@ __author__ = ["mloning", "fkiraly", "achieveordie"]
 
 import numbers
 import os
-import subprocess
-import sys
 import types
 from copy import deepcopy
 from inspect import getfullargspec, isclass, signature
@@ -801,8 +799,8 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
     def test_run_specific_tests(self, estimator_class):
         """Run estimator specific pytest modules defined in ``tests:specific``."""
         modules = estimator_class.get_class_tag("tests:specific", None)
-        if modules is None:
-            return None
+        if modules is None or modules == []:
+            pytest.skip(f"{estimator_class.__name__} does not define tests:specific")
         if isinstance(modules, str):
             modules = [modules]
 
@@ -814,15 +812,11 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         assert all(isinstance(module, str) for module in modules), msg
 
         for module in modules:
-            cmd = [sys.executable, "-m", "pytest", "--pyargs", module]
-            proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
-            if proc.returncode != 0:
-                stderr = proc.stderr.strip()
-                stdout = proc.stdout.strip()
+            ret = pytest.main(["--pyargs", module])
+            if ret != pytest.ExitCode.OK:
                 err_msg = (
                     f"running specific tests failed for {estimator_class.__name__}, "
-                    f"module {module}, return code {proc.returncode}\n"
-                    f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
+                    f"module {module}, return code {ret}"
                 )
                 raise RuntimeError(err_msg)
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -10,11 +10,10 @@ import io
 import numbers
 import os
 import re
-import subprocess
 import sys
-from importlib.util import find_spec
 import types
 from copy import deepcopy
+from importlib.util import find_spec
 from inspect import getfullargspec, isclass, signature
 from tempfile import TemporaryDirectory
 
@@ -67,7 +66,6 @@ def subsample_by_version_os(x):
     Currently assumes that matrix includes py3.8-3.10, and win/ubuntu/mac.
     """
     import platform
-    import sys
 
     ix = sys.version_info.minor % 3
     os_str = platform.system()

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -746,7 +746,6 @@ class QuickTester:
         return fixture_vars_return, fixture_prod_return, fixture_names_return
 
     def _make_builtin_fixture_equivalents(self, name):
-        import io
         import logging
         import tempfile
         from pathlib import Path
@@ -843,9 +842,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         if returncode != pytest.ExitCode.OK:
             err_msg = (
                 f"running specific tests failed for {estimator_class.__name__}, "
-                f"modules {modules_to_run}, return code {returncode}\n"
-                f"stdout:\n{stdout.getvalue().strip()}\n\n"
-                f"stderr:\n{stderr.getvalue().strip()}"
+                f"modules {modules_to_run}, return code {returncode}"
             )
             raise RuntimeError(err_msg)
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -804,6 +804,8 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         ``tests:specific`` must be a list of importable module paths, e.g.,
         ``["sktime.forecasting.tests.test_dummy_global"]``.
         """
+        import subprocess
+
         from skbase.utils.stderr_mute import StderrMute
         from skbase.utils.stdout_mute import StdoutMute
 
@@ -836,15 +838,21 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         if len(modules_to_run) == 0:
             return
 
-        raise ValueError(f"diagnostic raise of modules_to_run {modules_to_run}")
-
         with StderrMute(), StdoutMute():
-            returncode = pytest.main(["--pyargs", *modules_to_run])
+            result = subprocess.run(
+                [sys.executable, "-m", "pytest", "--pyargs", *modules_to_run],
+                capture_output=True,
+                text=True,
+            )
 
-        if returncode != pytest.ExitCode.OK:
+        returncode = result.returncode
+
+        if returncode != 0:
             err_msg = (
                 f"running specific tests failed for {estimator_class.__name__}, "
-                f"modules {modules_to_run}, return code {returncode}"
+                f"modules {modules_to_run}, return code {returncode}\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
             )
             raise RuntimeError(err_msg)
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -836,6 +836,8 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         if len(modules_to_run) == 0:
             return
 
+        raise ValueError(f"diagnostic raise of modules_to_run {modules_to_run}")
+
         with StderrMute(), StdoutMute():
             returncode = pytest.main(["--pyargs", *modules_to_run])
 

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -24,7 +24,7 @@ def run_test_for_class(cls, return_reason=False):
        If yes, behaviour depends on ONLY_CHANGED_MODULES setting:
        if off (False), always runs the test (return True);
        if on (True), runs test if and only if
-       at least one of conditions 2, 3, 4, 5, 6 below are met.
+       at least one of conditions 2, 3, 4, 5, 6, 7 below are met.
 
     2. Condition 2:
 
@@ -54,7 +54,12 @@ def run_test_for_class(cls, return_reason=False):
     6. Condition 6:
 
       If the object is an sktime ``BaseObject``, and any of the modules
-      in the class tag ``tests:libs`` hvae changed, condition 6 is met.
+      in the class tag ``tests:libs`` have changed, condition 6 is met.
+
+    7. Condition 7:
+
+      If the object is an sktime ``BaseObject``, and any of the modules
+      in the class tag ``tests:specific`` have changed, condition 7 is met.
 
     cls can also be a list of classes or functions,
     in this case the test is run if and only if both of the following are True:
@@ -62,7 +67,7 @@ def run_test_for_class(cls, return_reason=False):
     * all required soft dependencies are present
     * if ``ONLY_CHANGED_MODULES`` is True, additionally,
       if any of the estimators in the list should be tested by
-      at least one of criteria 2-5 above.
+      at least one of criteria 2-7 above.
       If ``ONLY_CHANGED_MODULES`` is False, this condition is always True.
 
     Also checks whether the class or function is on the exclude override list,
@@ -92,6 +97,7 @@ def run_test_for_class(cls, return_reason=False):
         * "True_changed_class" - run reason, module(s) containing class changed
         * "True_changed_framework" - run reason, core framework modules changed
         * "True_changed_libs" - run reason, library dependencies have changed
+        * "True_changed_specific" - run reason, estimator specific tests changed
 
         If multiple reasons are present, the first one in the above list is returned.
 
@@ -137,6 +143,7 @@ def run_test_for_class(cls, return_reason=False):
             "True_changed_class",
             "True_changed_framework",
             "True_changed_libs",
+            "True_changed_specific",
         ]
         for pos_reason in POS_REASONS:
             if any(reason == pos_reason for reason in reasons):
@@ -210,6 +217,7 @@ def _run_test_for_class(
         * "True_changed_class" - run reason, module(s) containing class changed
         * "True_changed_framework" - run reason, core framework modules changed
         * "True_changed_libs" - run reason, library dependencies changed
+        * "True_changed_specific" - run reason, estimator specific tests changed
 
         If multiple reasons are present, the first one in the above list is returned.
     """
@@ -290,16 +298,18 @@ def _run_test_for_class(
 
         return any(x in PACKAGE_REQ_CHANGED for x in package_deps)
 
-    def _is_impacted_by_lib_dep_change(cls, only_changed_modules):
-        """Check if library dependencies have changed, return bool."""
+    def _is_impacted_by_module_tag_change(cls, only_changed_modules, tag_name):
+        """Check if module dependencies from tag_name have changed, return bool."""
         if not isclass(cls) or not hasattr(cls, "get_class_tags"):
             return False
 
-        libs = cls.get_class_tag("tests:libs", [])
-        if libs is None or libs == []:
+        modules = cls.get_class_tag(tag_name, [])
+        if modules is None or modules == []:
             return False
 
-        return run_test_module_changed(libs, only_changed_modules=only_changed_modules)
+        return run_test_module_changed(
+            modules, only_changed_modules=only_changed_modules
+        )
 
     # Condition 1:
     # if any of the required soft dependencies are not present, do not run the test
@@ -364,8 +374,17 @@ def _run_test_for_class(
 
     # Condition 6:
     # any of the specified library dependencies within sktime have changed
-    if _is_impacted_by_lib_dep_change(cls, only_changed_modules=only_changed_modules):
+    if _is_impacted_by_module_tag_change(
+        cls, only_changed_modules=only_changed_modules, tag_name="tests:libs"
+    ):
         return True, "True_changed_libs"
+
+    # Condition 7:
+    # any of the specified estimator specific test modules have changed
+    if _is_impacted_by_module_tag_change(
+        cls, only_changed_modules=only_changed_modules, tag_name="tests:specific"
+    ):
+        return True, "True_changed_specific"
 
     # if none of the conditions are met, do not run the test
     # reason is that there was no change

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -24,7 +24,8 @@ def run_test_for_class(cls, return_reason=False):
        If yes, behaviour depends on ONLY_CHANGED_MODULES setting:
        if off (False), always runs the test (return True);
        if on (True), runs test if and only if
-       at least one of conditions 2, 3, 4, 5, 6, 7 below are met.
+       at least one of run conditions 2, 3, 4, 5, 6, 7 below are met
+       (condition 1 is the prerequisite dependency check).
 
     2. Condition 2:
 


### PR DESCRIPTION
Diagnostic test, stacks on #10628 which adds estimator specific test runner logic in VMs.

This diagnostic introduces a value error deliberately, to see whether #10628 actually runs the expected test.