### PR TITLE
remove doctest skips for dependency-free classes, fix 2 broken examples

### DIFF
--- a/sktime/performance_metrics/forecasting/_gmse.py
+++ b/sktime/performance_metrics/forecasting/_gmse.py
@@ -91,30 +91,30 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> gmse = GeometricMeanSquaredError()
-    >>> gmse(y_true, y_pred)  # doctest: +SKIP
+    >>> gmse(y_true, y_pred)
     np.float64(2.80399089461488e-07)
     >>> rgmse = GeometricMeanSquaredError(square_root=True)
-    >>> rgmse(y_true, y_pred)  # doctest: +SKIP
+    >>> rgmse(y_true, y_pred)
     np.float64(0.000529527232030127)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> gmse = GeometricMeanSquaredError()
-    >>> gmse(y_true, y_pred)  # doctest: +SKIP
+    >>> gmse(y_true, y_pred)
     np.float64(0.5000000000115499)
     >>> rgmse = GeometricMeanSquaredError(square_root=True)
-    >>> rgmse(y_true, y_pred)  # doctest: +SKIP
+    >>> rgmse(y_true, y_pred)
     np.float64(0.5000024031086919)
     >>> gmse = GeometricMeanSquaredError(multioutput='raw_values')
-    >>> gmse(y_true, y_pred)  # doctest: +SKIP
+    >>> gmse(y_true, y_pred)
     array([2.30997255e-11, 1.00000000e+00])
     >>> rgmse = GeometricMeanSquaredError(multioutput='raw_values', square_root=True)
-    >>> rgmse(y_true, y_pred)# doctest: +SKIP
+    >>> rgmse(y_true, y_pred)
     array([4.80621738e-06, 1.00000000e+00])
     >>> gmse = GeometricMeanSquaredError(multioutput=[0.3, 0.7])
-    >>> gmse(y_true, y_pred)  # doctest: +SKIP
+    >>> gmse(y_true, y_pred)
     np.float64(0.7000000000069299)
     >>> rgmse = GeometricMeanSquaredError(multioutput=[0.3, 0.7], square_root=True)
-    >>> rgmse(y_true, y_pred)  # doctest: +SKIP
+    >>> rgmse(y_true, y_pred)
     np.float64(0.7000014418652152)
     """
 

--- a/sktime/performance_metrics/forecasting/_masyme.py
+++ b/sktime/performance_metrics/forecasting/_masyme.py
@@ -108,26 +108,26 @@ class MeanAsymmetricError(BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> asymmetric_error = MeanAsymmetricError()
-    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
+    >>> asymmetric_error(y_true, y_pred)
     np.float64(0.5)
     >>> asymmetric_error = MeanAsymmetricError(left_error_function='absolute', \
     right_error_function='squared')
-    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
+    >>> asymmetric_error(y_true, y_pred)
     np.float64(0.4625)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> asymmetric_error = MeanAsymmetricError()
-    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
+    >>> asymmetric_error(y_true, y_pred)
     np.float64(0.75)
     >>> asymmetric_error = MeanAsymmetricError(left_error_function='absolute', \
     right_error_function='squared')
-    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
+    >>> asymmetric_error(y_true, y_pred)
     np.float64(0.7083333333333334)
     >>> asymmetric_error = MeanAsymmetricError(multioutput='raw_values')
-    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
+    >>> asymmetric_error(y_true, y_pred)
     array([0.5, 1. ])
     >>> asymmetric_error = MeanAsymmetricError(multioutput=[0.3, 0.7])
-    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
+    >>> asymmetric_error(y_true, y_pred)
     np.float64(0.85)
     """
 

