### PR TITLE
[MNT] add name to release tag check step for readability

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,7 +16,8 @@ jobs:
         with:
           python-version: '3.11'
 
-      - shell: bash
+      - name: Verify release tag matches pyproject.toml
+        shell: bash
         run: |
           TAG="${{ github.event.release.tag_name }}"
           GH_TAG_NAME="${TAG#v}"


### PR DESCRIPTION
## Problem

In `.github/workflows/wheels.yml`, the release-tag validation `run` step is unnamed and longer than **300 characters**. In the GitHub Actions UI that collapses into a generic label, which hurts readability when the tag/version mismatch check fails.

## Changes

Semantics are unchanged: same shell/python commands and the same exit-on-mismatch behavior.

- Add `name: Verify release tag matches pyproject.toml` to the existing check step

## Test plan
- [ ] Confirm the tag vs `pyproject.toml` comparison logic is unchanged
