### PR TITLE
[BUG] fix negative/zero-index slicing in SeasonalityPeriodogram.periodogram

### DIFF
--- a/sktime/param_est/seasonality/_periodogram.py
+++ b/sktime/param_est/seasonality/_periodogram.py
@@ -190,9 +190,11 @@ class SeasonalityPeriodogram(BaseParamFitter):
             else:
                 idx += 1
         power[periods == nperseg] = 0  # disregard the artifact at nperseg
-        min_i = len(periods[periods >= max_period]) - 1
+        min_i = max(len(periods[periods >= max_period]) - 1, 0)
         max_i = len(periods[periods < min_period])
-        periods, power = periods[min_i:-max_i], power[min_i:-max_i]
+        # not -max_i: -0 == 0 would empty the slice when max_i == 0
+        stop_i = len(periods) - max_i
+        periods, power = periods[min_i:stop_i], power[min_i:stop_i]
         return periods, power
 
     def _fit(self, X):

--- a/sktime/param_est/tests/test_seasonality.py
+++ b/sktime/param_est/tests/test_seasonality.py
@@ -8,7 +8,11 @@ import pytest
 from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.datasets import load_airline
-from sktime.param_est.seasonality import SeasonalityACF, SeasonalityACFqstat
+from sktime.param_est.seasonality import (
+    SeasonalityACF,
+    SeasonalityACFqstat,
+    SeasonalityPeriodogram,
+)
 
 
 @pytest.mark.skipif(
@@ -57,3 +61,32 @@ def test_seasonality_acf_qstat():
     actual = sp_est.get_fitted_params()["sp_significant"]
     expected = np.array([12, 7, 3])
     np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(SeasonalityPeriodogram, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+@pytest.mark.parametrize("min_period", [2, 4])
+def test_seasonality_periodogram_min_period_no_trim(min_period):
+    """Test SeasonalityPeriodogram with min_period at or below the Nyquist period."""
+    X = 10 * np.sin(2 * np.pi * np.arange(96) / 12)
+
+    sp_est = SeasonalityPeriodogram(min_period=min_period)
+    sp_est.fit(X)
+
+    assert sp_est.get_fitted_params()["sp"] == 12
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(SeasonalityPeriodogram, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+def test_seasonality_periodogram_max_period_no_trim():
+    """Test SeasonalityPeriodogram with max_period above the resolvable range."""
+    X = 10 * np.sin(2 * np.pi * np.arange(100) / 12)
+
+    sp_est = SeasonalityPeriodogram(max_period=60)
+    sp_est.fit(X)
+
+    assert sp_est.get_fitted_params()["sp"] == 12


### PR DESCRIPTION
[BUG] SeasonalityPeriodogram reports "no seasonality" when min_period <= 2 or max_period exceeds the resolvable range

#### Reference Issues/PRs

None found for this behavior.

#### What does this implement/fix? Explain your changes.

`SeasonalityPeriodogram.periodogram()` trims its computed period/power
arrays with one slice statement that has two ways to collapse to empty or
wrong on ordinary inputs, and then reports `sp_ = 1` (no seasonality) on
data with a clear, strong periodic signal.

```python
import numpy as np
from sktime.param_est.seasonality import SeasonalityPeriodogram

t = np.arange(96)
X = 10 * np.sin(2 * np.pi * t / 12)  # clean period-12 sinusoid

SeasonalityPeriodogram(min_period=2).fit(X).get_fitted_params()["sp"]
# 1, expected 12

SeasonalityPeriodogram(max_period=60).fit(X[:100]).get_fitted_params()["sp"]
# 1, expected 12
```

Expected `sp_ == 12` in both cases; actual `sp_ == 1`,
`sp_significant_ == []`.

In `_periodogram.py::periodogram`:

```python
min_i = len(periods[periods >= max_period]) - 1
max_i = len(periods[periods < min_period])
periods, power = periods[min_i:-max_i], power[min_i:-max_i]
```

`max_i` counts trailing entries to drop. When `max_i == 0`,
`periods[min_i:-max_i]` is `periods[min_i:-0]`, and since `-0 == 0` in
Python that's `periods[min_i:0]` -- an empty array instead of "keep
everything to the end". This happens whenever `min_period <= 2` (verified
by sweeping `min_period` over 0..7 against series lengths 12..400: `max_i
== 0` occurs for `min_period <= 2` and never for `min_period >= 3`, since
the periodogram's shortest resolvable period is always 2).

`min_i` has the same class of bug in the other direction: it is `-1`
whenever no computed period reaches `max_period`, which happens whenever
`max_period` exceeds `len(data) // 2` (the longest period `nperseg =
min(2*max_period, len(data)//2)` can resolve). `periods[-1:stop_i]` then
starts one entry before the array end, discarding everything except the
shortest period. Both cases feed an effectively empty `power` into
`periodogram_peaks()`, where `np.all(np.isclose(power, 0.0))` is vacuously
true on an empty array, so it returns `None` and `_fit` sets `sp_ = 1`.

Fix: replace the `-max_i` slice with an explicit stop index, and clamp
`min_i` to 0.

```python
min_i = max(len(periods[periods >= max_period]) - 1, 0)
max_i = len(periods[periods < min_period])
stop_i = len(periods) - max_i
periods, power = periods[min_i:stop_i], power[min_i:stop_i]
```

This line is inherited verbatim from the upstream `seasonal` package this
estimator is adapted from (github.com/welch/seasonal). Upstream defaults
`min_period=4` and doesn't expose it as a parameter, so it never hits the
`max_i == 0` case there; sktime's `min_period` is user-facing, which makes
the bug reachable.

Verified the fix does not change the existing doctest (`load_airline()`
example still returns `sp_ = 6`, `sp_significant_ = [6, 12, 14, 4, 10, 5]`)
and returns `sp_ = 12` across `min_period` in {1, 2, 5} and `max_period` in
{24, 50, 51, 60, 1000} on the sinusoid above.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

The two-line indexing fix; the two regression tests reproduce each trigger
directly (fail before the fix, pass after -- see
`pytest_RED_before_fix.txt` / `pytest_GREEN_after_fix.txt`).

#### Did you add any tests for the change?

Yes: `test_seasonality_periodogram_min_period_no_trim` (parametrized over
`min_period` in {2, 4}, with 4 acting as a control case that already
worked) and `test_seasonality_periodogram_max_period_no_trim`, both in
`sktime/param_est/tests/test_seasonality.py`. `SeasonalityPeriodogram` had
no dedicated correctness test in that file before this change (it is
exercised generically via `TestAllParamFitters` in `test_all_param_est.py`,
which does not check numeric output).

Happy to adjust the fix or tests if you'd prefer a different approach (e.g.
validating `min_period >= 3` instead of permitting it).
