### PR TITLE
[DOC] fix broken table of contents links in notebooks 01, 02 and 03

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2994,6 +2994,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "shivamlalakiya",
+      "name": "Shivam Lalakiya",
+      "avatar_url": "https://avatars.githubusercontent.com/u/50960482?v=4",
+      "profile": "https://github.com/shivamlalakiya",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/examples/01_forecasting.ipynb
+++ b/examples/01_forecasting.ipynb
@@ -25,13 +25,13 @@
     "\n",
     "`sktime` provides a common, `scikit-learn`-like interface to a variety of classical and ML-style forecasting algorithms, together with tools for building pipelines and composite machine learning models, including temporal tuning schemes, or reductions such as walk-forward application of `scikit-learn` regressors.\n",
     "\n",
-    "[**Section 1**](#chapter1) provides an overview of common forecasting workflows supported by `sktime`.\n",
+    "[**Section 1**](#1.-Basic-forecasting-workflows) provides an overview of common forecasting workflows supported by `sktime`.\n",
     "\n",
-    "[**Section 2**](#chapter2) discusses the families of forecasters available in `sktime`.\n",
+    "[**Section 2**](#2.-Forecasters-in-sktime---lookup,-properties,-main-families) discusses the families of forecasters available in `sktime`.\n",
     "\n",
-    "[**Section 3**](#chapter3) discusses advanced composition patterns, including pipeline building, reduction, tuning, ensembling, and autoML.\n",
+    "[**Section 3**](#3.-Advanced-composition-patterns---pipelines,-reduction,-autoML,-and-more) discusses advanced composition patterns, including pipeline building, reduction, tuning, ensembling, and autoML.\n",
     "\n",
-    "[**Section 4**](#chapter4) gives an introduction to how to write custom estimators compliant with the `sktime` interface.\n",
+    "[**Section 4**](#4.-Extension-guide---implementing-your-own-forecaster) gives an introduction to how to write custom estimators compliant with the `sktime` interface.\n",
     "\n",
     "Further references:\n",
     "* For further details on how forecasting is different from supervised prediction à la `scikit-learn`, and pitfalls of misdiagnosing forecasting as supervised prediction, have a look at [this notebook](./01a_forecasting_sklearn.ipynb)\n",
