### PR TITLE
[BUG] fix `_get_duration` for non-fixed frequencies

### DIFF
--- a/sktime/transformations/detrend/tests/test_deseasonalise.py
+++ b/sktime/transformations/detrend/tests/test_deseasonalise.py
@@ -6,7 +6,9 @@ __author__ = ["mloning"]
 __all__ = []
 
 import numpy as np
+import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.detrend import Deseasonalizer
@@ -14,6 +16,12 @@ from sktime.utils._testing.forecasting import make_forecasting_problem
 
 MODELS = ["additive", "multiplicative"]
 TEST_SPS = [3, 12]
+
+# frequencies of non-fixed duration, the "XE" aliases require pandas >= 2.1
+NON_FIXED_FREQ_STRS = ["W-WED", "MS"]
+
+if _check_soft_dependencies("pandas>=2.1.0", severity="none"):
+    NON_FIXED_FREQ_STRS += ["ME", "QE-DEC", "YE-DEC"]
 
 
 @pytest.mark.skipif(
@@ -91,6 +99,24 @@ def test_transform_inverse_transform_equivalence(sp, model):
     yit = transformer.inverse_transform(transformer.transform(y_train))
     np.testing.assert_array_equal(y_train.index, yit.index)
     np.testing.assert_array_almost_equal(y_train, yit)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(Deseasonalizer),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("freqstr", NON_FIXED_FREQ_STRS)
+def test_deseasonalizer_non_fixed_freq(freqstr):
+    """Test deseasonalizer on DatetimeIndex of non-fixed freq, see issue #7883."""
+    index = pd.date_range(start="2000-01-31", periods=24, freq=freqstr)
+    y = pd.Series(np.arange(24, dtype=float), index=index)
+
+    transformer = Deseasonalizer(sp=4)
+    yt = transformer.fit_transform(y)
+    yit = transformer.inverse_transform(yt)
+
+    np.testing.assert_array_equal(y.index, yt.index)
+    np.testing.assert_array_almost_equal(y, yit)
 
 
 @pytest.mark.skipif(

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -89,6 +89,60 @@ def _get_freq(x):
         return None
 
 
+def _coerce_datetime_to_period(x, y, freq):
+    """Coerce datetime-like x, y to period-like, if freq is not a fixed frequency.
+
+    Coercion to integer of a ``pd.Timedelta`` is possible only for fixed
+    frequencies, e.g., ``D`` or ``h``, and not for non-fixed ones, e.g., ``ME``,
+    ``QE``, ``YE``, ``W``, since months, years or weeks are not of fixed length.
+    Differences of ``pd.Period`` are ``pd.DateOffset``, which carry the number of
+    intervals, so coercion to integer is exact for non-fixed frequencies as well.
+
+    Parameters
+    ----------
+    x : pd.DatetimeIndex, pd.Timestamp, or other; only the former two are coerced
+    y : pd.Timestamp, or other; only coerced if both x and y are pd.Timestamp
+    freq : str, pd.tseries.offsets.BaseOffset, or None
+        Frequency of x, y. If None, no coercion takes place.
+
+    Returns
+    -------
+    x, y : coerced to pd.PeriodIndex, pd.Period, at frequency freq,
+        if datetime-like and freq is non-fixed; otherwise returned unchanged.
+
+    Raises
+    ------
+    ValueError : if freq has no equivalent period frequency, e.g., SME
+    """
+    if freq is None:
+        return x, y
+
+    with _suppress_pd22_warning():
+        offset = pd.tseries.frequencies.to_offset(freq)
+
+    # fixed frequencies are left to the pd.Timedelta based coercion, unchanged
+    if isinstance(offset, pd.tseries.offsets.Tick):
+        return x, y
+
+    # the offset object is passed to to_period, and not the frequency string,
+    # since offset and period frequency strings differ from pandas 2.2 onwards,
+    # e.g., the offset "YE-DEC" corresponds to the period frequency "Y-DEC"
+    try:
+        if isinstance(x, pd.DatetimeIndex):
+            x = x.to_period(offset)
+        elif isinstance(x, pd.Timestamp) and isinstance(y, pd.Timestamp):
+            x, y = pd.DatetimeIndex([x, y]).to_period(offset)
+    except ValueError as e:
+        raise ValueError(
+            f"Error in _get_duration, the frequency {offset.freqstr} has no "
+            "equivalent period frequency, therefore durations at this frequency "
+            "cannot be coerced to integer. Please consider using a different "
+            "frequency, or pd.PeriodIndex."
+        ) from e
+
+    return x, y
+
+
 def set_hier_freq(x):
     """Set frequency for multiindex dataframes without frequency.
 
@@ -243,6 +297,14 @@ def _get_duration(x, y=None, coerce_to_int=False, unit=None):
     ret : duration type
         Duration
     """
+    if coerce_to_int:
+        if unit is None:
+            # try to get the unit from the data if not given
+            unit = _get_freq(x)
+        # for non-fixed frequencies, e.g., ME, QE, YE, W, the difference of
+        # datetimes cannot be coerced to integer, so we take it between periods
+        x, y = _coerce_datetime_to_period(x, y, unit)
+
     if y is None:
         x = check_time_index(x)
         duration = x[-1] - x[0]
@@ -258,8 +320,5 @@ def _get_duration(x, y=None, coerce_to_int=False, unit=None):
     if coerce_to_int and isinstance(
         x, (pd.PeriodIndex, pd.DatetimeIndex, pd.Period, pd.Timestamp)
     ):
-        if unit is None:
-            # try to get the unit from the data if not given
-            unit = _get_freq(x)
         duration = _coerce_duration_to_int(duration, freq=unit)
     return duration

--- a/sktime/utils/tests/test_datetime.py
+++ b/sktime/utils/tests/test_datetime.py
@@ -16,10 +16,18 @@ from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils._testing.hierarchical import _bottom_hier_datagen
 from sktime.utils.datetime import (
     _coerce_duration_to_int,
+    _get_duration,
     _get_freq,
     infer_freq,
     set_hier_freq,
 )
+
+# frequencies of non-fixed duration, i.e., not expressible as a pd.Timedelta
+# the "XE" aliases are not available in pandas < 2.1
+NON_FIXED_FREQ_STRS = ["W-WED", "MS", "QS-OCT", "YS-JAN"]
+
+if _check_soft_dependencies("pandas>=2.1.0", severity="none"):
+    NON_FIXED_FREQ_STRS += ["ME", "2ME", "QE-DEC", "YE-DEC", "YE-MAR"]
 
 
 @pytest.mark.skipif(
@@ -77,6 +85,36 @@ def test_coerce_duration_to_int() -> None:
         _coerce_duration_to_int(duration=duration, freq="25T"),
         pd.Index([3, 4], dtype=int),
     )
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils", "sktime.datatypes"]),
+    reason="Run if utils or datatypes module has changed.",
+)
+@pytest.mark.parametrize("freqstr", NON_FIXED_FREQ_STRS)
+def test_get_duration_non_fixed_freq(freqstr) -> None:
+    """Test _get_duration on DatetimeIndex of non-fixed freq, see issue #7883."""
+    index = pd.date_range(start="2000-01-31", periods=9, freq=freqstr)
+    unit = _get_freq(index)
+
+    # index and index element interface must both return the number of intervals
+    assert _get_duration(index, coerce_to_int=True) == 8
+    assert _get_duration(index[-1], index[0], coerce_to_int=True, unit=unit) == 8
+
+    # durations are signed
+    assert _get_duration(index[0], index[-1], coerce_to_int=True, unit=unit) == -8
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils", "sktime.datatypes"]),
+    reason="Run if utils or datatypes module has changed.",
+)
+def test_get_duration_freq_without_period() -> None:
+    """Test informative error if freq has no period equivalent, see issue #7883."""
+    index = pd.date_range(start="2000-01-01", periods=9, freq=pd.offsets.SemiMonthEnd())
+
+    with pytest.raises(ValueError, match="no equivalent period frequency"):
+        _get_duration(index, coerce_to_int=True)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #7883.

