### PR TITLE
[DOC] add unequal length distance pattern to the classification tutorial

### DIFF
--- a/examples/02_classification.ipynb
+++ b/examples/02_classification.ipynb
@@ -4355,6 +4355,294 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instead of transforming the data, one can also use an estimator that handles unequal length series directly.\n",
+    "\n",
+    "For distance based classifiers such as `KNeighborsTimeSeriesClassifier`, this means choosing a time series distance that is valid for unequal length time series. Such distances carry the `capability:unequal_length` tag, and can be looked up with `all_estimators`, using `transformer-pairwise-panel` as the estimator type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>object</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AggrDist</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.compose_tab_to_pa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>CombinedDistance</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.algebra.CombinedD...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>ConstantPwTrafoPanel</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.dummy.ConstantPwT...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>CtwDistTslearn</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.ctw.CtwDistTslearn'&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>DistFromAligner</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.compose_from_alig...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>DistFromKernel</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.dist_to_kern.Dist...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>DtwDistTslearn</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.dtw._dtw_tslearn....</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>DtwDtaidistMultiv</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.dtw._dtw_dtaidist...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>DtwDtaidistUniv</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.dtw._dtw_dtaidist...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>DtwPythonDist</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.dtw._dtw_python.D...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>GAKernel</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.gak.GAKernel'&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>IndepDist</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.indep.IndepDist'&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>KernelFromDist</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.dist_to_kern.Kern...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>LcssTslearn</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.lcss.LcssTslearn'&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>LuckyDtwDist</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.lucky.LuckyDtwDist'&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>PwTrafoPanelPipeline</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.compose.PwTrafoPa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>SignatureKernel</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.signature_kernel....</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>SoftDtwDistTslearn</td>\n",
+       "      <td>&lt;class 'sktime.dists_kernels.dtw._dtw_tslearn....</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    name                                             object\n",
+       "0               AggrDist  <class 'sktime.dists_kernels.compose_tab_to_pa...\n",
+       "1       CombinedDistance  <class 'sktime.dists_kernels.algebra.CombinedD...\n",
+       "2   ConstantPwTrafoPanel  <class 'sktime.dists_kernels.dummy.ConstantPwT...\n",
+       "3         CtwDistTslearn  <class 'sktime.dists_kernels.ctw.CtwDistTslearn'>\n",
+       "4        DistFromAligner  <class 'sktime.dists_kernels.compose_from_alig...\n",
+       "5         DistFromKernel  <class 'sktime.dists_kernels.dist_to_kern.Dist...\n",
+       "6         DtwDistTslearn  <class 'sktime.dists_kernels.dtw._dtw_tslearn....\n",
+       "7      DtwDtaidistMultiv  <class 'sktime.dists_kernels.dtw._dtw_dtaidist...\n",
+       "8        DtwDtaidistUniv  <class 'sktime.dists_kernels.dtw._dtw_dtaidist...\n",
+       "9          DtwPythonDist  <class 'sktime.dists_kernels.dtw._dtw_python.D...\n",
+       "10              GAKernel        <class 'sktime.dists_kernels.gak.GAKernel'>\n",
+       "11             IndepDist     <class 'sktime.dists_kernels.indep.IndepDist'>\n",
+       "12        KernelFromDist  <class 'sktime.dists_kernels.dist_to_kern.Kern...\n",
+       "13           LcssTslearn    <class 'sktime.dists_kernels.lcss.LcssTslearn'>\n",
+       "14          LuckyDtwDist  <class 'sktime.dists_kernels.lucky.LuckyDtwDist'>\n",
+       "15  PwTrafoPanelPipeline  <class 'sktime.dists_kernels.compose.PwTrafoPa...\n",
+       "16       SignatureKernel  <class 'sktime.dists_kernels.signature_kernel....\n",
+       "17    SoftDtwDistTslearn  <class 'sktime.dists_kernels.dtw._dtw_tslearn...."
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# all time series distances and kernels that can handle unequal length series\n",
+    "from sktime.registry import all_estimators\n",
+    "\n",
+    "all_estimators(\n",
+    "    \"transformer-pairwise-panel\",\n",
+    "    as_dataframe=True,\n",
+    "    filter_tags={\"capability:unequal_length\": True},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Dynamic time warping is a common choice. `DtwPythonDist` supports unequal length series, so using it as the `distance` of `KNeighborsTimeSeriesClassifier` gives a classifier that can be fitted to an unequal length panel with no padding or truncation step.\n",
+    "\n",
+    "`load_plaid` is such a panel, its series range in length from 100 to 1344."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Importing the dtw module. When using in academic works please cite:\n",
+      "  T. Giorgino. Computing and Visualizing Dynamic Time Warping Alignments in R: The dtw Package.\n",
+      "  J. Stat. Soft., doi:10.18637/jss.v031.i07.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier\n",
+    "from sktime.datasets import load_plaid\n",
+    "from sktime.dists_kernels.dtw import DtwPythonDist\n",
+    "\n",
+    "# step 1-- load a dataset with unequal length series\n",
+    "X_train, y_train = load_plaid(split=\"train\")\n",
+    "X_new, _ = load_plaid(split=\"test\")\n",
+    "\n",
+    "# step 2-- define a classifier with a distance valid for unequal length series\n",
+    "knn_unequal = KNeighborsTimeSeriesClassifier(distance=DtwPythonDist())\n",
+    "\n",
+    "# step 3-- train the classifier, no padding or truncation needed\n",
+    "knn_unequal.fit(X_train, y_train)\n",
+    "\n",
+    "# step 4-- predict labels on new data\n",
+    "y_pred = knn_unequal.predict(X_new[:3])  # small set for faster runtime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['0', '6', '4'], dtype='<U2')"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y_pred"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The same approach extends to data that is both multivariate and of unequal length, by wrapping the univariate distance in `IndepDist`, as in [Section 2.2.5](#225-time-series-classification---handling-multivariate-data).\n",
+    "\n",
+    "`load_japanese_vowels` is such a dataset, with 12 variables and series of length 7 to 26."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sktime.datasets import load_japanese_vowels\n",
+    "from sktime.dists_kernels.indep import IndepDist\n",
+    "\n",
+    "# step 1-- load a dataset that is multivariate and of unequal length\n",
+    "X_train, y_train = load_japanese_vowels(split=\"train\")\n",
+    "X_new, _ = load_japanese_vowels(split=\"test\")\n",
+    "\n",
+    "# step 2-- make the univariate distance multivariate with IndepDist\n",
+    "knn_mv_unequal = KNeighborsTimeSeriesClassifier(distance=IndepDist(DtwPythonDist()))\n",
+    "\n",
+    "# step 3-- train the classifier\n",
+    "knn_mv_unequal.fit(X_train, y_train)\n",
+    "\n",
+    "# step 4-- predict labels on new data\n",
+    "y_pred = knn_mv_unequal.predict(X_new[:3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['1', '1', '1'], dtype='<U1')"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y_pred"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -4374,7 +4662,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4394,7 +4682,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
@@ -4403,7 +4691,7 @@
        "array([0.2, 0.8, 0.6, 0.8])"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4428,7 +4716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/02_classification.ipynb
