### PR TITLE
[BUG] Isolate MOIRAI vendored imports

### DIFF
--- a/sktime/forecasting/moirai.py
+++ b/sktime/forecasting/moirai.py
@@ -9,6 +9,56 @@ __author__ = ["gorold", "chenghaoliu89", "liu-jc", "benheid", "pranavvp16"]
 # gorold, chenghaoliu89, liu-jc are from SalesforceAIResearch/uni2ts
 
 
+def _get_moirai_checkpoint_safe_globals():
+    """Return vendored classes under the paths stored in MOIRAI checkpoints."""
+    from sktime.libs.uni2ts.distribution.log_normal import LogNormalOutput
+    from sktime.libs.uni2ts.distribution.mixture import MixtureOutput
+    from sktime.libs.uni2ts.distribution.negative_binomial import (
+        NegativeBinomialOutput,
+    )
+    from sktime.libs.uni2ts.distribution.normal import (
+        NormalFixedScaleOutput,
+        NormalOutput,
+    )
+    from sktime.libs.uni2ts.distribution.student_t import StudentTOutput
+    from sktime.libs.uni2ts.loss.packed.distribution import PackedNLLLoss
+
+    return [
+        (MixtureOutput, "uni2ts.distribution.mixture.MixtureOutput"),
+        (NormalOutput, "uni2ts.distribution.normal.NormalOutput"),
+        (
+            NormalFixedScaleOutput,
+            "uni2ts.distribution.normal.NormalFixedScaleOutput",
+        ),
+        (LogNormalOutput, "uni2ts.distribution.log_normal.LogNormalOutput"),
+        (
+            NegativeBinomialOutput,
+            "uni2ts.distribution.negative_binomial.NegativeBinomialOutput",
+        ),
+        (StudentTOutput, "uni2ts.distribution.student_t.StudentTOutput"),
+        (PackedNLLLoss, "uni2ts.loss.packed.distribution.PackedNLLLoss"),
+    ]
+
+
+def _load_moirai_checkpoint(model_class, model_kwargs):
+    """Load a legacy MOIRAI checkpoint without changing global import state."""
+    import torch
+
+    safe_globals = getattr(torch.serialization, "safe_globals", None)
+    if safe_globals is None:
+        return model_class.load_from_checkpoint(**model_kwargs)
+
+    get_safe_globals = getattr(torch.serialization, "get_safe_globals", lambda: ())
+    existing_globals = set(get_safe_globals())
+    checkpoint_globals = [
+        item
+        for item in _get_moirai_checkpoint_safe_globals()
+        if item not in existing_globals
+    ]
+    with safe_globals(checkpoint_globals):
+        return model_class.load_from_checkpoint(**model_kwargs)
+
+
 class MOIRAIForecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
     """MOIRAI Forecasters.
 
@@ -172,109 +222,22 @@ class MOIRAIForecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
         """Restore state from unpickled state dictionary."""
         self.__dict__.update(state)
 
-    # Apply a patch for redirecting imports to sktime.libs.uni2ts
-    if _check_soft_dependencies(["lightning", "huggingface_hub"], severity="none"):
+    def _instantiate_vendor_model(self, model_kwargs):
+        """Instantiate the model from sktime's vendored uni2ts package."""
+        from sktime.libs.uni2ts.forecast import MoiraiForecast
 
-        def _instantiate_patched_model(self, model_kwargs):
-            """Instantiate the model from the vendor package."""
-            import sys
+        if self.checkpoint_path.startswith("Salesforce"):
+            from sktime.libs.uni2ts.moirai_module import MoiraiModule
 
-            import torch
+            model_kwargs["module"] = MoiraiModule.from_pretrained(self.checkpoint_path)
+            return MoiraiForecast(**model_kwargs)
 
-            import sktime.libs.uni2ts as _uni2ts_mod
+        from huggingface_hub import hf_hub_download
 
