### PR TITLE
[BUG] Fix `PretrainedCloner` to skip non-skbase objects

### DIFF
--- a/sktime/forecasting/base/_clone_plugin.py
+++ b/sktime/forecasting/base/_clone_plugin.py
@@ -3,6 +3,7 @@
 
 from copy import deepcopy
 
+from skbase.base._base import BaseObject
 from skbase.base._clone_plugins import BaseCloner, _default_clone
 
 
@@ -32,6 +33,10 @@ class _PretrainedCloner(BaseCloner):
         - Runtime checks alone could trigger on non-pretrain estimators if
           ``_pretrained_attrs`` somehow got set incorrectly
         """
+        # recursive clone can attempt checking of object passed as parameter not
+        # inheriting from BaseObject e.g., sklearn.linear_model.LinearRegression
+        if not isinstance(obj, BaseObject):
+            return False
         has_pretrain_capability = obj.get_tag(
             "capability:pretrain", tag_value_default=False, raise_error=False
         )


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Tests attempting cloning of forecasters that takes a non-baseobject object as a param fails.
e.g., `sktime/forecasting/compose/tests/test_forecastx.py::test_forecastx_exog_for_forecaster_x`

```python
def test_forecastx_exog_for_forecaster_x():
    """Test that ForecastX forecaster_X uses exogenous data as told by parameter."""
    from sklearn.linear_model import LinearRegression

    from sktime.forecasting.compose import ForecastX, YfromX

    y, X = load_longley()

    fh = [1, 2, 3]

    model_supporting_exogenous = YfromX(LinearRegression())

    cols_to_forecast = ["GNPDEFL", "GNP"]

    model_1 = ForecastX(
        model_supporting_exogenous.clone(),
        model_supporting_exogenous.clone(),
        columns=cols_to_forecast,
        forecaster_X_exogeneous="None",
    )
```

`LinearRegression` is not a `BaseObject` so fails with error:
`AttributeError: LinearRegression has to attribute get_tags`


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [x] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.