### PR TITLE
[ENH] Add second test parameter set for PaddingTransformer

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2975,6 +2975,15 @@
         "bug",
         "test"
       ]
+    },
+    {
+      "login": "OfficialAbhinavSingh",
+      "name": "Abhinav Singh",
+      "avatar_url": "https://avatars.githubusercontent.com/u/221158347?v=4",
+      "profile": "https://github.com/OfficialAbhinavSingh",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -178,7 +178,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "MultioutputTimeSeriesRegressionForecaster",
         "OnlineEnsembleForecaster",
         "PAAlegacy",
-        "PaddingTransformer",
         "Prophetverse",
         "RandomIntervalClassifier",
         "RandomIntervalFeatureExtractor",

--- a/sktime/transformations/padder.py
+++ b/sktime/transformations/padder.py
@@ -145,6 +145,32 @@ class PaddingTransformer(BaseTransformer):
 
         return Xt
 
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+            There are currently no reserved values for transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
+            instance.
+            ``create_test_instance`` uses the first (or only) dictionary in ``params``
+        """
+        params = [
+            {"pad_length": None, "fill_value": 0},
+            {"pad_length": 120, "fill_value": -1.0},
+        ]
+        return params
+
 
 def _get_max_length(X):
     def get_length(input):


### PR DESCRIPTION
## LLM generated content, by Claude Opus 5

Drafted with AI assistance and reviewed by me. I have read every line of this
change, run the full test suite locally, and can explain each decision. Local
test output is included below.

#### Reference Issues/PRs

Part of #3429. Addresses the `PaddingTransformer` entry.

#### What does this implement/fix? Explain your changes.

`PaddingTransformer` did not implement `get_test_params`, so it fell back to the
base class default of a single empty parameter set. It was therefore listed in
`EXCLUDED_TESTS_BY_TEST["test_get_test_params_coverage"]`.

This PR adds two test parameter sets and removes the exclusion entry.

**1. `sktime/transformations/padder.py`** — adds `get_test_params` returning:

```python
params = [
    {"pad_length": None, "fill_value": 0},
    {"pad_length": 120, "fill_value": -1.0},
]
```

The first set restates the `__init__` defaults. This is deliberate:
`create_test_instance` uses the first dictionary, and `PaddingTransformer` is
used as a pipeline component in `test_compose.py`, `test_base.py`, and the
classification/clustering `test_pipeline.py` modules. Keeping the first entry at
the defaults means `create_test_instance()` is unchanged by this PR and those
tests continue to exercise the same configuration as before.

The second set is substantially different, and reaches code the first set cannot:

- `pad_length=120` takes the `else` branch of `_fit` (user-specified fixed
  length). Previously only the `pad_length is None` branch, which infers the max
  length from the data, was reachable from the general test suite.
- `fill_value=-1.0` makes padding visible in the output. With the default
  `fill_value=0`, an implementation that ignored `fill_value` and hardcoded a
  zero fill would produce identical output and go undetected. A negative float
  also sits outside the range of the generated test data and exercises the
  `float` coercion in `np.full(self.pad_length_, self.fill_value, float)`.

`pad_length=120` is the value already used in this estimator's own tests
(`sktime/transformations/tests/test_Padder.py`, lines 38 and 56), so no new
magic number is introduced. The value must be at least the longest series in the
test data, since `_transform` raises `ValueError` when
`max_length > self.pad_length_`.

**2. `sktime/tests/_config.py`** — removes `"PaddingTransformer"` from
`EXCLUDED_TESTS_BY_TEST["test_get_test_params_coverage"]`.

Both changes are required together. `test_excluded_tests_by_test` in
`sktime/tests/tests/test_test_utils.py` asserts that the exclusion list is a
subset of the estimators that genuinely have fewer than two test parameter sets,
so leaving the entry in place while adding the parameters fails that test
(verified locally, output below).

`PaddingTransformer` is not present in `EXCLUDE_SOFT_DEPS`, so no change is
needed there.

#### Does your contribution introduce a new dependency? If yes, which one?

No. `pyproject.toml` is untouched.

#### What should a reviewer concentrate their feedback on?

* The choice of `pad_length=120` for the second parameter set. It is the value
  already used in `test_Padder.py`, and the `_transform` guard is one-sided
  (larger is safe, smaller raises), but a smaller value would also work if
  preferred for speed.
* Whether the first parameter set should be spelled out as
  `{"pad_length": None, "fill_value": 0}` or left implicit. I made it explicit
  to keep `create_test_instance` behaviour identical for the composition tests
  that use this transformer.

#### Did you add any tests for the change?

No new test file. This PR enables an existing framework test,
`test_get_test_params_coverage`, which was previously not collected for this
estimator, and adds a second parameter set that is then exercised across the
whole standard estimator suite.

Local test output, on Python 3.14.6, pandas 2.3.3, numpy 2.4.6,
scikit-learn 1.7.2:

Before the change, the test is not collected at all, because the estimator is
in the exclusion list:

```
$ pytest sktime/tests/test_all_estimators.py \
    -k "test_get_test_params_coverage and PaddingTransformer"
53305 deselected in 150.89s
```

After removing the exclusion entry only, without adding `get_test_params`:

```
>           assert len(param_list) > 1, msg
E           AssertionError: PaddingTransformer.get_test_params should return at
E           least two test parameter sets, but only 1 found.
E           assert 1 > 1
E            +  where 1 = len([{}])

FAILED sktime/tests/test_all_estimators.py::TestAllObjects::test_get_test_params_coverage[PaddingTransformer]
1 failed, 53305 deselected
```

With both changes applied:

```
$ pytest sktime/tests/test_all_estimators.py \
    -k "test_get_test_params_coverage and PaddingTransformer"
1 passed, 53433 deselected in 153.85s
```

The deselected count rises from 53305 to 53433. The additional 128 collected
tests are the second parameter set being exercised across the standard suite.

Full standard suite for this estimator, both parameter sets:

```
$ pytest sktime/tests/test_all_estimators.py -k "PaddingTransformer"
270 passed, 53164 deselected in 153.98s
```

Guard test, this estimator's own tests, and every module that uses
`PaddingTransformer` as a pipeline component:

```
$ pytest sktime/tests/tests/test_test_utils.py \
         sktime/transformations/tests/test_Padder.py \
         sktime/transformations/tests/test_base.py \
         sktime/transformations/tests/test_compose.py \
         sktime/classification/compose/tests/test_pipeline.py \
         sktime/clustering/compose/tests/test_pipeline.py
108 passed, 3 skipped in 9.54s
```

Confirming the estimator's own tests and the guard test actually ran rather
than being skipped:

```
test_Padder.py::test_padding_transformer PASSED
test_Padder.py::test_padding_parameterised_transformer PASSED
test_Padder.py::test_padding_fill_value_transformer PASSED
test_test_utils.py::test_excluded_tests_by_test PASSED
4 passed
```

To confirm the two changes are coupled, I temporarily restored the exclusion
entry while keeping `get_test_params`, which fails as expected:

```
E         Extra items in the left set:
E         'PaddingTransformer'
FAILED sktime/tests/tests/test_test_utils.py::test_excluded_tests_by_test
```

`pre-commit run --files sktime/transformations/padder.py sktime/tests/_config.py`
passes, including `ruff format` and `ruff check`.

#### Any other comments?

The class docstring documents `pad_length` but not `fill_value`. I have left
that out of scope to keep this PR to a single concern, and am happy to open a
separate `[DOC]` PR for it if useful.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