-            sys.modules.setdefault("uni2ts", _uni2ts_mod)
-
-            from sktime.libs.uni2ts.distribution.log_normal import LogNormalOutput
-            from sktime.libs.uni2ts.distribution.mixture import MixtureOutput
-            from sktime.libs.uni2ts.distribution.negative_binomial import (
-                NegativeBinomialOutput,
-            )
-            from sktime.libs.uni2ts.distribution.normal import (
-                NormalFixedScaleOutput,
-                NormalOutput,
-            )
-            from sktime.libs.uni2ts.distribution.student_t import StudentTOutput
-            from sktime.libs.uni2ts.forecast import MoiraiForecast
-            from sktime.libs.uni2ts.loss.packed.distribution import PackedNLLLoss
-
-            # PyTorch 2.6+ defaults weights_only=True in torch.load, blocking
-            # unpickling of custom classes unless registered as safe globals.
-            # The checkpoint stores classes under "uni2ts.*" module paths, but
-            # sktime vendors them under "sktime.libs.uni2ts.*".
-            #
-            # PyTorch 2.12+ stores safe globals in a set and resolves
-            # cls.__module__ at unpickling time (not at add-time), so the
-            # tuple form (cls, "uni2ts.path.ClassName") must be used to
-            # specify the exact path stored in the checkpoint.
-            # PyTorch 2.6-2.11 resolves cls.__module__ at add-time, so we
-            # temporarily patch __module__ before calling add_safe_globals.
-            if hasattr(torch.serialization, "add_safe_globals"):
-                import torch._weights_only_unpickler as _wou
-
-                _cls_path_pairs = [
-                    (MixtureOutput, "uni2ts.distribution.mixture.MixtureOutput"),
-                    (NormalOutput, "uni2ts.distribution.normal.NormalOutput"),
-                    (
-                        NormalFixedScaleOutput,
-                        "uni2ts.distribution.normal.NormalFixedScaleOutput",
-                    ),
-                    (LogNormalOutput, "uni2ts.distribution.log_normal.LogNormalOutput"),
-                    (
-                        NegativeBinomialOutput,
-                        "uni2ts.distribution.negative_binomial.NegativeBinomialOutput",
-                    ),
-                    (StudentTOutput, "uni2ts.distribution.student_t.StudentTOutput"),
-                    (
-                        PackedNLLLoss,
-                        "uni2ts.loss.packed.distribution.PackedNLLLoss",
-                    ),
-                ]
-                # Use tuple form if supported (PyTorch 2.12+)
-                if hasattr(_wou, "_get_user_allowed_globals"):
-                    torch.serialization.add_safe_globals(_cls_path_pairs)
-                else:
-                    # Fallback for PyTorch 2.6-2.11: patch __module__ at add-time
-                    _safe_classes = [cls for cls, _ in _cls_path_pairs]
-                    _orig_modules = {cls: cls.__module__ for cls in _safe_classes}
-                    for cls, path in _cls_path_pairs:
-                        cls.__module__ = ".".join(path.split(".")[:-1])
-                    torch.serialization.add_safe_globals(_safe_classes)
-                    for cls in _safe_classes:
-                        cls.__module__ = _orig_modules[cls]
-
-            # Guard against incompatible hf_xet (e.g., PyO3 ABI mismatch when
-            # hf_xet was compiled for an older CPython than the current runtime).
-            # huggingface_hub reads HF_HUB_DISABLE_XET from constants.py at
-            # import time, and file_download.py accesses it as
-            # `constants.HF_HUB_DISABLE_XET` at call time. We must therefore
-            # patch huggingface_hub.constants directly (not file_download) so
-            # that _download_to_tmp_and_move skips xet_get for this session.
-            import os
-
-            try:
-                import hf_xet  # noqa: F401
-            except Exception:
-                os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
-                if _check_soft_dependencies("huggingface_hub", severity="none"):
-                    import huggingface_hub.constants as _hf_constants
-
-                    _hf_constants.HF_HUB_DISABLE_XET = True
-
-            if self.checkpoint_path.startswith("Salesforce"):
-                from sktime.libs.uni2ts.moirai_module import MoiraiModule
-
-                model_kwargs["module"] = MoiraiModule.from_pretrained(
-                    self.checkpoint_path
-                )
-                return MoiraiForecast(**model_kwargs)
-            else:
-                from huggingface_hub import hf_hub_download
-
-                model_kwargs["checkpoint_path"] = hf_hub_download(
-                    repo_id=self.checkpoint_path, filename="model.ckpt"
-                )
-                return MoiraiForecast.load_from_checkpoint(**model_kwargs)
+        model_kwargs["checkpoint_path"] = hf_hub_download(
+            repo_id=self.checkpoint_path, filename="model.ckpt"
+        )
+        return _load_moirai_checkpoint(MoiraiForecast, model_kwargs)
 
     def _fit(self, y, X=None, fh=None):
         if fh is not None:
