### PR TITLE
[BUG] fix `DistanceFeatures` for hierarchical data

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -155,7 +155,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "DirRecTimeSeriesRegressionForecaster",
         "DirectTimeSeriesRegressionForecaster",
         "DistFromAligner",
-        "DistanceFeatures",
         "DummyRegressor",
         "ElasticEnsemble",
         "FeatureSelection",

--- a/sktime/transformations/compose_distance.py
+++ b/sktime/transformations/compose_distance.py
@@ -29,8 +29,9 @@ class DistanceFeatures(BaseTransformer):
         mtype that distance expects for X and X2, if a callable
         only set this if distance is not BasePairwiseTransformerPanel descendant
     flatten_hierarchy : bool, optional, default=False.
-        whether column hierarchy in `transform` return is flattened (using `__` concat),
-        in case of a hierarchical series index seen in `fit`.
+        whether index and column hierarchy in `transform` return are flattened
+        (using `__` concat), in case of a hierarchical series index seen in
+        `fit` (columns) or `transform` (index).
 
     Examples
     --------
@@ -64,14 +65,14 @@ class DistanceFeatures(BaseTransformer):
         "capability:unequal_length:removes": False,
         "capability:missing_values": True,
         "capability:missing_values:removes": False,
+        # pairwise transformers do not support categorical features
+        "capability:categorical_in_X": False,
         # we leave remember_data as False, since updating self._X in update
         # would increase the number of columns in the transform return
         "remember_data": False,
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
-        # DistanceFeatures does ont work for hierarchical data, see #8077
-        "tests:skip_all": True,
     }
 
     def __init__(self, distance=None, distance_mtype=None, flatten_hierarchy=False):
@@ -136,12 +137,21 @@ class DistanceFeatures(BaseTransformer):
         X_ind = X.index.droplevel(-1).unique()
 
         def _coerce_to_panel(x):
-            """Coerce hierarchical or pandel x to panel."""
-            nlevels = x.index.nlevels
-            if nlevels > 2:
-                return x.droplevel(list(range(nlevels - 2)))
-            else:
+            """Coerce hierarchical or panel x to panel.
+
+            Hierarchy levels are replaced by a single integer instance level.
+            Dropping them instead would collapse distinct series that share the
+            same lower level index, see bug #8077.
+            """
+            if x.index.nlevels <= 2:
                 return x
+            inst_codes = x.index.droplevel(-1).factorize()[0]
+            x = x.copy()
+            x.index = pd.MultiIndex.from_arrays(
+                [inst_codes, x.index.get_level_values(-1)],
+                names=["instances", x.index.names[-1]],
+            )
+            return x
 
         X = _coerce_to_panel(X)
         X_train = _coerce_to_panel(X_train)
@@ -149,8 +159,31 @@ class DistanceFeatures(BaseTransformer):
         distmat = distance(X, X_train)
 
         if self.flatten_hierarchy:
-            X_ind = flatten_multiindex(X_ind)
+            if isinstance(X_ind, pd.MultiIndex):
+                X_ind = flatten_multiindex(X_ind)
+            if isinstance(X_train_ind, pd.MultiIndex):
+                X_train_ind = flatten_multiindex(X_train_ind)
 
         Xt = pd.DataFrame(distmat, columns=X_train_ind, index=X_ind)
 
         return Xt
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+        """
+        params1 = {}
+        params2 = {"distance": "cityblock", "flatten_hierarchy": True}
+
+        return [params1, params2]

--- a/sktime/transformations/tests/test_compose_distance.py
+++ b/sktime/transformations/tests/test_compose_distance.py
@@ -1,0 +1,105 @@
+"""Tests for DistanceFeatures."""
+
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
+
+__author__ = ["shivamlalakiya"]
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sktime.tests.test_switch import run_test_for_class
+from sktime.transformations.compose_distance import DistanceFeatures
+from sktime.utils._testing.hierarchical import _make_hierarchical
+
+
+def _expected_distmat(X):
+    """Euclidean distance between all pairs of instances, computed directly."""
+    insts = X.index.droplevel(-1).unique()
+    distmat = np.zeros((len(insts), len(insts)))
+    for i, inst_i in enumerate(insts):
+        for j, inst_j in enumerate(insts):
+            flat_i = X.loc[inst_i].to_numpy().flatten(order="F")
+            flat_j = X.loc[inst_j].to_numpy().flatten(order="F")
+            distmat[i, j] = np.linalg.norm(flat_i - flat_j)
+    return distmat
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DistanceFeatures),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("hierarchy_levels", [(3,), (2, 2), (2, 2, 2)])
+def test_distance_features_hierarchical(hierarchy_levels):
+    """Test that hierarchical input is handled, and distances are correct, see #8077."""
+    X = _make_hierarchical(
+        hierarchy_levels=hierarchy_levels,
+        n_columns=2,
+        min_timepoints=5,
+        max_timepoints=5,
+        random_state=42,
+    )
+
+    Xt = DistanceFeatures().fit_transform(X)
+
+    inst_ind = X.index.droplevel(-1).unique()
+
+    assert isinstance(Xt, pd.DataFrame)
+    assert Xt.shape == (len(inst_ind), len(inst_ind))
+    assert (Xt.index == inst_ind).all()
+    assert (Xt.columns == inst_ind).all()
+    np.testing.assert_allclose(Xt.to_numpy(), _expected_distmat(X))
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DistanceFeatures),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_distance_features_hierarchical_repeated_instance_labels():
+    """Test that series sharing a lower level index are not collapsed, see #8077."""
+    # both hierarchy nodes contain a series labelled "s0", with different values
+    index = pd.MultiIndex.from_product(
+        [["a", "b"], ["s0"], pd.RangeIndex(3)], names=["h0", "h1", "time"]
+    )
+    X = pd.DataFrame({"c0": [0.0, 0.0, 0.0, 3.0, 4.0, 0.0]}, index=index)
+
+    Xt = DistanceFeatures().fit_transform(X)
+
+    assert Xt.shape == (2, 2)
+    np.testing.assert_allclose(Xt.to_numpy(), [[0.0, 5.0], [5.0, 0.0]])
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DistanceFeatures),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_distance_features_flatten_hierarchy():
+    """Test that flatten_hierarchy flattens index and columns of the return."""
+    X = _make_hierarchical(
+        hierarchy_levels=(2, 2), n_columns=1, min_timepoints=4, max_timepoints=4
+    )
+
+    Xt = DistanceFeatures(flatten_hierarchy=True).fit_transform(X)
+
+    expected = ["h0_0__h1_0", "h0_0__h1_1", "h0_1__h1_0", "h0_1__h1_1"]
+    assert list(Xt.index) == expected
+    assert list(Xt.columns) == expected
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DistanceFeatures),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_distance_features_hierarchical_fit_transform_different():
+    """Test hierarchical data with different instances in fit and transform."""
+    X = _make_hierarchical(
+        hierarchy_levels=(2, 2), n_columns=1, min_timepoints=4, max_timepoints=4
+    )
+    X_train = X.loc[["h0_0"]]
+    X_test = X.loc[["h0_1"]]
+
+    Xt = DistanceFeatures().fit(X_train).transform(X_test)
+
+    assert Xt.shape == (2, 2)
+    assert (Xt.index == X_test.index.droplevel(-1).unique()).all()
+    assert (Xt.columns == X_train.index.droplevel(-1).unique()).all()


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #8077.

