### PR TITLE
[DOC] add Toto2 to 1.0.2 release note highlights

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -28,9 +28,10 @@ Highlights
   * Aurora multimodal foundation model forecaster (:pr:`10417`) :user:`Faakhir30`
   * Cisco TSFM forecaster (:pr:`10444`) :user:`vedantag17`
   * Falcon-X forecaster (:pr:`10430`) :user:`vedantag17`
-  * MIRA medical time series foundation model(:pr:`10398`) :user:`Faakhir30`
+  * MIRA medical time series foundation model (:pr:`10398`) :user:`Faakhir30`
   * Moirai 2.0 foundation model forecasters (:pr:`9678`, :pr:`10333`) :user:`ubermensch19`, :user:`vedantag17`
   * Thuml Sundial forecasting foundation model (:pr:`10428`) :user:`geetu040`
+  * Toto-2.0 forecasting foundation model (:pr:`10385`) :user:`siddharth7113`
   * WindFM forecasting foundation model (:pr:`10384`) :user:`geetu040`
 
 * Arps Decline Curve Analysis forecasters (:pr:`10258`) :user:`scuervo91`


### PR DESCRIPTION
Accidentally, Toto2 was missing from the 1.0.2 release note highlights.

Adds Toto2, and also fixes another minor typo.