--- a/sktime/performance_metrics/forecasting/_mlinex.py
+++ b/sktime/performance_metrics/forecasting/_mlinex.py
@@ -114,27 +114,27 @@ class MeanLinexError(BaseForecastingErrorMetricFunc):
     >>> linex_error = MeanLinexError()
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     np.float64(0.19802627763937575)
     >>> linex_error = MeanLinexError(b=2)
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     np.float64(0.3960525552787515)
     >>> linex_error = MeanLinexError(a=-1)
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     np.float64(0.2391800623225643)
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> linex_error = MeanLinexError()
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     np.float64(0.2700398392309829)
     >>> linex_error = MeanLinexError(a=-1)
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
-    np.float64(0.49660966225813563
+    >>> linex_error(y_true, y_pred)
+    np.float64(0.49660966225813563)
     >>> linex_error = MeanLinexError(multioutput='raw_values')
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     array([0.17220024, 0.36787944])
     >>> linex_error = MeanLinexError(multioutput=[0.3, 0.7])
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     np.float64(0.30917568000716666)
     """
 

--- a/sktime/regression/dummy/_dummy.py
+++ b/sktime/regression/dummy/_dummy.py
@@ -51,10 +51,10 @@ class DummyRegressor(BaseRegressor):
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train")
     >>> X_test, y_test = load_unit_test(split="test")
-    >>> regressor = DummyRegressor(strategy="median") # doctest: +SKIP
-    >>> regressor.fit(X_train,y_train) # doctest: +SKIP
+    >>> regressor = DummyRegressor(strategy="median")
+    >>> regressor.fit(X_train,y_train)
     DummyRegressor(strategy='median')
-    >>> y_pred = regressor.predict(X_test) # doctest: +SKIP
+    >>> y_pred = regressor.predict(X_test)
     """
 
     _tags = {

--- a/sktime/transformations/paa.py
+++ b/sktime/transformations/paa.py
@@ -41,10 +41,11 @@ class PAA(BaseTransformer):
 
     >>> X = arange(10)
     >>> paa = PAA(frames=3)
-    >>> paa.fit_transform(X)  # doctest: +SKIP
+    >>> paa.fit_transform(X)
     array([1.2, 4.5, 7.8])
-    >>> paa = PAA(frame_size=3)  # doctest: +SKIP
-    array([1, 4, 7, 9])
+    >>> paa = PAA(frame_size=3)
+    >>> paa.fit_transform(X)
+    array([1., 4., 7., 9.])
     """
 
     _tags = {

--- a/sktime/transformations/sax.py
+++ b/sktime/transformations/sax.py
@@ -51,9 +51,10 @@ class SAX(BaseTransformer):
 
     >>> X = arange(10)
     >>> sax = SAX(word_size=3, alphabet_size=5)
-    >>> sax.fit_transform(X)  # doctest: +SKIP
+    >>> sax.fit_transform(X)
     array([0, 2, 4])
-    >>> sax = SAX(frame_size=2, alphabet_size=5)  # doctest: +SKIP
+    >>> sax = SAX(frame_size=2, alphabet_size=5)
+    >>> sax.fit_transform(X)
     array([0, 1, 2, 3, 4])
     """
 


### PR DESCRIPTION
## Reference Issues/PRs
Part of #10671

## What does this implement/fix?
Issue #10671 asks to remove `doctest: +SKIP` directives now that the test framework selectively runs docstring examples by dependency tag, since the skips were originally only needed for soft-dependency isolation. Given the scale (1317 skip directives across 230 files), this PR tackles a small, low-risk first slice: 6 classes with `python_dependencies=None` (verified via resolved class tags, not just grepping the file), so no soft deps are needed to verify the examples.

Each example was actually run before removing its skip, per the issue's own caution that "some examples may be faulty." Found and fixed two real, pre-existing bugs in the process:

- `_mlinex.py`: one expected-output line was missing a closing parenthesis (`np.float64(0.49660966225813563` → `...813563)`).
- `paa.py` / `sax.py`: the second example in each constructed the transformer (`paa = PAA(frame_size=3)`) but never called `.fit_transform(X)` before the expected array output — the output was attached to a line that was never executed. Added the missing call and verified the actual output (also fixed a dtype mismatch in the PAA case: claimed `array([1, 4, 7, 9])`, actual is `array([1., 4., 7., 9.])`).

All 81 doctest examples across the 6 files verified passing via both `doctest.testmod` directly and `check_estimator`'s `test_doctest_examples`.

This is a first slice, not a full close, happy to continue with more dependency-free classes in follow-ups, and classes with real soft deps need separate verification with those deps installed.

## Does your contribution introduce a new dependency?
No.

## Did you add any tests for the change?
No new tests — this restores doctest coverage that was previously skipped; the doctests themselves now serve as the regression check via `test_doctest_examples`.