@@ -45,60 +45,60 @@
    "source": [
     "## Table of Contents\n",
     "\n",
-    "* [1. Basic forecasting workflows](#chapter1)\n",
-    "    * [1.1 Data container format](#section_1_1)\n",
-    "    * [1.2 Basic deployment workflow - batch fitting and forecasting](#section_1_2)\n",
-    "        * [1.2.1 Basic deployment workflow in a nutshell](#section_1_2_1)\n",
-    "        * [1.2.2 Forecasters that require the horizon when fitting](#section_1_2_2)\n",
-    "        * [1.2.3 Forecasters that can make use of exogeneous data](#section_1_2_3)\n",
-    "        * [1.2.4 Multivariate Forecasters](#section_1_2_4)\n",
-    "        * [1.2.5 Prediction intervals and quantile forecasts](#section_1_2_5)  \n",
-    "        * [1.2.6 Panel forecasts and hierarchical forecasts](#section_1_2_6)    \n",
-    "    * [1.3 Basic evaluation workflow - evaluating a batch of forecasts against ground truth observations](#section_1_3)   \n",
-    "        * [1.3.1 The basic batch forecast evaluation workflow in a nutshell - function metric interface](#section_1_3_1)\n",
-    "        * [1.3.2 The basic batch forecast evaluation workflow in a nutshell - metric class interface](#section_1_3_2)           \n",
-    "    * [1.4 Advanced deployment workflow: rolling updates & forecasts](#section_1_4) \n",
-    "        * [1.4.1 Updating a forecaster with the update method](#section_1_4_1)    \n",
-    "        * [1.4.2 Moving the \"now\" state without updating the model](#section_1_4_2)   \n",
-    "        * [1.4.3 Walk-forward predictions on a batch of data](#section_1_4_3)  \n",
-    "    * [1.5 Advanced evaluation workflow: rolling re-sampling and aggregate errors, rolling back-testing](#section_1_5)         \n",
-    "* [2. Forecasters in sktime - searching, tags, common families](#chapter2)\n",
-    "    * [2.1 Forecaster lookup - the registry](#section_2_1)\n",
-    "    * [2.2 Forecaster tags](#section_2_2)\n",
-    "        * [2.2.1 Capability tags: multivariate, probabilistic, hierarchical](#section_2_2_1)\n",
-    "        * [2.2.2 Finding and listing forecasters by tag](#section_2_2_2)\n",
-    "        * [2.2.3 Listing all forecaster tags](#section_2_2_3)\n",
-    "    * [2.3 Common forecaster types](#section_2_3)\n",
-    "        * [2.3.1 Exponential smoothing, theta forecaster, autoETS from statsmodels](#section_2_3_1)\n",
-    "        * [2.3.2 ARIMA and autoARIMA](#section_2_3_2)\n",
-    "        * [2.3.3 BATS and TBATS](#section_2_3_3)    \n",
-    "        * [2.3.4 Facebook prophet](#section_2_3_4)  \n",
-    "        * [2.3.5 State Space Model (Structural Time Series)](#section_2_3_5)  \n",
-    "        * [2.3.6 AutoArima from StatsForecast](#section_2_3_6)  \n",
-    "* [3. Advanced composition patterns - pipelines, reduction, autoML, and more](#chapter3)\n",
-    "    * [3.1 Reduction: from forecasting to regression](#section_3_1)\n",
-    "    * [3.2 Pipelining, detrending and deseasonalization](#section_3_2)    \n",
-    "        * [3.2.1 The basic forecasting pipeline](#section_3_2_1)\n",
-    "        * [3.2.2 The Detrender as pipeline component](#section_3_2_2) \n",
-    "        * [3.2.3 Complex pipeline composites and parameter inspection](#section_3_2_3)        \n",
-    "    * [3.3 Parameter tuning](#section_3_3)      \n",
-    "        * [3.3.1 Basic tuning using ForecastingGridSearchCV](#section_3_3_1)  \n",
-    "        * [3.3.2 Tuning of complex composites](#section_3_3_2)        \n",
-    "        * [3.3.3 Selecting the metric and retrieving scores](#section_3_3_3) \n",
-    "    * [3.4 autoML aka automated model selection, ensembling and hedging](#section_3_4) \n",
-    "        * [3.4.1 autoML aka automatic model selection, using tuning plus multiplexer](#section_3_4_1)   \n",
-    "        * [3.4.2 autoML: selecting transformer combinations via OptimalPassthrough](#section_3_4_2)  \n",
-    "        * [3.4.3 Simple ensembling strategies](#section_3_4_3)   \n",
-    "        * [3.4.4 Prediction weighted ensembles and hedge ensembles](#section_3_4_4)  \n",
-    "* [4. Extension guide - implementing your own forecaster](#chapter4)        \n",
-    "* [5. Summary](#chapter5)          "
+    "* [1. Basic forecasting workflows](#1.-Basic-forecasting-workflows)\n",
+    "    * [1.1 Data container format](#1.1-Data-container-format)\n",
+    "    * [1.2 Basic deployment workflow - batch fitting and forecasting](#1.2-Basic-deployment-workflow---batch-fitting-and-forecasting)\n",
+    "        * [1.2.1 The basic deployment workflow in a nutshell](#1.2.1-The-basic-deployment-workflow-in-a-nutshell)\n",
+    "        * [1.2.2 Forecasters that require the horizon already in fit](#1.2.2-Forecasters-that-require-the-horizon-already-in-fit)\n",
+    "        * [1.2.3 Forecasters that can make use of exogeneous data](#1.2.3-Forecasters-that-can-make-use-of-exogeneous-data)\n",
+    "        * [1.2.4. Multivariate forecasting](#1.2.4.-Multivariate-forecasting)\n",
+    "        * [1.2.5 Probabilistic forecasting: prediction intervals, quantile, variance, and distributional forecasts](#1.2.5-Probabilistic-forecasting:-prediction-intervals,-quantile,-variance,-and-distributional-forecasts)\n",
+    "        * [1.2.6 Panel forecasts and hierarchical forecasts](#1.2.6-Panel-forecasts-and-hierarchical-forecasts)\n",
+    "    * [1.3 Basic evaluation workflow - evaluating a batch of forecasts against ground truth observations](#1.3-Basic-evaluation-workflow---evaluating-a-batch-of-forecasts-against-ground-truth-observations)\n",
+    "        * [1.3.1 The basic batch forecast evaluation workflow in a nutshell - function metric interface](#1.3.1-The-basic-batch-forecast-evaluation-workflow-in-a-nutshell---function-metric-interface)\n",
+    "        * [1.3.2 The basic batch forecast evaluation workflow in a nutshell - metric class interface](#1.3.2-The-basic-batch-forecast-evaluation-workflow-in-a-nutshell---metric-class-interface)\n",
+    "    * [1.4 Advanced deployment workflow: rolling updates & forecasts](#1.4-Advanced-deployment-workflow:-rolling-updates-&-forecasts)\n",
+    "        * [1.4.1 Updating a forecaster with the update method](#1.4.1-Updating-a-forecaster-with-the-update-method)\n",
+    "        * [1.4.2 Moving the \"now\" state without updating the model](#1.4.2-Moving-the-\"now\"-state-without-updating-the-model)\n",
+    "        * [1.4.3 Walk-forward predictions on a batch of data](#1.4.3-Walk-forward-predictions-on-a-batch-of-data)\n",
+    "    * [1.5 Advanced evaluation workflow: rolling re-sampling and aggregate errors, rolling back-testing](#1.5-Advanced-evaluation-workflow:-rolling-re-sampling-and-aggregate-errors,-rolling-back-testing)\n",
+    "* [2. Forecasters in sktime - lookup, properties, main families](#2.-Forecasters-in-sktime---lookup,-properties,-main-families)\n",
+    "    * [2.1 Listing all forecasters in sktime](#2.1-Listing-all-forecasters-in-sktime)\n",
+    "    * [2.2 Forecaster tags](#2.2-Forecaster-tags)\n",
+    "        * [2.2.1 Capability tags: multivariate, probabilistic, hierarchical](#2.2.1-Capability-tags:-multivariate,-probabilistic,-hierarchical)\n",
+    "        * [2.2.2 Finding and listing forecasters by tag](#2.2.2-Finding-and-listing-forecasters-by-tag)\n",
+    "        * [2.2.3 Listing all forecaster tags](#2.2.3-Listing-all-forecaster-tags)\n",
+    "    * [2.3 Common forecasters in sktime](#2.3-Common-forecasters-in-sktime)\n",
+    "        * [2.3.1 Exponential smoothing, theta forecaster, autoETS from statsmodels](#2.3.1-Exponential-smoothing,-theta-forecaster,-autoETS-from-statsmodels)\n",
+    "        * [2.3.2 ARIMA and autoARIMA](#2.3.2-ARIMA-and-autoARIMA)\n",
+    "        * [2.3.3 BATS and TBATS](#2.3.3-BATS-and-TBATS)\n",
+    "        * [2.3.4 Facebook prophet](#2.3.4-Facebook-prophet)\n",
+    "        * [2.3.5 State Space Model (Structural Time Series)](#2.3.5-State-Space-Model-(Structural-Time-Series))\n",
+    "        * [2.3.6 AutoARIMA from StatsForecast](#2.3.6-AutoARIMA-from-StatsForecast)\n",
+    "* [3. Advanced composition patterns - pipelines, reduction, autoML, and more](#3.-Advanced-composition-patterns---pipelines,-reduction,-autoML,-and-more)\n",
+    "    * [3.1 Reduction: from forecasting to regression](#3.1-Reduction:-from-forecasting-to-regression)\n",
+    "    * [3.2 Pipelining, detrending and deseasonalization](#3.2-Pipelining,-detrending-and-deseasonalization)\n",
+    "        * [3.2.1 The basic forecasting pipeline](#3.2.1-The-basic-forecasting-pipeline)\n",
+    "        * [3.2.2 The Detrender as pipeline component](#3.2.2-The-Detrender-as-pipeline-component)\n",
+    "        * [3.2.3 Complex pipeline composites and parameter inspection](#3.2.3-Complex-pipeline-composites-and-parameter-inspection)\n",
+    "    * [3.3 Parameter tuning](#3.3-Parameter-tuning)\n",
+    "        * [3.3.1 Basic tuning using ForecastingGridSearchCV](#3.3.1-Basic-tuning-using-ForecastingGridSearchCV)\n",
+    "        * [3.3.2 Tuning of complex composites](#3.3.2-Tuning-of-complex-composites)\n",
+    "        * [3.3.3 Selecting the metric and retrieving scores](#3.3.3-Selecting-the-metric-and-retrieving-scores)\n",
+    "    * [3.4 autoML aka automated model selection, ensembling and hedging](#3.4-autoML-aka-automated-model-selection,-ensembling-and-hedging)\n",
+    "        * [3.4.1 autoML aka automatic model selection, using tuning plus multiplexer](#3.4.1-autoML-aka-automatic-model-selection,-using-tuning-plus-multiplexer)\n",
+    "        * [3.4.2 autoML: selecting transformer combinations via OptimalPassthrough](#3.4.2-autoML:-selecting-transformer-combinations-via-OptimalPassthrough)\n",
+    "        * [3.4.3 Simple ensembling strategies](#3.4.3-Simple-ensembling-strategies)\n",
+    "        * [3.4.4 Prediction weighted ensembles and hedge ensembles](#3.4.4-Prediction-weighted-ensembles-and-hedge-ensembles)\n",
+    "* [4. Extension guide - implementing your own forecaster](#4.-Extension-guide---implementing-your-own-forecaster)\n",
+    "* [5. Summary](#5.-Summary)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Package imports"
+    "### Package imports"
    ]
   },
   {
@@ -120,7 +120,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1. Basic forecasting workflows <a class=\"anchor\" id=\"chapter1\"></a>"
+    "## 1. Basic forecasting workflows"
    ]
   },
   {
@@ -141,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1.1 Data container format<a class=\"anchor\" id=\"section_1_1\"></a>\n",
+    "### 1.1 Data container format\n",
     "\n",
     "All workflows make common assumptions on the input data format.\n",
     "\n",
@@ -245,7 +245,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1.2 Basic deployment workflow - batch fitting and forecasting<a class=\"anchor\" id=\"section_1_2\"></a>"
+    "### 1.2 Basic deployment workflow - batch fitting and forecasting"
    ]
   },
   {
@@ -618,7 +618,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 1.2.1 The basic deployment workflow in a nutshell<a class=\"anchor\" id=\"section_1_2_1\"></a>\n",
+    "#### 1.2.1 The basic deployment workflow in a nutshell\n",
     "\n",
     "For convenience, we present the basic deployment workflow in one cell.\n",
     "This uses the same data, but different forecaster: predicting the latest value observed in the same month."
@@ -695,7 +695,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 1.2.2 Forecasters that require the horizon already in `fit` <a class=\"anchor\" id=\"section_1_2_2\"></a>\n",
+    "#### 1.2.2 Forecasters that require the horizon already in `fit`\n",
     "\n",
     "Some forecasters need the forecasting horizon provided already in `fit`. Such forecasters will produce informative error messages when it is not passed in `fit`. All forecaster will remember the horizon when already passed in `fit` for prediction. The modified workflow to allow for such forecasters in addition is as follows:"
    ]
