### PR TITLE
[MNT] version upgrade for upper bounds of deps: `numpy<2.6`, `scikit-base<1.2.0`, `numba<0.67`, and some soft deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,11 @@ classifiers = [
 # this set should be kept minimal!
 dependencies = [
   "joblib>=1.2.0,<1.6",  # required for parallel processing
-  "numpy>=1.21,<2.5",  # required for framework layer and base class logic
+  "numpy>=1.21,<2.6",  # required for framework layer and base class logic
   "packaging",  # for estimator specific dependency parsing
   "pandas<3.0.0,>=1.1",  # pandas is the main in-memory data container
-  "scikit-base>=1.0.0,<1.1.0",  # base module for sklearn compatible base API
-  "scikit-learn>=0.24,<1.8.0",  # required for estimators and framework layer
+  "scikit-base>=1.0.0,<1.2.0",  # base module for sklearn compatible base API
+  "scikit-learn>=0.24,<2.0.0",  # required for estimators and framework layer
   "scipy<2.0.0,>=1.2",  # required for estimators and framework layer
 ]
 
@@ -85,7 +85,7 @@ all_extras = [
   'cloudpickle',
   'holidays',
   'matplotlib!=3.9.1,>=3.3.2',
-  'numba<0.63,>=0.53; python_version < "3.14"',
+  'numba<0.67,>=0.53',
   'polars[pandas]>=0.20,<2.0',
   'seaborn>=0.11',
   "skpro>=2,<2.15.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   "packaging",  # for estimator specific dependency parsing
   "pandas<3.0.0,>=1.1",  # pandas is the main in-memory data container
   "scikit-base>=1.0.0,<1.2.0",  # base module for sklearn compatible base API
-  "scikit-learn>=0.24,<1.10.0",  # required for estimators and framework layer
+  "scikit-learn>=0.24,<1.8.0",  # required for estimators and framework layer
   "scipy<2.0.0,>=1.2",  # required for estimators and framework layer
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ all_extras = [
 alignment = [
   'dtaidistance<2.5; python_version < "3.13"',
   'dtw-python>=1.3,<1.8; python_version < "3.13"',
-  'numba<0.67,>=0.53; python_version < "3.14"',
+  'numba<0.67,>=0.53',
 ]
 classification = [
   'numba<0.67,>=0.53',
@@ -113,13 +113,13 @@ classification = [
 ]
 clustering = [
   'networkx<3.7',
-  'numba<0.67,>=0.53; python_version < "3.14"',
+  'numba<0.67,>=0.53',
   'tslearn<0.7.0,!=0.6.0,>=0.5.2; python_version < "3.12"',
   'ts2vg<1.3; python_version < "3.13" and platform_machine != "aarch64"',
 ]
 detection = [
   'hmmlearn<0.4,>=0.2.7; python_version < "3.13"',
-  'numba<0.67,>=0.53; python_version < "3.14"',
+  'numba<0.67,>=0.53',
   'pyod<1.2,>=0.8; python_version < "3.12"',
 ]
 forecasting = [
@@ -139,12 +139,12 @@ param_est = [
   'statsmodels<0.15,>=0.12.1; python_version < "3.13"',
 ]
 regression = [
-  'numba<0.67,>=0.53; python_version < "3.14"',
+  'numba<0.67,>=0.53',
   'tensorflow<2.20,>=2.15; python_version < "3.13"',
 ]
 transformations = [
   'holidays>=0.29,<0.59; python_version < "3.13"',
-  'numba<0.67,>=0.53; python_version < "3.14"',
+  'numba<0.67,>=0.53',
   'pycatch22>=0.4,<0.4.6; python_version < "3.13"',
   'simdkalman',
   'statsmodels<0.15,>=0.12.1; python_version < "3.13"',
@@ -246,7 +246,7 @@ notebooks = [
   "lightning>=2.0,<2.7",
   "skpro",
   "statsforecast",
-  'numba<0.67; python_version < "3.14"',
+  'numba<0.67',
 ]
 numpy1 = [
   "numpy<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,33 +102,28 @@ all_extras = [
 # users can install via "pip install sktime[forecasting,transformations]" etc
 #
 alignment = [
-  'dtaidistance<2.4; python_version < "3.13"',
-  'dtw-python>=1.3,<1.6; python_version < "3.13"',
-  'numba<0.63,>=0.53; python_version < "3.14"',
-]
-annotation = [
-  'hmmlearn<0.4,>=0.2.7; python_version < "3.13"',
-  'numba<0.63,>=0.53; python_version < "3.14"',
-  'pyod<1.2,>=0.8; python_version < "3.12"',
+  'dtaidistance<2.5; python_version < "3.13"',
+  'dtw-python>=1.3,<1.8; python_version < "3.13"',
+  'numba<0.67,>=0.53; python_version < "3.14"',
 ]
 classification = [
-  'numba<0.63,>=0.53; python_version < "3.14"',
+  'numba<0.67,>=0.53',
   'tensorflow<2.20,>=2.15; python_version < "3.13"',
-  'tsfresh<0.21,>=0.17; python_version < "3.12"',
+  'tsfresh<0.22,>=0.17; python_version < "3.12"',
 ]
 clustering = [
   'networkx<3.7',
-  'numba<0.63,>=0.53; python_version < "3.14"',
+  'numba<0.67,>=0.53; python_version < "3.14"',
   'tslearn<0.7.0,!=0.6.0,>=0.5.2; python_version < "3.12"',
   'ts2vg<1.3; python_version < "3.13" and platform_machine != "aarch64"',
 ]
 detection = [
   'hmmlearn<0.4,>=0.2.7; python_version < "3.13"',
-  'numba<0.63,>=0.53; python_version < "3.14"',
+  'numba<0.67,>=0.53; python_version < "3.14"',
   'pyod<1.2,>=0.8; python_version < "3.12"',
 ]
 forecasting = [
-  'arch>=5.6,<7.1; python_version < "3.13"',
+  'arch>=5.6,<9.1; python_version < "3.13"',
   'pmdarima!=1.8.1,<2.2,>=1.8',
   'prophet<1.4,>=1.2; python_version < "3.13"',
   'skforecast<0.19,>=0.12.1; python_version < "3.14"',
@@ -144,16 +139,16 @@ param_est = [
   'statsmodels<0.15,>=0.12.1; python_version < "3.13"',
 ]
 regression = [
-  'numba<0.63,>=0.53; python_version < "3.14"',
+  'numba<0.67,>=0.53; python_version < "3.14"',
   'tensorflow<2.20,>=2.15; python_version < "3.13"',
 ]
 transformations = [
   'holidays>=0.29,<0.59; python_version < "3.13"',
-  'numba<0.63,>=0.53; python_version < "3.14"',
+  'numba<0.67,>=0.53; python_version < "3.14"',
   'pycatch22>=0.4,<0.4.6; python_version < "3.13"',
   'simdkalman',
   'statsmodels<0.15,>=0.12.1; python_version < "3.13"',
-  'tsfresh<0.21,>=0.17; python_version < "3.12"',
+  'tsfresh<0.22,>=0.17; python_version < "3.12"',
 ]
 
 # dev - the developer dependency set, for contributors to sktime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   "packaging",  # for estimator specific dependency parsing
   "pandas<3.0.0,>=1.1",  # pandas is the main in-memory data container
   "scikit-base>=1.0.0,<1.2.0",  # base module for sklearn compatible base API
-  "scikit-learn>=0.24,<2.0.0",  # required for estimators and framework layer
+  "scikit-learn>=0.24,<1.10.0",  # required for estimators and framework layer
   "scipy<2.0.0,>=1.2",  # required for estimators and framework layer
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,7 +246,7 @@ notebooks = [
   "lightning>=2.0,<2.7",
   "skpro",
   "statsforecast",
-  'numba<0.63; python_version < "3.14"',
+  'numba<0.67; python_version < "3.14"',
 ]
 numpy1 = [
   "numpy<2.0.0",


### PR DESCRIPTION
Upgrades defensive upper bounds for different packages:

* `numpy<2.6`
* `scikit-base<1.2.0`
* `numba<0.67`

Also ups the bound for a few soft dependencies in the soft dependency sets.