### PR TITLE
[ENH] address `numpy.trapz` deprecation and fix test tags in related estimators

### DIFF
--- a/sktime/transformations/_clasp_numba.py
+++ b/sktime/transformations/_clasp_numba.py
@@ -263,7 +263,7 @@ def _roc_auc_score(y_score, y_true):
         else:
             return np.nan
 
-    if _check_soft_dependencies("numpy<2"):
+    if _check_soft_dependencies("numpy<2", severity="none"):
         trapz = np.trapz
     else:
         trapz = np.trapezoid

--- a/sktime/transformations/_clasp_numba.py
+++ b/sktime/transformations/_clasp_numba.py
@@ -205,6 +205,9 @@ def _binary_f1_score(y_true, y_pred):
     return np.mean(f1_scores)
 
 
+NUMPY1 = _check_soft_dependencies("numpy<2", severity="none")
+
+
 @njit(fastmath=True, cache=True)
 def _roc_auc_score(y_score, y_true):
     """Compute roc-auc score.
@@ -263,7 +266,7 @@ def _roc_auc_score(y_score, y_true):
         else:
             return np.nan
 
-    if _check_soft_dependencies("numpy<2", severity="none"):
+    if NUMPY1:
         trapz = np.trapz
     else:
         trapz = np.trapezoid

--- a/sktime/transformations/_clasp_numba.py
+++ b/sktime/transformations/_clasp_numba.py
@@ -4,6 +4,7 @@ __author__ = ["ermshaua", "patrickzib"]
 
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.transformations.matrix_profile._mp_features import _sliding_dot_products
 from sktime.utils.numba.njit import njit
@@ -262,7 +263,12 @@ def _roc_auc_score(y_score, y_true):
         else:
             return np.nan
 
-    area = direction * np.trapz(tpr, fpr)
+    if _check_soft_dependencies("numpy<2"):
+        trapz = np.trapz
+    else:
+        trapz = np.trapezoid
+
+    area = direction * trapz(tpr, fpr)
     return area
 
 

--- a/sktime/transformations/catch22.py
+++ b/sktime/transformations/catch22.py
@@ -290,6 +290,10 @@ class Catch22(BaseTransformer):
         "y_inner_mtype": "None",
         "fit_is_empty": True,
         "capability:categorical_in_X": False,
+        # CI and test flags
+        # -----------------
+        "tests:vm": True,
+        "tests:libs": ["sktime.transformations._catch22_numba"],
     }
 
     def __init__(

--- a/sktime/transformations/clasp.py
+++ b/sktime/transformations/clasp.py
@@ -74,6 +74,10 @@ class ClaSPTransformer(BaseTransformer):
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
         "capability:multivariate": False,
         "fit_is_empty": True,
+        # CI and test flags
+        # -----------------
+        "tests:vm": True,
+        "tests:libs": ["sktime.transformations._clasp_numba"],
     }
 
     def __init__(


### PR DESCRIPTION
Addresses the deprecation of `numpy.trapz` from `numpy 2.0` onwards and its removal in 2.4.

Also fixes a few test tags to ensure VM based testing of `numba` based estimators and correct test triggers given changes in the `numba` facing code.