@@ -733,7 +733,7 @@
     }
    },
    "source": [
-    "#### 1.2.3 Forecasters that can make use of exogeneous data<a class=\"anchor\" id=\"section_1_2_3\"></a>\n",
+    "#### 1.2.3 Forecasters that can make use of exogeneous data\n",
     "\n",
     "Many forecasters can make use of exogeneous time series, i.e., other time series that are not forecast, but are useful for forecasting `y`. Exogeneous time series are always passed as an `X` argument, in `fit`, `predict`, and other methods (see below). Exogeneous time series should always be passed as `pandas.DataFrames`. Most forecasters that can deal with exogeneous time series will assume that the time indices of `X` passed to `fit` are a super-set of the time indices in `y` passed to `fit`; and that the time indices of `X` passed to `predict` are a super-set of time indices in `fh`, although this is not a general interface restriction. Forecasters that do not make use of exogeneous time series still accept the argument (and do not use it internally).\n",
     "\n",
@@ -768,7 +768,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "NOTE: as in workflows [1.2.1](#section_1_2_1) and [1.2.2](#section_1_2_2), some forecasters that use exogeneous variables may also require the forecasting horizon only in `predict`. Such forecasters may also be called with steps 4 and 5 being\n",
+    "NOTE: as in workflows [1.2.1](#1.2.1-The-basic-deployment-workflow-in-a-nutshell) and [1.2.2](#1.2.2-Forecasters-that-require-the-horizon-already-in-fit), some forecasters that use exogeneous variables may also require the forecasting horizon only in `predict`. Such forecasters may also be called with steps 4 and 5 being\n",
     "```python\n",
     "forecaster.fit(y, X=X)\n",
     "y_pred = forecaster.predict(fh=fh, X=X)\n",
@@ -779,7 +779,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 1.2.4. Multivariate forecasting <a class=\"anchor\" id=\"section_1_2_4\"></a>"
+    "#### 1.2.4. Multivariate forecasting"
    ]
   },
   {
@@ -1141,7 +1141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 1.2.5 Probabilistic forecasting: prediction intervals, quantile, variance, and distributional forecasts <a class=\"anchor\" id=\"section_1_2_5\"></a>\n",
+    "#### 1.2.5 Probabilistic forecasting: prediction intervals, quantile, variance, and distributional forecasts\n",
     "\n",
     "`sktime` provides a unified interface to make probabilistic forecasts.\n",
     "The following methods are possibly available for probabilistic forecasts:\n",
@@ -1726,7 +1726,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 1.2.6 Panel forecasts and hierarchical forecasts <a class=\"anchor\" id=\"section_1_2_6\"></a>\n",
+    "#### 1.2.6 Panel forecasts and hierarchical forecasts\n",
     "\n",
     "`sktime` provides a unified interface to make panel and hierarchical forecasts.\n",
     "\n",
@@ -2260,7 +2260,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1.3 Basic evaluation workflow - evaluating a batch of forecasts against ground truth observations<a class=\"anchor\" id=\"section_1_3\"></a>\n",
+    "### 1.3 Basic evaluation workflow - evaluating a batch of forecasts against ground truth observations\n",
     "\n",
     "It is good practice to evaluate statistical performance of a forecaster before deploying it, and regularly re-evaluate performance if in continuous deployment. The evaluation workflow for the basic batch forecasting task, as solved by the workflow in Section 1.2, consists of comparing batch forecasts with actuals. This is sometimes called (batch-wise) backtesting.\n",
     "\n",
@@ -2528,7 +2528,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 1.3.1 The basic batch forecast evaluation workflow in a nutshell - function metric interface<a class=\"anchor\" id=\"section_1_3_1\"></a>\n",
+    "#### 1.3.1 The basic batch forecast evaluation workflow in a nutshell - function metric interface\n",
     "\n",
     "For convenience, we present the basic batch forecast evaluation workflow in one cell.\n",
     "This cell is using the lean function metric interface."
@@ -2586,7 +2586,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 1.3.2 The basic batch forecast evaluation workflow in a nutshell - metric class interface<a class=\"anchor\" id=\"section_1_3_2\"></a>\n",
+    "#### 1.3.2 The basic batch forecast evaluation workflow in a nutshell - metric class interface\n",
     "\n",
     "For convenience, we present the basic batch forecast evaluation workflow in one cell.\n",
     "This cell is using the advanced class specification interface for metrics."
@@ -2647,7 +2647,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1.4 Advanced deployment workflow: rolling updates & forecasts<a class=\"anchor\" id=\"section_1_4\"></a>\n",
+    "### 1.4 Advanced deployment workflow: rolling updates & forecasts\n",
     "\n",
     "A common use case requires the forecaster to regularly update with new data and make forecasts on a rolling basis. This is especially useful if the same kind of forecast has to be made at regular time points, e.g., daily or weekly. `sktime` forecasters support this type of deployment workflow via the `update` and `update_predict` methods."
    ]