@@ -312,28 +275,27 @@ class MOIRAIForecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
         model_kwargs = self._get_model_kwargs(prediction_length)
         # Load model from source package
         if self.use_source_package:
-            if _check_soft_dependencies("uni2ts", severity="none"):
-                from uni2ts.model.moirai import MoiraiForecast, MoiraiModule
+            _check_soft_dependencies("uni2ts")
+            from uni2ts.model.moirai import MoiraiForecast, MoiraiModule
 
-                if self.checkpoint_path.startswith("Salesforce"):
-                    model_kwargs["module"] = MoiraiModule.from_pretrained(
-                        self.checkpoint_path
-                    )
-                    return MoiraiForecast(**model_kwargs)
-                else:
-                    from huggingface_hub import hf_hub_download
+            if self.checkpoint_path.startswith("Salesforce"):
+                model_kwargs["module"] = MoiraiModule.from_pretrained(
+                    self.checkpoint_path
+                )
+                return MoiraiForecast(**model_kwargs)
 
-                    model_kwargs["checkpoint_path"] = hf_hub_download(
-                        repo_id=self.checkpoint_path, filename="model.ckpt"
-                    )
-                    model = MoiraiForecast.load_from_checkpoint(**model_kwargs)
-                    model.to(self.map_location)
-                    return model
-        # Load model from sktime
-        else:
-            model = self._instantiate_patched_model(model_kwargs)
+            from huggingface_hub import hf_hub_download
+
+            model_kwargs["checkpoint_path"] = hf_hub_download(
+                repo_id=self.checkpoint_path, filename="model.ckpt"
+            )
+            model = MoiraiForecast.load_from_checkpoint(**model_kwargs)
             model.to(self.map_location)
             return model
+        # Load model from sktime
+        model = self._instantiate_vendor_model(model_kwargs)
+        model.to(self.map_location)
+        return model
 
     def _predict(self, fh, X=None):
         if fh is None:

--- a/sktime/forecasting/moirai2.py
+++ b/sktime/forecasting/moirai2.py
@@ -148,32 +148,9 @@ class Moirai2Forecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
                 }
             )
 
-    def _instantiate_patched_model(self, model_kwargs):
-        """Instantiate the model from the local sktime uni2ts copy."""
-        import sys
-
-        import sktime.libs.uni2ts as _uni2ts_mod
-
-        sys.modules.setdefault("uni2ts", _uni2ts_mod)
-        # Guard against incompatible hf_xet (e.g., PyO3 ABI mismatch when
-        # hf_xet was compiled for an older CPython than the current runtime).
-        # huggingface_hub reads HF_HUB_DISABLE_XET from constants.py at
-        # import time, and file_download.py accesses it as
-        # `constants.HF_HUB_DISABLE_XET` at call time. We must therefore
-        # patch huggingface_hub.constants directly (not file_download) so
-        # that _download_to_tmp_and_move skips xet_get for this session.
-        import os
-
+    def _instantiate_vendor_model(self, model_kwargs):
+        """Instantiate the model from sktime's vendored uni2ts package."""
         from sktime.libs.uni2ts.moirai2_forecast import Moirai2Forecast
-
-        try:
-            import hf_xet  # noqa: F401
-        except Exception:
-            os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
-            if _check_soft_dependencies("huggingface_hub", severity="none"):
-                import huggingface_hub.constants as _hf_constants
-
-                _hf_constants.HF_HUB_DISABLE_XET = True
 
         if self.checkpoint_path.startswith("Salesforce"):
             from sktime.libs.uni2ts.moirai2_module import Moirai2Module
