### PR TITLE
[BUG] fix sklearn init specification non-conformance in 4 estimators

### DIFF
--- a/sktime/classification/deep_learning/gru.py
+++ b/sktime/classification/deep_learning/gru.py
@@ -303,8 +303,8 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
         dropout: float = 0.0,
         gru_dropout: float = 0.0,
         bidirectional: bool = False,
-        conv_layers: list = [128, 256, 128],
-        kernel_sizes: list = [7, 5, 3],
+        conv_layers: list = None,
+        kernel_sizes: list = None,
         # base classifier specific
         num_epochs: int = 10,
         batch_size: int = 8,
@@ -354,12 +354,30 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
 
         self.criterions = {}
 
+    def _instantiate_optimizer(self):
+        """Instantiate optimizer, applying default Adam betas if needed.
+
+        Overrides the base class to apply the default Adam betas
+        ``(0.9, 0.999)`` when ``optimizer="Adam"`` and ``optimizer_kwargs``
+        is ``None`` or empty.
+        """
+        if self.optimizer and self.optimizer == "Adam":
+            kwargs = self.optimizer_kwargs if self.optimizer_kwargs else {}
+            if "betas" not in kwargs:
+                kwargs = {**kwargs, "betas": (0.9, 0.999)}
+            return self.optimizers[self.optimizer](
+                self.network.parameters(), lr=self.lr, **kwargs
+            )
+        return super()._instantiate_optimizer()
+
     def _build_network(self, X, y):
         from sktime.networks.gru import GRUFCNN
 
         # n_instances, n_dims, n_timesteps = X.shape
         self.numclasses = len(np.unique(y))
         _, self.input_size, _ = X.shape
+        conv_layers = self.conv_layers if self.conv_layers is not None else [128, 256, 128]
+        kernel_sizes = self.kernel_sizes if self.kernel_sizes is not None else [7, 5, 3]
         return GRUFCNN(
             input_size=self.input_size,
             hidden_dim=self.hidden_dim,
@@ -371,8 +389,8 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
             dropout=self.dropout,
             gru_dropout=self.gru_dropout,
             bidirectional=self.bidirectional,
-            conv_layers=self.conv_layers,
-            kernel_sizes=self.kernel_sizes,
+            conv_layers=conv_layers,
+            kernel_sizes=kernel_sizes,
         )
 
     @classmethod

--- a/sktime/classification/deep_learning/gru.py
+++ b/sktime/classification/deep_learning/gru.py
@@ -376,8 +376,12 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
         # n_instances, n_dims, n_timesteps = X.shape
         self.numclasses = len(np.unique(y))
         _, self.input_size, _ = X.shape