@@ -2656,7 +2656,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1.4.1 Updating a forecaster with the `update` method<a class=\"anchor\" id=\"section_1_4_1\"></a>\n",
+    "### 1.4.1 Updating a forecaster with the `update` method\n",
     "\n",
     "The `update` method can be called when a forecaster is already fitted, to ingest new data and make updated forecasts - this is referred to as an \"update step\".\n",
     "\n",
@@ -2955,7 +2955,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1.4.2 Moving the \"now\" state without updating the model<a class=\"anchor\" id=\"section_1_4_2\"></a>\n",
+    "### 1.4.2 Moving the \"now\" state without updating the model\n",
     "\n",
     "In the rolling deployment mode, may be useful to move the estimator's \"now\" state (the `cutoff`) to later, for example if no new data was observed, but time has progressed; or, if computations take too long, and forecasts have to be queried.\n",
     "\n",
@@ -2994,7 +2994,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1.4.3 Walk-forward predictions on a batch of data<a class=\"anchor\" id=\"section_1_4_3\"></a>\n",
+    "### 1.4.3 Walk-forward predictions on a batch of data\n",
     "\n",
     "`sktime` can also simulate the update/predict deployment mode with a full batch of data.\n",
     "\n",
@@ -3058,9 +3058,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1.5 Advanced evaluation workflow: rolling re-sampling and aggregate errors, rolling back-testing<a class=\"anchor\" id=\"section_1_5\"></a>\n",
+    "### 1.5 Advanced evaluation workflow: rolling re-sampling and aggregate errors, rolling back-testing\n",
     "\n",
-    "To evaluate forecasters with respect to their performance in rolling forecasting, the forecaster needs to be tested in a set-up mimicking rolling forecasting, usually on past data. Note that the batch back-testing as in [Section 1.3](#section_1_3) would not be an appropriate evaluation set-up for rolling deployment, as that tests only a single forecast batch. \n",
+    "To evaluate forecasters with respect to their performance in rolling forecasting, the forecaster needs to be tested in a set-up mimicking rolling forecasting, usually on past data. Note that the batch back-testing as in [Section 1.3](#1.3-Basic-evaluation-workflow---evaluating-a-batch-of-forecasts-against-ground-truth-observations) would not be an appropriate evaluation set-up for rolling deployment, as that tests only a single forecast batch. \n",
     "\n",
     "The advanced evaluation workflow can be carried out using the `evaluate` benchmarking function.\n",
     "`evaluate` takes as arguments:\n",
@@ -3246,7 +3246,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Forecasters in `sktime` - lookup, properties, main families<a class=\"anchor\" id=\"chapter2\"></a>\n",
+    "## 2. Forecasters in `sktime` - lookup, properties, main families\n",
     "\n",
     "This section summarizes how to:\n",
     "\n",
@@ -3259,7 +3259,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.1 Listing all forecasters in `sktime` <a class=\"anchor\" id=\"section_2_1\"></a>\n",
+    "### 2.1 Listing all forecasters in `sktime`\n",
     "\n",
     "Generally, all forecasters available in `sktime` can be listed with the `all_estimators` command.\n",
     "\n",
@@ -3676,7 +3676,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.2 Forecaster tags <a class=\"anchor\" id=\"section_2_2\"></a>\n",
+    "### 2.2 Forecaster tags\n",
     "\n",
     "All forecasters `sktime` have so-called tags which describe properties of the estimator, e.g., whether it is multivariate, probabilistic, or not. Use of tags, inspection, and retrieval will be described in this section."
    ]
