### PR TITLE
[BUG] fix MantisClassifier CUDA deepcopy/serialization with map_location

### DIFF
--- a/sktime/classification/foundation_models/mantis.py
+++ b/sktime/classification/foundation_models/mantis.py
@@ -361,7 +361,9 @@ default="full"
             buf = io.BytesIO()
             torch.save(network.state_dict(), buf)
             buf.seek(0)
-            network_copy.load_state_dict(torch.load(buf, weights_only=True))
+            network_copy.load_state_dict(
+                torch.load(buf, weights_only=True, map_location=device)
+            )
             network = network_copy
 
         return MantisTrainer(device=self._device_, network=network)
@@ -386,7 +388,11 @@ default="full"
             # Restore backbone weights if we serialised them
             network_bytes = getattr(self, "_network_state_bytes_", None)
             if network_bytes is not None:
-                state = torch.load(io.BytesIO(network_bytes), weights_only=True)
+                state = torch.load(
+                    io.BytesIO(network_bytes),
+                    weights_only=True,
+                    map_location=self._device_,
+                )
                 trainer.network.load_state_dict(state)
 
             # Restore the fine-tuned model weights.
@@ -414,7 +420,11 @@ default="full"
                     batch_size=n_classes,
                     learning_rate_adjusting=False,
                 )
-                state = torch.load(io.BytesIO(model_bytes), weights_only=True)
+                state = torch.load(
+                    io.BytesIO(model_bytes),
+                    weights_only=True,
+                    map_location=self._device_,
+                )
                 trainer.fine_tuned_model.load_state_dict(state)
 
             self._trainer_ = trainer


### PR DESCRIPTION
Fixes #10599

_adds map_location=self._device_ to all torch.load() calls in MantisClassifier._build_trainer and _ensure_trainer_loaded.

Previously, loading a GPU-trained model on CPU would fail with:
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False

This fix ensures cross-device compatibility when deepcopying or unpickling models.