### PR TITLE
[ENH] Replace nested_univ with numpy3D for ElbowClassSum

### DIFF
--- a/sktime/transformations/channel_selection.py
+++ b/sktime/transformations/channel_selection.py
@@ -194,7 +194,7 @@ class ElbowClassSum(BaseTransformer):
         # what scitype is returned: Primitives, Series, Panel
         "scitype:instancewise": True,  # is this an instance-wise transform?
         "capability:multivariate": True,  # can the transformer handle multivariate X?
-        "X_inner_mtype": "nested_univ",  # which mtypes do _fit/_predict support for X?
+        "X_inner_mtype": "numpy3D",  # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "numpy1D",  # which mtypes do _fit/_predict support for y?
         "requires_y": True,  # does y need to be passed in fit?
         "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
@@ -243,12 +243,12 @@ class ElbowClassSum(BaseTransformer):
         start = int(round(time.time() * 1000))
         centroid_obj = _shrunk_centroid(1e-5)
 
-        X_np = convert(X, "nested_univ", "numpy3D")
-        centroids = centroid_obj.create_centroid(X_np, y)
+        X_nested = convert(X, from_type="numpy3D", to_type="nested_univ")
+        centroids = centroid_obj.create_centroid(X, y)
         centroids_no_y = centroids.drop("class_vals", axis=1)
-        centroids_no_y.columns = X.columns
+        centroids_no_y.columns = X_nested.columns
 
-        dists = [t(X[[c]]).sum() for c in X.columns]
+        dists = [t(X_nested[[c]]).sum() for c in X_nested.columns]
         dists = pd.Series(dists)
         self.distance_frame_ = dists
 
@@ -258,7 +258,7 @@ class ElbowClassSum(BaseTransformer):
         idx = _detect_knee_point(distance, indices)[0]
 
         self.channels_selected_ = idx
-        self.channels_selected_idx_ = [X.columns[i] for i in idx]
+        self.channels_selected_idx_ = [X_nested.columns[i] for i in idx]
 
         self.train_time_ = int(round(time.time() * 1000)) - start
 
@@ -277,7 +277,7 @@ class ElbowClassSum(BaseTransformer):
         output : pandas DataFrame
             X with a subset of channels
         """
-        return X[self.channels_selected_idx_]
+        return X[:, self.channels_selected_, :]
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
#### Reference Issues/PRs

Part of #10716

#### What does this implement/fix? Explain your changes.

This pull request updates the `ElbowClassSum` transformer by replacing the obsolete `nested_univ` input type with `numpy3D`, in accordance with the migration referred to in #10716.

The changes include:

- updating the `X_inner_mtype` tag to `numpy3D`
- removing the redundant conversion from `nested_univ` to `numpy3D`
- updating the implementation to work with `numpy3D` inputs
- preserving the existing behaviour of `channels_selected_idx_`

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the migration to `numpy3D` is in keeping with the intended datatype transition.
- Whether the current behaviour of `ElbowClassSum` is maintained after the change.

#### Did you add any tests for the change?

No additional tests were included.

The following existing test suites were run successfully:

- `sktime/transformations/tests/test_channel_selection.py`
- `sktime/transformations/tests/test_all_transformers.py`

#### Any other comments?

No additional comments.

#### PR checklist

##### For all contributions

- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators

- [ ] I've added the estimator to the API reference.
- [ ] I've added one or more illustrative usage examples to the docstring.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured dependency isolation.