### PR TITLE
[ENH] Replace nested_univ type for DummyClassifier

### DIFF
--- a/sktime/classification/dummy/_dummy.py
+++ b/sktime/classification/dummy/_dummy.py
@@ -79,7 +79,7 @@ class DummyClassifier(BaseClassifier):
         "maintainers": ["ZiyaoWei"],
         # estimator type
         # --------------
-        "X_inner_mtype": "nested_univ",
+        "X_inner_mtype": ["df-list", "numpy3D"],
         "capability:missing_values": True,
         "capability:unequal_length": True,
         "capability:multivariate": True,
@@ -115,7 +115,7 @@ class DummyClassifier(BaseClassifier):
         -------
         self : reference to self.
         """
-        self.sklearn_dummy_classifier.fit(np.zeros(X.shape), y)
+        self.sklearn_dummy_classifier.fit(np.zeros((len(X), 1)), y)
         return self
 
     def _predict(self, X) -> np.ndarray:
@@ -129,7 +129,7 @@ class DummyClassifier(BaseClassifier):
         -------
         y : predictions of labels for X, np.ndarray
         """
-        return self.sklearn_dummy_classifier.predict(np.zeros(X.shape))
+        return self.sklearn_dummy_classifier.predict(np.zeros((len(X), 1)))
 
     def _predict_proba(self, X) -> np.ndarray:
         """Predicts labels probabilities for sequences in X.
@@ -142,7 +142,7 @@ class DummyClassifier(BaseClassifier):
         -------
         y : predictions of probabilities for class values of X, np.ndarray
         """
-        return self.sklearn_dummy_classifier.predict_proba(np.zeros(X.shape))
+        return self.sklearn_dummy_classifier.predict_proba(np.zeros((len(X), 1)))
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
### Problem
Issue #10716 highlights that sktime relies on the nested_univ input format (a pandas DataFrame where each cell contains a pandas Series or numpy array). This format is being aggressively deprecated in pandas 3.0, causing internal errors.

### Solution
This PR tackles one simple estimator, DummyClassifier, migrating it away from nested_univ to the modern, flattened representations ['df-list', 'numpy3D']. I also updated the internal shape-checking from X.shape to len(X) to handle list-based and multi-indexed input types universally without raising an AttributeError.

### Files changed
- sktime/classification/dummy/_dummy.py

### Testing performed
- Ran the sktime universal estimator checks via check_estimator(DummyClassifier).
- Verified that all dummy strategies (prior, stratified, uniform, etc.) correctly process both equal-length and unequal-length time series without raising conversion or reshaping errors.

**Reviewer Notes:**
As this is my first open-source contribution to sktime, I wanted to keep the scope extremely minimal. I deliberately avoided doing a bulk find-and-replace across multiple estimators to avoid accidentally breaking complex estimators. This PR strictly limits changes to the DummyClassifier as a safe proof-of-concept for the nested_univ migration strategy. The modification does not change any core logic�only the internal mtype tags and standardizing the way the row count is accessed.
