### PR TITLE
[BUG] fix plot_series KeyError on multivariate interval plots (Fixes #9523)

### DIFF
--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -237,15 +237,15 @@ def plot_interval(ax, interval_df):
 
     import seaborn as sns
 
-    var_name = interval_df.columns.levels[0][0]
+    var_name = interval_df.columns.get_level_values(0).unique()[0]
 
-    n = len(interval_df.columns.levels[1])
+    n = len(interval_df.columns.get_level_values(1).unique())
     if n == 1:
         colors = [ax.get_lines()[-1].get_c()]
     else:
         colors = sns.color_palette("colorblind", n_colors=n)
 
-    for i, cov in enumerate(interval_df.columns.levels[1]):
+    for i, cov in enumerate(interval_df.columns.get_level_values(1).unique()):
         ax.fill_between(
             interval_df.index,
             interval_df[var_name][cov]["lower"].astype("float64").to_numpy(),


### PR DESCRIPTION
Fixes #9523. Uses get_level_values instead of levels to get unique values after slicing.