### PR TITLE
[BUG] fix MonthStart 'MS' frequency not coerced to 'M' in forecasting horizon (Fixes #7610)

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -433,11 +433,11 @@ class ForecastingHorizon:
                     f"Current: {freq_from_self}, from update: {freq_from_obj}."
                 )
         elif freq_from_obj is not None:  # only freq_from_obj is not None
-            if freq_from_obj == "ME":
+            if freq_from_obj in ("ME", "MS"):
                 freq_from_obj = "M"
             self._freq = freq_from_obj
         else:
-            if freq_from_obj == "ME":
+            if freq_from_obj in ("ME", "MS"):
                 freq_from_obj = "M"
             # leave self._freq as freq_from_self, or set to None if does not exist yet
             self._freq = freq_from_self


### PR DESCRIPTION
## Description
Fixes #7610

This PR fixes the issue where  ('MS') frequency strings are not coerced to 'M' in the forecasting horizon, causing  with pandas >= 2.2.

## Changes
- Added 'MS' to the frequency coercion alongside 'ME' in 

## Testing
- Verified that both 'ME' and 'MS' are now correctly coerced to 'M'
- Existing tests should continue to pass