@@ -3685,7 +3685,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.2.1 Capability tags: multivariate, probabilistic, hierarchical <a class=\"anchor\" id=\"section_2_2_1\"></a>"
+    "### 2.2.1 Capability tags: multivariate, probabilistic, hierarchical"
    ]
   },
   {
@@ -3757,7 +3757,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.2.2 Finding and listing forecasters by tag <a class=\"anchor\" id=\"section_2_2_2\"></a>"
+    "### 2.2.2 Finding and listing forecasters by tag"
    ]
   },
   {
@@ -4434,7 +4434,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.2.3 Listing all forecaster tags <a class=\"anchor\" id=\"section_2_2_3\"></a>"
+    "### 2.2.3 Listing all forecaster tags"
    ]
   },
   {
@@ -4555,7 +4555,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.3 Common forecasters in `sktime` <a class=\"anchor\" id=\"section_2_3\"></a>\n",
+    "### 2.3 Common forecasters in `sktime`\n",
     "\n",
     "`sktime` supports a number of commonly used forecasters, many of them interfaced from state-of-art forecasting packages. All forecasters are available under the unified `sktime` interface.\n",
     "\n",
@@ -4568,9 +4568,9 @@
     "* `PolynomialTrend` for forecasting polynomial trends\n",
     "* `Prophet` which interfaces Facebook `prophet`\n",
     "\n",
-    "This is not the full list, use `all_estimators` as demonstrated in Sections [2.1](#section_2_1) and [2.2](#section_2_2) for that.\n",
+    "This is not the full list, use `all_estimators` as demonstrated in Sections [2.1](#2.1-Listing-all-forecasters-in-sktime) and [2.2](#2.2-Forecaster-tags) for that.\n",
     "\n",
-    "For illustration, all estimators below will be presented on the basic forecasting workflow - though they also support the advanced forecasting and evaluation workflows under the unified `sktime` interface (see [Section 1](#chapter1)).\n",
+    "For illustration, all estimators below will be presented on the basic forecasting workflow - though they also support the advanced forecasting and evaluation workflows under the unified `sktime` interface (see [Section 1](#1.-Basic-forecasting-workflows)).\n",
     "\n",
     "For use in the other workflows, simply replace the \"forecaster specification block\" (\"`forecaster=`\") by the forecaster specification block in the examples presented below."
    ]
@@ -4598,7 +4598,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.3.1 Exponential smoothing, theta forecaster, autoETS from `statsmodels`<a class=\"anchor\" id=\"section_2_3_1\"></a>\n",
+    "### 2.3.1 Exponential smoothing, theta forecaster, autoETS from `statsmodels`\n",
     "\n",
     "`sktime` interfaces a number of statistical forecasting algorithms from `statsmodels`: exponential smoothing, theta, and auto-ETS.\n",
     "\n",
@@ -4720,7 +4720,7 @@
     "tags": []
    },
    "source": [
-    "### 2.3.2 ARIMA and autoARIMA<a class=\"anchor\" id=\"section_2_3_2\"></a>\n",
+    "### 2.3.2 ARIMA and autoARIMA\n",
     "\n",
     "`sktime` interfaces `pmdarima` for its ARIMA class models.\n",
     "For a classical ARIMA model with set parameters, use the `ARIMA` forecaster:"
@@ -4897,7 +4897,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.3.3 BATS and TBATS<a class=\"anchor\" id=\"section_2_3_3\"></a>\n",
+    "### 2.3.3 BATS and TBATS\n",
     "\n",
     "`sktime` interfaces BATS and TBATS from the [`tbats`](https://github.com/intive-DataScience/tbats) package."
    ]
@@ -4998,7 +4998,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.3.4 Facebook prophet<a class=\"anchor\" id=\"section_2_3_4\"></a>\n",
+    "### 2.3.4 Facebook prophet\n",
     "\n",
     "`sktime` provides an interface to [`fbprophet`](https://github.com/facebook/prophet) by Facebook."
    ]
@@ -5081,7 +5081,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.3.5 State Space Model (Structural Time Series)<a class=\"anchor\" id=\"section_2_3_5\"></a>\n",
+    "### 2.3.5 State Space Model (Structural Time Series)\n",
     "\n",
     "We can also use the [`UnobservedComponents`](https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.structural.UnobservedComponents.html) class from [`statsmodels`](https://www.statsmodels.org/stable/index.html) to generate predictions using a state space model."
    ]
@@ -5141,7 +5141,7 @@
     "tags": []
    },
    "source": [
-    "### 2.3.6 AutoARIMA from [StatsForecast](https://github.com/Nixtla/statsforecast)<a class=\"anchor\" id=\"section_2_3_6\"></a>\n",
+    "### 2.3.6 AutoARIMA from [StatsForecast](https://github.com/Nixtla/statsforecast)\n",
     "\n",
     "`sktime` interfaces `StatsForecast` for its `AutoARIMA` class models. `AutoARIMA` is an automatically tuned `ARIMA` variant that obtains the optimal pdq parameters automatically:"
    ]
@@ -5196,7 +5196,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Advanced composition patterns - pipelines, reduction, autoML, and more<a class=\"anchor\" id=\"chapter3\"></a>\n",
+    "## 3. Advanced composition patterns - pipelines, reduction, autoML, and more\n",
     "\n",
     "`sktime` supports a number of advanced composition patterns to create forecasters out of simpler components:\n",
     "\n",
@@ -5233,7 +5233,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.1 Reduction: from forecasting to regression<a class=\"anchor\" id=\"section_3_1\"></a>\n",
+    "### 3.1 Reduction: from forecasting to regression\n",
     "\n",
     "`sktime` provides a meta-estimator that allows the use of any `scikit-learn` estimator for forecasting.\n",
     "\n",
@@ -5360,7 +5360,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.2 Pipelining, detrending and deseasonalization<a class=\"anchor\" id=\"section_3_2\"></a>\n",
+    "### 3.2 Pipelining, detrending and deseasonalization\n",
     "\n",
     "A common composition motif is pipelining: for example, first deseasonalizing or detrending the data, then forecasting the detrended/deseasonalized series. When forecasting, one needs to add the trend and seasonal component back to the data. "
    ]
@@ -5369,7 +5369,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 3.2.1 The basic forecasting pipeline<a class=\"anchor\" id=\"section_3_2_1\"></a>\n",
+    "#### 3.2.1 The basic forecasting pipeline\n",
     "\n",
     "`sktime` provides a generic pipeline object for this kind of composite modelling, the `TransformedTargetForecaster`. It chains an arbitrary number of transformations with a forecaster. The transformations can either be pre-processing transformations or a post-processing transformations. An example of a forecaster with pre-processing\n",
     "transformations can be seen below."