@@ -235,7 +212,7 @@ class Moirai2Forecaster(_GlobalForecastingDeprecationMixin, BaseForecaster):
                     self.model = Moirai2Forecast.load_from_checkpoint(**model_kwargs)
                     self.model.to(self.map_location)
         else:
-            self.model = self._instantiate_patched_model(model_kwargs)
+            self.model = self._instantiate_vendor_model(model_kwargs)
             self.model.to(self.map_location)
 
     def _predict(self, fh, X=None):

--- a/sktime/forecasting/tests/test_moirai_vendor_imports.py
+++ b/sktime/forecasting/tests/test_moirai_vendor_imports.py
@@ -1,0 +1,143 @@
+"""Tests for MOIRAI vendored import handling."""
+
+import sys
+from contextlib import contextmanager
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    [
+        "forecaster_path",
+        "class_name",
+        "forecast_path",
+        "forecast_name",
+        "module_path",
+        "module_name",
+    ],
+    [
+        (
+            "sktime.forecasting.moirai",
+            "MOIRAIForecaster",
+            "sktime.libs.uni2ts.forecast",
+            "MoiraiForecast",
+            "sktime.libs.uni2ts.moirai_module",
+            "MoiraiModule",
+        ),
+        (
+            "sktime.forecasting.moirai2",
+            "Moirai2Forecaster",
+            "sktime.libs.uni2ts.moirai2_forecast",
+            "Moirai2Forecast",
+            "sktime.libs.uni2ts.moirai2_module",
+            "Moirai2Module",
+        ),
+    ],
+)
+def test_vendor_loader_does_not_alias_uni2ts(
+    monkeypatch,
+    forecaster_path,
+    class_name,
+    forecast_path,
+    forecast_name,
+    module_path,
+    module_name,
+):
+    """Vendor model loading should not install a top-level uni2ts alias."""
+    from importlib import import_module
+
+    forecaster_class = getattr(import_module(forecaster_path), class_name)
+    loaded_module = object()
+
+    class DummyModule:
+        @classmethod
+        def from_pretrained(cls, checkpoint_path):
+            assert checkpoint_path.startswith("Salesforce/")
+            return loaded_module
+
+    class DummyForecast:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    forecast_module = ModuleType(forecast_path)
+    setattr(forecast_module, forecast_name, DummyForecast)
+    model_module = ModuleType(module_path)
+    setattr(model_module, module_name, DummyModule)
+
+    monkeypatch.setitem(sys.modules, forecast_path, forecast_module)
+    monkeypatch.setitem(sys.modules, module_path, model_module)
+    monkeypatch.delitem(sys.modules, "uni2ts", raising=False)
+
+    forecaster = forecaster_class("Salesforce/moirai-test")
+    model = forecaster._instantiate_vendor_model({"prediction_length": 1})
+
+    assert model.kwargs["module"] is loaded_module
+    assert "uni2ts" not in sys.modules
+
+
+def test_upstream_config_targets_use_vendor_namespace():
+    """Upstream Hydra targets should be mapped without an import alias."""
+    from sktime.libs.uni2ts.moirai_module import _use_vendor_module_paths
+
+    config = {
+        "_target_": "uni2ts.distribution.mixture.MixtureOutput",
+        "components": [
+            {"_target_": "uni2ts.distribution.normal.NormalOutput"},
+            {"_target_": "external.package.Output"},
+        ],
+    }
+
+    mapped = _use_vendor_module_paths(config)
+
+    assert mapped == {
+        "_target_": "sktime.libs.uni2ts.distribution.mixture.MixtureOutput",
+        "components": [
+            {"_target_": "sktime.libs.uni2ts.distribution.normal.NormalOutput"},
+            {"_target_": "external.package.Output"},
+        ],
+    }
+    assert config["_target_"] == "uni2ts.distribution.mixture.MixtureOutput"
+
+
+def test_checkpoint_safe_globals_are_scoped(monkeypatch):
+    """Legacy checkpoint globals should be removed after model loading."""
+    import sktime.forecasting.moirai as moirai
+
+    events = []
+    existing_alias = (object(), "uni2ts.example.Existing")
+    new_alias = (object(), "uni2ts.example.New")
+    aliases = [existing_alias, new_alias]
+
+    @contextmanager
+    def safe_globals(values):
+        events.append(("enter", values))
+        yield
+        events.append(("exit", values))
+
+    torch_module = ModuleType("torch")
+    torch_module.serialization = SimpleNamespace(
+        get_safe_globals=lambda: [existing_alias],
+        safe_globals=safe_globals,
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch_module)
+    monkeypatch.setattr(
+        moirai,
+        "_get_moirai_checkpoint_safe_globals",
+        lambda: aliases,
+    )
+
+    class DummyModel:
+        @classmethod
+        def load_from_checkpoint(cls, **kwargs):
+            events.append(("load", kwargs))
+            return "model"
+
+    result = moirai._load_moirai_checkpoint(DummyModel, {"checkpoint_path": "model"})
+
+    assert result == "model"
+    assert events == [
+        ("enter", [new_alias]),
+        ("load", {"checkpoint_path": "model"}),
+        ("exit", [new_alias]),
+    ]

