### PR TITLE
[ENH] `LagLlamaForecaster` - add test registry reference to vendor library

### DIFF
--- a/sktime/forecasting/lagllama.py
+++ b/sktime/forecasting/lagllama.py
@@ -235,6 +235,19 @@ class LagLlamaForecaster(BaseForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["pranavvp16"],
+        "maintainers": ["pranavvp16"],
+        "python_version": "<3.14",
+        "python_dependencies": [
+            "gluonts>=0.14.0",
+            "torch",
+            "lightning>=2.0",
+            "huggingface_hub",
+        ],
+        # estimator type
+        # --------------
         "y_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         "capability:exogenous": False,
         "capability:multivariate": False,  # LagLlama is univariate only
@@ -247,16 +260,10 @@ class LagLlamaForecaster(BaseForecaster):
         "capability:pred_int": True,
         "capability:pred_int:insample": False,
         "capability:unequal_length": False,
-        "authors": ["pranavvp16"],
-        "maintainers": ["pranavvp16"],
-        "python_version": "<3.14",
-        "python_dependencies": [
-            "gluonts>=0.14.0",
-            "torch",
-            "lightning>=2.0",
-            "huggingface_hub",
-        ],
+        # test and CI flags
+        # -----------------
         "tests:vm": True,
+        "tests:libs": ["sktime.libs.lag_llama"],
     }
 
     def __init__(


### PR DESCRIPTION
cleans up the tag dict in `LagLlamaForecaster` by adding sections and comments.

Adds reference to the `sktime` vendor to ensure testing triggers are correct. Also reformats the tag dict, adding comments.