@@ -5606,7 +5606,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 3.2.2 The `Detrender` as pipeline component<a class=\"anchor\" id=\"section_3_2_2\"></a>\n",
+    "#### 3.2.2 The `Detrender` as pipeline component\n",
     "\n",
     "For detrending, we can use the `Detrender`. This is an estimator of series-to-transformer scitype that wraps an arbitrary forecaster. For example, for linear detrending, we can use `PolynomialTrendForecaster` to fit a linear trend, and then subtract/add it using the `Detrender` transformer inside `TransformedTargetForecaster`.\n",
     "\n",
@@ -5712,7 +5712,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 3.2.3 Complex pipeline composites and parameter inspection<a class=\"anchor\" id=\"section_3_2_3\"></a>\n",
+    "#### 3.2.3 Complex pipeline composites and parameter inspection\n",
     "\n",
     "`sktime` follows the `scikit-learn` philosophy of composability and nested parameter inspection. As long as an estimator has the right scitype, it can be used as part of any composition principle requiring that scitype. Above, we have already seen the example of a forecaster inside a `Detrender`, which is an estimator of scitype series-to-series-transformer, with one component of forecaster scitype. Similarly, in a `TransformedTargetForecaster`, we can use the reduction composite from Section 3.1 as the last forecaster element in the pipeline, which inside has an estimator of tabular regressor scitype, the `KNeighborsRegressor`:"
    ]
@@ -5834,7 +5834,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.3 Parameter tuning<a class=\"anchor\" id=\"section_3_3\"></a>\n",
+    "### 3.3 Parameter tuning\n",
     "\n",
     "`sktime` provides parameter tuning strategies as compositors of forecaster scitype, similar to `scikit-learn`'s `GridSearchCV`."
    ]
@@ -5843,7 +5843,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.3.1 Basic tuning using `ForecastingGridSearchCV`<a class=\"anchor\" id=\"section_3_3_1\"></a>\n",
+    "### 3.3.1 Basic tuning using `ForecastingGridSearchCV`\n",
     "\n",
     "The compositor `ForecastingGridSearchCV` (and other tuners) are constructed with a forecaster to tune, a cross-validation constructor, a `scikit-learn` parameter grid, and parameters specific to the tuning strategy. Cross-validation constructors follow the `scikit-learn` interface for re-samplers, and can be slotted in exchangeably.\n",
     "\n",
@@ -5982,7 +5982,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.3.2 Tuning of complex composites<a class=\"anchor\" id=\"section_3_3_2\"></a>\n",
+    "### 3.3.2 Tuning of complex composites\n",
     "\n",
     "As in `scikit-learn`, parameters of nested components can be tuned by accessing their `get_params` key - by default this is `[estimatorname]__[parametername]` if `[estimatorname]` is the name of the component, and `[parametername]` the name of a parameter within the estimator `[estimatorname]`. \n",
     "\n",
@@ -6145,7 +6145,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.3.3 Selecting the metric and retrieving scores<a class=\"anchor\" id=\"section_3_3_3\"></a>\n",
+    "### 3.3.3 Selecting the metric and retrieving scores\n",
     "\n",
     "All tuning algorithms in `sktime` allow the user to set a score; for forecasting the default is mean absolute percentage error. The score can be set using the `score` argument, to any scorer function or class, as in Section 1.3.\n",
     "\n",
@@ -6274,7 +6274,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  3.4 autoML  aka automated model selection, ensembling and hedging<a class=\"anchor\" id=\"section_3_4\"></a>\n",
+    "### 3.4 autoML aka automated model selection, ensembling and hedging\n",
     "\n",
     "`sktime` provides a number of compositors for ensembling and automated model selection. In contrast to tuning, which uses data-driven strategies to find optimal hyper-parameters for a fixed forecaster, the strategies in this section combine or select on the level of estimators, using a collection of forecasters to combine or select from.\n",
     "\n",
@@ -6288,7 +6288,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  3.4.1 autoML aka automatic model selection, using tuning plus multiplexer<a class=\"anchor\" id=\"section_3_4_1\"></a>\n",
+    "### 3.4.1 autoML aka automatic model selection, using tuning plus multiplexer\n",
     "\n",
     "The most flexible way to perform model selection over forecasters is by using the `MultiplexForecaster`, which exposes the choice of a forecaster from a list as a hyper-parameter that is tunable by generic hyper-parameter tuning strategies such as in Section 3.3.\n",
     "\n",
@@ -6493,7 +6493,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.4.2 autoML: selecting transformer combinations via `OptimalPassthrough`<a class=\"anchor\" id=\"section_3_4_2\"></a>\n",
+    "### 3.4.2 autoML: selecting transformer combinations via `OptimalPassthrough`\n",
     "\n",
     "`sktime` also provides capabilities for automated selection of pipeline components *inside* a pipeline, i.e., pipeline structure. This is achieved with the `OptionalPassthrough` transformer.\n",
     "\n",
@@ -6593,7 +6593,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  3.4.3 Simple ensembling strategies<a class=\"anchor\" id=\"section_3_4_3\"></a>\n",
+    "### 3.4.3 Simple ensembling strategies\n",
     "\n",
     "TODO - contributions in this section are appreciated"
    ]
@@ -6659,7 +6659,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.4.4 Prediction weighted ensembles and hedge ensembles<a class=\"anchor\" id=\"section_3_4_4\"></a>\n",
+    "### 3.4.4 Prediction weighted ensembles and hedge ensembles\n",
     "\n",
     "For model evaluation, we sometimes want to evaluate multiple forecasts, using temporal cross-validation with a sliding window over the test data. For this purpose, we can leverage the forecasters from the `online_forecasting` module which use a composite forecaster, `PredictionWeightedEnsemble`, to keep track of the loss accumulated by each forecaster and create a prediction weighted by the predictions of the most \"accurate\" forecasters.\n",
     "\n",