+++ b/examples/02_classification.ipynb
@@ -4594,7 +4594,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The same approach extends to data that is both multivariate and of unequal length, by wrapping the univariate distance in `IndepDist`, as in [Section 2.2.5](#225-time-series-classification---handling-multivariate-data).\n",
+    "The same approach extends to data that is both multivariate and of unequal length, by wrapping the univariate distance in `IndepDist`, as in [Section 2.2.5](#2.2.5-Time-Series-Classification---handling-multivariate-data).\n",
     "\n",
     "`load_japanese_vowels` is such a dataset, with 12 variables and series of length 7 to 26."
    ]


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #7237. Completes the third bullet of that issue.

#7362 covered the first two bullets, and in your approving review there you noted: *"I am also noting that the additions address only multivariate data, not unequal length data."* This is the unequal length half.

#### What does this implement/fix? Explain your changes.

Section 2.4.3 *"Using transformers to deal with unequal length or missing values"* previously showed only the transformer route — padding, cutting, resampling. This adds the alternative the issue asks for: pick a time series distance that is **valid for unequal length series**, and skip the transformation entirely.

Following your answer in discussion #7232, three cells of content:

1. how to look the distances up — `all_estimators` on `capability:unequal_length`
2. univariate vignette — `DtwPythonDist` as the `distance` of `KNeighborsTimeSeriesClassifier`, on `load_plaid`
3. multivariate vignette — the same distance wrapped in `IndepDist`, on `load_japanese_vowels`, cross-linked to Section 2.2.5

Written in the `step 1--` vignette style of Section 2.2.5 so the two sections read consistently.

**One correction worth noting:** the estimator type for this lookup is `transformer-pairwise-panel`, not `transformer-pairwise`. The latter returns zero results, since the unequal-length distances are all panel-to-panel transformers.

`DtwPythonDist` was chosen deliberately over `DtwDtaidistMultiv` / `DtwDistTslearn`: only `dtw-python` is in the `notebooks` extra of `pyproject.toml`, so the other two would not be installable in a docs build.

Both datasets are genuinely unequal length, verified rather than assumed:

| dataset | variables | series lengths |
|---|---|---|
| `load_plaid` | 1 | 100 – 1344 |
| `load_japanese_vowels` | 12 | 7 – 26 |

#### Does your contribution introduce a new dependency? If yes, which one?

No. `dtw-python` is already in the `notebooks` extra.

#### What should a reviewer concentrate their feedback on?

* Placement — Section 2.4.3 seemed the natural home since it is the existing unequal-length section, but Section 2.2.5 would also be defensible given it is where the multivariate patterns landed.
* One stored output is `dtw-python`'s citation banner (*"Importing the dtw module. When using in academic works please cite..."*), printed by the library on import. I kept it because it is what a reader actually sees when running the cell, but happy to suppress it if you would rather the docs be clean.
* The `load_japanese_vowels` prediction happens to return the same class for all three test instances. Real output, but let me know if you would prefer a larger or shuffled slice for a more illustrative result.

#### Did you add any tests for the change?

No, this is tutorial content. Verification done:

* every added cell was executed and its real output stored — required, since `docs/source/conf.py:628` sets `nbsphinx_execute = "never"`, so the site renders stored outputs
* **only the added cells were executed**, so no unrelated output churn. The diff is 292 insertions and 4 deletions, and all 4 deletions are `execution_count` bumps on the three following code cells
* `nbformat.validate` passes; cell `id` keys were stripped, as this notebook is nbformat 4.2 which predates them
* `pre-commit` on the notebook — all hooks pass

#### PR checklist

<details><summary>For all contributions</summary>

- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc). Not yet in the list, happy to be added via the all-contributors bot.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

</details>