#### What does this implement/fix? Explain your changes.

`_get_duration(x, y, coerce_to_int=True, unit=freq)` computes `x - y` as a bare `pd.Timedelta` and hands it to `_coerce_duration_to_int(duration, freq=unit)`, where `unit` is a pandas *offset* alias. For frequencies that are not of fixed length, that is either an error or, worse, silently wrong.

On current `main`, for `pd.date_range("2000-01-31", periods=9, freq=...)`, where the answer is `8` in every row:

| freq | `_get_duration(idx, coerce_to_int=True)` on `main` |
|---|---|
| `MS` | `20995200000` |
| `ME` | `ValueError: Index type not supported. Please consider using pd.PeriodIndex...` |
| `YE-DEC` | same `ValueError` |
| `W-WED` | same `ValueError` |
| `D` | `8` |

`MS` is the damaging one. It is the most common monthly alias in pandas, and it is *also* a valid `pd.Timedelta` unit meaning milliseconds — so the coercion succeeds and returns a millisecond count instead of a number of months, with no error anywhere. The other three do raise, but the message names the wrong cause: the index type is fine, the frequency is what cannot be coerced.

This is reached in normal use from `transformations/detrend/_deseasonalize.py:107`, which is the only non-test caller of `_get_duration` in the codebase.