@@ -6750,7 +6750,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. Extension guide - implementing your own forecaster<a class=\"anchor\" id=\"chapter4\"></a>\n",
+    "## 4. Extension guide - implementing your own forecaster\n",
     "\n",
     "`sktime` is meant to be easily extensible, for direct contribution to `sktime` as well as for local/private extension with custom methods.\n",
     "\n",
@@ -6779,7 +6779,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5. Summary<a class=\"anchor\" id=\"chapter5\"></a>\n",
+    "## 5. Summary\n",
     "\n",
     "* `sktime` comes with several forecasting algorithms (or forecasters), all of which share a common interface. The interface is fully interoperable with the `scikit-learn` interface, and provides dedicated interface points for forecasting in batch and rolling mode.\n",
     "\n",

--- a/examples/02_classification.ipynb
+++ b/examples/02_classification.ipynb
@@ -1437,7 +1437,7 @@
     "\n",
     "**Classifiers with native multivariate capability**, e.g., `TimeSeriesForestClassifier`.\n",
     "\n",
-    "Estimators with the `capability: multivariate` tag support multivariate `X` out of the box. Refer [Section 2.3](#23-searching-for-estimators-estimator-tags) for how to search for these.\n",
+    "Estimators with the `capability: multivariate` tag support multivariate `X` out of the box. Refer [Section 2.3](#2.3-Searching-for-estimators,-estimator-tags) for how to search for these.\n",
     "\n",
     "**Distance aggregation via `IndepDist` or `CombinedDistance`.** \n",
     "\n",

