### PR TITLE
[ENH] add second test parameter set for SummaryClassifier

### DIFF
--- a/sktime/classification/feature_based/_summary_classifier.py
+++ b/sktime/classification/feature_based/_summary_classifier.py
@@ -224,7 +224,15 @@ class SummaryClassifier(BaseClassifier):
         if parameter_set == "results_comparison":
             return {"estimator": RandomForestClassifier(n_estimators=10)}
         else:
-            return {
+            # summary functions with default quantiles
+            params1 = {
                 "estimator": RandomForestClassifier(n_estimators=2),
                 "summary_functions": ("mean", "min", "max"),
             }
+            # different summary functions, and quantile calculation switched off
+            params2 = {
+                "estimator": RandomForestClassifier(n_estimators=2),
+                "summary_functions": ("median", "std"),
+                "summary_quantiles": None,
+            }
+            return [params1, params2]

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -188,7 +188,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "ShapeletTransformClassifier",
         "SlidingWindowSegmenter",
         "StackingForecaster",
-        "SummaryClassifier",
         "SupervisedTimeSeriesForest",
         "TEASER",
         "TSFreshClassifier",


### PR DESCRIPTION
#### Reference Issues/PRs

Part of #3429.

#### What does this implement/fix? Explain your changes.

`SummaryClassifier.get_test_params` returned a single dict for the unconditional
parameter set, so the estimator was excluded from `test_get_test_params_coverage`
via `EXCLUDED_TESTS_BY_TEST` in `sktime/tests/_config.py`.

This PR returns two parameter sets from the unconditional branch:

* the existing set, using `("mean", "min", "max")` with the default quantiles;
* a second set using `("median", "std")` with `summary_quantiles=None`, which
  also covers the path where no quantiles are computed.

Both use `n_estimators=2` to keep `fit` fast, per the constraints in #3429.
The `results_comparison` parameter set is left unchanged, as the recipe in #3429
instructs.

`SummaryClassifier` is also removed from the exclusion list. Both changes are
needed together, since `test_excluded_tests_by_test` asserts that the exclusion
list only contains estimators with fewer than two parameter sets.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Did you add any tests for the change?

No new tests; this enables an existing test,
`test_get_test_params_coverage`, for this estimator.

#### Any other comments?

Ran locally on Python 3.11: `check_estimator(SummaryClassifier)` passes 202/202
checks, and `test_excluded_tests_by_test` passes.