-        conv_layers = self.conv_layers if self.conv_layers is not None else [128, 256, 128]
-        kernel_sizes = self.kernel_sizes if self.kernel_sizes is not None else [7, 5, 3]
+        conv_layers = (
+            self.conv_layers if self.conv_layers is not None else [128, 256, 128]
+        )
+        kernel_sizes = (
+            self.kernel_sizes if self.kernel_sizes is not None else [7, 5, 3]
+        )
         return GRUFCNN(
             input_size=self.input_size,
             hidden_dim=self.hidden_dim,

--- a/sktime/classification/deep_learning/gru.py
+++ b/sktime/classification/deep_learning/gru.py
@@ -331,7 +331,7 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
         self.criterion = criterion
         self.criterion_kwargs = criterion_kwargs
         self.optimizer = optimizer
-        self.optimizer_kwargs = {"betas": (0.9, 0.999)} if optimizer == "Adam" else {}
+        self.optimizer_kwargs = optimizer_kwargs
         self.lr = lr
         self.verbose = verbose
         self.random_state = random_state

--- a/sktime/classification/deep_learning/mcdcnn/_mcdcnn_torch.py
+++ b/sktime/classification/deep_learning/mcdcnn/_mcdcnn_torch.py
@@ -185,11 +185,12 @@ class MCDCNNClassifierTorch(BaseDeepClassifierPytorch):
         self.optimizer = optim
         self.optimizer_kwargs = optim_kwargs
 
-        # default case
-        if self.optim is None:
-            self.optimizer = "SGD"
-            if self.optimizer_kwargs is None:
-                self.optimizer_kwargs = {"momentum": 0.9, "weight_decay": 0.0005}
+        # Compute effective optimizer values for super().__init__()
+        # without mutating the stored parameters
+        effective_optimizer = optim if optim is not None else "SGD"
+        effective_optimizer_kwargs = optim_kwargs
+        if optim is None and optim_kwargs is None:
+            effective_optimizer_kwargs = {"momentum": 0.9, "weight_decay": 0.0005}
 
         if len(self.filter_sizes) != len(self.kernel_sizes):
             raise ValueError(
@@ -204,8 +205,8 @@ class MCDCNNClassifierTorch(BaseDeepClassifierPytorch):
             activation=self.activation,
             criterion=self.criterion,
             criterion_kwargs=self.criterion_kwargs,
-            optimizer=self.optimizer,
-            optimizer_kwargs=self.optimizer_kwargs,
+            optimizer=effective_optimizer,
+            optimizer_kwargs=effective_optimizer_kwargs,
             callbacks=self.callbacks,
             callback_kwargs=self.callback_kwargs,
             metrics=self.metrics,

--- a/sktime/classification/deep_learning/tests/test_sklearn_init_spec.py
+++ b/sktime/classification/deep_learning/tests/test_sklearn_init_spec.py
@@ -1,0 +1,79 @@
+"""Tests for sklearn init specification conformance in deep learning classifiers.
+
+Regression tests for #10208: parameters must be stored exactly as passed
+to ``__init__``, so that ``get_params``, ``clone`` and ``set_params`` work.
+"""
+
+__author__ = ["Rythamo8055"]
+
+import numpy as np
+import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
+from sklearn.base import clone
+
+from sktime.classification.deep_learning.gru import GRUFCNNClassifier
+from sktime.classification.deep_learning.mcdcnn._mcdcnn_torch import (
+    MCDCNNClassifierTorch,
+)
+
+torch_available = _check_soft_dependencies("torch", severity="none")
+
+
+def test_grufcn_classifier_init_spec():
+    """GRUFCNNClassifier stores optimizer_kwargs and layer params as passed."""
+    clf = GRUFCNNClassifier(hidden_dim=8, gru_layers=1, optimizer_kwargs=None)
+    params = clf.get_params()
+    assert params["optimizer_kwargs"] is None
+    assert params["conv_layers"] is None
+    assert params["kernel_sizes"] is None
+
+    # clone round-trip preserves parameters
+    cloned = clone(clf)
+    assert cloned.get_params() == params
+
+    # explicit values are stored as-is
+    clf2 = GRUFCNNClassifier(
+        hidden_dim=8,
+        gru_layers=1,
+        conv_layers=[16, 32, 16],
+        kernel_sizes=[3, 5, 3],
+        optimizer_kwargs={"betas": (0.5, 0.99)},
+    )
+    params2 = clf2.get_params()
+    assert params2["conv_layers"] == [16, 32, 16]
+    assert params2["kernel_sizes"] == [3, 5, 3]
+    assert params2["optimizer_kwargs"] == {"betas": (0.5, 0.99)}
+    assert clone(clf2).get_params() == params2
+
+
+@pytest.mark.skipif(not torch_available, reason="torch not available")
+def test_mcdcnn_classifier_torch_init_spec():
+    """MCDCNNClassifierTorch stores optim and optim_kwargs as passed."""
+    clf = MCDCNNClassifierTorch(optim_kwargs=None)
+    params = clf.get_params()
+    assert params["optim"] is None
+    assert params["optim_kwargs"] is None
+
+    # clone round-trip preserves parameters
+    cloned = clone(clf)
+    assert cloned.get_params() == params
+
+    # explicit values are stored as-is
+    clf2 = MCDCNNClassifierTorch(optim="Adam", optim_kwargs={"lr": 0.05})
+    params2 = clf2.get_params()
+    assert params2["optim"] == "Adam"
+    assert params2["optim_kwargs"] == {"lr": 0.05}
+    assert clone(clf2).get_params() == params2
+
+
+@pytest.mark.skipif(not torch_available, reason="torch required for fit test")
+def test_grufcn_optimizer_defaults_preserved():
+    """GRUFCNNClassifier applies default Adam betas when optimizer_kwargs is None."""
+    X = np.random.randn(20, 1, 10).astype("float32")
+    y = np.array([0, 1] * 10)
+
+    clf = GRUFCNNClassifier(
+        hidden_dim=8, gru_layers=1, num_epochs=1, batch_size=8, lr=0.01
+    )
+    clf.fit(X, y)
+    assert clf._optimizer.param_groups[0]["betas"] == (0.9, 0.999)

--- a/sktime/forecasting/rbf.py
+++ b/sktime/forecasting/rbf.py
@@ -135,7 +135,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         self.centers = centers
         self.gamma = gamma
         self.rbf_type = rbf_type
-        self.hidden_layers = hidden_layers if hidden_layers is not None else [64, 32]
+        self.hidden_layers = hidden_layers
         self.optimizer = optimizer
         self.lr = lr
         self.epochs = epochs
@@ -206,6 +206,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
             Prediction length (output dimension for direct mode, ignored for AR).
         """
         output_size = fh if self.mode == "direct" else 1
+        hidden_layers = self.hidden_layers if self.hidden_layers is not None else [64, 32]
 
         return RBFNetwork(
             input_size=self.window_length,
@@ -214,7 +215,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
             centers=self.centers,
             gamma=self.gamma,
             rbf_type=self.rbf_type,
-            hidden_layers=self.hidden_layers,
+            hidden_layers=hidden_layers,
             mode=self.mode,
             activation=self.activation,
             dropout_rate=self.dropout_rate,

--- a/sktime/forecasting/rbf.py
+++ b/sktime/forecasting/rbf.py
@@ -206,7 +206,9 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
             Prediction length (output dimension for direct mode, ignored for AR).
         """
         output_size = fh if self.mode == "direct" else 1
-        hidden_layers = self.hidden_layers if self.hidden_layers is not None else [64, 32]
+        hidden_layers = (
+            self.hidden_layers if self.hidden_layers is not None else [64, 32]
+        )
 
         return RBFNetwork(
             input_size=self.window_length,

--- a/sktime/forecasting/rbf.py
+++ b/sktime/forecasting/rbf.py
@@ -117,7 +117,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         centers=None,
         gamma=1.0,
         rbf_type="gaussian",
-        hidden_layers=[64, 32],
+        hidden_layers=None,
         optimizer="adam",
         lr=0.01,
         epochs=100,
@@ -135,7 +135,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         self.centers = centers
         self.gamma = gamma
         self.rbf_type = rbf_type
-        self.hidden_layers = hidden_layers
+        self.hidden_layers = hidden_layers if hidden_layers is not None else [64, 32]
         self.optimizer = optimizer
         self.lr = lr
         self.epochs = epochs

--- a/sktime/forecasting/tests/test_rbf_init_spec.py
+++ b/sktime/forecasting/tests/test_rbf_init_spec.py
@@ -1,0 +1,28 @@
+"""Tests for sklearn init specification conformance in RBFForecaster.
+
+Regression tests for #10208: parameters must be stored exactly as passed
+to ``__init__``, so that ``get_params``, ``clone`` and ``set_params`` work.
+"""
+
+__author__ = ["Rythamo8055"]
+
+from sklearn.base import clone
+
+from sktime.forecasting.rbf import RBFForecaster
+
+
+def test_rbf_forecaster_init_spec():
+    """RBFForecaster stores hidden_layers as passed."""
+    f = RBFForecaster()
+    params = f.get_params()
+    assert params["hidden_layers"] is None
+
+    # clone round-trip preserves parameters
+    cloned = clone(f)
+    assert cloned.get_params() == params
+
+    # explicit values are stored as-is
+    f2 = RBFForecaster(hidden_layers=[16, 8])
+    params2 = f2.get_params()
+    assert params2["hidden_layers"] == [16, 8]
+    assert clone(f2).get_params() == params2

--- a/sktime/regression/deep_learning/mcdcnn/_mcdcnn_torch.py
+++ b/sktime/regression/deep_learning/mcdcnn/_mcdcnn_torch.py
@@ -177,19 +177,20 @@ class MCDCNNRegressorTorch(BaseDeepRegressorTorch):
         self.optimizer = self.optim
         self.optimizer_kwargs = self.optim_kwargs
 
-        # default case
-        if self.optim is None:
-            self.optimizer = "SGD"
-            if self.optimizer_kwargs is None:
-                self.optimizer_kwargs = {"momentum": 0.9, "weight_decay": 0.0005}
+        # Compute effective optimizer values for super().__init__()
+        # without mutating the stored parameters
+        effective_optimizer = self.optim if self.optim is not None else "SGD"
+        effective_optimizer_kwargs = self.optim_kwargs
+        if self.optim is None and self.optim_kwargs is None:
+            effective_optimizer_kwargs = {"momentum": 0.9, "weight_decay": 0.0005}
 
         super().__init__(
             num_epochs=self.n_epochs,
             batch_size=self.batch_size,
             criterion=self.criterion,
             criterion_kwargs=self.criterion_kwargs,
-            optimizer=self.optimizer,
-            optimizer_kwargs=self.optimizer_kwargs,
+            optimizer=effective_optimizer,
+            optimizer_kwargs=effective_optimizer_kwargs,
             callbacks=self.callbacks,
             callback_kwargs=self.callback_kwargs,
             lr=self.lr,

--- a/sktime/regression/deep_learning/tests/test_sklearn_init_spec_reg.py
+++ b/sktime/regression/deep_learning/tests/test_sklearn_init_spec_reg.py
@@ -1,0 +1,37 @@
+"""Tests for sklearn init specification conformance in deep learning regressors.
+
+Regression tests for #10208: parameters must be stored exactly as passed
+to ``__init__``, so that ``get_params``, ``clone`` and ``set_params`` work.
+"""
+
+__author__ = ["Rythamo8055"]
+
+import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
+from sklearn.base import clone
+
+from sktime.regression.deep_learning.mcdcnn._mcdcnn_torch import (
+    MCDCNNRegressorTorch,
+)
+
+torch_available = _check_soft_dependencies("torch", severity="none")
+
+
+@pytest.mark.skipif(not torch_available, reason="torch not available")
+def test_mcdcnn_regressor_torch_init_spec():
+    """MCDCNNRegressorTorch stores optim and optim_kwargs as passed."""
+    reg = MCDCNNRegressorTorch(optim_kwargs=None)
+    params = reg.get_params()
+    assert params["optim"] is None
+    assert params["optim_kwargs"] is None
+
+    # clone round-trip preserves parameters
+    cloned = clone(reg)
+    assert cloned.get_params() == params
+
+    # explicit values are stored as-is
+    reg2 = MCDCNNRegressorTorch(optim="Adam", optim_kwargs={"lr": 0.05})
+    params2 = reg2.get_params()
+    assert params2["optim"] == "Adam"
+    assert params2["optim_kwargs"] == {"lr": 0.05}
+    assert clone(reg2).get_params() == params2


### PR DESCRIPTION
Fixes #10208

## Changes

### GRUFCNNClassifier
- Store optimizer_kwargs as-is instead of computing based on optimizer

### MCDCNNClassifierTorch
- Use effective_optimizer/effective_optimizer_kwargs for super().__init__() without mutating stored parameters

### MCDCNNRegressorTorch
- Same fix as MCDCNNClassifierTorch

### RBFForecaster
- Use None as default for hidden_layers to avoid mutable default argument

## Why this matters
sklearn's __init__ contract requires that every parameter is stored exactly as passed. Violating this breaks get_params(), clone(), and set_params() which are essential for sklearn-compatible tooling like grid search and pipelines.