### PR TITLE
[BUG] fix SubLOF TypeError with timedelta window_size and integer index

### DIFF
--- a/sktime/detection/lof.py
+++ b/sktime/detection/lof.py
@@ -207,6 +207,12 @@ class SubLOF(BaseDetector):
 
         if isinstance(interval_size, int) and not is_integer_index(x):
             interval_size = x.freq * interval_size
+        elif isinstance(interval_size, datetime.timedelta) and is_integer_index(x):
+            raise ValueError(
+                "window_size cannot be a timedelta when the input data has an "
+                "integer index. Use an integer window_size instead, or fit on "
+                "data with a datetime-like index."
+            )
         n_intervals = math.floor(x_span / interval_size) + 1
 
         if x_max >= x_min + (n_intervals - 1) * interval_size:

--- a/sktime/detection/tests/test_lof.py
+++ b/sktime/detection/tests/test_lof.py
@@ -84,6 +84,19 @@ def test_predict(X, y_expected):
     not run_test_for_class(SubLOF),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
+def test_sublof_timedelta_window_with_integer_index_raises():
+    """Check informative error for timedelta window_size with an integer index."""
+    X = pd.DataFrame({"sensor_reading": [0.1, 0.5, 0.2, 100.0, 0.1, 0.0]})
+    model = SubLOF(n_neighbors=2, window_size=datetime.timedelta(days=1))
+
+    with pytest.raises(ValueError, match="window_size cannot be a timedelta"):
+        model.fit(X)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SubLOF),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_sublof_does_not_mutate_input():
     """Check that SubLOF does not modify the input DataFrame."""
     X = pd.DataFrame([0, 0.5, 100, 0.1, 0, 0.2, 0.3, 50])


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9929

#### What does this implement/fix? Explain your changes.
`SubLOF._split_into_intervals` had a guard converting an `int` `window_size` to a `timedelta` when the index is not an integer index (`x.freq * interval_size`), but no guard for the reverse mismatch: a `timedelta`/`datetime.timedelta` `window_size` combined with an integer index. That case fell through to `math.floor(x_span / interval_size)`, dividing an `int` by a `timedelta`, which raises an opaque `TypeError`.

This adds an explicit check for that mismatch and raises an informative `ValueError` instead, e.g.:

```
ValueError: window_size cannot be a timedelta when the input data has an integer index. Use an integer window_size instead, or fit on data with a datetime-like index.
```

The three previously-working combinations (int window + int index, int window + datetime index, timedelta window + datetime index) are unaffected.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
The new `elif` branch in `SubLOF._split_into_intervals` (`sktime/detection/lof.py`), and the added regression test in `sktime/detection/tests/test_lof.py`.

#### Did you add any tests for the change?
Yes — `test_sublof_timedelta_window_with_integer_index_raises` in `sktime/detection/tests/test_lof.py`, which asserts the informative `ValueError` is raised. Ran the full `sktime/detection/` test suite locally (44 passed, 56 skipped for missing soft deps) plus `ruff check`/`ruff format --check` on the changed files.

#### Any other comments?
None.

#### PR checklist
- [x] The PR title starts with `[BUG]`
- [x] Added/modified tests
- [x] Used pre-commit hooks (`ruff check` / `ruff format --check` pass on changed files)