### PR TITLE
[DOC] document feature layout of 1st generation reduction forecasters

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1244,6 +1244,42 @@ class DirectTabularRegressionForecaster(_DirectReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix.
+
+    Notes
+    -----
+    Layout of the feature matrix passed to ``estimator``:
+
+    Let ``w = window_length``, and let ``X`` have columns ``x1, ..., xk``.
+    Each row of the feature matrix is the concatenation of one block of ``w``
+    values per variable, in the order ``y, x1, ..., xk``::
+
+        [y(t-w+1), ..., y(t), x1(t-w+1), ..., x1(t), ..., xk(t-w+1), ..., xk(t)]
+
+    where ``t`` is the last time stamp of the window.
+    The feature matrix therefore has ``w * (1 + k)`` columns, and ``w`` columns
+    if no ``X`` is passed.
+    Within a block, columns are in chronological order, that is, the oldest
+    observation of the window comes first and the most recent one comes last.
+    Values of ``X`` at the time stamps being forecast are not used as features,
+    only lagged values inside the window are.
+
+    One clone of ``estimator`` is fitted per element of ``fh``, all of them
+    using the above layout. The fitted clones are available as the fitted
+    parameter ``estimators``.
+
+    This layout is what feature indexed attributes of a fitted clone refer to,
+    for instance ``coef_`` or ``feature_importances_`` of ``scikit-learn``
+    regressors. With ``w = 5`` and ``X`` having columns ``x1, x2``, for example,
+    ``feature_importances_`` has ``5 * 3 = 15`` entries: entries 0 to 4 are the
+    lags of ``y``, entries 5 to 9 the lags of ``x1``, and entries 10 to 14 the
+    lags of ``x2``, each ordered from oldest to most recent.
+
+    If ``pooling="global"``, a ``pandas.DataFrame`` with named columns is passed
+    to ``estimator`` instead of a ``numpy`` array. The ``w`` lags of ``y`` are
+    named ``y_lag_1``, ..., ``y_lag_w``, most recent lag first, and are followed
+    by the columns of ``X``, which are not lagged in this case. For
+    ``scikit-learn`` regressors, these names can be read off
+    ``estimator.feature_names_in_``.
     """
 
     def __init__(
@@ -1294,6 +1330,35 @@ class MultioutputTabularRegressionForecaster(_MultioutputReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix.
+
+    Notes
+    -----
+    Layout of the feature matrix passed to ``estimator``:
+
+    Let ``w = window_length``, and let ``X`` have columns ``x1, ..., xk``.
+    Each row of the feature matrix is the concatenation of one block of ``w``
+    values per variable, in the order ``y, x1, ..., xk``::
+
+        [y(t-w+1), ..., y(t), x1(t-w+1), ..., x1(t), ..., xk(t-w+1), ..., xk(t)]
+
+    where ``t`` is the last time stamp of the window.
+    The feature matrix therefore has ``w * (1 + k)`` columns, and ``w`` columns
+    if no ``X`` is passed.
+    Within a block, columns are in chronological order, that is, the oldest
+    observation of the window comes first and the most recent one comes last.
+    Values of ``X`` at the time stamps being forecast are not used as features,
+    only lagged values inside the window are.
+
+    The target passed to ``estimator`` is 2D, with one column per element of
+    ``fh``, in the order of ``fh``.
+
+    This layout is what feature indexed attributes of the fitted ``estimator``
+    refer to, for instance ``coef_`` or ``feature_importances_`` of
+    ``scikit-learn`` regressors. With ``w = 5`` and ``X`` having columns
+    ``x1, x2``, for example, ``feature_importances_`` has ``5 * 3 = 15``
+    entries: entries 0 to 4 are the lags of ``y``, entries 5 to 9 the lags of
+    ``x1``, and entries 10 to 14 the lags of ``x2``, each ordered from oldest
+    to most recent.
     """
 
     _estimator_scitype = "tabular-regressor"
@@ -1322,6 +1387,44 @@ class RecursiveTabularRegressionForecaster(_RecursiveReducer):
     pooling: str {"local", "global"}, optional
         Specifies whether separate models will be fit at the level of each instance
         (local) of if you wish to fit a single model to all instances ("global").
+
+    Notes
+    -----
+    Layout of the feature matrix passed to ``estimator``:
+
+    Let ``w = window_length``, and let ``X`` have columns ``x1, ..., xk``.
+    Each row of the feature matrix is the concatenation of one block of ``w``
+    values per variable, in the order ``y, x1, ..., xk``::
+
+        [y(t-w+1), ..., y(t), x1(t-w+1), ..., x1(t), ..., xk(t-w+1), ..., xk(t)]
+
+    where ``t`` is the last time stamp of the window.
+    The feature matrix therefore has ``w * (1 + k)`` columns, and ``w`` columns
+    if no ``X`` is passed.
+    Within a block, columns are in chronological order, that is, the oldest
+    observation of the window comes first and the most recent one comes last.
+    Values of ``X`` at the time stamps being forecast are not used as features,
+    only lagged values inside the window are.
+
+    A single clone of ``estimator`` is fitted, always on a one step ahead
+    target, and applied iteratively in ``predict``. For horizons beyond the
+    first, previously predicted values of ``y`` enter the window in place of
+    observed values.
+
+    This layout is what feature indexed attributes of the fitted ``estimator``
+    refer to, for instance ``coef_`` or ``feature_importances_`` of
+    ``scikit-learn`` regressors. With ``w = 5`` and ``X`` having columns
+    ``x1, x2``, for example, ``feature_importances_`` has ``5 * 3 = 15``
+    entries: entries 0 to 4 are the lags of ``y``, entries 5 to 9 the lags of
+    ``x1``, and entries 10 to 14 the lags of ``x2``, each ordered from oldest
+    to most recent.
+
+    If ``pooling="global"``, a ``pandas.DataFrame`` with named columns is passed
+    to ``estimator`` instead of a ``numpy`` array. The ``w`` lags of ``y`` are
+    named ``y_lag_1``, ..., ``y_lag_w``, most recent lag first, and are followed
+    by the columns of ``X``, which are not lagged in this case. For
+    ``scikit-learn`` regressors, these names can be read off
+    ``estimator.feature_names_in_``.
     """
 
     _tags = {
@@ -1377,6 +1480,26 @@ class DirRecTabularRegressionForecaster(_DirRecReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix
+
+    Notes
+    -----
+    Layout of the feature matrix passed to ``estimator``:
+
+    Let ``w = window_length``. One clone of ``estimator`` is fitted per element
+    of ``fh``, and the ``i``-th clone, counting from 1 in the order of ``fh``,
+    is passed ``w + i - 1`` features::
+
+        [y(t-w+1), ..., y(t), y at the horizons preceding the i-th one]
+
+    where ``t`` is the last time stamp of the window. The first ``w`` columns
+    are the window, in chronological order, oldest observation first. The
+    trailing ``i - 1`` columns are the values of ``y`` at the earlier horizons,
+    in the order of ``fh``; these are observed values in ``fit`` and predicted
+    values in ``predict``. The fitted clones are available as the fitted
+    parameter ``estimators``.
+
+    Exogenous data ``X`` is currently not supported by the ``dirrec`` strategy,
+    and is silently ignored if passed.
     """
 
     _estimator_scitype = "tabular-regressor"
@@ -1395,6 +1518,22 @@ class DirectTimeSeriesRegressionForecaster(_DirectReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix.
+
+    Notes
+    -----
+    Layout of the panel passed to ``estimator``:
+
+    Let ``w = window_length``, and let ``X`` have columns ``x1, ..., xk``.
+    ``estimator`` is passed a 3D ``numpy`` array of shape
+    ``(n_windows, 1 + k, w)``. The variable axis is ordered ``y, x1, ..., xk``,
+    and the time axis is in chronological order, oldest observation of the
+    window first.
+    Values of ``X`` at the time stamps being forecast are not used as features,
+    only lagged values inside the window are.
+
+    One clone of ``estimator`` is fitted per element of ``fh``, all of them
+    using the above layout. The fitted clones are available as the fitted
+    parameter ``estimators``.
     """
 
     _estimator_scitype = "time-series-regressor"
@@ -1413,6 +1552,21 @@ class MultioutputTimeSeriesRegressionForecaster(_MultioutputReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix.
+
+    Notes
+    -----
+    Layout of the panel passed to ``estimator``:
+
+    Let ``w = window_length``, and let ``X`` have columns ``x1, ..., xk``.
+    ``estimator`` is passed a 3D ``numpy`` array of shape
+    ``(n_windows, 1 + k, w)``. The variable axis is ordered ``y, x1, ..., xk``,
+    and the time axis is in chronological order, oldest observation of the
+    window first.
+    Values of ``X`` at the time stamps being forecast are not used as features,
+    only lagged values inside the window are.
+
+    The target passed to ``estimator`` is 2D, with one column per element of
+    ``fh``, in the order of ``fh``.
     """
 
     _estimator_scitype = "time-series-regressor"
@@ -1431,6 +1585,23 @@ class RecursiveTimeSeriesRegressionForecaster(_RecursiveReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix.
+
+    Notes
+    -----
+    Layout of the panel passed to ``estimator``:
+
+    Let ``w = window_length``, and let ``X`` have columns ``x1, ..., xk``.
+    ``estimator`` is passed a 3D ``numpy`` array of shape
+    ``(n_windows, 1 + k, w)``. The variable axis is ordered ``y, x1, ..., xk``,
+    and the time axis is in chronological order, oldest observation of the
+    window first.
+    Values of ``X`` at the time stamps being forecast are not used as features,
+    only lagged values inside the window are.
+
+    A single clone of ``estimator`` is fitted, always on a one step ahead
+    target, and applied iteratively in ``predict``. For horizons beyond the
+    first, previously predicted values of ``y`` enter the window in place of
+    observed values.
     """
 
     _tags = {
@@ -1456,6 +1627,22 @@ class DirRecTimeSeriesRegressionForecaster(_DirRecReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix
+
+    Notes
+    -----
+    Layout of the panel passed to ``estimator``:
+
+    Let ``w = window_length``. One clone of ``estimator`` is fitted per element
+    of ``fh``, and the ``i``-th clone, counting from 1 in the order of ``fh``,
+    is passed a 3D ``numpy`` array of shape ``(n_windows, 1, w + i - 1)``.
+    The time axis holds the window in chronological order, oldest observation
+    first, followed by the values of ``y`` at the earlier horizons in the order
+    of ``fh``; these are observed values in ``fit`` and predicted values in
+    ``predict``. The fitted clones are available as the fitted parameter
+    ``estimators``.
+
+    Exogenous data ``X`` is currently not supported by the ``dirrec`` strategy,
+    and is silently ignored if passed.
     """
 
     _estimator_scitype = "time-series-regressor"
@@ -1596,6 +1783,40 @@ def make_reduction(
     forecaster : an sktime forecaster object
         the reduction forecaster, wrapping ``estimator``
         class is determined by the ``strategy`` argument and type of ``estimator``.
+
+    See Also
+    --------
+    DirectTabularRegressionForecaster
+    RecursiveTabularRegressionForecaster
+    MultioutputTabularRegressionForecaster
+    DirRecTabularRegressionForecaster
+    DirectTimeSeriesRegressionForecaster
+    RecursiveTimeSeriesRegressionForecaster
+    MultioutputTimeSeriesRegressionForecaster
+    DirRecTimeSeriesRegressionForecaster
+
+    Notes
+    -----
+    The class of the constructed forecaster is determined by ``strategy`` and by
+    the type of ``estimator``. For a tabular regressor, ``strategy`` values
+    ``"direct"``, ``"recursive"``, ``"multioutput"``, ``"dirrec"`` construct,
+    respectively, ``DirectTabularRegressionForecaster``,
+    ``RecursiveTabularRegressionForecaster``,
+    ``MultioutputTabularRegressionForecaster``,
+    ``DirRecTabularRegressionForecaster``.
+    For a time series regressor, the same ``strategy`` values construct the
+    corresponding ``...TimeSeriesRegressionForecaster`` classes.
+
+    Which features are generated, and in which order they are passed to
+    ``estimator``, is documented in the class docstring of the constructed
+    forecaster, see the classes listed above. The constructed class can be
+    inspected via ``type(forecaster)``, or from the html representation of the
+    constructed forecaster.
+
+    That feature layout is what is needed to interpret feature indexed
+    attributes of the fitted ``estimator``, such as ``coef_`` or
+    ``feature_importances_`` of ``scikit-learn`` regressors, since these are
+    indexed by generated lag feature and not by the columns of ``y`` and ``X``.
 
     Examples
     --------

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -399,6 +399,48 @@ def test_consistent_data_passing_to_component_estimators_in_fit_and_predict(
     not run_test_module_changed(["sktime.forecasting.compose._reduce"]),
     reason="run test only if reduce module has changed",
 )
+@pytest.mark.parametrize("strategy", ["direct", "recursive", "multioutput"])
+def test_feature_layout_passed_to_estimator(strategy):
+    """Test the feature layout documented in the reducer class docstrings.
+
+    The class docstrings state that each row of the feature matrix passed to the
+    wrapped estimator is the concatenation of one block of ``window_length``
+    values per variable, in the order ``y``, then the columns of ``X``, with the
+    values inside a block in chronological order, oldest observation first.
+    """
+    y = pd.Series(np.arange(9, dtype=float))
+    X = pd.DataFrame({"x1": y + 100, "x2": y + 200})
+
+    forecaster = make_reduction(
+        _TestTabularRegressor(), window_length=2, strategy=strategy
+    )
+    forecaster.fit(y, X=X, fh=ForecastingHorizon([1], is_relative=True))
+
+    if strategy == "direct":
+        estimator_ = forecaster.estimators_[0]
+    else:
+        estimator_ = forecaster.estimator_
+
+    # blocks of length 2, in the order y, x1, x2, each block oldest value first
+    X_fit_expected = np.array(
+        [
+            [0.0, 1.0, 100.0, 101.0, 200.0, 201.0],
+            [1.0, 2.0, 101.0, 102.0, 201.0, 202.0],
+            [2.0, 3.0, 102.0, 103.0, 202.0, 203.0],
+            [3.0, 4.0, 103.0, 104.0, 203.0, 204.0],
+            [4.0, 5.0, 104.0, 105.0, 204.0, 205.0],
+            [5.0, 6.0, 105.0, 106.0, 205.0, 206.0],
+            [6.0, 7.0, 106.0, 107.0, 206.0, 207.0],
+        ]
+    )
+
+    np.testing.assert_array_equal(estimator_.X_fit, X_fit_expected)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.compose._reduce"]),
+    reason="run test only if reduce module has changed",
+)
 @pytest.mark.parametrize("scitype, strategy, klass", _REGISTRY)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
 def test_make_reduction_construct_instance(scitype, strategy, klass, window_length):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #7200.

#### What does this implement/fix? Explain your changes.

Documents which features the 1st generation reduction forecasters generate, and in which order they are passed to the wrapped `estimator`. Without this, users cannot map `feature_importances_` or `coef_` of the fitted regressor back onto `y` and the columns of `X`, which is exactly what #7200 reports.

Two entry points, as suggested by @fkiraly in the issue thread:

* `make_reduction` gains a `See Also` section listing the eight classes it can construct, a note on which `strategy` / estimator type maps to which class, and a pointer that the feature layout is documented in the class docstring of the constructed forecaster.
* Each of the eight 1st generation reducer classes gains a `Notes` section giving the feature layout for that class.

For the tabular reducers with `pooling="local"`, the documented layout is:

```
[y(t-w+1), ..., y(t), x1(t-w+1), ..., x1(t), ..., xk(t-w+1), ..., xk(t)]
```

i.e. one block of `window_length` values per variable, in the order `y`, then the columns of `X`, each block in chronological order, oldest observation first, and no contemporaneous values of `X`. This confirms the behaviour the issue reporter observed. The docstrings also cover the time series regressor 3D panel layout, the `dirrec` expanding feature vector, and the fact that under `pooling="global"` a named `pandas.DataFrame` is passed, so `estimator.feature_names_in_` is available (there the `y` lags are named `y_lag_1 ... y_lag_w`, most recent lag first, and the `X` columns are not lagged, the reverse of the local convention).

The documented ordering was verified in three independent ways: by deriving the index arithmetic in `_sliding_window_transform_local`, against the existing golden test `test_sliding_window_transform_explicit`, and empirically by recording the array the wrapped estimator is actually fitted on.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their time on?

Whether the layout as documented matches your understanding, in particular the `pooling="global"` paragraph, since that path reverses the lag order and uses non-lagged exogenous columns.

The new test `test_feature_layout_passed_to_estimator` is deliberately end to end, it asserts on the matrix the wrapped estimator receives rather than on the output of `_sliding_window_transform`, so that the documented user facing contract is the thing under test.

#### Any other comments?

Docstring content only, plus one test. No behaviour is changed.

#### PR checklist

<details><summary>For all contributions</summary>

- [x] My contribution is within the scope of this repository.
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc). Not yet in the list, happy to be added via the all-contributors bot.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

</details>