--- a/examples/03_transformers.ipynb
+++ b/examples/03_transformers.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Transformers in `sktime` <a class=\"anchor\" id=\"chapter3\"></a>"
+    "# Transformers in `sktime`"
    ]
   },
   {
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Overview of this notebook\n",
+    "## Overview of this notebook\n",
     "\n",
     "* why transformers? transformers in `sktime`\n",
     "\n",
@@ -50,17 +50,17 @@
    "source": [
     "## Table of Contents\n",
     "\n",
-    "* [3. Transformers in sktime](#chapter3)\n",
-    "    * [3.1 Wherefore transformers?](#section_3_1)\n",
-    "    * [3.2 Transformers - interface and features](#section_3_2)\n",
-    "        * [3.2.1 What are transformers?](#section_3_2_1)\n",
-    "        * [3.2.2 Different types of transformers](#section_3_2_2)\n",
-    "        * [3.2.3 Broadcasting aka vectorization of transformers](#section_3_2_3)         \n",
-    "        * [3.2.4 Transformers as pipeline components](#section_3_2_4)\n",
-    "    * [3.3 Combining transformers, feature engineering](#section_3_3) \n",
-    "    * [3.4 Technical details - transformer types and signatures](#section_3_4)\n",
-    "    * [3.5 Extension guide](#section_3_5)        \n",
-    "    * [3.6 Summary](#section_3_6) "
+    "* [Transformers in sktime](#Transformers-in-sktime)\n",
+    "    * [3.1 Wherefore transformers?](#3.1-Wherefore-transformers?)\n",
+    "    * [3.2 Transformers - interface and features](#3.2-Transformers---interface-and-features)\n",
+    "        * [3.2.1 What are transformers?](#3.2.1-What-are-transformers?)\n",
+    "        * [3.2.2 Different types of transformers](#3.2.2-Different-types-of-transformers)\n",
+    "        * [3.2.3 Broadcasting aka vectorization of transformers](#3.2.3-Broadcasting-aka-vectorization-of-transformers)\n",
+    "        * [3.2.4 Transformers as pipeline components](#3.2.4-Transformers-as-pipeline-components)\n",
+    "    * [3.3 Combining transformers, feature engineering](#3.3-Combining-transformers,-feature-engineering)\n",
+    "    * [3.4 Technical details - transformer types and signatures](#3.4-Technical-details---transformer-types-and-signatures)\n",
+    "    * [3.5 Extension guide - implementing your own transformer](#3.5-Extension-guide---implementing-your-own-transformer)\n",
+    "    * [3.6 Summary](#3.6-Summary)"
    ]
   },
   {
@@ -76,7 +76,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3.1 Wherefore transformers? <a class=\"anchor\" id=\"section_3_1\"></a>\n",
+    "## 3.1 Wherefore transformers?\n",
     "\n",
     "or: why sktime transformers will improve your life!\n",
     "\n",
@@ -764,7 +764,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3.2 Transformers - interface and features <a class=\"anchor\" id=\"section_3_2\"></a>\n",
+    "## 3.2 Transformers - interface and features\n",
     "\n",
     "* transformer interface\n",
     "* transformer types\n",
@@ -778,7 +778,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.2.1 What are transformers? <a class=\"anchor\" id=\"section_3_2_1\"></a>\n",
+    "### 3.2.1 What are transformers?\n",
     "\n",
     "Transformer = modular data processing steps commonly used in machine learning\n",
     "\n",
@@ -911,7 +911,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.2.2 Different types of transformers <a class=\"anchor\" id=\"section_3_2_2\"></a>\n",
+    "### 3.2.2 Different types of transformers\n",
     "\n",
     "`sktime` distinguishes different types of transformer, depending on the input type of `fit` and `transform`, and the output type of `transform`.\n",
     "\n",
@@ -1284,7 +1284,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.2.3 Broadcasting aka vectorization of transformers <a class=\"anchor\" id=\"section_3_2_3\"></a>\n",
+    "### 3.2.3 Broadcasting aka vectorization of transformers\n",
     "\n",
     "`sktime` transformers may be natively univariate, or apply only to a single time series.\n",
     "\n",
@@ -2044,7 +2044,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.2.4 Transformers as pipeline components <a class=\"anchor\" id=\"section_3_2_4\"></a>\n",
+    "### 3.2.4 Transformers as pipeline components\n",
     "\n",
     "`sktime` transformers can be pipelined with any other `sktime` estimator type, including forecasters, classifiers, and other transformers.\n",
     "\n",
@@ -2220,7 +2220,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3.3 Combining transformers, feature engineering <a class=\"anchor\" id=\"section_3_3\"></a>\n",
+    "## 3.3 Combining transformers, feature engineering\n",
     "\n",
     "transformers are natural pipeline components\n",
     "\n",
@@ -3791,7 +3791,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3.4 Technical details - transformer types and signatures <a class=\"anchor\" id=\"section_3_4\"></a>"
+    "## 3.4 Technical details - transformer types and signatures"
    ]
   },
   {
@@ -3823,7 +3823,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.4.1 Data container format<a class=\"anchor\" id=\"section_3_4_1\"></a>\n",
+    "### 3.4.1 Data container format\n",
     "\n",
     "`sktime` transformers apply to individual time series and panels. Panels are collections of time series, and we refer to each time series in a panel as an \"instance\" of the panel.\n",
     "This is formalized as abstract \"scientific types\" `Series` and `Panel`, with multiple possible in-memory representations, so-called \"mtypes\".\n",
@@ -4117,7 +4117,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.4.2 General transformer signature - time series transformers<a class=\"anchor\" id=\"section_3_4_2\"></a>"
+    "### 3.4.2 General transformer signature - time series transformers"
    ]
   },
   {
@@ -4716,7 +4716,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.4.3 General transformer signature - pairwise series transformers<a class=\"anchor\" id=\"section_3_4_3\"></a>"
+    "### 3.4.3 General transformer signature - pairwise series transformers"
    ]
   },
   {
@@ -4933,7 +4933,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.4.4 General transformer signature - pairwise transformers<a class=\"anchor\" id=\"section_3_4_4\"></a>"
+    "### 3.4.4 General transformer signature - pairwise transformers"
    ]
   },
   {
@@ -5009,7 +5009,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.4.5 Searching for transformers<a class=\"anchor\" id=\"section_3_4_5\"></a>"
+    "### 3.4.5 Searching for transformers"
    ]
   },
   {
@@ -5636,7 +5636,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3.5 Extension guide - implementing your own transformer <a class=\"anchor\" id=\"section_3_5\"></a>"
+    "## 3.5 Extension guide - implementing your own transformer"
    ]
   },
   {
@@ -5667,7 +5667,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3.6 Summary <a class=\"anchor\" id=\"section_3_6\"></a>\n",
+    "## 3.6 Summary\n",
     "\n",
     "* transformers are data processing steps with unified interface - `fit`, `transform`, and optional `inverse_transform`\n",
     "\n",


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2274.

#### What does this implement/fix? Explain your changes.

The tables of contents in `examples/01_forecasting.ipynb` and `examples/03_transformers.ipynb` linked to anchors that were defined as raw HTML in the headings, e.g.

```markdown
### 1.1 Data container format<a class="anchor" id="section_1_1"></a>
...
* [1.1 Data container format](#section_1_1)
```

Neither `nbsphinx` (docs build) nor `nbconvert` (nbviewer) turns such tags into link targets, so all entries were dead. On the docs page the links silently degrade to plain text - `<li><p>1.1 Data container format</p></li>` - which is why the table of contents on https://www.sktime.net/en/stable/examples/01_forecasting.html is currently not clickable at all.

Changes:

1. Removed the 63 raw HTML anchor tags and pointed all links (table of contents plus the in-text cross references) at the section anchors that `nbsphinx` and `nbconvert` generate from the heading text, e.g. `#1.1-Data-container-format`.
2. Updated the table of contents entries to the current heading wording. Several had drifted from the sections they name, e.g. the entry `1.2.5 Prediction intervals and quantile forecasts` for the section `1.2.5 Probabilistic forecasting: prediction intervals, quantile, variance, and distributional forecasts`. Since the anchor is now derived from the heading, entry and heading have to agree.
3. Normalised two headings that skipped a heading level. Notebook 01 used `####` (Package imports) before any `###`, notebook 03 used `###` (Overview of this notebook) before any `##`. `docutils` then rejects every later heading of the skipped level with `CRITICAL: Title level inconsistent` and drops those sections from the page - which is why, on the current docs page, sections 1.1 through 3.4.4 of notebook 01 have no heading and no anchor to link to, and the `#### Example ...` sections of notebook 03 are missing. This had to be fixed for the links to have targets.

No code cells or outputs are touched, only markdown cells.

One trade-off worth flagging: GitHub's own notebook renderer slugs headings differently (lowercased, punctuation stripped, e.g. `#11-data-container-format`), so a single link target cannot serve both GitHub and `nbsphinx`/`nbviewer`. This PR targets the docs build and nbviewer, in line with the resolution suggested in #2274. If maintainers prefer GitHub-style targets instead, happy to switch - notebook `02_classification.ipynb` currently uses that convention for its one internal link.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

* the heading level normalisation in point 3 - it changes two heading levels, which is what makes the dropped sections appear in the docs build
* whether refreshing the table of contents wording (point 2) is wanted in this PR, or should be a separate one
* the GitHub vs nbsphinx anchor convention trade-off described above

#### Did you add any tests for the change?

No test - notebooks are not part of the test suite. Verified by building both notebooks locally with `nbsphinx` (Sphinx 8.2.3, nbsphinx 0.9.8, `nbsphinx_execute = "never"` as in `docs/source/conf.py`) and with `nbconvert` (nbviewer's renderer), then checking every in-page `href="#..."` in the generated HTML against the ids present in it.

`nbsphinx` (docs build), both notebooks together:

| | before | after |
|---|---|---|
| `WARNING: undefined label` | 68 | 0 |
| `CRITICAL: Title level inconsistent` | 37 | 0 |
| `<section>` anchors generated | 62 | 99 |
| in-page links rendered | 122 | 264 |
| broken in-page links | 0 of 122 | 0 of 264 |

The 68 table of contents links do not show up as broken links before the change because sphinx drops the reference entirely and renders the entry as plain text, which is the reported symptom. After the change all 264 in-page links, including those 68, resolve to an existing id.

`nbconvert` (nbviewer), both notebooks together: 167 in-page links, 0 broken, before and after. nbviewer keeps the raw `id` attributes, which is why the table of contents worked there but not in the docs build - the change keeps nbviewer working via the heading anchors instead.

#### Any other comments?

The same raw-HTML anchor pattern does not appear in other notebooks in `examples/`, so notebooks 01 and 03 were the only ones affected.
