### PR TITLE
[DOC] remove ARM troubleshooting section which is no longer applicable

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -201,28 +201,6 @@ your environment is activated and linked to whatever IDE you are using.  If you 
 Notebooks, follow `these instructions <https://janakiev.com/blog/jupyter-virtual-envs/>`_ for
 adding your virtual environment as a new kernel for your notebook.
 
-Installing ``all_extras`` on mac with ARM processor
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you are using a mac with an ARM processor, you may encounter an error when installing
-``sktime[all_extras]``.  This is due to the fact that some libraries included in ``all_extras``
-are not compatible with ARM-based processors.
-
-The workaround is not to install some of the packages in ``all_extras`` and install ARM compatible
-replacements for others:
-
-* Do not install the following packages:
-    * ``esig``
-    * ``prophet``
-    * ``tsfresh``
-    * ``tslearn``
-* Replace ``tensorflow`` package with the following packages:
-    * ``tensorflow-macos``
-    * ``tensorflow-metal`` (optional)
-
-Also, ARM-based processors have issues when installing packages distributed as source distributions
-instead of Python wheels. To avoid this issue when installing a package you can try installing it
-through conda or use a prior version of the package that was distributed as a wheel.
-
 Other Startup Resources
 -----------------------
 


### PR DESCRIPTION
Removes a troubleshooting section referring to dependencies of `all_extras` which are no longer in said dependency set (hence the section is no longer applicable)