Draft PR #8090 (2025-04-02) targets the same issue and I am not trying to snipe it. It has gone unreviewed since it was opened, and it can no longer be merged as written: it patches `sktime/transformations/panel/compose_distance.py`, and the module has since moved to `sktime/transformations/compose_distance.py`. Its approach also differs — it maps the hierarchical index to a dummy panel index and back again around the distance call, whereas this PR keeps the coercion in one place. Happy to close this in favour of a rebased #8090 if @wilsbj wants to pick it back up.

#### What does this implement/fix? Explain your changes.

`DistanceFeatures._transform` coerced hierarchical input to panel with

```python
return x.droplevel(list(range(nlevels - 2)))
```

which throws away every level above the last two. Two distinct series that happen to share the same second-to-last index value collapse into one, so the distance matrix is computed against the wrong rows — silently, whenever the hierarchy has more than one level and the lower level repeats across branches, which is the normal case.

Changes:

- `_coerce_to_panel` now replaces the hierarchy with a single integer instance level, built with `factorize()` on the index minus its time level. Distinct series stay distinct, and the resulting object is a well-formed panel, which is what `distance` expects.
- `flatten_multiindex` is applied only when the index actually is a `pd.MultiIndex`, on both `X_ind` and `X_train_ind`. Previously the training side was left unflattened and the non-MultiIndex case was not guarded.
- `get_test_params` added, so the estimator is exercised with a second parameter set rather than defaults only.
- the `"tests:skip_all": True` tag and the `DistanceFeatures` entry in `sktime/tests/_config.py` are both removed, which puts the estimator back into the test suite.
- the `flatten_hierarchy` docstring now describes what it does to the index as well as the columns; previously it mentioned only columns.

#### Testing

`sktime/transformations/tests/test_compose_distance.py` — 6 tests, covering hierarchical input with a repeated lower level (the collapse case), the flattening behaviour of both index and columns, and the panel and single-level paths as regression guards.

CI runs on my PRs are gated pending a first merge, so the numbers below are local, against `upstream/main` and against this branch:

| | `upstream/main` | this branch |
|---|---|---|
| `pytest sktime/transformations/tests/test_all_transformers.py -k DistanceFeatures` | 0 selected — estimator skipped entirely | **38 passed** |
| `check_estimator(DistanceFeatures)` | 161 checks, **16 failed** | 308 checks, **0 failed** |
| `pytest sktime/transformations/tests/test_compose_distance.py` | n/a (new file) | 6 passed |

The `check_estimator` numbers are the informative pair: it ignores the skip configuration, so it was already reporting 16 failures against code that CI never ran. Those are what the tag was hiding.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Whether re-labelling the hierarchy as a plain integer instance level is acceptable, or whether the original index should be reconstructed on the way out, as #8090 attempts. Reconstructing it is more faithful but the output of a distance-feature transform is a matrix indexed by series, so the integer labelling seemed like the honest representation. The `flatten_hierarchy=True` path does preserve the original labels in the flattened names.

#### Did you add any tests for the change?

Yes, six, in a new test module.