#### The fix

A private helper `_coerce_datetime_to_period(x, y, freq)` in the same module, called from `_get_duration` while both endpoints are still in scope:

- fixed (`Tick`) offsets — `D`, `h`, `min`, `s` — are returned untouched and keep the existing `pd.Timedelta` path, so nothing about the working cases changes;
- non-fixed offsets go through `to_period(offset)`; the difference of two `pd.Period` carries the number of intervals, so the coercion is exact;
- the offset **object** is passed to `to_period`, not the alias string — from pandas 2.2 the offset alias and the period alias differ (`YE-DEC` vs `Y-DEC`), which is precisely the conversion the issue reporter could not find;
- offsets with no period equivalent, e.g. `SME`, now raise a `ValueError` naming the real cause instead of "Index type not supported."

The coercion deliberately sits in `_get_duration` and not in `_coerce_duration_to_int`: the latter only ever receives a `pd.Timedelta`, with the endpoints already discarded, and the comment at `datetime.py:48-49` states that it is meant to stay that way.

#### Testing

`sktime/utils/tests/test_datetime.py` (`_get_duration` was not previously imported there):

- `test_get_duration_non_fixed_freq` — parametrized over `W-WED`, `MS`, `QS-OCT`, `YS-JAN`, plus `ME`, `2ME`, `QE-DEC`, `YE-DEC`, `YE-MAR` on pandas >= 2.1. Covers both call signatures (index, and two timestamps with an explicit `unit`) and asserts durations stay signed.
- `test_get_duration_freq_without_period` — the `SME` error path. This one is slightly wider than the issue as filed; it pins the new error message so the `SME`-style case cannot silently regress into the old misleading one.

`sktime/transformations/detrend/tests/test_deseasonalise.py`:

- `test_deseasonalizer_non_fixed_freq` — the end-to-end route from the issue report; `fit_transform` followed by `inverse_transform` round-trips on a non-fixed-frequency index.

CI runs on my PRs are still gated pending a first merge, so this was run locally against this branch:

```
# new tests, unmodified source (RED)
14 failed, 22 passed in 1.04s
# with the fix (GREEN)
36 passed in 0.44s
# blast radius: sktime/utils/tests, forecasting/base/tests/test_fh.py,
#               sktime/split/tests, sktime/transformations/detrend
5966 passed, 108 skipped in 65.89s
```

`ruff check` and `ruff format --check` are clean on all three files.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Two judgment calls. First, whether `Tick` is the right dividing line between "keep the `pd.Timedelta` path" and "route through periods" — it is the property that actually matters here (fixed length), but it is a pandas-internal class. Second, whether `SME` and friends should raise as they now do, or fall back to something lossier.

#### Did you add any tests for the change?

Yes, three, listed above.