--- a/sktime/libs/uni2ts/moirai_module.py
+++ b/sktime/libs/uni2ts/moirai_module.py
@@ -64,11 +64,29 @@ def encode_distr_output(
     return _encode(distr_output)
 
 
+def _use_vendor_module_paths(config):
+    """Point upstream uni2ts config targets at sktime's vendored modules."""
+    if isinstance(config, dict):
+        mapped = {}
+        for key, value in config.items():
+            if (
+                key == "_target_"
+                and isinstance(value, str)
+                and value.startswith("uni2ts.")
+            ):
+                value = f"sktime.libs.{value}"
+            mapped[key] = _use_vendor_module_paths(value)
+        return mapped
+    if isinstance(config, list):
+        return [_use_vendor_module_paths(value) for value in config]
+    return config
+
+
 def decode_distr_output(config) -> DistributionOutput:
     """Deserialize function for DistributionOutput."""
     from hydra.utils import instantiate
 
-    return instantiate(config, _convert_="all")
+    return instantiate(_use_vendor_module_paths(config), _convert_="all")
 
 
 class MoiraiModule(


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10654

#### What does this implement/fix? Explain your changes.

`MOIRAIForecaster` installed `sktime.libs.uni2ts` in `sys.modules` under the
top-level name `uni2ts`. The alias remained after model loading and could
interfere with a separately installed upstream package.

This change removes that alias. Vendored Hydra config targets are rewritten to
their `sktime.libs.uni2ts` paths before instantiation. Legacy Lightning
checkpoints still use the class paths stored in the checkpoint files, but those
names are allowlisted only for the duration of checkpoint loading.

The vendor loader is now a regular method instead of being defined conditionally.
The same import isolation is applied to `Moirai2Forecaster`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Loading vendored models when the upstream `uni2ts` package is already imported
- The scoped safe-global handling for legacy checkpoints on PyTorch 2.6 and later
- Rewriting upstream Hydra targets to the vendored module paths

#### Did you add any tests for the change?

Yes. The new regression tests cover both MOIRAI vendor loaders, Hydra target
rewriting, and cleanup of temporary checkpoint safe globals.

Validation:

- 1,164 MOIRAI v1 and v2 forecaster contract tests passed
- Real `fit` and `predict` calls passed for the Salesforce MOIRAI v1 model,
  sktime's legacy MOIRAI v1 checkpoint, and the Salesforce MOIRAI 2 model
- The upstream `uni2ts` package remained usable while both vendored MOIRAI v1
  artifact formats were loaded
- The upstream and legacy MOIRAI v1 paths passed on PyTorch 2.6 and 2.13
- Ruff formatting and lint checks passed

#### Any other comments?

None.

#### PR checklist

##### For all contributions

- [ ] I've added myself to the list of contributors
- [x] The PR title starts with `[BUG]`
